### PR TITLE
add instruction to install guide to use tag

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,7 +20,7 @@
   gcloud container clusters create ${CLUSTER_NAME} --workload-pool=${CLUSTER_PROJECT_ID}.svc.id.goog
   gcloud container clusters get-credentials ${CLUSTER_NAME}
   ```
-- For an exising cluster, run the following commands to enable Workload Identity.
+- For an existing cluster, run the following commands to enable Workload Identity.
   ```bash
   CLUSTER_PROJECT_ID=<cluster-project-id>
   CLUSTER_NAME=<cluster-name>
@@ -29,13 +29,24 @@
   ```
 
 ## Install
+- If you aren't using your own containers, you will need to checkout a release tag, otherwise the build will generate a "dirty" tag for a git commit version
+  that does not exist. From the root of the gcs-fuse-csi-driver clone, that might look like this:
+  
+  ```bash
+  # fetch tags to build a release version
+  $ git fetch
+
+  # View tags with "git tag" and then choose one
+  $ git checkout v0.4.1
+  ```
 - Run the following command to install the driver. The driver will be installed under a new namespace `gcs-fuse-csi-driver`. The installation may take a few minutes.
   ```bash
   # Optionally, specify the image registry and image version if you have built the images from source code.
+  # If you do not choose a custom registry and staging version you will need to fetch and checkout a tag, shown previously.
   export REGISTRY=<your-container-registry>
   export STAGINGVERSION=<staging-version>
   # Optionally, specify the overlay if you want to try out features that are only available in the dev overlay.
-  export OVERLAY=dev
+  export OVERLAY=dev  
   make install
   ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -74,13 +74,13 @@ In order to let the CSI driver authenticate with GCP APIs, you will need to do t
 
 ## Using the GCS Fuse CSI driver
 
-The GCS Fuse CSI driver allows developers to use standard Kubernetes API to consume pre-exising GCS buckets. There are two types of volume configuration supported:
+The GCS Fuse CSI driver allows developers to use standard Kubernetes API to consume pre-existing GCS buckets. There are two types of volume configuration supported:
 1. [Static Provisioning](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#static) using a PersistentVolumeClaim bound to the PersistentVolume
 2. Using [CSI Ephemeral Inline volumes](https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/#csi-ephemeral-volumes)
 
 The GCS Fuse CSI driver natively supports the above volume configuration methods. Currently, the [Dynamic Provisioning](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#dynamic) is under development and not officially supported.
 
-No matter which configuration method you choose, the CSI driver webhook depends on Pod annotations to inject and configure a sidecar contianer containing gcsfuse. Specifically, the annotation `gke-gcsfuse/volumes: "true"` is required. By default, the sidecar contianer has **300m CPU, 100Mi memory, and 1Gi ephemeral storage** allocated. You can overwrite these values by specifing the annotation `gke-gcsfuse/[cpu-limit | memory-limit | ephemeral-storage-limit]`. For example:
+No matter which configuration method you choose, the CSI driver webhook depends on Pod annotations to inject and configure a sidecar container containing gcsfuse. Specifically, the annotation `gke-gcsfuse/volumes: "true"` is required. By default, the sidecar container has **300m CPU, 100Mi memory, and 1Gi ephemeral storage** allocated. You can overwrite these values by specifying the annotation `gke-gcsfuse/[cpu-limit | memory-limit | ephemeral-storage-limit]`. For example:
 
 ```yaml
 apiVersion: v1


### PR DESCRIPTION
Currently, if the user does not specify a tag, the "make deploy" will generate a dirty commit tag that does not exist. In addition, I found a few spelling mistakes I am correcting.

This will close #1 