### PR TITLE
fix: migrate from k8s.gcr.io to registry.k8s.io

### DIFF
--- a/cmd/csi_driver/Dockerfile
+++ b/cmd/csi_driver/Dockerfile
@@ -24,7 +24,7 @@ ADD . .
 RUN make driver BINDIR=/bin
 
 # Start from Kubernetes Debian base.
-FROM k8s.gcr.io/build-image/debian-base:buster-v1.9.0 as debian
+FROM registry.k8s.io/build-image/debian-base:buster-v1.9.0 as debian
 # Install necessary dependencies
 RUN clean-install mount bash
 

--- a/deploy/base/controller/controller.yaml
+++ b/deploy/base/controller/controller.yaml
@@ -35,7 +35,7 @@ spec:
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
-          image: k8s.gcr.io/sig-storage/livenessprobe
+          image: registry.k8s.io/sig-storage/livenessprobe
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock
@@ -50,7 +50,7 @@ spec:
               cpu: 10m
               memory: 20Mi
         - name: csi-external-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner
+          image: registry.k8s.io/sig-storage/csi-provisioner
           imagePullPolicy: IfNotPresent
           args:
             - "--v=5"

--- a/deploy/base/node/node.yaml
+++ b/deploy/base/node/node.yaml
@@ -78,7 +78,7 @@ spec:
             capabilities:
               drop:
                 - all
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar
           imagePullPolicy: IfNotPresent
           args:
             - "--v=5"

--- a/deploy/images/stable/image.yaml
+++ b/deploy/images/stable/image.yaml
@@ -17,7 +17,7 @@ kind: ImageTagTransformer
 metadata:
   name: imagetag-livenessprobe
 imageTag:
-  name: k8s.gcr.io/sig-storage/livenessprobe
+  name: registry.k8s.io/sig-storage/livenessprobe
   newTag: "v2.9.0"
 ---
 
@@ -26,7 +26,7 @@ kind: ImageTagTransformer
 metadata:
   name: imagetag-csi-provisioner
 imageTag:
-  name: k8s.gcr.io/sig-storage/csi-provisioner
+  name: registry.k8s.io/sig-storage/csi-provisioner
   newTag: "v3.4.0"
 ---
 
@@ -35,7 +35,7 @@ kind: ImageTagTransformer
 metadata:
   name: imagetag-csi-node-registrar
 imageTag:
-  name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
+  name: registry.k8s.io/sig-storage/csi-node-driver-registrar
   newTag: "v2.7.0"
 ---
 


### PR DESCRIPTION
Kubernetes is migrating its image registry from [k8s.gcr.io](http://k8s.gcr.io/) to [registry.k8s.io](http://registry.k8s.io/).

Part of kubernetes/k8s.io#4780