### PR TITLE
Run gcsfuse e2e tests from master of gcsfuse repo

### DIFF
--- a/examples/gcsfuse-e2e-test/pod.yaml
+++ b/examples/gcsfuse-e2e-test/pod.yaml
@@ -43,10 +43,10 @@ spec:
         export PATH=$PATH:/usr/local/go/bin;
         go version;
         echo "Cloning the gcsfuse repo...";
-        git clone -b gcsfuse_gke_test https://github.com/GoogleCloudPlatform/gcsfuse.git;
+        git clone https://github.com/GoogleCloudPlatform/gcsfuse.git;
         cd gcsfuse/tools/integration_tests/implicitdir;
         echo "Running the gcsfuse e2e test...";
-        GODEBUG="asyncpreemptoff=1" go test -v --args mnt_dir_path="/gcs" > /output.log;
+        GODEBUG="asyncpreemptoff=1" go test -v --mountedDirectory="/gcs" > /output.log;
         echo "Copying gcsfuse E2E test result...";
         mkdir /gcs/e2e-logs -p;
         cp /output.log /gcs/e2e-logs/output-${MY_NODE_NAME}-$(date '+%Y-%m-%d').log;


### PR DESCRIPTION
Currently, the gcsfuse e2e tests(integration tests) are run from a test branch in gcsfuse repo because the master branch didn't support running the tests on already mounted directory. 
The master branch now supports running the tests from already mounted directory and these changes to shift to using master branch.