### PR TITLE
Add replace statements for k8s.io/kubernetes packages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -117,3 +117,35 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+replace (
+	k8s.io/api => k8s.io/api v0.26.4
+	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.26.4
+	k8s.io/apimachinery => k8s.io/apimachinery v0.26.4
+	k8s.io/apiserver => k8s.io/apiserver v0.26.4
+	k8s.io/cli-runtime => k8s.io/cli-runtime v0.26.4
+	k8s.io/client-go => k8s.io/client-go v0.26.4
+	k8s.io/cloud-provider => k8s.io/cloud-provider v0.26.4
+	k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.26.4
+	k8s.io/code-generator => k8s.io/code-generator v0.26.4
+	k8s.io/component-base => k8s.io/component-base v0.26.4
+	k8s.io/component-helpers => k8s.io/component-helpers v0.26.4
+	k8s.io/controller-manager => k8s.io/controller-manager v0.26.4
+	k8s.io/cri-api => k8s.io/cri-api v0.26.4
+	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.26.4
+	k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.26.4
+	k8s.io/kms => k8s.io/kms v0.26.4
+	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.26.4
+	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.26.4
+	k8s.io/kube-proxy => k8s.io/kube-proxy v0.26.4
+	k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.26.4
+	k8s.io/kubectl => k8s.io/kubectl v0.26.4
+	k8s.io/kubelet => k8s.io/kubelet v0.26.4
+	k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.26.4
+	k8s.io/metrics => k8s.io/metrics v0.26.4
+	k8s.io/mount-utils => k8s.io/mount-utils v0.26.4
+	k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.26.4
+	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.26.4
+	k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.26.4
+	k8s.io/sample-controller => k8s.io/sample-controller v0.26.4
+)

--- a/release-tools/README.md
+++ b/release-tools/README.md
@@ -1,0 +1,61 @@
+<!-- 
+Copyright 2018 The Kubernetes Authors.
+Copyright 2022 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. -->
+
+Dependencies and vendoring
+--------------------------
+
+Most projects will (eventually) use `go mod` to manage
+dependencies.
+
+The usual instructions for using [go
+modules](https://github.com/golang/go/wiki/Modules) apply. Here's a cheat sheet
+for some of the relevant commands:
+- list available updates: `go list -u -m all`
+- update or add a single dependency: `go get <package>`
+- update all dependencies to their next minor or patch release:
+  `go get ./...` (add `-u=patch` to limit to patch
+  releases)
+- lock onto a specific version: `go get <package>@<version>`
+- clean up `go.mod`: `go mod tidy`
+- update vendor directory: `go mod vendor`
+
+`go mod tidy` must be used to ensure that the listed dependencies are
+really still needed. Changing import statements or a tentative `go
+get` can result in stale dependencies.
+
+The `test-vendor` verifies that it was used when run locally or in a
+pre-merge CI job. If a `vendor` directory is present, it will also
+verify that it's content is up-to-date.
+
+The `vendor` directory is optional. It is still present in projects
+because it avoids downloading sources during CI builds. If this is no
+longer deemed necessary, then a project can also remove the directory.
+
+### Updating Kubernetes dependencies
+
+When using packages that are part of the Kubernetes source code, the
+commands above are not enough because the [lack of semantic
+versioning](https://github.com/kubernetes/kubernetes/issues/72638)
+prevents `go mod` from finding newer releases. Importing directly from
+`kubernetes/kubernetes` also needs `replace` statements to override
+the fake `v0.0.0` versions
+(https://github.com/kubernetes/kubernetes/issues/79384). The
+`go-get-kubernetes.sh` script can be used to update all packages in
+lockstep to a different Kubernetes version. Example usage:
+```
+$ ./release-tools/go-get-kubernetes.sh 1.26.4
+```
+Since the go.mod file already requires `k8s.io/kubernetes v1.26.4`, I passed this version to the script.

--- a/release-tools/go-get-kubernetes.sh
+++ b/release-tools/go-get-kubernetes.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script can be used while converting a repo from "dep" to "go mod"
+# by calling it after "go mod init" or to update the Kubernetes packages
+# in a repo that has already been converted. Only packages that are
+# part of kubernetes/kubernetes and thus part of a Kubernetes release
+# are modified. Other k8.io packages (like k8s.io/klog, k8s.io/utils)
+# need to be updated separately.
+
+set -o pipefail
+
+cmd=$0
+
+function help () {
+    cat <<EOF
+$cmd -p <kubernetes version = x.y.z>
+
+Update all components from kubernetes/kubernetes to that version.
+
+By default, replace statements are added for all Kubernetes packages,
+whether they are used or not.  This is useful when preparing a
+repository for using k8s.io/kubernetes, because those replace
+statements are needed to avoid "unknown revision v0.0.0" errors
+(https://github.com/kubernetes/kubernetes/issues/79384).
+
+With the optional -p flag, all unused replace statements are
+pruned. This makes go.mod smaller, but isn't required.
+
+The replace statements are needed for "go get -u ./..." which
+otherwise ends up updating Kubernetes packages like client-go to
+incompatible versions (in that case, a very old 1.x release which
+happens to have a "higher" version number than the current
+0.<Kubernetes minor version>.<Kubernetes patch version> numbers.
+EOF
+}
+
+prune=false
+
+while getopts "ph" o; do
+    case "$o" in
+        h) help; exit 0;;
+        p) prune=true;;
+        *) help; exit 1;;
+    esac
+done
+shift $((OPTIND-1))
+
+if [ $# -ne 1 ]; then
+    help
+    exit 1
+fi
+
+die () {
+    echo >&2 "$@"
+    exit 1
+}
+
+k8s="$1"
+
+# If the repo imports k8s.io/kubernetes (directly or indirectly), then
+# "go mod" will try to find "v0.0.0" versions because
+# k8s.io/kubernetes has those in it's go.mod file
+# (https://github.com/kubernetes/kubernetes/blob/2bd9643cee5b3b3a5ecbd3af49d09018f0773c77/go.mod#L146-L157).
+# (https://github.com/kubernetes/kubernetes/issues/79384).
+#
+# We need to replicate the replace statements to override those fake
+# versions also in our go.mod file (idea and some code from
+# https://github.com/kubernetes/kubernetes/issues/79384#issuecomment-521493597).
+mods=$( (set -x; curl --silent --show-error --fail "https://raw.githubusercontent.com/kubernetes/kubernetes/v${k8s}/go.mod") |
+          sed -n 's|.*k8s.io/\(.*\) => ./staging/src/k8s.io/.*|k8s.io/\1|p'
+   ) || die "failed to determine Kubernetes staging modules"
+for mod in $mods; do
+    if $prune && ! (env GO111MODULE=on go mod graph) | grep "$mod@" > /dev/null; then
+        echo "Kubernetes module $mod is not used, skipping"
+        # Remove the module from go.mod "replace" that was added by an older version of this script.
+        (set -x;  env GO111MODULE=on go mod edit "-dropreplace=$mod") || die "'go mod edit' failed"
+        continue
+    fi
+    # The presence of a potentially incomplete go.mod file affects this command,
+    # so move elsewhere.
+    modinfo=$(set -x; cd /; env GO111MODULE=on go mod download -json "$mod@kubernetes-${k8s}") ||
+        die "failed to determine version of $mod: $modinfo"
+    v=$(echo "$modinfo" | sed -n 's|.*"Version": "\(.*\)".*|\1|p')
+    (set -x; env GO111MODULE=on go mod edit "-replace=$mod=$mod@$v") || die "'go mod edit' failed"
+done
+
+packages=
+
+# Beware that we have to work with packages, not modules (i.e. no -m
+# flag), because some modules trigger a "no Go code except tests"
+# error.  Getting their packages works.
+if ! packages=$( (set -x; env GO111MODULE=on go list all) | grep ^k8s.io/ | sed -e 's; *;;'); then
+    cat >&2 <<EOF
+
+Warning: "GO111MODULE=on go list all" failed, trying individual packages instead.
+
+EOF
+    if ! packages=$( (set -x; env GO111MODULE=on go list -f '{{ join .Deps "\n" }}' ./...) | grep ^k8s.io/); then
+        cat >&2 <<EOF
+
+ERROR: could not obtain package list, both of these commands failed:
+       GO111MODULE=on go list all
+       GO111MODULE=on go list -f '{{ join .Deps "\n" }}' ./pkg/...
+EOF
+        exit 1
+    fi
+fi
+
+deps=
+for package in $packages; do
+    # Some k8s.io packages do not come from Kubernetes staging and
+    # thus have different versioning (or none at all...). We need to
+    # skip those.  We know what packages are from staging because we
+    # now have "replace" statements for them in go.mod.
+    #
+    # shellcheck disable=SC2001
+    module=$(echo "$package" | sed -e 's;k8s.io/\([^/]*\)/.*;k8s.io/\1;')
+    if grep -q -w "$module *=>" go.mod; then
+        deps="$deps $(echo "$package" | sed -e "s;\$;@kubernetes-$k8s;" -e 's;^k8s.io/kubernetes\(/.*\)@kubernetes-;k8s.io/kubernetes\1@v;')"
+    fi
+done
+
+# shellcheck disable=SC2086
+(set -x; env GO111MODULE=on go get $deps 2>&1) || die "go get failed"
+echo "SUCCESS"

--- a/test/e2e/specs/specs.go
+++ b/test/e2e/specs/specs.go
@@ -32,6 +32,9 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
+
+	// TODO(songjiaxun): Try to remove usage from k8s.io/kubernetes if possible. This will make release-tools/go-get-kubernetes.sh script no longer necessary.
+	//  From https://github.com/kubernetes/kubernetes/#to-start-using-k8s, Use of the k8s.io/kubernetes module or k8s.io/kubernetes/... packages as libraries is not supported.
 	"k8s.io/kubernetes/pkg/kubelet/events"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2edeployment "k8s.io/kubernetes/test/e2e/framework/deployment"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -614,7 +614,7 @@ gopkg.in/yaml.v2
 # gopkg.in/yaml.v3 v3.0.1
 ## explicit
 gopkg.in/yaml.v3
-# k8s.io/api v0.26.4
+# k8s.io/api v0.26.4 => k8s.io/api v0.26.4
 ## explicit; go 1.19
 k8s.io/api/admission/v1
 k8s.io/api/admission/v1beta1
@@ -669,11 +669,11 @@ k8s.io/api/scheduling/v1beta1
 k8s.io/api/storage/v1
 k8s.io/api/storage/v1alpha1
 k8s.io/api/storage/v1beta1
-# k8s.io/apiextensions-apiserver v0.26.4
+# k8s.io/apiextensions-apiserver v0.26.4 => k8s.io/apiextensions-apiserver v0.26.4
 ## explicit; go 1.19
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
-# k8s.io/apimachinery v0.26.4
+# k8s.io/apimachinery v0.26.4 => k8s.io/apimachinery v0.26.4
 ## explicit; go 1.19
 k8s.io/apimachinery/pkg/api/equality
 k8s.io/apimachinery/pkg/api/errors
@@ -729,7 +729,7 @@ k8s.io/apimachinery/pkg/watch
 k8s.io/apimachinery/third_party/forked/golang/json
 k8s.io/apimachinery/third_party/forked/golang/netutil
 k8s.io/apimachinery/third_party/forked/golang/reflect
-# k8s.io/apiserver v0.26.4
+# k8s.io/apiserver v0.26.4 => k8s.io/apiserver v0.26.4
 ## explicit; go 1.19
 k8s.io/apiserver/pkg/admission
 k8s.io/apiserver/pkg/admission/configuration
@@ -767,7 +767,7 @@ k8s.io/apiserver/pkg/util/feature
 k8s.io/apiserver/pkg/util/webhook
 k8s.io/apiserver/pkg/util/x509metrics
 k8s.io/apiserver/pkg/warning
-# k8s.io/client-go v0.26.4
+# k8s.io/client-go v0.26.4 => k8s.io/client-go v0.26.4
 ## explicit; go 1.19
 k8s.io/client-go/applyconfigurations/admissionregistration/v1
 k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1
@@ -1029,10 +1029,10 @@ k8s.io/client-go/util/homedir
 k8s.io/client-go/util/keyutil
 k8s.io/client-go/util/retry
 k8s.io/client-go/util/workqueue
-# k8s.io/cloud-provider v0.26.4
+# k8s.io/cloud-provider v0.26.4 => k8s.io/cloud-provider v0.26.4
 ## explicit; go 1.19
 k8s.io/cloud-provider
-# k8s.io/component-base v0.26.4
+# k8s.io/component-base v0.26.4 => k8s.io/component-base v0.26.4
 ## explicit; go 1.19
 k8s.io/component-base/cli/flag
 k8s.io/component-base/config
@@ -1047,13 +1047,13 @@ k8s.io/component-base/metrics/prometheusextension
 k8s.io/component-base/tracing
 k8s.io/component-base/tracing/api/v1
 k8s.io/component-base/version
-# k8s.io/component-helpers v0.26.4
+# k8s.io/component-helpers v0.26.4 => k8s.io/component-helpers v0.26.4
 ## explicit; go 1.19
 k8s.io/component-helpers/node/util/sysctl
 k8s.io/component-helpers/scheduling/corev1
 k8s.io/component-helpers/scheduling/corev1/nodeaffinity
 k8s.io/component-helpers/storage/volume
-# k8s.io/csi-translation-lib v0.26.4
+# k8s.io/csi-translation-lib v0.26.4 => k8s.io/csi-translation-lib v0.26.4
 ## explicit; go 1.19
 # k8s.io/klog/v2 v2.90.1
 ## explicit; go 1.13
@@ -1077,7 +1077,7 @@ k8s.io/kube-openapi/pkg/schemamutation
 k8s.io/kube-openapi/pkg/spec3
 k8s.io/kube-openapi/pkg/util/proto
 k8s.io/kube-openapi/pkg/validation/spec
-# k8s.io/kubectl v0.26.4
+# k8s.io/kubectl v0.26.4 => k8s.io/kubectl v0.26.4
 ## explicit; go 1.19
 k8s.io/kubectl/pkg/scale
 k8s.io/kubectl/pkg/util/podutils
@@ -1146,10 +1146,10 @@ k8s.io/kubernetes/test/e2e/testing-manifests
 k8s.io/kubernetes/test/utils
 k8s.io/kubernetes/test/utils/image
 k8s.io/kubernetes/test/utils/kubeconfig
-# k8s.io/mount-utils v0.26.4
+# k8s.io/mount-utils v0.26.4 => k8s.io/mount-utils v0.26.4
 ## explicit; go 1.19
 k8s.io/mount-utils
-# k8s.io/pod-security-admission v0.26.4
+# k8s.io/pod-security-admission v0.26.4 => k8s.io/pod-security-admission v0.26.4
 ## explicit; go 1.19
 k8s.io/pod-security-admission/api
 k8s.io/pod-security-admission/policy
@@ -1220,3 +1220,32 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
+# k8s.io/api => k8s.io/api v0.26.4
+# k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.26.4
+# k8s.io/apimachinery => k8s.io/apimachinery v0.26.4
+# k8s.io/apiserver => k8s.io/apiserver v0.26.4
+# k8s.io/cli-runtime => k8s.io/cli-runtime v0.26.4
+# k8s.io/client-go => k8s.io/client-go v0.26.4
+# k8s.io/cloud-provider => k8s.io/cloud-provider v0.26.4
+# k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.26.4
+# k8s.io/code-generator => k8s.io/code-generator v0.26.4
+# k8s.io/component-base => k8s.io/component-base v0.26.4
+# k8s.io/component-helpers => k8s.io/component-helpers v0.26.4
+# k8s.io/controller-manager => k8s.io/controller-manager v0.26.4
+# k8s.io/cri-api => k8s.io/cri-api v0.26.4
+# k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.26.4
+# k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.26.4
+# k8s.io/kms => k8s.io/kms v0.26.4
+# k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.26.4
+# k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.26.4
+# k8s.io/kube-proxy => k8s.io/kube-proxy v0.26.4
+# k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.26.4
+# k8s.io/kubectl => k8s.io/kubectl v0.26.4
+# k8s.io/kubelet => k8s.io/kubelet v0.26.4
+# k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.26.4
+# k8s.io/metrics => k8s.io/metrics v0.26.4
+# k8s.io/mount-utils => k8s.io/mount-utils v0.26.4
+# k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.26.4
+# k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.26.4
+# k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.26.4
+# k8s.io/sample-controller => k8s.io/sample-controller v0.26.4


### PR DESCRIPTION
add replace statements for k8s.io/kubernetes packages. From https://github.com/kubernetes/kubernetes/#to-start-using-k8s, Use of the k8s.io/kubernetes module or k8s.io/kubernetes/... packages as libraries is not supported. We are using these packages in the test/e2e/specs. 

This caused an issue when trying to add module dependencies for boskos for managed prow tests. See [this comment](https://github.com/GoogleCloudPlatform/gcs-fuse-csi-driver/pull/24#issuecomment-1550367390). This added a lot of files, so I am going to split the managed prow test grid in to two PRs. The first will be updating go.mod file with the replace statements as described in the README. To do this I ran these commands: 
```
# needed this because I was getting permission denied and found this solution here: https://www.shells.com/l/en-US/tutorial/How-to-Fix-Shell-Script-Permission-Denied-Error-in-Linux
sudo chmod +x release-tools/go-get-kubernetes.sh 
./release-tools/go-get-kubernetes.sh 1.26.4
go mod vendor 
go mod tidy
```
