### PR TITLE
Update installation step to mention required machine type

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -33,13 +33,13 @@ limitations under the License.
   sudo apt-get install jq
   ```
 - Create a standard GKE cluster with [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) enabled. Autopilot clusters are not supported for manual installation.
-- Run the following commands to create a GKE cluster with Workload Identity enabled.
+- Run the following commands to create a n2-standard-4 GKE cluster with Workload Identity enabled. Note other machine types may experience out of memory failures when running e2e tests.
   ```bash
   CLUSTER_PROJECT_ID=<cluster-project-id>
   CLUSTER_NAME=<cluster-name>
-  gcloud container clusters create ${CLUSTER_NAME} --workload-pool=${CLUSTER_PROJECT_ID}.svc.id.goog
+  gcloud container clusters create ${CLUSTER_NAME} --workload-pool=${CLUSTER_PROJECT_ID}.svc.id.goog --machine-type=n2-standard-4
   ```
-- For an existing cluster, run the following commands to enable Workload Identity.
+- For an existing cluster, run the following commands to enable Workload Identity. Make sure machine type has enough memory if running e2e tests. Consider using machine type n2-standard-4
   ```bash
   CLUSTER_PROJECT_ID=<cluster-project-id>
   CLUSTER_NAME=<cluster-name>


### PR DESCRIPTION
The e2e tests only pass with --machine-type=n2-standard-4 so adding that here.