### PR TITLE
 Upgrade go version to 1.22.2

### DIFF
--- a/test/e2e/run-e2e-ci.sh
+++ b/test/e2e/run-e2e-ci.sh
@@ -36,7 +36,7 @@ readonly node_machine_type=${MACHINE_TYPE:-n2-standard-4}
 readonly number_nodes=${NUMBER_NODES:-1}
 
 # Install golang
-version=1.22.1
+version=1.22.2
 wget -O go_tar.tar.gz https://go.dev/dl/go${version}.linux-amd64.tar.gz -q
 rm -rf /usr/local/go && tar -xzf go_tar.tar.gz -C /usr/local
 export PATH=$PATH:/usr/local/go/bin && go version && rm go_tar.tar.gz


### PR DESCRIPTION
gcsfuse now requires at least 1.22.2 which is causing our tests to fail. 

gcsfuse pr:
https://github.com/GoogleCloudPlatform/gcsfuse/commit/923987bb58b9ad6180eb16d98e06b74ae8aba8d3