### PR TITLE
Remove skip access check from mount options

### DIFF
--- a/pkg/csi_driver/utils_test.go
+++ b/pkg/csi_driver/utils_test.go
@@ -331,6 +331,16 @@ func TestParseVolumeAttributes(t *testing.T) {
 					volumeAttributesToMountOptionsMapping[VolumeContextKeyMetadataCacheTTLSeconds] + "3600",
 				},
 			},
+			{
+				name:          "unexpected value for VolumeContextKeySkipCSIBucketAccessCheck",
+				volumeContext: map[string]string{VolumeContextKeySkipCSIBucketAccessCheck: "blah"},
+				expectedErr:   true,
+			},
+			{
+				name:                 "value set to false for VolumeContextKeySkipCSIBucketAccessCheck",
+				volumeContext:        map[string]string{VolumeContextKeySkipCSIBucketAccessCheck: "false"},
+				expectedMountOptions: []string{},
+			},
 		}
 
 		for _, tc := range testCases {


### PR DESCRIPTION
In PR #255 we used volumeAttributesToMountOptionsMapping to iterate the expected keys and check for `VolumeContextKeySkipCSIBucketAccessCheck`. This may add confusion to the reader, as this is not strictly a mount option.

Moving the check for the existence of the key in a separate block. 

Address [comment](https://github.com/GoogleCloudPlatform/gcs-fuse-csi-driver/pull/272#issue-2321519510)