### PR TITLE
support metadataCacheTtlSeconds volume attribute

### DIFF
--- a/pkg/csi_driver/utils.go
+++ b/pkg/csi_driver/utils.go
@@ -48,6 +48,9 @@ const (
 	VolumeContextKeyMetadataCacheTTLSeconds   = "metadataCacheTTLSeconds"
 	VolumeContextKeyGcsfuseLoggingSeverity    = "gcsfuseLoggingSeverity"
 	VolumeContextKeySkipCSIBucketAccessCheck  = "skipCSIBucketAccessCheck"
+
+	//nolint:revive,stylecheck
+	VolumeContextKeyMetadataCacheTtlSeconds = "metadataCacheTtlSeconds"
 )
 
 func NewVolumeCapabilityAccessMode(mode csi.VolumeCapability_AccessMode_Mode) *csi.VolumeCapability_AccessMode {
@@ -161,6 +164,7 @@ var volumeAttributesToMountOptionsMapping = map[string]string{
 	VolumeContextKeyMetadataStatCacheCapacity: "metadata-cache:stat-cache-max-size-mb:",
 	VolumeContextKeyMetadataTypeCacheCapacity: "metadata-cache:type-cache-max-size-mb:",
 	VolumeContextKeyMetadataCacheTTLSeconds:   "metadata-cache:ttl-secs:",
+	VolumeContextKeyMetadataCacheTtlSeconds:   "metadata-cache:ttl-secs:",
 	VolumeContextKeyGcsfuseLoggingSeverity:    "logging:severity:",
 }
 
@@ -208,7 +212,7 @@ func parseVolumeAttributes(fuseMountOptions []string, volumeContext map[string]s
 			}
 
 		// parse int volume attributes
-		case VolumeContextKeyMetadataCacheTTLSeconds:
+		case VolumeContextKeyMetadataCacheTTLSeconds, VolumeContextKeyMetadataCacheTtlSeconds:
 			if intVal, err := strconv.Atoi(value); err == nil {
 				if intVal < 0 {
 					intVal = -1

--- a/pkg/csi_driver/utils_test.go
+++ b/pkg/csi_driver/utils_test.go
@@ -281,6 +281,36 @@ func TestParseVolumeAttributes(t *testing.T) {
 				expectedErr:   true,
 			},
 			{
+				name:                 "should return correct metadataCacheTtlSeconds 1",
+				volumeContext:        map[string]string{VolumeContextKeyMetadataCacheTtlSeconds: "100"},
+				expectedMountOptions: []string{volumeAttributesToMountOptionsMapping[VolumeContextKeyMetadataCacheTtlSeconds] + "100"},
+			},
+			{
+				name:                 "should return correct metadataCacheTtlSeconds 2",
+				volumeContext:        map[string]string{VolumeContextKeyMetadataCacheTtlSeconds: "0"},
+				expectedMountOptions: []string{volumeAttributesToMountOptionsMapping[VolumeContextKeyMetadataCacheTtlSeconds] + "0"},
+			},
+			{
+				name:                 "should return correct metadataCacheTtlSeconds 3",
+				volumeContext:        map[string]string{VolumeContextKeyMetadataCacheTtlSeconds: "-1"},
+				expectedMountOptions: []string{volumeAttributesToMountOptionsMapping[VolumeContextKeyMetadataCacheTtlSeconds] + "-1"},
+			},
+			{
+				name:                 "should return correct metadataCacheTtlSeconds 4",
+				volumeContext:        map[string]string{VolumeContextKeyMetadataCacheTtlSeconds: "-100"},
+				expectedMountOptions: []string{volumeAttributesToMountOptionsMapping[VolumeContextKeyMetadataCacheTtlSeconds] + "-1"},
+			},
+			{
+				name:          "should throw error for invalid metadataCacheTtlSeconds 1",
+				volumeContext: map[string]string{VolumeContextKeyMetadataCacheTtlSeconds: "abc"},
+				expectedErr:   true,
+			},
+			{
+				name:          "should throw error for invalid metadataCacheTtlSeconds 2",
+				volumeContext: map[string]string{VolumeContextKeyMetadataCacheTtlSeconds: "0.01"},
+				expectedErr:   true,
+			},
+			{
 				name:                 "should return correct gcsfuseLoggingSeverity",
 				volumeContext:        map[string]string{VolumeContextKeyGcsfuseLoggingSeverity: "trace"},
 				expectedMountOptions: []string{volumeAttributesToMountOptionsMapping[VolumeContextKeyGcsfuseLoggingSeverity] + TraceStr},


### PR DESCRIPTION
There is a typo in the public documentation. This change adds `metadataCacheTtlSeconds` volume attribute support. The existing `metadataCacheTTLSeconds` volume attribute is not changed.