### PR TITLE
support equal sign for gcsfuse config file mount options

### DIFF
--- a/pkg/sidecar_mounter/sidecar_mounter_config.go
+++ b/pkg/sidecar_mounter/sidecar_mounter_config.go
@@ -161,8 +161,16 @@ func (mc *MountConfig) prepareMountArgs() {
 	invalidArgs := []string{}
 
 	for _, arg := range mc.Options {
+		// The GCSFuse configuration file can be configured via mount options,
+		// for example, mount option file-cache:max-size-mb:100, or file-cache:max-size-mb=100
+		// will be translated to yaml file
+		// file-cache:
+		//   max-size-mb:100
 		if strings.Contains(arg, ":") {
-			i := strings.LastIndex(arg, ":")
+			i := strings.LastIndex(arg, "=")
+			if i == -1 {
+				i = strings.LastIndex(arg, ":")
+			}
 			f, v := arg[:i], arg[i+1:]
 
 			if disallowedFlags[f] {

--- a/pkg/sidecar_mounter/sidecar_mounter_config_test.go
+++ b/pkg/sidecar_mounter/sidecar_mounter_config_test.go
@@ -211,6 +211,23 @@ func TestPrepareMountArgs(t *testing.T) {
 				"file-cache:max-size-mb": "100",
 			},
 		},
+		{
+			name: "should return valid args when config file field is configured using equal sign",
+			mc: &MountConfig{
+				BucketName: "test-bucket",
+				BufferDir:  "test-buffer-dir",
+				CacheDir:   "test-cache-dir",
+				ConfigFile: "test-config-file",
+				Options:    []string{"file-cache:max-size-mb=100"},
+			},
+			expectedArgs: defaultFlagMap,
+			expectedConfigMapArgs: map[string]string{
+				"logging:file-path":      "/dev/fd/1",
+				"logging:format":         "json",
+				"cache-dir":              "test-cache-dir",
+				"file-cache:max-size-mb": "100",
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
With this change, the GCSFuse configuration file can be configured via CSI mount options using `=` equal sign. The existing logic is not changed. For example, mount option `file-cache:max-size-mb:100`, or `file-cache:max-size-mb=100` will be translated to yaml file:

```yaml
file-cache:
  max-size-mb:100
```