### PR TITLE
[WIP] retry gcsfuse launch in sidecar container

### DIFF
--- a/cmd/sidecar_mounter/main.go
+++ b/cmd/sidecar_mounter/main.go
@@ -56,10 +56,6 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	for _, sp := range socketPaths {
-		// sleep 1.5 seconds before launch the next gcsfuse to avoid
-		// 1. different gcsfuse logs mixed together.
-		// 2. memory usage peak.
-		time.Sleep(1500 * time.Millisecond)
 		mc := sidecarmounter.NewMountConfig(sp)
 		if mc != nil {
 			if err := mounter.Mount(ctx, mc); err != nil {

--- a/pkg/sidecar_mounter/logger.go
+++ b/pkg/sidecar_mounter/logger.go
@@ -28,6 +28,8 @@ import (
 type stderrWriterInterface interface {
 	io.Writer
 	WriteMsg(errMsg string)
+	GetFullMsg() string
+	EmptyErrorFile()
 }
 
 type stderrWriter struct {
@@ -60,5 +62,20 @@ func (w *stderrWriter) WriteMsg(errMsg string) {
 	klog.Errorf(errMsg)
 	if _, e := w.Write([]byte(errMsg)); e != nil {
 		klog.Errorf("failed to write the error message %q: %v", errMsg, e)
+	}
+}
+
+func (w *stderrWriter) GetFullMsg() string {
+	errMsg, err := os.ReadFile(w.errorFile)
+	if err != nil {
+		return ""
+	}
+
+	return string(errMsg)
+}
+
+func (w *stderrWriter) EmptyErrorFile() {
+	if e := os.Truncate(w.errorFile, 0); e != nil {
+		klog.Errorf("failed to empty the error file %q: %v", w.errorFile, e)
 	}
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -151,3 +151,8 @@ func PrepareEmptyDir(targetPath string, createEmptyDir bool) (string, error) {
 
 	return emptyDirBasePath, nil
 }
+
+func IsRetriableErr(_ string) bool {
+	// TODO: implement details
+	return true
+}


### PR DESCRIPTION
This is a POC PR showing the feasibility of relaunching gcsfuse in sidecar container. The ultimate goal is to remove the bucket access logic from the CSI `NodePublishVolume` call.