### PR TITLE
use Pod informer to avoid Pod GET API calls

### DIFF
--- a/deploy/base/node/node_setup.yaml
+++ b/deploy/base/node/node_setup.yaml
@@ -35,7 +35,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["pods"]
-    verbs: ["get"]
+    verbs: ["get", "watch", "list"]
   - apiGroups: [""]
     resources: ["serviceaccounts"]
     verbs: ["get"]

--- a/pkg/cloud_provider/clientset/fake.go
+++ b/pkg/cloud_provider/clientset/fake.go
@@ -28,7 +28,9 @@ import (
 
 type FakeClientset struct{}
 
-func (c *FakeClientset) GetPod(_ context.Context, namespace, name string) (*corev1.Pod, error) {
+func (c *FakeClientset) ConfigurePodLister(_ string) {}
+
+func (c *FakeClientset) GetPod(namespace, name string) (*corev1.Pod, error) {
 	config := webhook.FakeConfig()
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -166,7 +166,7 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 	}
 
 	// Check if the sidecar container was injected into the Pod
-	pod, err := s.k8sClients.GetPod(ctx, vc[VolumeContextKeyPodNamespace], vc[VolumeContextKeyPodName])
+	pod, err := s.k8sClients.GetPod(vc[VolumeContextKeyPodNamespace], vc[VolumeContextKeyPodName])
 	if err != nil {
 		return nil, status.Errorf(codes.NotFound, "failed to get pod: %v", err)
 	}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -57,7 +57,7 @@ var _ = func() bool {
 	flag.Parse()
 	framework.AfterReadingAllFlags(&framework.TestContext)
 
-	c, err = clientset.New(framework.TestContext.KubeConfig)
+	c, err = clientset.New(framework.TestContext.KubeConfig, 0)
 	if err != nil {
 		klog.Fatalf("Failed to configure k8s client: %v", err)
 	}


### PR DESCRIPTION
This change refactors `GetPod` function to use Pod informer and lister to get Pod spec. This change avoids direct Pod GET API calls to increase the CSI node driver scalability.