### PR TITLE
cache token sources

### DIFF
--- a/cmd/csi_driver/main.go
+++ b/cmd/csi_driver/main.go
@@ -35,14 +35,16 @@ import (
 )
 
 var (
-	endpoint         = flag.String("endpoint", "unix:/tmp/csi.sock", "CSI endpoint")
-	nodeID           = flag.String("nodeid", "", "node id")
-	runController    = flag.Bool("controller", false, "run controller service")
-	runNode          = flag.Bool("node", false, "run node service")
-	kubeconfigPath   = flag.String("kubeconfig-path", "", "The kubeconfig path.")
-	identityPool     = flag.String("identity-pool", "", "The Identity Pool to authenticate with GCS API.")
-	identityProvider = flag.String("identity-provider", "", "The Identity Provider to authenticate with GCS API.")
-	enableProfiling  = flag.Bool("enable-profiling", false, "enable the golang pprof at port 6060")
+	endpoint                 = flag.String("endpoint", "unix:/tmp/csi.sock", "CSI endpoint")
+	nodeID                   = flag.String("nodeid", "", "node id")
+	runController            = flag.Bool("controller", false, "run controller service")
+	runNode                  = flag.Bool("node", false, "run node service")
+	kubeconfigPath           = flag.String("kubeconfig-path", "", "The kubeconfig path.")
+	identityPool             = flag.String("identity-pool", "", "The Identity Pool to authenticate with GCS API.")
+	identityProvider         = flag.String("identity-provider", "", "The Identity Provider to authenticate with GCS API.")
+	enableProfiling          = flag.Bool("enable-profiling", false, "enable the golang pprof at port 6060")
+	tokenStoreTTLSec         = flag.Int("token-store-ttl-sec", 120, "time-to-live for service account token sources")
+	tokenStoreCleanupFreqSec = flag.Int("token-store-cleanup-freq-sec", 30, "cleanup frequency to remove stale service account token sources")
 
 	// These are set at compile time.
 	version = "unknown"
@@ -83,7 +85,8 @@ func main() {
 		klog.Fatalf("Failed to set up metadata service: %v", err)
 	}
 
-	tm := auth.NewTokenManager(meta, clientset)
+	tm := auth.NewTokenManager(meta, clientset,
+		time.Duration(*tokenStoreTTLSec)*time.Second, time.Duration(*tokenStoreCleanupFreqSec)*time.Second)
 	ssm, err := storage.NewGCSServiceManager()
 	if err != nil {
 		klog.Fatalf("Failed to set up storage service manager: %v", err)

--- a/pkg/cloud_provider/auth/token_source_store.go
+++ b/pkg/cloud_provider/auth/token_source_store.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+Copyright 2024 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"sync"
+	"time"
+)
+
+type TokenSourceItem struct {
+	tokenSource *GCPTokenSource
+	lastAccess  time.Time
+}
+
+type TokenSourceStore struct {
+	tokenSources map[string]*TokenSourceItem
+	mu           sync.RWMutex
+	ttl          time.Duration // Time-to-live for tokenSources
+	cleanupFreq  time.Duration
+}
+
+func NewTokenSourceStore(ttl, cleanupFreq time.Duration) *TokenSourceStore {
+	c := &TokenSourceStore{
+		tokenSources: make(map[string]*TokenSourceItem),
+		ttl:          ttl,
+		cleanupFreq:  cleanupFreq,
+	}
+
+	go c.cleanup() // Start the cleanup goroutine
+
+	return c
+}
+
+func (c *TokenSourceStore) Set(ns, name string, ts *GCPTokenSource) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.tokenSources[ns+"/"+name] = &TokenSourceItem{tokenSource: ts, lastAccess: time.Now()}
+}
+
+func (c *TokenSourceStore) Get(ns, name string) *GCPTokenSource {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	ts, found := c.tokenSources[ns+"/"+name]
+	if !found {
+		return nil
+	}
+
+	ts.lastAccess = time.Now()
+
+	return ts.tokenSource
+}
+
+func (c *TokenSourceStore) cleanup() {
+	ticker := time.NewTicker(c.cleanupFreq)
+	for range ticker.C {
+		c.mu.Lock()
+		for k, v := range c.tokenSources {
+			if time.Since(v.lastAccess) > c.ttl {
+				delete(c.tokenSources, k)
+			}
+		}
+		c.mu.Unlock()
+	}
+}

--- a/pkg/cloud_provider/auth/token_source_store_test.go
+++ b/pkg/cloud_provider/auth/token_source_store_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+Copyright 2024 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestTokenSourceStore(t *testing.T) {
+	t.Parallel()
+
+	ttl := 100 * time.Millisecond
+	cleanupFreq := 50 * time.Millisecond
+	store := NewTokenSourceStore(ttl, cleanupFreq)
+
+	// Test Set and Get
+	store.Set("ns1", "name1", &GCPTokenSource{
+		k8sSATokenStr: "token1",
+	})
+	value := store.Get("ns1", "name1")
+	if value == nil || value.k8sSATokenStr != "token1" {
+		t.Errorf("Get failed: expected token1, got %v", value.k8sSATokenStr)
+	}
+
+	// Test Expiration
+	time.Sleep(cleanupFreq + ttl) // Wait for item to expire
+	if store.Get("ns1", "name1") != nil {
+		t.Errorf("Item should have expired but was still found")
+	}
+
+	// Test Last Access Update
+	store.Set("ns2", "name2", &GCPTokenSource{
+		k8sSATokenStr: "token2",
+	})
+	time.Sleep(ttl / 2)
+	value = store.Get("ns2", "name2") // Access to update last access time
+	time.Sleep(ttl / 2)
+	if value == nil || value.k8sSATokenStr != "token2" {
+		t.Errorf("Get failed: expected token2, got %v", value)
+	}
+
+	time.Sleep(cleanupFreq + ttl) // Wait for item to expire
+	if store.Get("ns2", "name2") != nil {
+		t.Errorf("Item should have expired but was still found")
+	}
+
+	// Test Concurrent Access
+	numRoutines := 10
+	var wg sync.WaitGroup
+	wg.Add(numRoutines)
+	for i := 0; i < numRoutines; i++ {
+		go func(i int) {
+			defer wg.Done()
+			store.Set(fmt.Sprintf("ns%d", i), fmt.Sprintf("name%d", i), &GCPTokenSource{
+				k8sSATokenStr: fmt.Sprintf("token%d", i),
+			})
+			value := store.Get(fmt.Sprintf("ns%d", i), fmt.Sprintf("name%d", i))
+			if value == nil || value.k8sSATokenStr != fmt.Sprintf("token%d", i) {
+				t.Errorf("Concurrent Get failed for ns%d, name%d", i, i)
+			}
+		}(i)
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
This change caches service account tokens to avoid frequent STS and IAM API calls.