### PR TITLE
Cherrypick #288, #286, #285 to release-1.4

### DIFF
--- a/cmd/csi_driver/Dockerfile
+++ b/cmd/csi_driver/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Build driver go binary
-FROM golang:1.22.3 as driver-builder
+FROM golang:1.22.4 as driver-builder
 
 ARG STAGINGVERSION
 

--- a/cmd/sidecar_mounter/Dockerfile
+++ b/cmd/sidecar_mounter/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Build sidecar-mounter go binary
-FROM golang:1.22.3 as sidecar-mounter-builder
+FROM golang:1.22.4 as sidecar-mounter-builder
 
 ARG STAGINGVERSION
 

--- a/cmd/webhook/Dockerfile
+++ b/cmd/webhook/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Build webhook go binary
-FROM golang:1.22.3 as webhook-builder
+FROM golang:1.22.4 as webhook-builder
 
 ARG STAGINGVERSION
 


### PR DESCRIPTION
Bump golang for cve fixes