### PR TITLE
cache NodePublishVolume response state for republish

### DIFF
--- a/pkg/cloud_provider/storage/fake.go
+++ b/pkg/cloud_provider/storage/fake.go
@@ -74,6 +74,10 @@ func (service *fakeService) SetIAMPolicy(_ context.Context, _ *ServiceBucket, _,
 	return nil
 }
 
+func (service *fakeService) RemoveIAMPolicy(_ context.Context, _ *ServiceBucket, _, _ string) error {
+	return nil
+}
+
 func (service *fakeService) CheckBucketExists(_ context.Context, obj *ServiceBucket) (bool, error) {
 	if _, ok := service.sm.createdBuckets[obj.Name]; ok {
 		return true, nil

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -50,6 +50,11 @@ type nodeServer struct {
 	volumeLocks           *util.VolumeLocks
 	k8sClients            clientset.Interface
 	limiter               rate.Limiter
+	volumeStateStore      map[string]*volumeState
+}
+
+type volumeState struct {
+	bucketAccessCheckPassed bool
 }
 
 func newNodeServer(driver *GCSDriver, mounter mount.Interface) csi.NodeServer {
@@ -60,6 +65,7 @@ func newNodeServer(driver *GCSDriver, mounter mount.Interface) csi.NodeServer {
 		volumeLocks:           util.NewVolumeLocks(),
 		k8sClients:            driver.config.K8sClients,
 		limiter:               *rate.NewLimiter(rate.Every(time.Second), 10),
+		volumeStateStore:      make(map[string]*volumeState),
 	}
 }
 
@@ -101,15 +107,28 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 	vc := req.GetVolumeContext()
 
 	// Check if the given Service Account has the access to the GCS bucket, and the bucket exists.
+	// skip check if it has ever succeeded
 	if bucketName != "_" && !skipBucketAccessCheck {
-		storageService, err := s.prepareStorageService(ctx, vc)
-		if err != nil {
-			return nil, status.Errorf(codes.Unauthenticated, "failed to prepare storage service: %v", err)
+		// Use target path as an volume identifier because it corresponds to Pods and volumes.
+		// Pods may belong to different namespaces and would need their own access check.
+		vs, ok := s.volumeStateStore[targetPath]
+		if !ok {
+			s.volumeStateStore[targetPath] = &volumeState{}
+			vs = s.volumeStateStore[targetPath]
 		}
-		defer storageService.Close()
 
-		if exist, err := storageService.CheckBucketExists(ctx, &storage.ServiceBucket{Name: bucketName}); !exist {
-			return nil, status.Errorf(storage.ParseErrCode(err), "failed to get GCS bucket %q: %v", bucketName, err)
+		if !vs.bucketAccessCheckPassed {
+			storageService, err := s.prepareStorageService(ctx, vc)
+			if err != nil {
+				return nil, status.Errorf(codes.Unauthenticated, "failed to prepare storage service: %v", err)
+			}
+			defer storageService.Close()
+
+			if exist, err := storageService.CheckBucketExists(ctx, &storage.ServiceBucket{Name: bucketName}); !exist {
+				return nil, status.Errorf(storage.ParseErrCode(err), "failed to get GCS bucket %q: %v", bucketName, err)
+			}
+
+			vs.bucketAccessCheckPassed = true
 		}
 	}
 
@@ -199,6 +218,8 @@ func (s *nodeServer) NodeUnpublishVolume(_ context.Context, req *csi.NodeUnpubli
 		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, targetPath)
 	}
 	defer s.volumeLocks.Release(targetPath)
+
+	delete(s.volumeStateStore, targetPath)
 
 	// Check if the target path is already mounted
 	if mounted, err := s.isDirMounted(targetPath); mounted || err != nil {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/clientset"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/metadata"
+	"github.com/googlecloudplatform/gcs-fuse-csi-driver/test/e2e/specs"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/test/e2e/testsuites"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -110,7 +111,7 @@ var _ = ginkgo.Describe("E2E Test Suite", func() {
 		testsuites.InitGcsFuseCSIIstioTestSuite,
 	}
 
-	testDriver := InitGCSFuseCSITestDriver(c, m, *bucketLocation, *skipGcpSaTest)
+	testDriver := specs.InitGCSFuseCSITestDriver(c, m, *bucketLocation, *skipGcpSaTest)
 
 	ginkgo.Context(fmt.Sprintf("[Driver: %s]", testDriver.GetDriverInfo().Name), func() {
 		storageframework.DefineTestSuites(testDriver, GCSFuseCSITestSuites)

--- a/test/e2e/utils/handler.go
+++ b/test/e2e/utils/handler.go
@@ -223,7 +223,7 @@ func generateTestSkip(testParams *TestParameters) string {
 	// TODO(songjiaxun) remove this logic after the next CSI driver release.
 	// TODO(saikatroyc) remove the skip bucket access checks when managed driver created with skip bucket access check support
 	if testParams.UseGKEManagedDriver {
-		skipTests = append(skipTests, "Pod.RestartPolicy.is.OnFailure$", "Job.with.RestartPolicy.OnFailure.eventually.succeed", "fast.termination", "fileCache", "gcsfuseIntegrationFileCache", "init.container", "istio", "csi-skip-bucket-access-check", "concurrent_operations", "kernel_list_cache")
+		skipTests = append(skipTests, "Pod.RestartPolicy.is.OnFailure$", "Job.with.RestartPolicy.OnFailure.eventually.succeed", "fast.termination", "fileCache", "gcsfuseIntegrationFileCache", "init.container", "istio", "csi-skip-bucket-access-check", "concurrent_operations", "kernel_list_cache", "service.account.permission.changes")
 
 		if strings.HasPrefix(testParams.GkeClusterVersion, "1.29") && testParams.SupportsNativeSidecar {
 			skipTests = append(skipTests, "autoTermination", "custom.sidecar.container")


### PR DESCRIPTION
This change caches NodePublishVolume response state in memory. In the following republish calls, the bucket access check will be skipped if it has ever succeeded. The volume state is cleaned up when the NodeUnpublishVolume is called against the same target path.

This change will completely remove STS API requests, Kube API SA API GET requests, and GCS API Object List requests in the node republish calls.