### PR TITLE
always check the control plane version to decide native sidecar

### DIFF
--- a/pkg/webhook/injection.go
+++ b/pkg/webhook/injection.go
@@ -29,6 +29,10 @@ import (
 const IstioSidecarName = "istio-proxy"
 
 func (si *SidecarInjector) supportsNativeSidecar() (bool, error) {
+	if si.ServerVersion != nil && !si.ServerVersion.AtLeast(minimumSupportedVersion) {
+		return false, nil
+	}
+
 	clusterNodes, err := si.NodeLister.List(labels.Everything())
 	if err != nil {
 		return false, fmt.Errorf("failed to get cluster nodes: %w", err)


### PR DESCRIPTION
This change adds the control plane version check to decide if the gcsfuse sidecar container needs to be a native sidecar container.