### PR TITLE
add ValidatingAdmissionPolicy in 1.30 clusters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,9 +184,11 @@ install:
 	make generate-spec-yaml OVERLAY=${OVERLAY} REGISTRY=${REGISTRY} STAGINGVERSION=${STAGINGVERSION}
 	kubectl apply -f ${BINDIR}/gcs-fuse-csi-driver-specs-generated.yaml
 	./deploy/base/webhook/create-cert.sh --namespace gcs-fuse-csi-driver --service gcs-fuse-csi-driver-webhook --secret gcs-fuse-csi-driver-webhook-secret
+	./deploy/base/webhook/manage-validating_admission_policy.sh --install
 
 uninstall:
 	kubectl delete -k deploy/overlays/${OVERLAY} --wait
+	./deploy/base/webhook/manage-validating_admission_policy.sh --uninstall
 
 generate-spec-yaml:
 	mkdir -p ${BINDIR}

--- a/deploy/base/webhook/manage-validating_admission_policy.sh
+++ b/deploy/base/webhook/manage-validating_admission_policy.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+# Copyright 2018 The Kubernetes Authors.
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+usage() {
+    cat <<EOF
+Install or uninstall ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding.
+usage: ${0} [OPTIONS]
+One of the following flags are required: --install or --uninstall
+EOF
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case ${1} in
+        --install)
+            install=true
+            ;;
+        --uninstall)
+            uninstall=true
+            ;;
+        *)
+            usage
+            ;;
+    esac
+    shift
+done
+
+[ -z ${install} ] && install=false
+[ -z ${uninstall} ] && uninstall=false
+
+versionStr=$(kubectl version | head -n 1 | cut -d " " -f 3)
+
+# Extract the version number
+versionRegex="^v([0-9]+)\.([0-9]+)\.([0-9]+)$"
+if [[ $versionStr =~ $versionRegex ]]; then
+    majorVersion=${BASH_REMATCH[1]}
+    minorVersion=${BASH_REMATCH[2]}
+
+    # Check if version is greater than or equal to 1.30
+    if (( majorVersion >= 1 && minorVersion >= 30 )) || (( majorVersion > 1 )); then
+        echo "Cluster version is greater than or equal to 1.30"
+        script_path=$(dirname "$(realpath "$0")")
+        
+        if ( $install == "true" ); then
+            echo "Installing ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding"
+            kubectl apply -f "${script_path}/validating_admission_policy.yaml"
+        fi
+
+        if ( $uninstall == "true" ); then
+            echo "Uninstalling ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding"
+            kubectl delete -f "${script_path}/validating_admission_policy.yaml"
+        fi
+
+    else
+        echo "Cluster version is less than 1.30, skip ValidatingAdmissionPolicy management"
+    fi
+else
+    echo "Invalid version format: ${versionStr}"
+fi

--- a/deploy/base/webhook/validating_admission_policy.yaml
+++ b/deploy/base/webhook/validating_admission_policy.yaml
@@ -1,0 +1,60 @@
+# Copyright 2018 The Kubernetes Authors.
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "gcsfuse-sidecar-validator.csi.storage.gke.io"
+spec:
+  failurePolicy: Ignore # will not block other Pod requests
+  matchConstraints:
+    resourceRules:
+    - apiGroups: [""]
+      apiVersions: ["v1"]
+      resources: ["pods"]
+      operations: ["CREATE"]
+  matchConditions:
+  - name: "include-pods-with-gcsfuse-volumes"
+    expression: 'has(object.metadata.annotations) && "gke-gcsfuse/volumes" in object.metadata.annotations && object.metadata.annotations["gke-gcsfuse/volumes"] == "true"'
+  - name: "include-pods-with-native-sidecar"
+    expression: 'has(object.spec.initContainers) && object.spec.initContainers.exists(c, c.name == "gke-gcsfuse-sidecar")'
+  variables:
+  - name: "sidecar"
+    expression: 'object.spec.initContainers.filter(c, c.name == "gke-gcsfuse-sidecar")[0]'
+  validations:
+  - messageExpression: '"the native gcsfuse sidecar init container must have restartPolicy:Always."'
+    reason: Invalid
+    expression: |-
+      has(variables.sidecar.restartPolicy) &&
+      variables.sidecar.restartPolicy == "Always"
+  - messageExpression: '"the native gcsfuse sidecar init container must have env var NATIVE_SIDECAR with value TRUE."'
+    reason: Invalid
+    expression: |-
+      has(variables.sidecar.env) &&
+      variables.sidecar.env.exists(e, e.name == "NATIVE_SIDECAR" && e.value == "TRUE")
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: "gcsfuse-sidecar-validator-binding.csi.storage.gke.io"
+spec:
+  policyName: "gcsfuse-sidecar-validator.csi.storage.gke.io"
+  validationActions: [Deny]
+  matchResources:
+    resourceRules:
+    - apiGroups: [""]
+      apiVersions: ["v1"]
+      resources: ["pods"]
+      operations: ["CREATE"]

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.30.3
 	k8s.io/apimachinery v0.30.3
+	k8s.io/apiserver v0.30.3
 	k8s.io/client-go v0.30.3
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/kubernetes v1.30.3
@@ -141,7 +142,6 @@ require (
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/apiextensions-apiserver v0.30.3 // indirect
-	k8s.io/apiserver v0.30.3 // indirect
 	k8s.io/cloud-provider v0.30.3 // indirect
 	k8s.io/component-base v0.30.3 // indirect
 	k8s.io/component-helpers v0.30.3 // indirect

--- a/pkg/webhook/validating_admission_policy_test.go
+++ b/pkg/webhook/validating_admission_policy_test.go
@@ -1,0 +1,268 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+Copyright 2022 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/admission/plugin/cel"
+	"k8s.io/apiserver/pkg/admission/plugin/policy/validating"
+	"k8s.io/apiserver/pkg/admission/plugin/webhook/matchconditions"
+	celconfig "k8s.io/apiserver/pkg/apis/cel"
+	"k8s.io/apiserver/pkg/cel/environment"
+	"k8s.io/utils/ptr"
+)
+
+func testPod(initContainer bool, annotation map[string]string, restartPolicy *corev1.ContainerRestartPolicy, env []corev1.EnvVar) *corev1.Pod {
+	container := corev1.Container{
+		Name:          SidecarContainerName,
+		RestartPolicy: restartPolicy,
+		Env:           env,
+	}
+
+	pod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: annotation,
+		},
+		Spec: corev1.PodSpec{},
+	}
+
+	if initContainer {
+		pod.Spec.InitContainers = []corev1.Container{container}
+	} else {
+		pod.Spec.Containers = []corev1.Container{container}
+	}
+
+	return &pod
+}
+
+func expectedValidateResult(d1, d2 *validating.PolicyDecision) validating.ValidateResult {
+	vr := validating.ValidateResult{
+		Decisions:        []validating.PolicyDecision{},
+		AuditAnnotations: []validating.PolicyAuditAnnotation{},
+	}
+
+	if d1 != nil {
+		vr.Decisions = append(vr.Decisions, *d1)
+	}
+
+	if d2 != nil {
+		vr.Decisions = append(vr.Decisions, *d2)
+	}
+
+	if d1 == nil && d2 == nil {
+		vr.Decisions = nil
+		vr.AuditAnnotations = nil
+	}
+
+	return vr
+}
+
+var admittedDecision = validating.PolicyDecision{
+	Action:     validating.ActionAdmit,
+	Evaluation: validating.EvalAdmit,
+}
+
+var missingRestartPolicyDecision = validating.PolicyDecision{
+	Action:  validating.ActionDeny,
+	Message: "the native gcsfuse sidecar init container must have restartPolicy:Always.",
+	Reason:  metav1.StatusReasonInvalid,
+}
+
+var missingEnvVarDecision = validating.PolicyDecision{
+	Action:  validating.ActionDeny,
+	Message: "the native gcsfuse sidecar init container must have env var NATIVE_SIDECAR with value TRUE.",
+	Reason:  metav1.StatusReasonInvalid,
+}
+
+var testCases = []struct {
+	name           string
+	pod            *corev1.Pod
+	expectedResult validating.ValidateResult
+}{
+	{
+		name:           "validation passed with a valid native sidecar container",
+		pod:            testPod(true, map[string]string{GcsFuseVolumeEnableAnnotation: "true"}, ptr.To(corev1.ContainerRestartPolicyAlways), []corev1.EnvVar{{Name: "NATIVE_SIDECAR", Value: "TRUE"}}),
+		expectedResult: expectedValidateResult(&admittedDecision, &admittedDecision),
+	},
+	{
+		name:           "validation failed with a native sidecar container missing RestartPolicy",
+		pod:            testPod(true, map[string]string{GcsFuseVolumeEnableAnnotation: "true"}, nil, []corev1.EnvVar{{Name: "NATIVE_SIDECAR", Value: "TRUE"}}),
+		expectedResult: expectedValidateResult(&missingRestartPolicyDecision, &admittedDecision),
+	},
+	{
+		name:           "validation failed with a native sidecar container missing env var",
+		pod:            testPod(true, map[string]string{GcsFuseVolumeEnableAnnotation: "true"}, ptr.To(corev1.ContainerRestartPolicyAlways), nil),
+		expectedResult: expectedValidateResult(&admittedDecision, &missingEnvVarDecision),
+	},
+	{
+		name:           "validation failed with a valid native sidecar container missing correct env var",
+		pod:            testPod(true, map[string]string{GcsFuseVolumeEnableAnnotation: "true"}, ptr.To(corev1.ContainerRestartPolicyAlways), []corev1.EnvVar{{Name: "NATIVE_SIDECAR", Value: "FALSE"}}),
+		expectedResult: expectedValidateResult(&admittedDecision, &missingEnvVarDecision),
+	},
+	{
+		name:           "validation failed with a native sidecar container missing RestartPolicy and env var",
+		pod:            testPod(true, map[string]string{GcsFuseVolumeEnableAnnotation: "true"}, nil, nil),
+		expectedResult: expectedValidateResult(&missingRestartPolicyDecision, &missingEnvVarDecision),
+	},
+	{
+		name:           "validation skipped without pod annotations",
+		pod:            testPod(true, nil, nil, nil),
+		expectedResult: expectedValidateResult(nil, nil),
+	},
+	{
+		name:           "validation skipped with a pod annotation gke-gcsfuse/volumes: false",
+		pod:            testPod(true, map[string]string{GcsFuseVolumeEnableAnnotation: "false"}, nil, nil),
+		expectedResult: expectedValidateResult(nil, nil),
+	},
+	{
+		name:           "validation skipped with a regular sidecar container",
+		pod:            testPod(false, map[string]string{GcsFuseVolumeEnableAnnotation: "true"}, nil, nil),
+		expectedResult: expectedValidateResult(nil, nil),
+	},
+}
+
+func TestValidatingAdmissionPolicy(t *testing.T) {
+	t.Parallel()
+
+	filename := "../../deploy/base/webhook/validating_admission_policy.yaml"
+	policy, err := loadValidatingAdmissionPolicy(filename)
+	if err != nil {
+		t.Fatalf("failed to load policy: %v", err)
+	}
+
+	validator := compilePolicy(policy)
+
+	for _, tc := range testCases {
+		fakeAttr := admission.NewAttributesRecord(tc.pod, nil, schema.GroupVersionKind{}, "", "", schema.GroupVersionResource{}, "", "", nil, false, nil)
+		fakeVersionedAttr, _ := admission.NewVersionedAttributes(fakeAttr, schema.GroupVersionKind{}, nil)
+		validateResult := validator.Validate(context.TODO(), fakeVersionedAttr.GetResource(), fakeVersionedAttr, nil, nil, celconfig.RuntimeCELCostBudget, nil)
+
+		if diff := cmp.Diff(validateResult, tc.expectedResult); diff != "" {
+			t.Errorf("unexpected options args (-got, +want)\n%s", diff)
+		}
+	}
+}
+
+func loadValidatingAdmissionPolicy(filename string) (*admissionregistrationv1.ValidatingAdmissionPolicy, error) {
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	decoder := yaml.NewYAMLToJSONDecoder(bytes.NewReader(data))
+
+	obj := &admissionregistrationv1.ValidatingAdmissionPolicy{}
+	err = decoder.Decode(obj)
+
+	return obj, err
+}
+
+func compilePolicy(policy *admissionregistrationv1.ValidatingAdmissionPolicy) validating.Validator {
+	hasParam := false
+	if policy.Spec.ParamKind != nil {
+		hasParam = true
+	}
+	optionalVars := cel.OptionalVariableDeclarations{HasParams: hasParam, HasAuthorizer: true, StrictCost: true}
+	expressionOptionalVars := cel.OptionalVariableDeclarations{HasParams: hasParam, HasAuthorizer: false, StrictCost: true}
+	failurePolicy := policy.Spec.FailurePolicy
+	matchConditions := policy.Spec.MatchConditions
+
+	compositionEnvTemplate, err := cel.NewCompositionEnv(cel.VariablesTypeName, environment.MustBaseEnvSet(environment.DefaultCompatibilityVersion(), true))
+	if err != nil {
+		panic(err)
+	}
+	filterCompiler := cel.NewCompositedCompilerFromTemplate(compositionEnvTemplate)
+	filterCompiler.CompileAndStoreVariables(convertv1beta1Variables(policy.Spec.Variables), optionalVars, environment.StoredExpressions)
+
+	matchExpressionAccessors := make([]cel.ExpressionAccessor, len(matchConditions))
+	for i := range matchConditions {
+		matchExpressionAccessors[i] = (*matchconditions.MatchCondition)(&matchConditions[i])
+	}
+
+	matcher := matchconditions.NewMatcher(filterCompiler.Compile(matchExpressionAccessors, optionalVars, environment.StoredExpressions), failurePolicy, "policy", "validate", policy.Name)
+	res := validating.NewValidator(
+		filterCompiler.Compile(convertv1Validations(policy.Spec.Validations), optionalVars, environment.StoredExpressions),
+		matcher,
+		filterCompiler.Compile(convertv1AuditAnnotations(policy.Spec.AuditAnnotations), optionalVars, environment.StoredExpressions),
+		filterCompiler.Compile(convertv1MessageExpressions(policy.Spec.Validations), expressionOptionalVars, environment.StoredExpressions),
+		failurePolicy,
+	)
+
+	return res
+}
+
+func convertv1Validations(inputValidations []admissionregistrationv1.Validation) []cel.ExpressionAccessor {
+	celExpressionAccessor := make([]cel.ExpressionAccessor, len(inputValidations))
+	for i, validation := range inputValidations {
+		validation := validating.ValidationCondition{
+			Expression: validation.Expression,
+			Message:    validation.Message,
+			Reason:     validation.Reason,
+		}
+		celExpressionAccessor[i] = &validation
+	}
+
+	return celExpressionAccessor
+}
+
+func convertv1MessageExpressions(inputValidations []admissionregistrationv1.Validation) []cel.ExpressionAccessor {
+	celExpressionAccessor := make([]cel.ExpressionAccessor, len(inputValidations))
+	for i, validation := range inputValidations {
+		if validation.MessageExpression != "" {
+			condition := validating.MessageExpressionCondition{
+				MessageExpression: validation.MessageExpression,
+			}
+			celExpressionAccessor[i] = &condition
+		}
+	}
+
+	return celExpressionAccessor
+}
+
+func convertv1AuditAnnotations(inputValidations []admissionregistrationv1.AuditAnnotation) []cel.ExpressionAccessor {
+	celExpressionAccessor := make([]cel.ExpressionAccessor, len(inputValidations))
+	for i, validation := range inputValidations {
+		validation := validating.AuditAnnotationCondition{
+			Key:             validation.Key,
+			ValueExpression: validation.ValueExpression,
+		}
+		celExpressionAccessor[i] = &validation
+	}
+
+	return celExpressionAccessor
+}
+
+func convertv1beta1Variables(variables []admissionregistrationv1.Variable) []cel.NamedExpressionAccessor {
+	namedExpressions := make([]cel.NamedExpressionAccessor, len(variables))
+	for i, variable := range variables {
+		namedExpressions[i] = &validating.Variable{Name: variable.Name, Expression: variable.Expression}
+	}
+
+	return namedExpressions
+}


### PR DESCRIPTION
Add a `ValidatingAdmissionPolicy` in 1.30+ clusters.

This `ValidatingAdmissionPolicy` does the following validations:

1. It filters out Pods with an annotation `gke-gcsfuse/volumes: true`, and has a native sidecar container with name `gke-gcsfuse-sidecar`. The validation skips any other unmatched Pods.
2. It checks if the native sidecar container `restartPolicy` is `Always`.
3. It checks if the native sidecar container has env var `NATIVE_SIDECAR: TRUE`.

If there is any errors in the validator, it does not block the Pod creation request because of `failurePolicy: Ignore`.

This change gives users clear error message when the native sidecar container is mutated by other conflicting webhooks.