### PR TITLE
add istio e2e tests

### DIFF
--- a/test/e2e/main.go
+++ b/test/e2e/main.go
@@ -38,6 +38,7 @@ var (
 	useGKEAutopilot     = flag.Bool("use-gke-autopilot", false, "use GKE Autopilot cluster for the tests")
 	apiEndpointOverride = flag.String("api-endpoint-override", "https://container.googleapis.com/", "CloudSDK API endpoint override to use for the cluster environment")
 	nodeImageType       = flag.String("node-image-type", "cos_containerd", "image type to use for the cluster")
+	istioVersion        = flag.String("istio-version", "1.23.0", "istio version to install on the cluster")
 
 	// Test infrastructure flags.
 	inProw             = flag.Bool("run-in-prow", false, "whether or not to run the test in PROW")
@@ -101,6 +102,7 @@ func main() {
 		GinkgoTimeout:          *ginkgoTimeout,
 		GinkgoFlakeAttempts:    *ginkgoFlakeAttempts,
 		GinkgoSkipGcpSaTest:    *ginkgoSkipGcpSaTest,
+		IstioVersion:           *istioVersion,
 	}
 
 	if strings.Contains(testParams.GinkgoFocus, "performance") {

--- a/test/e2e/specs/istio-service-entry.yaml
+++ b/test/e2e/specs/istio-service-entry.yaml
@@ -1,0 +1,30 @@
+# Copyright 2018 The Kubernetes Authors.
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: networking.istio.io/v1
+kind: ServiceEntry
+metadata:
+  name: googleapi
+spec:
+  hosts:
+  - storage.googleapis.com
+  exportTo:
+  - "." # restricts the visibility to the current namespace
+  location: MESH_EXTERNAL
+  ports:
+  - name: https
+    number: 443
+    protocol: TLS
+  resolution: DNS

--- a/test/e2e/specs/istio-sidecar.yaml
+++ b/test/e2e/specs/istio-sidecar.yaml
@@ -1,0 +1,22 @@
+# Copyright 2018 The Kubernetes Authors.
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: networking.istio.io/v1
+kind: Sidecar
+metadata:
+  name: default
+spec:
+  outboundTrafficPolicy:
+    mode: REGISTRY_ONLY

--- a/test/e2e/specs/specs.go
+++ b/test/e2e/specs/specs.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2eevents "k8s.io/kubernetes/test/e2e/framework/events"
 	e2ejob "k8s.io/kubernetes/test/e2e/framework/job"
+	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2epodooutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
 	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
@@ -109,6 +110,7 @@ func NewTestPod(c clientset.Interface, ns *corev1.Namespace) *TestPod {
 					"gke-gcsfuse/memory-request":            "100Mi",
 					"gke-gcsfuse/ephemeral-storage-request": "100Mi",
 				},
+				Labels: map[string]string{},
 			},
 			Spec: corev1.PodSpec{
 				TerminationGracePeriodSeconds: ptr.To(int64(5)),
@@ -213,6 +215,17 @@ func (t *TestPod) WaitForFailedMountError(ctx context.Context, msg string) {
 		t.client,
 		t.namespace.Name,
 		fields.Set{"reason": events.FailedMountVolume}.AsSelector().String(),
+		msg,
+		pollTimeoutSlow)
+	framework.ExpectNoError(err)
+}
+
+func (t *TestPod) WaitForFailedContainerError(ctx context.Context, msg string) {
+	err := e2eevents.WaitTimeoutForEvent(
+		ctx,
+		t.client,
+		t.namespace.Name,
+		fields.Set{"reason": events.FailedToStartContainer}.AsSelector().String(),
 		msg,
 		pollTimeoutSlow)
 	framework.ExpectNoError(err)
@@ -366,6 +379,12 @@ func (t *TestPod) SetAnnotations(annotations map[string]string) {
 	}
 }
 
+func (t *TestPod) SetLabels(labels map[string]string) {
+	for k, v := range labels {
+		t.pod.Labels[k] = v
+	}
+}
+
 func (t *TestPod) SetServiceAccount(sa string) {
 	t.pod.Spec.ServiceAccountName = sa
 }
@@ -388,55 +407,6 @@ func (t *TestPod) SetNonRootSecurityContext(uid, gid, fsgroup int) {
 
 func (t *TestPod) SetCommand(cmd string) {
 	t.pod.Spec.Containers[0].Args = []string{"-c", cmd}
-}
-
-func (t *TestPod) SetIstioSidecar(isNativeSidecar bool) {
-	istioSidecar := []corev1.Container{{
-		Name:  webhook.IstioSidecarName,
-		Image: imageutils.GetE2EImage(imageutils.BusyBox),
-	}}
-	if isNativeSidecar {
-		t.pod.Spec.InitContainers = append(istioSidecar, t.pod.Spec.InitContainers...)
-	} else {
-		t.pod.Spec.Containers = append(istioSidecar, t.pod.Spec.Containers...)
-	}
-}
-
-func (t *TestPod) VerifyInjectionOrder(gcsFuseNativeSidecar, istioNativeSidecar bool) {
-	if gcsFuseNativeSidecar {
-		// Expect the gcsfuse sidecar to be native.
-		if istioNativeSidecar {
-			// Expect both gcsfuse and istio to be native sidecar.
-			gomega.Expect(t.pod.Spec.InitContainers).To(gomega.HaveLen(2))
-
-			// Verify ordering of sidecars.
-			gomega.Expect(t.pod.Spec.InitContainers[0].Name).To(gomega.BeEquivalentTo(webhook.IstioSidecarName))
-			gomega.Expect(t.pod.Spec.InitContainers[1].Name).To(gomega.BeEquivalentTo(webhook.SidecarContainerName))
-
-			// Verify workload is present
-			gomega.Expect(t.pod.Spec.Containers).To(gomega.HaveLen(1))
-		} else {
-			gomega.Panic().FailureMessage("container istio-proxy is not supported with native GCSFuse sidecar")
-		}
-	} else {
-		// Expect gcsfuse sidecar to be regular container.
-		if istioNativeSidecar {
-			// Verify istio-proxy is first in native containers.
-			gomega.Expect(t.pod.Spec.InitContainers).To(gomega.HaveLen(1))
-			gomega.Expect(t.pod.Spec.InitContainers[0].Name).To(gomega.BeEquivalentTo(webhook.IstioSidecarName))
-
-			// Verify gcsfuse is first in regular containers.
-			gomega.Expect(t.pod.Spec.Containers).To(gomega.HaveLen(2))
-			gomega.Expect(t.pod.Spec.Containers[0].Name).To(gomega.BeEquivalentTo(webhook.SidecarContainerName))
-		} else {
-			// Expect both gcsfuse and istio to be regular containers.
-			gomega.Expect(t.pod.Spec.Containers).To(gomega.HaveLen(3))
-
-			// Verify ordering of sidecars.
-			gomega.Expect(t.pod.Spec.Containers[0].Name).To(gomega.BeEquivalentTo(webhook.IstioSidecarName))
-			gomega.Expect(t.pod.Spec.Containers[1].Name).To(gomega.BeEquivalentTo(webhook.SidecarContainerName))
-		}
-	}
 }
 
 func (t *TestPod) SetGracePeriod(s int) {
@@ -1166,4 +1136,12 @@ func GetGCSFuseVersion(ctx context.Context, client clientset.Interface) string {
 	gomega.Expect(len(l)).To(gomega.BeNumerically(">", 3))
 
 	return l[2]
+}
+
+func DeployIstioSidecar(namespace string) {
+	e2ekubectl.RunKubectlOrDie(namespace, "apply", "--filename", "./specs/istio-sidecar.yaml")
+}
+
+func DeployIstioServiceEntry(namespace string) {
+	e2ekubectl.RunKubectlOrDie(namespace, "apply", "--filename", "./specs/istio-service-entry.yaml")
 }

--- a/test/e2e/testsuites/istio.go
+++ b/test/e2e/testsuites/istio.go
@@ -20,14 +20,11 @@ package testsuites
 import (
 	"context"
 	"fmt"
-	"os"
-	"strconv"
 
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/test/e2e/specs"
-	"github.com/googlecloudplatform/gcs-fuse-csi-driver/test/e2e/utils"
 	"github.com/onsi/ginkgo/v2"
+	"google.golang.org/grpc/codes"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2evolume "k8s.io/kubernetes/test/e2e/framework/volume"
 	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
@@ -60,12 +57,6 @@ func (t *gcsFuseCSIIstioTestSuite) SkipUnsupportedTests(_ storageframework.TestD
 }
 
 func (t *gcsFuseCSIIstioTestSuite) DefineTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {
-	envVar := os.Getenv(utils.TestWithNativeSidecarEnvVar)
-	gcsFuseSupportsNativeSidecar, err := strconv.ParseBool(envVar)
-	if err != nil {
-		klog.Fatalf(`env variable "%s" could not be converted to boolean`, envVar)
-	}
-
 	type local struct {
 		config         *storageframework.PerTestConfig
 		volumeResource *storageframework.VolumeResource
@@ -92,42 +83,97 @@ func (t *gcsFuseCSIIstioTestSuite) DefineTests(driver storageframework.TestDrive
 		framework.ExpectNoError(err, "while cleaning up")
 	}
 
-	testSidecarStoreDataSupportScenario := func(setGcsFuseNativeSidecar bool, setIstioNativeSidecar bool) {
+	testGCSFuseWithIstio := func(holdApplicationUntilProxyStarts, registryOnly bool) {
 		init()
 		defer cleanup()
 
 		ginkgo.By("Configuring the pod")
 		tPod := specs.NewTestPod(f.ClientSet, f.Namespace)
 		tPod.SetupVolume(l.volumeResource, volumeName, mountPath, false)
-		tPod.SetIstioSidecar(setIstioNativeSidecar)
+		tPod.SetLabels(map[string]string{"sidecar.istio.io/inject": "true"})
+
+		if holdApplicationUntilProxyStarts {
+			tPod.SetAnnotations(map[string]string{"proxy.istio.io/config": "{ \"holdApplicationUntilProxyStarts\": true }"})
+		}
+
+		if registryOnly {
+			tPod.SetAnnotations(map[string]string{"traffic.sidecar.istio.io/excludeOutboundIPRanges": "169.254.169.254/32"})
+			specs.DeployIstioSidecar(f.Namespace.Name)
+			specs.DeployIstioServiceEntry(f.Namespace.Name)
+		}
 
 		ginkgo.By("Deploying the pod")
 		tPod.Create(ctx)
 		defer tPod.Cleanup(ctx)
 
+		if !holdApplicationUntilProxyStarts {
+			ginkgo.By("Checking that the pod has failed container error")
+			tPod.WaitForFailedContainerError(ctx, "Error: failed to reserve container name")
+		}
+
 		ginkgo.By("Checking that the pod is running")
 		tPod.WaitForRunning(ctx)
-
-		ginkgo.By("Checking injection ordering")
-		tPod.VerifyInjectionOrder(setGcsFuseNativeSidecar, setIstioNativeSidecar)
 
 		ginkgo.By("Checking that the pod command exits with no error")
 		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("mount | grep %v | grep rw,", mountPath))
 		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("echo 'hello world' > %v/data && grep 'hello world' %v/data", mountPath, mountPath))
 	}
 
-	// We do not support the case where:
-	// - GCSFuse is native sidecar.
-	// - Istio is a regular container.
-	ginkgo.It("should store data with istio regular container present", func() {
-		if gcsFuseSupportsNativeSidecar {
-			ginkgo.Skip("Unsupported case: istio-proxy is regular container while GCSFuse is an native sidecar")
-		} else {
-			testSidecarStoreDataSupportScenario(gcsFuseSupportsNativeSidecar, false /* setIstioNativeSidecar */)
-		}
+	ginkgo.It("should store data with istio injected at index 0", func() {
+		testGCSFuseWithIstio(true, false)
 	})
 
-	ginkgo.It("should store data with istio native container present", func() {
-		testSidecarStoreDataSupportScenario(gcsFuseSupportsNativeSidecar, true /* setIstioNativeSidecar */)
+	ginkgo.It("should store data with istio injected at the last index", func() {
+		testGCSFuseWithIstio(false, false)
+	})
+
+	ginkgo.It("should store data with istio registry only outbound traffic policy mode", func() {
+		testGCSFuseWithIstio(true, true)
+	})
+
+	ginkgo.It("should fail with istio registry only outbound traffic policy mode missing Pod annotation", func() {
+		init()
+		defer cleanup()
+
+		ginkgo.By("Configuring the pod")
+		tPod := specs.NewTestPod(f.ClientSet, f.Namespace)
+		tPod.SetupVolume(l.volumeResource, volumeName, mountPath, false)
+		tPod.SetLabels(map[string]string{"sidecar.istio.io/inject": "true"})
+		tPod.SetAnnotations(map[string]string{"proxy.istio.io/config": "{ \"holdApplicationUntilProxyStarts\": true }"})
+
+		specs.DeployIstioSidecar(f.Namespace.Name)
+		specs.DeployIstioServiceEntry(f.Namespace.Name)
+
+		ginkgo.By("Deploying the pod")
+		tPod.Create(ctx)
+		defer tPod.Cleanup(ctx)
+
+		ginkgo.By("Checking that the pod has failed mount error")
+		tPod.WaitForFailedMountError(ctx, codes.Internal.String())
+		tPod.WaitForFailedMountError(ctx, "the sidecar container failed with error: mountWithStorageHandle: fs.NewServer: create file system: SetUpBucket: Error in iterating through objects: Get")
+		tPod.WaitForFailedMountError(ctx, "compute: Received 502")
+	})
+
+	ginkgo.It("should fail with istio registry only outbound traffic policy mode missing ServiceEntry", func() {
+		init()
+		defer cleanup()
+
+		ginkgo.By("Configuring the pod")
+		tPod := specs.NewTestPod(f.ClientSet, f.Namespace)
+		tPod.SetupVolume(l.volumeResource, volumeName, mountPath, false)
+		tPod.SetLabels(map[string]string{"sidecar.istio.io/inject": "true"})
+		tPod.SetAnnotations(map[string]string{"proxy.istio.io/config": "{ \"holdApplicationUntilProxyStarts\": true }"})
+		tPod.SetAnnotations(map[string]string{"traffic.sidecar.istio.io/excludeOutboundIPRanges": "169.254.169.254/32"})
+
+		specs.DeployIstioSidecar(f.Namespace.Name)
+
+		ginkgo.By("Deploying the pod")
+		tPod.Create(ctx)
+		defer tPod.Cleanup(ctx)
+
+		ginkgo.By("Checking that the pod has failed mount error")
+		tPod.WaitForFailedMountError(ctx, codes.Internal.String())
+		tPod.WaitForFailedMountError(ctx, "the sidecar container failed with error: mountWithStorageHandle: fs.NewServer: create file system: SetUpBucket: Error in iterating through objects: Get")
+		tPod.WaitForFailedMountError(ctx, "EOF")
 	})
 }

--- a/test/e2e/utils/handler.go
+++ b/test/e2e/utils/handler.go
@@ -68,6 +68,7 @@ type TestParameters struct {
 	GinkgoSkipGcpSaTest bool
 
 	SupportsNativeSidecar bool
+	IstioVersion          string
 }
 
 const TestWithNativeSidecarEnvVar = "TEST_WITH_NATIVE_SIDECAR"
@@ -173,13 +174,18 @@ func Handle(testParams *TestParameters) error {
 		klog.Fatalf(`env variable "%s" could not be set: %v`, TestWithNativeSidecarEnvVar, err)
 	}
 
+	testSkipStr := generateTestSkip(testParams)
+	if !strings.Contains(testSkipStr, "istio") && (len(testFocusStr) == 0 || strings.Contains(testFocusStr, "istio")) {
+		installIstio(testParams.IstioVersion)
+	}
+
 	//nolint:gosec
 	cmd := exec.Command("ginkgo", "run", "-v",
 		"--procs", testParams.GinkgoProcs,
 		"--flake-attempts", testParams.GinkgoFlakeAttempts,
 		"--timeout", testParams.GinkgoTimeout,
 		"--focus", testFocusStr,
-		"--skip", generateTestSkip(testParams),
+		"--skip", testSkipStr,
 		"--junit-report", "junit-gcsfusecsi.xml",
 		"--output-dir", artifactsDir,
 		testParams.PkgDir+"/test/e2e/",
@@ -228,4 +234,15 @@ func generateTestSkip(testParams *TestParameters) string {
 	klog.Infof("Generated ginkgo skip string: %q", skipString)
 
 	return skipString
+}
+
+func installIstio(istioVersion string) {
+	if err := os.Setenv("ISTIO_VERSION", istioVersion); err != nil {
+		klog.Fatalf(`env variable "ISTIO_VERSION" could not be set: %v`, err)
+	}
+
+	cmd := exec.Command("bash", "./test/e2e/utils/install-istio.sh")
+	if err := runCommand("Installing Istio...", cmd); err != nil {
+		klog.Fatalf(`failed to install Istio: %v`, err)
+	}
 }

--- a/test/e2e/utils/install-istio.sh
+++ b/test/e2e/utils/install-istio.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Copyright 2019 The Kubernetes Authors.
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script will install kustomize, which is a tool that simplifies patching
+# Kubernetes manifests for different environments.
+# https://github.com/kubernetes-sigs/kustomize
+
+set -o nounset
+set -o errexit
+
+readonly INSTALL_DIR="$( dirname -- "$( readlink -f -- "$0"; )"; )/../../../bin"
+
+if [ ! -f "${INSTALL_DIR}" ]; then
+  mkdir -p "${INSTALL_DIR}"
+fi
+
+cd ${INSTALL_DIR}
+
+curl -L https://istio.io/downloadIstio | sh -
+
+cd istio-${ISTIO_VERSION}
+export PATH=$PWD/bin:$PATH
+
+istioctl install --set profile="default" -y


### PR DESCRIPTION
This change adds real istio test cases. The test does the following:

- Install Istio.
- Deploy workloads with istio proxy injected.
- Happy path test: read/write works with the proxy injected, with proper pod annotations, and service entry.
- Failure test: with the pod or service entry missing, we should see specific errors.

We don't rely on or test the sidecar ordering, so removing the sidecar ordering test.

Docs will be updated in follow-up PRs.