### PR TITLE
Use protobuf encoding for core K8s APIs in gcs-fuse-csi-driver

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -77,7 +78,9 @@ func main() {
 	kubeConfig := config.GetConfigOrDie()
 
 	// Setup client
-	client, err := kubernetes.NewForConfig(kubeConfig)
+	coreKubeConfig := rest.CopyConfig(kubeConfig)
+	coreKubeConfig.ContentType = runtime.ContentTypeProtobuf
+	client, err := kubernetes.NewForConfig(coreKubeConfig)
 	if err != nil {
 		klog.Warningf("Unable to get clientset: %v", err)
 	}

--- a/pkg/cloud_provider/clientset/clientset.go
+++ b/pkg/cloud_provider/clientset/clientset.go
@@ -26,6 +26,7 @@ import (
 	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	listersv1 "k8s.io/client-go/listers/core/v1"
@@ -65,6 +66,7 @@ func New(kubeconfigPath string, informerResyncDurationSec int) (Interface, error
 	if err != nil {
 		return nil, fmt.Errorf("failed to read kubeconfig: %w", err)
 	}
+	rc.ContentType = runtime.ContentTypeProtobuf
 
 	clientset, err := kubernetes.NewForConfig(rc)
 	if err != nil {


### PR DESCRIPTION
For core K8s API objects like Pods, Nodes, etc., we can use protobuf encoding which, compared to the default JSON encoding, reduces CPU consumption related to (de)serialization, reduces overall latency of the API calls, reduces memory footprint and the work performed by the GC and results in quicker propagation of objects to event handlers of shared informers.

Core system components of K8s default their serialization method to protobuf for 8 years already: https://github.com/kubernetes/kubernetes/pull/25738.

Some benchmarks comparing JSON vs. protobuf showcasing how the latter data format (de)serializes faster and uses less memory:

- https://medium.com/@akresling/go-benchmark-json-v-protobuf-4ec3c62ec8d4
- https://www.codingexplorations.com/blog/performance-comparison-protobuf-marshaling-vs-json-marshaling-in-go
- https://medium.com/@david_turner/protocol-buffers-just-how-fast-are-they-9ec19ea580db