### PR TITLE
Add annotation to manually enable/disable native sidecar injection.

### DIFF
--- a/pkg/webhook/mutatingwebhook_test.go
+++ b/pkg/webhook/mutatingwebhook_test.go
@@ -365,6 +365,41 @@ func TestValidateMutatingWebhookResponse(t *testing.T) {
 			nodes:        skewVersionNodes(),
 		},
 		{
+			name:         "native container set via annotation injection successful test.",
+			operation:    admissionv1.Create,
+			inputPod:     validInputPodWithNativeAnnotation(false, "true"),
+			wantResponse: wantResponse(t, false, true),
+			nodes:        nativeSupportNodes(),
+		},
+		{
+			name:         "native container set via annotation injection successful with custom image test.",
+			operation:    admissionv1.Create,
+			inputPod:     validInputPodWithNativeAnnotation(true, "true"),
+			wantResponse: wantResponse(t, true, true),
+			nodes:        nativeSupportNodes(),
+		},
+		{
+			name:         "regular container set via annotation injection successful test.",
+			operation:    admissionv1.Create,
+			inputPod:     validInputPodWithNativeAnnotation(false, "false"),
+			wantResponse: wantResponse(t, false, false),
+			nodes:        nativeSupportNodes(),
+		},
+		{
+			name:         "native container set via invalid annotation injection successful test.",
+			operation:    admissionv1.Create,
+			inputPod:     validInputPodWithNativeAnnotation(false, "maybe"),
+			wantResponse: wantResponse(t, false, true),
+			nodes:        nativeSupportNodes(),
+		},
+		{
+			name:         "native container set via annotation injection unsupported test.",
+			operation:    admissionv1.Create,
+			inputPod:     validInputPodWithNativeAnnotation(false, "true"),
+			wantResponse: wantResponse(t, false, false),
+			nodes:        skewVersionNodes(),
+		},
+		{
 			name:         "Injection with custom sidecar container image successful test.",
 			operation:    admissionv1.Create,
 			inputPod:     validInputPod(true),
@@ -525,6 +560,13 @@ func getDuplicateDeclarationPodSpecResponse() *corev1.Pod {
 	result := modifySpec(*validInputPod(true), true, true)
 
 	return result
+}
+
+func validInputPodWithNativeAnnotation(customImage bool, enableNativeSidecarAnnotation string) *corev1.Pod {
+	pod := validInputPod(customImage)
+	pod.ObjectMeta.Annotations[GcsFuseNativeSidecarEnableAnnotation] = enableNativeSidecarAnnotation
+
+	return pod
 }
 
 func validInputPod(customImage bool) *corev1.Pod {

--- a/pkg/webhook/parsers.go
+++ b/pkg/webhook/parsers.go
@@ -27,6 +27,17 @@ import (
 
 var minimumSupportedVersion = version.MustParseGeneric("1.29.0")
 
+func ParseBool(str string) (bool, error) {
+	switch str {
+	case "True", "true":
+		return true, nil
+	case "False", "false":
+		return false, nil
+	default:
+		return false, fmt.Errorf("could not parse string to bool: the acceptable values for %q are 'True', 'true', 'false' or 'False'", str)
+	}
+}
+
 // parseSidecarContainerImage supports our Privately Hosted Sidecar Image option
 // by iterating the container list and finding a container named "gke-gcsfuse-sidecar"
 // If we find "gke-gcsfuse-sidecar":


### PR DESCRIPTION
Some webhooks are not running the latest kubernetes api version. these webhooks do not recognize the native sidecar feature and strip important data from gke-gcsfuse-sidecar spec, causing startup failures. This PR allows the user to manually disable native sidecar injection so that they're able to use these older webhooks. (eg. https://github.com/GoogleCloudPlatform/gcs-fuse-csi-driver/issues/296)