### PR TITLE
Add Cloud Storage FUSE Metadata/Stat cache prefetch from kubernetes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,10 +29,12 @@ IDENTITY_PROVIDER ?= $(shell kubectl get --raw /.well-known/openid-configuration
 DRIVER_BINARY = gcs-fuse-csi-driver
 SIDECAR_BINARY = gcs-fuse-csi-driver-sidecar-mounter
 WEBHOOK_BINARY = gcs-fuse-csi-driver-webhook
+PREFETCH_BINARY = gcs-fuse-csi-driver-metadata-prefetch
 
 DRIVER_IMAGE = ${REGISTRY}/${DRIVER_BINARY}
 SIDECAR_IMAGE = ${REGISTRY}/${SIDECAR_BINARY}
 WEBHOOK_IMAGE = ${REGISTRY}/${WEBHOOK_BINARY}
+PREFETCH_IMAGE = ${REGISTRY}/${PREFETCH_BINARY}
 
 DOCKER_BUILDX_ARGS ?= --push --builder multiarch-multiplatform-builder --build-arg STAGINGVERSION=${STAGINGVERSION}
 ifneq ("$(shell docker buildx build --help | grep 'provenance')", "")
@@ -46,7 +48,7 @@ $(info DRIVER_IMAGE is ${DRIVER_IMAGE})
 $(info SIDECAR_IMAGE is ${SIDECAR_IMAGE})
 $(info WEBHOOK_IMAGE is ${WEBHOOK_IMAGE})
 
-all: driver sidecar-mounter webhook
+all: driver sidecar-mounter webhook metadata-prefetch
 
 driver:
 	mkdir -p ${BINDIR}
@@ -55,6 +57,10 @@ driver:
 sidecar-mounter:
 	mkdir -p ${BINDIR}
 	CGO_ENABLED=0 GOOS=linux GOARCH=$(shell dpkg --print-architecture) go build -mod vendor -ldflags "${LDFLAGS}" -o ${BINDIR}/${SIDECAR_BINARY} cmd/sidecar_mounter/main.go
+
+metadata-prefetch:
+	mkdir -p ${BINDIR}
+	CGO_ENABLED=0 GOOS=linux GOARCH=$(shell dpkg --print-architecture) go build -mod vendor -ldflags "${LDFLAGS}" -o ${BINDIR}/${PREFETCH_BINARY} cmd/metadata_prefetch/main.go
 
 webhook:
 	mkdir -p ${BINDIR}
@@ -129,18 +135,27 @@ ifeq (${BUILD_ARM}, true)
 	make build-image-linux-arm64
 	docker manifest create ${DRIVER_IMAGE}:${STAGINGVERSION} ${DRIVER_IMAGE}:${STAGINGVERSION}_linux_amd64 ${DRIVER_IMAGE}:${STAGINGVERSION}_linux_arm64
 	docker manifest create ${SIDECAR_IMAGE}:${STAGINGVERSION} ${SIDECAR_IMAGE}:${STAGINGVERSION}_linux_amd64 ${SIDECAR_IMAGE}:${STAGINGVERSION}_linux_arm64
+	docker manifest create ${PREFETCH_IMAGE}:${STAGINGVERSION} ${PREFETCH_IMAGE}:${STAGINGVERSION}_linux_amd64 ${PREFETCH_IMAGE}:${STAGINGVERSION}_linux_arm64
 else
 	docker manifest create ${DRIVER_IMAGE}:${STAGINGVERSION} ${DRIVER_IMAGE}:${STAGINGVERSION}_linux_amd64
 	docker manifest create ${SIDECAR_IMAGE}:${STAGINGVERSION} ${SIDECAR_IMAGE}:${STAGINGVERSION}_linux_amd64
+	docker manifest create ${PREFETCH_IMAGE}:${STAGINGVERSION} ${PREFETCH_IMAGE}:${STAGINGVERSION}_linux_amd64
 endif
 
 	docker manifest create ${WEBHOOK_IMAGE}:${STAGINGVERSION} ${WEBHOOK_IMAGE}:${STAGINGVERSION}_linux_amd64
 
 	docker manifest push --purge ${DRIVER_IMAGE}:${STAGINGVERSION}
 	docker manifest push --purge ${SIDECAR_IMAGE}:${STAGINGVERSION}
+	docker manifest push --purge ${PREFETCH_IMAGE}:${STAGINGVERSION}
 	docker manifest push --purge ${WEBHOOK_IMAGE}:${STAGINGVERSION}
 
 build-image-linux-amd64:
+	docker buildx build ${DOCKER_BUILDX_ARGS} \
+		--file ./cmd/metadata_prefetch/Dockerfile \
+		--tag ${PREFETCH_IMAGE}:${STAGINGVERSION}_linux_amd64 \
+		--platform linux/amd64 \
+		--build-arg TARGETPLATFORM=linux/amd64 .
+
 	docker buildx build \
 		--file ./cmd/csi_driver/Dockerfile \
 		--tag validation_linux_amd64 \
@@ -164,6 +179,12 @@ build-image-linux-amd64:
 		--platform linux/amd64 .
 
 build-image-linux-arm64:
+	docker buildx build ${DOCKER_BUILDX_ARGS} \
+		--file ./cmd/metadata_prefetch/Dockerfile \
+		--tag ${PREFETCH_IMAGE}:${STAGINGVERSION}_linux_arm64 \
+		--platform linux/arm64 \
+		--build-arg TARGETPLATFORM=linux/arm64 .
+
 	docker buildx build \
 		--file ./cmd/csi_driver/Dockerfile \
 		--tag validation_linux_arm64 \
@@ -198,6 +219,7 @@ generate-spec-yaml:
 	cd ./deploy/overlays/${OVERLAY}; ${BINDIR}/kustomize edit set image gke.gcr.io/gcs-fuse-csi-driver=${DRIVER_IMAGE}:${STAGINGVERSION};
 	cd ./deploy/overlays/${OVERLAY}; ${BINDIR}/kustomize edit set image gke.gcr.io/gcs-fuse-csi-driver-webhook=${WEBHOOK_IMAGE}:${STAGINGVERSION};
 	cd ./deploy/overlays/${OVERLAY}; ${BINDIR}/kustomize edit add configmap gcsfusecsi-image-config --behavior=merge --disableNameSuffixHash --from-literal=sidecar-image=${SIDECAR_IMAGE}:${STAGINGVERSION};
+	cd ./deploy/overlays/${OVERLAY}; ${BINDIR}/kustomize edit add configmap gcsfusecsi-image-config --behavior=merge --disableNameSuffixHash --from-literal=metadata-sidecar-image=${PREFETCH_IMAGE}:${STAGINGVERSION};
 	echo "[{\"op\": \"replace\",\"path\": \"/spec/tokenRequests/0/audience\",\"value\": \"${PROJECT}.svc.id.goog\"}]" > ./deploy/overlays/${OVERLAY}/project_patch_csi_driver.json
 	echo "[{\"op\": \"replace\",\"path\": \"/webhooks/0/clientConfig/caBundle\",\"value\": \"${CA_BUNDLE}\"}]" > ./deploy/overlays/${OVERLAY}/caBundle_patch_MutatingWebhookConfiguration.json
 	echo "[{\"op\": \"replace\",\"path\": \"/spec/template/spec/containers/0/env/1/value\",\"value\": \"${IDENTITY_PROVIDER}\"}]" > ./deploy/overlays/${OVERLAY}/identity_provider_patch_csi_node.json

--- a/cmd/metadata_prefetch/Dockerfile
+++ b/cmd/metadata_prefetch/Dockerfile
@@ -1,0 +1,54 @@
+# Copyright 2018 The Kubernetes Authors.
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build metadata-prefetch go binary
+FROM --platform=$BUILDPLATFORM golang:1.22.7 AS metadata-prefetch-builder
+
+ARG STAGINGVERSION
+
+WORKDIR /gcs-fuse-csi-driver
+ADD . .
+RUN make metadata-prefetch BINDIR=/bin
+
+# go/gke-releasing-policies#base-images
+FROM gke.gcr.io/debian-base:bookworm-v1.0.4-gke.2 AS debian
+
+# go/gke-releasing-policies#base-images
+FROM  gcr.io/distroless/base-debian12 AS output-image
+
+# Copy existing binaries.
+COPY --from=debian /bin/ls /bin/ls
+
+# Copy dependencies.
+COPY --from=debian /lib/x86_64-linux-gnu/libselinux.so.1 /lib/x86_64-linux-gnu/libselinux.so.1
+COPY --from=debian /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
+COPY --from=debian /lib/x86_64-linux-gnu/libpcre2-8.so.0 /lib/x86_64-linux-gnu/libpcre2-8.so.0
+COPY --from=debian /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2 
+
+# Validate dependencies
+FROM output-image AS validator-image
+COPY --from=debian /bin/bash /bin/bash
+COPY --from=debian /usr/bin/ldd /usr/bin/ldd
+COPY --from=debian /bin/grep /bin/grep
+SHELL ["/bin/bash", "-c"]
+RUN if ldd /bin/ls | grep "not found"; then echo "!!! Missing deps for ls command !!!" && exit 1; fi
+
+# Final image
+FROM output-image
+
+# Copy the built binaries
+COPY --from=metadata-prefetch-builder /bin/gcs-fuse-csi-driver-metadata-prefetch /gcs-fuse-csi-driver-metadata-prefetch
+
+ENTRYPOINT ["/gcs-fuse-csi-driver-metadata-prefetch"]

--- a/cmd/metadata_prefetch/main.go
+++ b/cmd/metadata_prefetch/main.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+Copyright 2024 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"flag"
+	"os"
+	"os/exec"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	"k8s.io/klog/v2"
+)
+
+const (
+	mountPathsLocation = "/volumes/"
+)
+
+func main() {
+	klog.InitFlags(nil)
+	flag.Parse()
+
+	// Create cancellable context to pass into exec.
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Handle SIGTERM signal.
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGTERM)
+
+	go func() {
+		<-sigs
+		klog.Info("Caught SIGTERM signal: Terminating...")
+		cancel()
+
+		os.Exit(0) // Exit gracefully
+	}()
+
+	// Start the "ls" command in the background.
+	// All our volumes are mounted under the /volumes/ directory.
+	cmd := exec.CommandContext(ctx, "ls", "-R", mountPathsLocation)
+	cmd.Stdout = nil // Connects file descriptor to the null device (os.DevNull).
+
+	// TODO(hime): We should research stratergies to parallelize ls execution and speed up cache population.
+	err := cmd.Start()
+	if err == nil {
+		mountPaths, err := getDirectoryNames(mountPathsLocation)
+		if err == nil {
+			klog.Infof("Running ls on mountPath(s): %s", strings.Join(mountPaths, ", "))
+		} else {
+			klog.Warningf("failed to get mountPaths: %v", err)
+		}
+
+		err = cmd.Wait()
+		if err != nil {
+			klog.Errorf("Error while executing ls command: %v", err)
+		} else {
+			klog.Info("Metadata prefetch complete")
+		}
+	} else {
+		klog.Errorf("Error starting ls command: %v.", err)
+	}
+
+	klog.Info("Going to sleep...")
+
+	// Keep the process running.
+	select {}
+}
+
+// getDirectoryNames returns a list of strings representing the names of
+// the directories within the provided path.
+func getDirectoryNames(dirPath string) ([]string, error) {
+	directories := []string{}
+	items, err := os.ReadDir(dirPath)
+	if err != nil {
+		return directories, err
+	}
+
+	for _, item := range items {
+		if item.IsDir() {
+			directories = append(directories, item.Name())
+		}
+	}
+
+	return directories, nil
+}

--- a/deploy/base/node/node.yaml
+++ b/deploy/base/node/node.yaml
@@ -133,3 +133,4 @@ metadata:
   name: gcsfusecsi-image-config
 data:
   sidecar-image: gke.gcr.io/gcs-fuse-csi-driver-sidecar-mounter
+  metadata-sidecar-image: gke.gcr.io/gcs-fuse-csi-driver-metadata-prefetch

--- a/deploy/base/webhook/deployment.yaml
+++ b/deploy/base/webhook/deployment.yaml
@@ -54,6 +54,7 @@ spec:
             - --sidecar-ephemeral-storage-limit=0
             - --sidecar-ephemeral-storage-request=5Gi
             - --sidecar-image=$(SIDECAR_IMAGE)
+            - --metadata-sidecar-image=$(METADATA_SIDECAR_IMAGE)
             - --sidecar-image-pull-policy=$(SIDECAR_IMAGE_PULL_POLICY)
             - --cert-dir=/etc/tls-certs
             - --port=22030
@@ -66,6 +67,11 @@ spec:
                 configMapKeyRef:
                   name: gcsfusecsi-image-config
                   key: sidecar-image
+            - name: METADATA_SIDECAR_IMAGE
+              valueFrom:
+                configMapKeyRef:
+                  name: gcsfusecsi-image-config
+                  key: metadata-sidecar-image
           resources:
             limits:
               cpu: 200m

--- a/deploy/base/webhook/webhook_setup.yaml
+++ b/deploy/base/webhook/webhook_setup.yaml
@@ -34,7 +34,7 @@ metadata:
   name: gcs-fuse-csi-webhook-role
 rules:
   - apiGroups: [""]
-    resources: ["nodes"]
+    resources: ["nodes", "persistentvolumes", "persistentvolumeclaims"]
     verbs: ["get","list","watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/cloud_provider/clientset/fake.go
+++ b/pkg/cloud_provider/clientset/fake.go
@@ -46,7 +46,7 @@ func (c *FakeClientset) GetPod(namespace, name string) (*corev1.Pod, error) {
 		Status: corev1.PodStatus{
 			ContainerStatuses: []corev1.ContainerStatus{
 				{
-					Name: webhook.SidecarContainerName,
+					Name: webhook.GcsFuseSidecarName,
 					State: corev1.ContainerState{
 						Running: &corev1.ContainerStateRunning{},
 					},

--- a/pkg/csi_driver/utils.go
+++ b/pkg/csi_driver/utils.go
@@ -313,7 +313,7 @@ func putExitFile(pod *corev1.Pod, targetPath string) error {
 		for _, cs := range pod.Status.ContainerStatuses {
 			switch {
 			// skip the sidecar container itself
-			case cs.Name == webhook.SidecarContainerName:
+			case cs.Name == webhook.GcsFuseSidecarName:
 				continue
 
 			// If the Pod is terminating, the container status from Kubernetes API is not reliable
@@ -453,7 +453,7 @@ func getSidecarContainerStatus(isInitContainer bool, pod *corev1.Pod) (*corev1.C
 	}
 
 	for _, cs := range containerStatusList {
-		if cs.Name == webhook.SidecarContainerName {
+		if cs.Name == webhook.GcsFuseSidecarName {
 			return &cs, nil
 		}
 	}

--- a/pkg/webhook/client.go
+++ b/pkg/webhook/client.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+Copyright 2024 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"errors"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// IsPreprovisionCSIVolume checks whether the volume is a pre-provisioned volume for the desired csiDriver.
+func (si *SidecarInjector) IsPreprovisionCSIVolume(csiDriver string, pvc *corev1.PersistentVolumeClaim) (bool, error) {
+	_, ok, err := si.GetPreprovisionCSIVolume(csiDriver, pvc)
+
+	return ok, err
+}
+
+// GetPreprovisionCSIVolume gets the pre-provisioned persistentVolume when backed by the desired csiDriver.
+func (si *SidecarInjector) GetPreprovisionCSIVolume(csiDriver string, pvc *corev1.PersistentVolumeClaim) (*corev1.PersistentVolume, bool, error) {
+	if csiDriver == "" {
+		return nil, false, errors.New("csiDriver is empty, cannot verify storage type")
+	}
+
+	if pvc == nil {
+		return nil, false, errors.New("pvc is nil, cannot get pv")
+	}
+
+	// We return a nil error because this volume is still valid.
+	// A pvc can have this field missing when requesting a dynamically provisioned volume and said PV it is not yet bound.
+	if pvc.Spec.VolumeName == "" {
+		return nil, false, nil
+	}
+
+	// GetPV returns an error if pvc.Spec.VolumeName is not empty and the associated PV object is not found in the API server.
+	pv, err := si.GetPV(pvc.Spec.VolumeName)
+	if err != nil {
+		return nil, false, err // no additional context needed for error.
+	}
+
+	if pv == nil {
+		return nil, false, errors.New("pv is nil, cannot get storage type")
+	}
+
+	// Returns false when PV - PVC pair was created for a different csi driver or different storage type.
+	if pv.Spec.CSI != nil && pv.Spec.CSI.Driver == csiDriver {
+		return pv, true, nil
+	}
+
+	return pv, false, nil
+}
+
+func (si *SidecarInjector) GetPV(name string) (*corev1.PersistentVolume, error) {
+	pv, err := si.PvLister.Get(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return pv, nil
+}
+
+func (si *SidecarInjector) GetPVC(namespace, name string) (*corev1.PersistentVolumeClaim, error) {
+	pvc, err := si.PvcLister.PersistentVolumeClaims(namespace).Get(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return pvc, nil
+}

--- a/pkg/webhook/client_test.go
+++ b/pkg/webhook/client_test.go
@@ -1,0 +1,415 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+Copyright 2024 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/klog/v2"
+)
+
+const resyncDuration = time.Second * 1
+
+func TestIsPreprovisionCSIVolume(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		testName         string
+		csiDriverName    string
+		pvc              *corev1.PersistentVolumeClaim
+		pvsInK8s         []corev1.PersistentVolume
+		expectedResponse bool
+		expectedError    error
+	}{
+		{
+			testName:         "nil pvc passed into IsPreprovisionCSIVolume",
+			csiDriverName:    "fake-csi-driver",
+			pvc:              nil,
+			expectedResponse: false,
+			expectedError:    errors.New(`pvc is nil, cannot get pv`),
+		},
+		{
+			testName:         "given blank csiDriver name",
+			csiDriverName:    "",
+			pvc:              &corev1.PersistentVolumeClaim{},
+			expectedResponse: false,
+			expectedError:    errors.New("csiDriver is empty, cannot verify storage type"),
+		},
+		{
+			testName:         "not preprovisioned pvc",
+			csiDriverName:    "fake-csi-driver",
+			pvc:              &corev1.PersistentVolumeClaim{},
+			expectedResponse: false,
+			expectedError:    nil,
+		},
+		{
+			testName:      "preprovisioned pvc volume not found",
+			csiDriverName: "fake-csi-driver",
+			pvc: &corev1.PersistentVolumeClaim{
+				Spec: corev1.PersistentVolumeClaimSpec{
+					VolumeName: "pv-1234",
+				},
+			},
+			expectedResponse: false,
+			expectedError:    errors.New(`persistentvolume "pv-1234" not found`),
+		},
+		{
+			testName:      "preprovisioned pvc for different csi driver",
+			csiDriverName: "fake-csi-driver",
+			pvc: &corev1.PersistentVolumeClaim{
+				Spec: corev1.PersistentVolumeClaimSpec{
+					VolumeName: "pv-1234",
+				},
+			},
+			pvsInK8s: []corev1.PersistentVolume{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pv-1234",
+					},
+					Spec: corev1.PersistentVolumeSpec{
+						PersistentVolumeSource: corev1.PersistentVolumeSource{
+							CSI: &corev1.CSIPersistentVolumeSource{
+								Driver: "other-csi-driver",
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pv-135",
+					},
+					Spec: corev1.PersistentVolumeSpec{
+						PersistentVolumeSource: corev1.PersistentVolumeSource{
+							CSI: &corev1.CSIPersistentVolumeSource{
+								Driver: "fake-csi-driver",
+							},
+						},
+					},
+				},
+			},
+			expectedResponse: false,
+		},
+		{
+			testName:      "preprovisioned pvc for different csi driver",
+			csiDriverName: "fake-csi-driver",
+			pvc: &corev1.PersistentVolumeClaim{
+				Spec: corev1.PersistentVolumeClaimSpec{
+					VolumeName: "pv-1234",
+				},
+			},
+			pvsInK8s: []corev1.PersistentVolume{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pv-1234",
+					},
+					Spec: corev1.PersistentVolumeSpec{
+						PersistentVolumeSource: corev1.PersistentVolumeSource{
+							CSI: &corev1.CSIPersistentVolumeSource{
+								Driver: "fake-csi-driver",
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pv-135",
+					},
+					Spec: corev1.PersistentVolumeSpec{
+						PersistentVolumeSource: corev1.PersistentVolumeSource{
+							CSI: &corev1.CSIPersistentVolumeSource{
+								Driver: "fake-csi-driver",
+							},
+						},
+					},
+				},
+			},
+			expectedResponse: true,
+			expectedError:    nil,
+		},
+		{
+			testName:      "preprovisioned pvc with no csi specified",
+			csiDriverName: "fake-csi-driver",
+			pvc: &corev1.PersistentVolumeClaim{
+				Spec: corev1.PersistentVolumeClaimSpec{
+					VolumeName: "pv-1234",
+				},
+			},
+			pvsInK8s: []corev1.PersistentVolume{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pv-1234",
+					},
+					Spec: corev1.PersistentVolumeSpec{
+						PersistentVolumeSource: corev1.PersistentVolumeSource{},
+					},
+				},
+			},
+			expectedResponse: false,
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.testName, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			fakeClient := fake.NewSimpleClientset()
+
+			for _, pvInK8s := range testcase.pvsInK8s {
+				_, err := fakeClient.CoreV1().PersistentVolumes().Create(context.TODO(), &pvInK8s, metav1.CreateOptions{})
+				if err != nil {
+					klog.Errorf("test setup failed: %v", err)
+				}
+			}
+
+			csiGroupClient := SidecarInjector{}
+
+			informer := informers.NewSharedInformerFactoryWithOptions(fakeClient, resyncDuration, informers.WithNamespace(metav1.NamespaceAll))
+			csiGroupClient.PvLister = informer.Core().V1().PersistentVolumes().Lister()
+			csiGroupClient.PvcLister = informer.Core().V1().PersistentVolumeClaims().Lister()
+
+			informer.Start(ctx.Done())
+			informer.WaitForCacheSync(ctx.Done())
+
+			response, err := csiGroupClient.IsPreprovisionCSIVolume(testcase.csiDriverName, testcase.pvc)
+			if err != nil && testcase.expectedError != nil {
+				if err.Error() != testcase.expectedError.Error() {
+					t.Error("for test: ", testcase.testName, ", want: ", testcase.expectedError.Error(), " but got: ", err.Error())
+				}
+			} else if err != nil || testcase.expectedError != nil {
+				// if one of them is nil, both must be nil to pass
+				t.Error("for test: ", testcase.testName, ", want: ", testcase.expectedError, " but got: ", err)
+			}
+
+			if response != testcase.expectedResponse {
+				t.Error("for test: ", testcase.testName, ", want: ", testcase.expectedResponse, " but got: ", response)
+			}
+		})
+	}
+}
+
+func TestGetPV(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		testName         string
+		pvName           string
+		pvsInK8s         []corev1.PersistentVolume
+		expectedResponse *corev1.PersistentVolume
+		expectedError    error
+	}{
+		{
+			testName:         "pv not in k8s",
+			pvName:           "pvc-5678",
+			pvsInK8s:         []corev1.PersistentVolume{},
+			expectedResponse: nil,
+			expectedError:    errors.New(`persistentvolume "pvc-5678" not found`),
+		},
+		{
+			testName: "pv in k8s",
+			pvName:   "pvc-12345",
+			pvsInK8s: []corev1.PersistentVolume{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pvc-13",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pvc-124",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pvc-12345",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pvc-135",
+					},
+				},
+			},
+			expectedResponse: &corev1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pvc-12345",
+				},
+			},
+			expectedError: nil,
+		},
+	}
+
+	for _, testcase := range testcases {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		fakeClient := fake.NewSimpleClientset()
+		for _, pvInK8s := range testcase.pvsInK8s {
+			_, err := fakeClient.CoreV1().PersistentVolumes().Create(context.TODO(), &pvInK8s, metav1.CreateOptions{})
+			if err != nil {
+				klog.Errorf("test setup failed: %v", err)
+			}
+		}
+		csiGroupClient := SidecarInjector{}
+		informer := informers.NewSharedInformerFactoryWithOptions(fakeClient, resyncDuration, informers.WithNamespace(metav1.NamespaceAll))
+		csiGroupClient.PvLister = informer.Core().V1().PersistentVolumes().Lister()
+		csiGroupClient.PvcLister = informer.Core().V1().PersistentVolumeClaims().Lister()
+
+		informer.Start(ctx.Done())
+		informer.WaitForCacheSync(ctx.Done())
+
+		response, err := csiGroupClient.GetPV(testcase.pvName)
+		if err != nil && testcase.expectedError != nil {
+			if err.Error() != testcase.expectedError.Error() {
+				t.Error("for test: ", testcase.testName, ", want: ", testcase.expectedError.Error(), " but got: ", err.Error())
+			}
+		} else if err != nil || testcase.expectedError != nil {
+			// if one of them is nil, both must be nil to pass
+			t.Error("for test: ", testcase.testName, ", want: ", testcase.expectedError, " but got: ", err)
+		}
+
+		if response.String() != testcase.expectedResponse.String() {
+			t.Error("for test: ", testcase.testName, ", want: ", testcase.expectedResponse, " but got: ", response)
+		}
+	}
+}
+
+func TestGetPVC(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		testName         string
+		pvcName          string
+		pvcNamespace     string
+		pvcsInK8s        []corev1.PersistentVolumeClaim
+		expectedResponse *corev1.PersistentVolumeClaim
+		expectedError    error
+	}{
+		{
+			testName:         "pvc not in k8s",
+			pvcName:          "pvc-5678",
+			pvcNamespace:     metav1.NamespaceAll,
+			pvcsInK8s:        []corev1.PersistentVolumeClaim{},
+			expectedResponse: nil,
+			expectedError:    errors.New(`persistentvolumeclaim "pvc-5678" not found`),
+		},
+		{
+			testName:     "pvc in k8s on different namespace",
+			pvcName:      "pvc-12345",
+			pvcNamespace: metav1.NamespaceSystem,
+			pvcsInK8s: []corev1.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pvc-13",
+						Namespace: metav1.NamespaceDefault,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pvc-12345",
+						Namespace: metav1.NamespaceDefault,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pvc-124",
+						Namespace: metav1.NamespaceDefault,
+					},
+				},
+			},
+			expectedResponse: nil,
+			expectedError:    errors.New(`persistentvolumeclaim "pvc-12345" not found`),
+		},
+		{
+			testName:     "pvc in k8s",
+			pvcName:      "pvc-12345",
+			pvcNamespace: metav1.NamespaceDefault,
+			pvcsInK8s: []corev1.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pvc-13",
+						Namespace: metav1.NamespaceDefault,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pvc-12345",
+						Namespace: metav1.NamespaceDefault,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pvc-124",
+						Namespace: metav1.NamespaceDefault,
+					},
+				},
+			},
+			expectedResponse: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pvc-12345",
+					Namespace: metav1.NamespaceDefault,
+				},
+			},
+			expectedError: nil,
+		},
+	}
+
+	for _, testcase := range testcases {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		fakeClient := fake.NewSimpleClientset()
+		for _, pvcInK8s := range testcase.pvcsInK8s {
+			_, err := fakeClient.CoreV1().PersistentVolumeClaims(pvcInK8s.Namespace).Create(context.TODO(), &pvcInK8s, metav1.CreateOptions{})
+			if err != nil {
+				klog.Errorf("failed to setup test: %v", err)
+			}
+		}
+
+		csiGroupClient := SidecarInjector{}
+
+		informer := informers.NewSharedInformerFactoryWithOptions(fakeClient, resyncDuration, informers.WithNamespace(metav1.NamespaceAll))
+		csiGroupClient.PvLister = informer.Core().V1().PersistentVolumes().Lister()
+		csiGroupClient.PvcLister = informer.Core().V1().PersistentVolumeClaims().Lister()
+
+		informer.Start(ctx.Done())
+		informer.WaitForCacheSync(ctx.Done())
+
+		response, err := csiGroupClient.GetPVC(testcase.pvcNamespace, testcase.pvcName)
+		if err != nil && testcase.expectedError != nil {
+			if err.Error() != testcase.expectedError.Error() {
+				t.Error("for test: ", testcase.testName, ", want: ", testcase.expectedError.Error(), " but got: ", err.Error())
+			}
+		} else if err != nil || testcase.expectedError != nil {
+			// if one of them is nil, both must be nil to pass
+			t.Error("for test: ", testcase.testName, ", want: ", testcase.expectedError, " but got: ", err)
+		}
+
+		if response.String() != testcase.expectedResponse.String() {
+			t.Error("for test: ", testcase.testName, ", want: ", testcase.expectedResponse, " but got: ", response)
+		}
+	}
+}

--- a/pkg/webhook/config.go
+++ b/pkg/webhook/config.go
@@ -27,8 +27,9 @@ import (
 )
 
 type Config struct {
-	ContainerImage  string `json:"-"`
-	ImagePullPolicy string `json:"-"`
+	ContainerImage         string `json:"-"`
+	MetadataContainerImage string `json:"-"`
+	ImagePullPolicy        string `json:"-"`
 	//nolint:tagliatelle
 	CPURequest resource.Quantity `json:"gke-gcsfuse/cpu-request,omitempty"`
 	//nolint:tagliatelle
@@ -43,9 +44,10 @@ type Config struct {
 	EphemeralStorageLimit resource.Quantity `json:"gke-gcsfuse/ephemeral-storage-limit,omitempty"`
 }
 
-func LoadConfig(containerImage, imagePullPolicy, cpuRequest, cpuLimit, memoryRequest, memoryLimit, ephemeralStorageRequest, ephemeralStorageLimit string) *Config {
+func LoadConfig(containerImage, metadataContainerImage, imagePullPolicy, cpuRequest, cpuLimit, memoryRequest, memoryLimit, ephemeralStorageRequest, ephemeralStorageLimit string) *Config {
 	return &Config{
 		ContainerImage:          containerImage,
+		MetadataContainerImage:  metadataContainerImage,
 		ImagePullPolicy:         imagePullPolicy,
 		CPURequest:              resource.MustParse(cpuRequest),
 		CPULimit:                resource.MustParse(cpuLimit),
@@ -57,7 +59,10 @@ func LoadConfig(containerImage, imagePullPolicy, cpuRequest, cpuLimit, memoryReq
 }
 
 func FakeConfig() *Config {
-	return LoadConfig("fake-repo/fake-sidecar-image:v999.999.999-gke.0@sha256:c9cd4cde857ab8052f416609184e2900c0004838231ebf1c3817baa37f21d847", "Always", "250m", "250m", "256Mi", "256Mi", "5Gi", "5Gi")
+	fakeImage1 := "fake-repo/fake-sidecar-image:v999.999.999-gke.0@sha256:c9cd4cde857ab8052f416609184e2900c0004838231ebf1c3817baa37f21d847"
+	fakeImage2 := "fake-repo/fake-sidecar-image:v888.888.888-gke.0@sha256:c9cd4cde857ab8052f416609184e2900c0004838231ebf1c3817baa37f21d847"
+
+	return LoadConfig(fakeImage1, fakeImage2, "Always", "250m", "250m", "256Mi", "256Mi", "5Gi", "5Gi")
 }
 
 func prepareResourceList(c *Config) (corev1.ResourceList, corev1.ResourceList) {
@@ -112,8 +117,9 @@ func populateResource(requestQuantity, limitQuantity *resource.Quantity, default
 // remaining values that are not specified by user are kept as the default config values.
 func (si *SidecarInjector) prepareConfig(annotations map[string]string) (*Config, error) {
 	config := &Config{
-		ContainerImage:  si.Config.ContainerImage,
-		ImagePullPolicy: si.Config.ImagePullPolicy,
+		ContainerImage:         si.Config.ContainerImage,
+		MetadataContainerImage: si.Config.MetadataContainerImage,
+		ImagePullPolicy:        si.Config.ImagePullPolicy,
 	}
 
 	jsonData, err := json.Marshal(annotations)

--- a/pkg/webhook/injection_test.go
+++ b/pkg/webhook/injection_test.go
@@ -19,6 +19,7 @@ package webhook
 
 import (
 	"context"
+	"reflect"
 	"testing"
 	"time"
 
@@ -28,9 +29,175 @@ import (
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/utils/ptr"
 )
 
 var UnsupportedVersion = version.MustParseGeneric("1.28.0")
+
+func TestInjectAsNativeSidecar(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		testName      string
+		cpVersion     *version.Version
+		nodes         []corev1.Node
+		pod           *corev1.Pod
+		expect        bool
+		expectedError error
+	}{
+		{
+			testName: "test should allow native sidecar",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						GcsFuseNativeSidecarEnableAnnotation: "true",
+					},
+				},
+			},
+			cpVersion: minimumSupportedVersion,
+			nodes:     nativeSupportNodes(),
+			expect:    true,
+		},
+		{
+			testName: "test should not native sidecar by user request",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						GcsFuseNativeSidecarEnableAnnotation: "false",
+					},
+				},
+			},
+			cpVersion: minimumSupportedVersion,
+			nodes:     nativeSupportNodes(),
+			expect:    false,
+		},
+		{
+			testName: "test should be native sidecar, user sent malformed request",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						GcsFuseNativeSidecarEnableAnnotation: "maybe",
+					},
+				},
+			},
+			cpVersion: minimumSupportedVersion,
+			nodes:     nativeSupportNodes(),
+			expect:    true,
+		},
+		{
+			testName: "test should not allow native sidecar, skew",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						GcsFuseNativeSidecarEnableAnnotation: "true",
+					},
+				},
+			},
+			cpVersion: minimumSupportedVersion,
+			nodes:     skewVersionNodes(),
+			expect:    false,
+		},
+		{
+			testName:  "test should not allow native sidecar, all under 1.29",
+			cpVersion: minimumSupportedVersion,
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						GcsFuseNativeSidecarEnableAnnotation: "true",
+					},
+				},
+			},
+			nodes:  regularSidecarSupportNodes(),
+			expect: false,
+		},
+		{
+			testName:  "test should not allow native sidecar, all nodes are 1.29, cp is 1.28",
+			cpVersion: UnsupportedVersion,
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						GcsFuseNativeSidecarEnableAnnotation: "true",
+					},
+				},
+			},
+			nodes:  nativeSupportNodes(),
+			expect: false,
+		},
+		{
+			testName:  "test no nodes present, native sidecar support false",
+			cpVersion: UnsupportedVersion,
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						GcsFuseNativeSidecarEnableAnnotation: "true",
+					},
+				},
+			},
+			nodes:  []corev1.Node{},
+			expect: false,
+		},
+		{
+			testName:  "test no nodes present, allow native sidecar support true",
+			cpVersion: minimumSupportedVersion,
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						GcsFuseNativeSidecarEnableAnnotation: "true",
+					},
+				},
+			},
+			nodes:  []corev1.Node{},
+			expect: true,
+		},
+		{
+			testName:  "test no nodes present, allow native sidecar support false",
+			cpVersion: minimumSupportedVersion,
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						GcsFuseNativeSidecarEnableAnnotation: "false",
+					},
+				},
+			},
+			nodes:  []corev1.Node{},
+			expect: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			t.Parallel()
+
+			fakeClient := fake.NewSimpleClientset()
+			// Create the nodes.
+			for _, node := range tc.nodes {
+				n := node
+				_, err := fakeClient.CoreV1().Nodes().Create(context.Background(), &n, metav1.CreateOptions{})
+				if err != nil {
+					t.Error("failed to setup/create nodes")
+				}
+			}
+
+			informerFactory := informers.NewSharedInformerFactoryWithOptions(fakeClient, time.Second*1, informers.WithNamespace(metav1.NamespaceAll))
+			lister := informerFactory.Core().V1().Nodes().Lister()
+			si := &SidecarInjector{
+				NodeLister:    lister,
+				ServerVersion: tc.cpVersion,
+			}
+
+			stopCh := make(<-chan struct{})
+			informerFactory.Start(stopCh)
+			informerFactory.WaitForCacheSync(stopCh)
+
+			result, err := si.injectAsNativeSidecar(tc.pod)
+			if result != tc.expect {
+				t.Errorf("\nfor %s, got native sidecar support to be: %t, but want: %t", tc.testName, result, tc.expect)
+				if err != nil {
+					t.Errorf("error returned from method: %v", err)
+				}
+			}
+		})
+	}
+}
 
 func TestSupportsNativeSidecar(t *testing.T) {
 	t.Parallel()
@@ -341,5 +508,861 @@ func TestGetInjectIndex(t *testing.T) {
 		if idx != tc.idx {
 			t.Errorf(`expected injection to be at index "%d" but got "%d"`, tc.idx, idx)
 		}
+	}
+}
+
+func TestInjectMetadataPrefetchSidecar(t *testing.T) {
+	t.Parallel()
+
+	limits, requests := prepareResourceList(getMetadataPrefetchConfig("fake-image"))
+
+	testCases := []struct {
+		testName      string
+		pod           *corev1.Pod
+		config        Config
+		nativeSidecar *bool
+		expectedPod   *corev1.Pod
+	}{
+		{
+			testName: "no injection",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name: "one",
+						},
+						{
+							Name: "two",
+						},
+						{
+							Name: "three",
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name: "workload-one",
+						},
+						{
+							Name: "workload-two",
+						},
+						{
+							Name: "workload-three",
+						},
+					},
+				},
+			},
+			expectedPod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name: "one",
+						},
+						{
+							Name: "two",
+						},
+						{
+							Name: "three",
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name: "workload-one",
+						},
+						{
+							Name: "workload-two",
+						},
+						{
+							Name: "workload-three",
+						},
+					},
+				},
+			},
+		},
+		{
+			testName: "fuse sidecar present, no injection",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name: GcsFuseSidecarName,
+						},
+						{
+							Name: "two",
+						},
+						{
+							Name: "three",
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name: "workload-one",
+						},
+						{
+							Name: "workload-two",
+						},
+						{
+							Name: "workload-three",
+						},
+					},
+				},
+			},
+			expectedPod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name: GcsFuseSidecarName,
+						},
+						{
+							Name: "two",
+						},
+						{
+							Name: "three",
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name: "workload-one",
+						},
+						{
+							Name: "workload-two",
+						},
+						{
+							Name: "workload-three",
+						},
+					},
+				},
+			},
+		},
+		{
+			testName: "fuse sidecar present, no injection due to different driver",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name: GcsFuseSidecarName,
+						},
+						{
+							Name: "two",
+						},
+						{
+							Name: "three",
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name: "workload-one",
+						},
+						{
+							Name: "workload-two",
+						},
+						{
+							Name: "workload-three",
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "my-volume",
+							VolumeSource: corev1.VolumeSource{
+								CSI: &corev1.CSIVolumeSource{
+									Driver: "other-csi",
+									VolumeAttributes: map[string]string{
+										gcsFuseMetadataPrefetchOnMountVolumeAttribute: "false",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedPod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name: GcsFuseSidecarName,
+						},
+						{
+							Name: "two",
+						},
+						{
+							Name: "three",
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name: "workload-one",
+						},
+						{
+							Name: "workload-two",
+						},
+						{
+							Name: "workload-three",
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "my-volume",
+							VolumeSource: corev1.VolumeSource{
+								CSI: &corev1.CSIVolumeSource{
+									Driver: "other-csi",
+									VolumeAttributes: map[string]string{
+										gcsFuseMetadataPrefetchOnMountVolumeAttribute: "false",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			testName: "fuse sidecar present, no injection with volume annotation",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name: GcsFuseSidecarName,
+						},
+						{
+							Name: "two",
+						},
+						{
+							Name: "three",
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name: "workload-one",
+						},
+						{
+							Name: "workload-two",
+						},
+						{
+							Name: "workload-three",
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "my-volume",
+							VolumeSource: corev1.VolumeSource{
+								CSI: &corev1.CSIVolumeSource{
+									Driver: gcsFuseCsiDriverName,
+									VolumeAttributes: map[string]string{
+										gcsFuseMetadataPrefetchOnMountVolumeAttribute: "false",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedPod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name: GcsFuseSidecarName,
+						},
+						{
+							Name: "two",
+						},
+						{
+							Name: "three",
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name: "workload-one",
+						},
+						{
+							Name: "workload-two",
+						},
+						{
+							Name: "workload-three",
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "my-volume",
+							VolumeSource: corev1.VolumeSource{
+								CSI: &corev1.CSIVolumeSource{
+									Driver: gcsFuseCsiDriverName,
+									VolumeAttributes: map[string]string{
+										gcsFuseMetadataPrefetchOnMountVolumeAttribute: "false",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			testName: "fuse sidecar not present, already injected",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name:            MetadataPrefetchSidecarName,
+							Image:           "my-private-image",
+							SecurityContext: GetSecurityContext(),
+						},
+						{
+							Name: "two",
+						},
+						{
+							Name: "three",
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name: "workload-one",
+						},
+						{
+							Name: "workload-two",
+						},
+						{
+							Name: "workload-three",
+						},
+					},
+				},
+			},
+			expectedPod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name:            MetadataPrefetchSidecarName,
+							Image:           "my-private-image",
+							SecurityContext: GetSecurityContext(),
+						},
+						{
+							Name: "two",
+						},
+						{
+							Name: "three",
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name: "workload-one",
+						},
+						{
+							Name: "workload-two",
+						},
+						{
+							Name: "workload-three",
+						},
+					},
+				},
+			},
+		},
+		{
+			testName: "fuse sidecar not present, privately hosted image",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name:  MetadataPrefetchSidecarName,
+							Image: "my-private-image",
+						},
+						{
+							Name: "two",
+						},
+						{
+							Name: "three",
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name: "workload-one",
+						},
+						{
+							Name: "workload-two",
+						},
+						{
+							Name: "workload-three",
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "my-volume",
+							VolumeSource: corev1.VolumeSource{
+								CSI: &corev1.CSIVolumeSource{
+									Driver: gcsFuseCsiDriverName,
+									VolumeAttributes: map[string]string{
+										gcsFuseMetadataPrefetchOnMountVolumeAttribute: "true",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedPod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name: "two",
+						},
+						{
+							Name: "three",
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name: "workload-one",
+						},
+						{
+							Name: "workload-two",
+						},
+						{
+							Name: "workload-three",
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "my-volume",
+							VolumeSource: corev1.VolumeSource{
+								CSI: &corev1.CSIVolumeSource{
+									Driver: gcsFuseCsiDriverName,
+									VolumeAttributes: map[string]string{
+										gcsFuseMetadataPrefetchOnMountVolumeAttribute: "true",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			testName: "fuse sidecar present, injection successful",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name: GcsFuseSidecarName,
+						},
+						{
+							Name: "two",
+						},
+						{
+							Name: "three",
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name: "workload-one",
+						},
+						{
+							Name: "workload-two",
+						},
+						{
+							Name: "workload-three",
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "my-volume",
+							VolumeSource: corev1.VolumeSource{
+								CSI: &corev1.CSIVolumeSource{
+									Driver: gcsFuseCsiDriverName,
+									VolumeAttributes: map[string]string{
+										gcsFuseMetadataPrefetchOnMountVolumeAttribute: "true",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedPod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name: GcsFuseSidecarName,
+						},
+						{
+							Name:            MetadataPrefetchSidecarName,
+							Env:             []corev1.EnvVar{{Name: "NATIVE_SIDECAR", Value: "TRUE"}},
+							RestartPolicy:   ptr.To(corev1.ContainerRestartPolicyAlways),
+							SecurityContext: GetSecurityContext(),
+							Resources: corev1.ResourceRequirements{
+								Requests: requests,
+								Limits:   limits,
+							},
+							VolumeMounts: []corev1.VolumeMount{{Name: "my-volume", ReadOnly: true, MountPath: "/volumes/my-volume"}},
+						},
+						{
+							Name: "two",
+						},
+						{
+							Name: "three",
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name: "workload-one",
+						},
+						{
+							Name: "workload-two",
+						},
+						{
+							Name: "workload-three",
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "my-volume",
+							VolumeSource: corev1.VolumeSource{
+								CSI: &corev1.CSIVolumeSource{
+									Driver: gcsFuseCsiDriverName,
+									VolumeAttributes: map[string]string{
+										gcsFuseMetadataPrefetchOnMountVolumeAttribute: "true",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			testName: "fuse sidecar present with many volumes and config, injection successful",
+			config:   *FakeConfig(),
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name: GcsFuseSidecarName,
+						},
+						{
+							Name: "two",
+						},
+						{
+							Name: "three",
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name: "workload-one",
+						},
+						{
+							Name: "workload-two",
+						},
+						{
+							Name: "workload-three",
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "my-volume",
+							VolumeSource: corev1.VolumeSource{
+								CSI: &corev1.CSIVolumeSource{
+									Driver: gcsFuseCsiDriverName,
+									VolumeAttributes: map[string]string{
+										gcsFuseMetadataPrefetchOnMountVolumeAttribute: "true",
+									},
+								},
+							},
+						},
+						{
+							Name: "my-other-volume",
+							VolumeSource: corev1.VolumeSource{
+								CSI: &corev1.CSIVolumeSource{
+									Driver: gcsFuseCsiDriverName,
+									VolumeAttributes: map[string]string{
+										gcsFuseMetadataPrefetchOnMountVolumeAttribute: "false",
+									},
+								},
+							},
+						},
+						{
+							Name: "other-csi-vol",
+							VolumeSource: corev1.VolumeSource{
+								CSI: &corev1.CSIVolumeSource{
+									Driver: "other-csi",
+								},
+							},
+						},
+						{
+							Name: "my-emptydir",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
+							},
+						},
+					},
+				},
+			},
+			expectedPod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name: GcsFuseSidecarName,
+						},
+						{
+							Name:            MetadataPrefetchSidecarName,
+							Image:           FakeConfig().MetadataContainerImage,
+							Env:             []corev1.EnvVar{{Name: "NATIVE_SIDECAR", Value: "TRUE"}},
+							RestartPolicy:   ptr.To(corev1.ContainerRestartPolicyAlways),
+							SecurityContext: GetSecurityContext(),
+							Resources: corev1.ResourceRequirements{
+								Requests: requests,
+								Limits:   limits,
+							},
+							VolumeMounts: []corev1.VolumeMount{{Name: "my-volume", ReadOnly: true, MountPath: "/volumes/my-volume"}},
+						},
+						{
+							Name: "two",
+						},
+						{
+							Name: "three",
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name: "workload-one",
+						},
+						{
+							Name: "workload-two",
+						},
+						{
+							Name: "workload-three",
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "my-volume",
+							VolumeSource: corev1.VolumeSource{
+								CSI: &corev1.CSIVolumeSource{
+									Driver: gcsFuseCsiDriverName,
+									VolumeAttributes: map[string]string{
+										gcsFuseMetadataPrefetchOnMountVolumeAttribute: "true",
+									},
+								},
+							},
+						},
+						{
+							Name: "my-other-volume",
+							VolumeSource: corev1.VolumeSource{
+								CSI: &corev1.CSIVolumeSource{
+									Driver: gcsFuseCsiDriverName,
+									VolumeAttributes: map[string]string{
+										gcsFuseMetadataPrefetchOnMountVolumeAttribute: "false",
+									},
+								},
+							},
+						},
+						{
+							Name: "other-csi-vol",
+							VolumeSource: corev1.VolumeSource{
+								CSI: &corev1.CSIVolumeSource{
+									Driver: "other-csi",
+								},
+							},
+						},
+						{
+							Name: "my-emptydir",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			testName: "fuse sidecar present & using privately hosted image, injection successful",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name: GcsFuseSidecarName,
+						},
+						{
+							Name: "two",
+						},
+						{
+							Name: "three",
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name:  MetadataPrefetchSidecarName,
+							Image: "my-private-image",
+						},
+						{
+							Name: "workload-one",
+						},
+						{
+							Name: "workload-two",
+						},
+						{
+							Name: "workload-three",
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "my-volume",
+							VolumeSource: corev1.VolumeSource{
+								CSI: &corev1.CSIVolumeSource{
+									Driver: gcsFuseCsiDriverName,
+									VolumeAttributes: map[string]string{
+										gcsFuseMetadataPrefetchOnMountVolumeAttribute: "true",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedPod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name: GcsFuseSidecarName,
+						},
+						{
+							Name:            MetadataPrefetchSidecarName,
+							Env:             []corev1.EnvVar{{Name: "NATIVE_SIDECAR", Value: "TRUE"}},
+							RestartPolicy:   ptr.To(corev1.ContainerRestartPolicyAlways),
+							SecurityContext: GetSecurityContext(),
+							Resources: corev1.ResourceRequirements{
+								Requests: requests,
+								Limits:   limits,
+							},
+							Image:        "my-private-image",
+							VolumeMounts: []corev1.VolumeMount{{Name: "my-volume", ReadOnly: true, MountPath: "/volumes/my-volume"}},
+						},
+						{
+							Name: "two",
+						},
+						{
+							Name: "three",
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name: "workload-one",
+						},
+						{
+							Name: "workload-two",
+						},
+						{
+							Name: "workload-three",
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "my-volume",
+							VolumeSource: corev1.VolumeSource{
+								CSI: &corev1.CSIVolumeSource{
+									Driver: gcsFuseCsiDriverName,
+									VolumeAttributes: map[string]string{
+										gcsFuseMetadataPrefetchOnMountVolumeAttribute: "true",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			testName: "fuse sidecar present & using privately hosted image, injection fail",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name: GcsFuseSidecarName,
+						},
+						{
+							Name: "two",
+						},
+						{
+							Name: "three",
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name:  MetadataPrefetchSidecarName,
+							Image: "a:a:a:a",
+						},
+						{
+							Name: "workload-one",
+						},
+						{
+							Name: "workload-two",
+						},
+						{
+							Name: "workload-three",
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "my-volume",
+							VolumeSource: corev1.VolumeSource{
+								CSI: &corev1.CSIVolumeSource{
+									Driver: gcsFuseCsiDriverName,
+									VolumeAttributes: map[string]string{
+										gcsFuseMetadataPrefetchOnMountVolumeAttribute: "true",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedPod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name: GcsFuseSidecarName,
+						},
+						{
+							Name: "two",
+						},
+						{
+							Name: "three",
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name: "workload-one",
+						},
+						{
+							Name: "workload-two",
+						},
+						{
+							Name: "workload-three",
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "my-volume",
+							VolumeSource: corev1.VolumeSource{
+								CSI: &corev1.CSIVolumeSource{
+									Driver: gcsFuseCsiDriverName,
+									VolumeAttributes: map[string]string{
+										gcsFuseMetadataPrefetchOnMountVolumeAttribute: "true",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			t.Parallel()
+			if tc.nativeSidecar == nil {
+				tc.nativeSidecar = ptr.To(true)
+			}
+			si := SidecarInjector{}
+			si.injectMetadataPrefetchSidecarContainer(tc.pod, &tc.config, *tc.nativeSidecar)
+			if !reflect.DeepEqual(tc.pod, tc.expectedPod) {
+				t.Errorf(`failed to run %s, expected: "%v", but got "%v". Diff: %s`, tc.testName, tc.expectedPod, tc.pod, cmp.Diff(tc.expectedPod, tc.pod))
+			}
+		})
 	}
 }

--- a/pkg/webhook/mutatingwebhook.go
+++ b/pkg/webhook/mutatingwebhook.go
@@ -49,6 +49,8 @@ type SidecarInjector struct {
 	Config        *Config
 	Decoder       admission.Decoder
 	NodeLister    listersv1.NodeLister
+	PvcLister     listersv1.PersistentVolumeClaimLister
+	PvLister      listersv1.PersistentVolumeLister
 	ServerVersion *version.Version
 }
 
@@ -92,26 +94,29 @@ func (si *SidecarInjector) Handle(_ context.Context, req admission.Request) admi
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
-	if image, err := parseSidecarContainerImage(pod); err == nil {
-		if image != "" {
-			config.ContainerImage = image
+	if userProvidedGcsFuseSidecarImage, err := ExtractImageAndDeleteContainer(&pod.Spec, GcsFuseSidecarName); err == nil {
+		if userProvidedGcsFuseSidecarImage != "" {
+			config.ContainerImage = userProvidedGcsFuseSidecarImage
 		}
 	} else {
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
 	// Check support for native sidecar.
-	supportsNativeSidecar, err := si.supportsNativeSidecar()
+	injectAsNativeSidecar, err := si.injectAsNativeSidecar(pod)
 	if err != nil {
 		return admission.Errored(http.StatusInternalServerError, fmt.Errorf("failed to verify native sidecar support: %w", err))
 	}
 
 	// Inject container.
-	injectSidecarContainer(pod, config, supportsNativeSidecar)
+	injectSidecarContainer(pod, config, injectAsNativeSidecar)
 	pod.Spec.Volumes = append(GetSidecarContainerVolumeSpec(pod.Spec.Volumes...), pod.Spec.Volumes...)
 
 	// Log pod mutation.
 	LogPodMutation(pod, config)
+
+	// Inject metadata prefetch sidecar.
+	si.injectMetadataPrefetchSidecarContainer(pod, config, injectAsNativeSidecar)
 
 	marshaledPod, err := json.Marshal(pod)
 	if err != nil {

--- a/pkg/webhook/sidecar_spec_test.go
+++ b/pkg/webhook/sidecar_spec_test.go
@@ -74,7 +74,7 @@ func TestValidatePodHasSidecarContainerInjectedForAutoInjection(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name:  SidecarContainerName,
+							Name:  GcsFuseSidecarName,
 							Image: FakeConfig().ContainerImage,
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser:  ptr.To(int64(NobodyUID)),
@@ -108,7 +108,7 @@ func TestValidatePodHasSidecarContainerInjectedForAutoInjection(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name:  SidecarContainerName,
+							Name:  GcsFuseSidecarName,
 							Image: FakeConfig().ContainerImage,
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser:  ptr.To(int64(NobodyUID)),
@@ -135,7 +135,7 @@ func TestValidatePodHasSidecarContainerInjectedForAutoInjection(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name:  SidecarContainerName,
+							Name:  GcsFuseSidecarName,
 							Image: "private-repo/sidecar-image",
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser:  ptr.To(int64(NobodyUID)),
@@ -164,7 +164,7 @@ func TestValidatePodHasSidecarContainerInjectedForAutoInjection(t *testing.T) {
 				Spec: corev1.PodSpec{
 					InitContainers: []corev1.Container{
 						{
-							Name:  SidecarContainerName,
+							Name:  GcsFuseSidecarName,
 							Image: "private-repo/sidecar-image",
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser:  ptr.To(int64(NobodyUID)),
@@ -194,7 +194,7 @@ func TestValidatePodHasSidecarContainerInjectedForAutoInjection(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name:  SidecarContainerName,
+							Name:  GcsFuseSidecarName,
 							Image: FakeConfig().ContainerImage,
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser:  ptr.To(int64(1234)),
@@ -237,7 +237,7 @@ func TestValidatePodHasSidecarContainerInjectedForAutoInjection(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name:  SidecarContainerName,
+							Name:  GcsFuseSidecarName,
 							Image: FakeConfig().ContainerImage,
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser:  ptr.To(int64(NobodyUID)),
@@ -266,7 +266,7 @@ func TestValidatePodHasSidecarContainerInjectedForAutoInjection(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name:  SidecarContainerName,
+							Name:  GcsFuseSidecarName,
 							Image: FakeConfig().ContainerImage,
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser:  ptr.To(int64(NobodyUID)),

--- a/pkg/webhook/validating_admission_policy_test.go
+++ b/pkg/webhook/validating_admission_policy_test.go
@@ -40,7 +40,7 @@ import (
 
 func testPod(initContainer bool, annotation map[string]string, restartPolicy *corev1.ContainerRestartPolicy, env []corev1.EnvVar) *corev1.Pod {
 	container := corev1.Container{
-		Name:          SidecarContainerName,
+		Name:          GcsFuseSidecarName,
 		RestartPolicy: restartPolicy,
 		Env:           env,
 	}

--- a/pkg/webhook/volumes.go
+++ b/pkg/webhook/volumes.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+Copyright 2024 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+)
+
+const (
+	gcsFuseCsiDriverName = "gcsfuse.csi.storage.gke.io"
+)
+
+// isGcsFuseCSIVolume checks if the given volume is backed by gcsfuse csi driver.
+//
+// Returns the following (in order):
+//   - isGcsFuseCSIVolume - (bool) whether volume is backed by gcsfuse csi driver.
+//   - isDynamicMount - (bool) True if volume is attempting to mount all of the buckets in project.
+//   - volumeAttributes (map[string]string)
+//   - error - if check failed
+func (si *SidecarInjector) isGcsFuseCSIVolume(volume corev1.Volume, namespace string) (bool, bool, map[string]string, error) {
+	var isDynamicMount bool
+
+	// Check if it is ephemeral volume.
+	if volume.CSI != nil {
+		if volume.CSI.Driver == gcsFuseCsiDriverName {
+			// Ephemeral volume is using dynamic mounting,
+			// See details: https://cloud.google.com/storage/docs/gcsfuse-mount#dynamic-mount
+			if val, ok := volume.CSI.VolumeAttributes["bucketName"]; ok && val == "_" {
+				isDynamicMount = true
+			}
+
+			return true, isDynamicMount, volume.CSI.VolumeAttributes, nil
+		}
+
+		return false, false, nil, nil
+	}
+
+	// Check if it's a persistent volume.
+	pvc := volume.PersistentVolumeClaim
+	if pvc == nil {
+		return false, false, nil, nil
+	}
+	pvcName := pvc.ClaimName
+	pvcObj, err := si.GetPVC(namespace, pvcName)
+	if err != nil {
+		return false, false, nil, err
+	}
+
+	// Check if the PVC is a preprovisioned gcsfuse volume.
+	pv, ok, err := si.GetPreprovisionCSIVolume(gcsFuseCsiDriverName, pvcObj)
+	if err != nil || pv == nil {
+		klog.Warningf("unable to determine if PVC %s/%s is a pre-provisioned gcsfuse volume: %v", namespace, pvcName, err)
+
+		return false, false, nil, nil
+	}
+
+	if ok {
+		if pv.Spec.CSI != nil && pv.Spec.CSI.VolumeHandle == "_" {
+			isDynamicMount = true
+		}
+
+		return true, isDynamicMount, pv.Spec.CSI.VolumeAttributes, nil
+	}
+
+	return false, false, nil, nil
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -111,6 +111,7 @@ var _ = ginkgo.Describe("E2E Test Suite", func() {
 		testsuites.InitGcsFuseCSIGCSFuseIntegrationFileCacheParallelDownloadsTestSuite,
 		testsuites.InitGcsFuseCSIIstioTestSuite,
 		testsuites.InitGcsFuseCSIMetricsTestSuite,
+		testsuites.InitGcsFuseCSIMetadataPrefetchTestSuite,
 	}
 
 	testDriver := specs.InitGCSFuseCSITestDriver(c, m, *bucketLocation, *skipGcpSaTest, false)

--- a/test/e2e/specs/testdriver.go
+++ b/test/e2e/specs/testdriver.go
@@ -57,6 +57,7 @@ type gcsVolume struct {
 	shared                  bool
 	readOnly                bool
 	skipBucketAccessCheck   bool
+	metadataPrefetch        bool
 }
 
 // InitGCSFuseCSITestDriver returns GCSFuseCSITestDriver that implements TestDriver interface.
@@ -151,7 +152,7 @@ func (n *GCSFuseCSITestDriver) CreateVolume(ctx context.Context, config *storage
 			bucketName = uuid.NewString()
 		case InvalidVolumePrefix, SkipCSIBucketAccessCheckAndInvalidVolumePrefix:
 			bucketName = InvalidVolume
-		case ForceNewBucketPrefix, EnableFileCacheForceNewBucketPrefix:
+		case ForceNewBucketPrefix, EnableFileCacheForceNewBucketPrefix, EnableMetadataPrefetchPrefixForceNewBucketPrefix:
 			bucketName = n.createBucket(ctx, config.Framework.Namespace.Name)
 		case MultipleBucketsPrefix:
 			isMultipleBucketsPrefix = true
@@ -220,6 +221,9 @@ func (n *GCSFuseCSITestDriver) CreateVolume(ctx context.Context, config *storage
 			CreateImplicitDirInBucket(ImplicitDirsPath, bucketName)
 			mountOptions += ",implicit-dirs"
 			v.skipBucketAccessCheck = true
+		case EnableMetadataPrefetchPrefix:
+			mountOptions += ",file-system:kernel-list-cache-ttl-secs:-1"
+			v.metadataPrefetch = true
 		}
 
 		v.mountOptions = mountOptions
@@ -252,6 +256,13 @@ func (n *GCSFuseCSITestDriver) GetPersistentVolumeSource(readOnly bool, _ string
 	gv, _ := volume.(*gcsVolume)
 	va := map[string]string{
 		driver.VolumeContextKeyMountOptions: gv.mountOptions,
+	}
+
+	if gv.metadataPrefetch {
+		va["gcsfuseMetadataPrefetchOnMount"] = "true"
+		va["metadataStatCacheCapacity"] = "-1"
+		va["metadataTypeCacheCapacity"] = "-1"
+		va["metadataCacheTtlSeconds"] = "-1"
 	}
 
 	if gv.fileCacheCapacity != "" {
@@ -287,6 +298,13 @@ func (n *GCSFuseCSITestDriver) GetVolume(config *storageframework.PerTestConfig,
 
 	if gv.skipBucketAccessCheck {
 		va[driver.VolumeContextKeySkipCSIBucketAccessCheck] = util.TrueStr
+	}
+
+	if gv.metadataPrefetch {
+		va["gcsfuseMetadataPrefetchOnMount"] = "true"
+		va["metadataStatCacheCapacity"] = "-1"
+		va["metadataTypeCacheCapacity"] = "-1"
+		va["metadataCacheTtlSeconds"] = "-1"
 	}
 
 	return va, gv.shared, gv.readOnly

--- a/test/e2e/testsuites/file_cache.go
+++ b/test/e2e/testsuites/file_cache.go
@@ -263,7 +263,7 @@ func (t *gcsFuseCSIFileCacheTestSuite) DefineTests(driver storageframework.TestD
 		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("mount | grep %v | grep rw,", mountPath))
 		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("cat %v/%v > /dev/null", mountPath, fileName))
 
-		tPod.WaitForLog(ctx, webhook.SidecarContainerName, "while inserting into the cache: size of the entry is more than the cache's maxSize")
+		tPod.WaitForLog(ctx, webhook.GcsFuseSidecarName, "while inserting into the cache: size of the entry is more than the cache's maxSize")
 	})
 
 	ginkgo.It("should have cache miss when the fileCacheCapacity is larger than underlying storage", func() {
@@ -300,6 +300,6 @@ func (t *gcsFuseCSIFileCacheTestSuite) DefineTests(driver storageframework.TestD
 		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("mount | grep %v | grep rw,", mountPath))
 		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("cat %v/%v > /dev/null", mountPath, fileName))
 
-		tPod.WaitForLog(ctx, webhook.SidecarContainerName, "no space left on device")
+		tPod.WaitForLog(ctx, webhook.GcsFuseSidecarName, "no space left on device")
 	})
 }

--- a/test/e2e/testsuites/metadata_prefetch.go
+++ b/test/e2e/testsuites/metadata_prefetch.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+Copyright 2024 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testsuites
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/googlecloudplatform/gcs-fuse-csi-driver/test/e2e/specs"
+	"github.com/googlecloudplatform/gcs-fuse-csi-driver/test/e2e/utils"
+	"github.com/onsi/ginkgo/v2"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
+	e2evolume "k8s.io/kubernetes/test/e2e/framework/volume"
+	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+type gcsFuseCSIMetadataPrefetchTestSuite struct {
+	tsInfo storageframework.TestSuiteInfo
+}
+
+// InitGcsFuseCSIMetadataPrefetchTestSuite returns gcsFuseCSIMetadataPrefetchTestSuite that implements TestSuite interface.
+func InitGcsFuseCSIMetadataPrefetchTestSuite() storageframework.TestSuite {
+	return &gcsFuseCSIMetadataPrefetchTestSuite{
+		tsInfo: storageframework.TestSuiteInfo{
+			Name: "metadataPrefetch",
+			TestPatterns: []storageframework.TestPattern{
+				storageframework.DefaultFsCSIEphemeralVolume,
+				storageframework.DefaultFsPreprovisionedPV,
+			},
+		},
+	}
+}
+
+func (t *gcsFuseCSIMetadataPrefetchTestSuite) GetTestSuiteInfo() storageframework.TestSuiteInfo {
+	return t.tsInfo
+}
+
+func (t *gcsFuseCSIMetadataPrefetchTestSuite) SkipUnsupportedTests(_ storageframework.TestDriver, _ storageframework.TestPattern) {
+}
+
+func (t *gcsFuseCSIMetadataPrefetchTestSuite) DefineTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {
+	envVar := os.Getenv(utils.TestWithNativeSidecarEnvVar)
+	supportsNativeSidecar, err := strconv.ParseBool(envVar)
+	if err != nil {
+		klog.Fatalf(`env variable "%s" could not be converted to boolean`, envVar)
+	}
+
+	type local struct {
+		config         *storageframework.PerTestConfig
+		volumeResource *storageframework.VolumeResource
+	}
+	var l local
+	ctx := context.Background()
+
+	// Beware that it also registers an AfterEach which renders f unusable. Any code using
+	// f must run inside an It or Context callback.
+	f := framework.NewFrameworkWithCustomTimeouts("volumes", storageframework.GetDriverTimeouts(driver))
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	init := func(configPrefix ...string) {
+		l = local{}
+		l.config = driver.PrepareTest(ctx, f)
+		if len(configPrefix) > 0 {
+			l.config.Prefix = configPrefix[0]
+		}
+		l.volumeResource = storageframework.CreateVolumeResource(ctx, driver, l.config, pattern, e2evolume.SizeRange{})
+	}
+
+	cleanup := func() {
+		var cleanUpErrs []error
+		cleanUpErrs = append(cleanUpErrs, l.volumeResource.CleanupResource(ctx))
+		err := utilerrors.NewAggregate(cleanUpErrs)
+		framework.ExpectNoError(err, "while cleaning up")
+	}
+
+	testCaseStoreAndRetainData := func(configPrefix string) {
+		init(configPrefix)
+		defer cleanup()
+
+		ginkgo.By("Configuring the first pod")
+		tPod1 := specs.NewTestPod(f.ClientSet, f.Namespace)
+		tPod1.SetupVolume(l.volumeResource, volumeName, mountPath, false)
+
+		ginkgo.By("Deploying the first pod")
+		tPod1.Create(ctx)
+
+		ginkgo.By("Checking that the first pod is running")
+		tPod1.WaitForRunning(ctx)
+
+		ginkgo.By("Checking that the first pod command exits with no error")
+		tPod1.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("mount | grep %v | grep rw,", mountPath))
+		tPod1.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("echo 'hello world' > %v/data && grep 'hello world' %v/data", mountPath, mountPath))
+
+		ginkgo.By("Deleting the first pod")
+		tPod1.Cleanup(ctx)
+
+		ginkgo.By("Configuring the second pod")
+		tPod2 := specs.NewTestPod(f.ClientSet, f.Namespace)
+		tPod2.SetupVolume(l.volumeResource, volumeName, mountPath, false)
+
+		ginkgo.By("Deploying the second pod")
+		tPod2.Create(ctx)
+		defer tPod2.Cleanup(ctx)
+
+		ginkgo.By("Checking that the second pod is running")
+		tPod2.WaitForRunning(ctx)
+
+		ginkgo.By("Checking that the second pod command exits with no error")
+		tPod2.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("mount | grep %v | grep rw,", mountPath))
+		tPod2.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("grep 'hello world' %v/data", mountPath))
+
+		if supportsNativeSidecar {
+			ginkgo.By("Checking metadata prefetch sidecar present on the second pod")
+			tPod2.VerifyMetadataPrefetchPresence()
+		} else {
+			ginkgo.By("Checking metadata prefetch sidecar not present on the second pod")
+			tPod2.VerifyMetadataPrefetchNotPresent()
+		}
+
+		tPod2.Cleanup(ctx)
+	}
+
+	ginkgo.It("[metadata prefetch] should store data and retain the data", func() {
+		if pattern.VolType == storageframework.DynamicPV {
+			e2eskipper.Skipf("skip for volume type %v", storageframework.DynamicPV)
+		}
+		testCaseStoreAndRetainData(specs.EnableMetadataPrefetchPrefix)
+	})
+}

--- a/test/e2e/testsuites/multivolume.go
+++ b/test/e2e/testsuites/multivolume.go
@@ -20,12 +20,16 @@ package testsuites
 import (
 	"context"
 	"fmt"
+	"os"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/test/e2e/specs"
+	"github.com/googlecloudplatform/gcs-fuse-csi-driver/test/e2e/utils"
 	"github.com/onsi/ginkgo/v2"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	e2evolume "k8s.io/kubernetes/test/e2e/framework/volume"
@@ -58,6 +62,11 @@ func (t *gcsFuseCSIMultiVolumeTestSuite) SkipUnsupportedTests(_ storageframework
 }
 
 func (t *gcsFuseCSIMultiVolumeTestSuite) DefineTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {
+	envVar := os.Getenv(utils.TestWithNativeSidecarEnvVar)
+	supportsNativeSidecar, err := strconv.ParseBool(envVar)
+	if err != nil {
+		klog.Fatalf(`env variable "%s" could not be converted to boolean`, envVar)
+	}
 	type local struct {
 		config             *storageframework.PerTestConfig
 		volumeResourceList []*storageframework.VolumeResource
@@ -244,6 +253,15 @@ func (t *gcsFuseCSIMultiVolumeTestSuite) DefineTests(driver storageframework.Tes
 	//   [bucket1]  [bucket2]
 	ginkgo.It("should access multiple volumes backed by different buckets from the same Pod", func() {
 		init(2, specs.ForceNewBucketPrefix)
+		defer cleanup()
+
+		testOnePodTwoVols()
+	})
+	ginkgo.It("[metadata prefetch] should access multiple volumes backed by different buckets from the same Pod", func() {
+		if pattern.VolType == storageframework.DynamicPV || !supportsNativeSidecar {
+			e2eskipper.Skipf("skip for volume type %v", storageframework.DynamicPV)
+		}
+		init(2, specs.EnableMetadataPrefetchPrefixForceNewBucketPrefix)
 		defer cleanup()
 
 		testOnePodTwoVols()

--- a/test/e2e/testsuites/volumes.go
+++ b/test/e2e/testsuites/volumes.go
@@ -147,6 +147,13 @@ func (t *gcsFuseCSIVolumesTestSuite) DefineTests(driver storageframework.TestDri
 		testCaseStoreAndRetainData(specs.SkipCSIBucketAccessCheckPrefix)
 	})
 
+	ginkgo.It("[metadata prefetch] should store data and retain the data", func() {
+		if pattern.VolType == storageframework.DynamicPV || !supportsNativeSidecar {
+			e2eskipper.Skipf("skip for volume type %v", storageframework.DynamicPV)
+		}
+		testCaseStoreAndRetainData(specs.EnableMetadataPrefetchPrefix)
+	})
+
 	testCaseReadOnlyFailedWrite := func(configPrefix string) {
 		init(configPrefix)
 		defer cleanup()
@@ -197,6 +204,12 @@ func (t *gcsFuseCSIVolumesTestSuite) DefineTests(driver storageframework.TestDri
 	})
 	ginkgo.It("[read-only][csi-skip-bucket-access-check] should fail when write", func() {
 		testCaseReadOnlyFailedWrite(specs.SkipCSIBucketAccessCheckPrefix)
+	})
+	ginkgo.It("[read-only][metadata prefetch] should fail when write", func() {
+		if pattern.VolType == storageframework.DynamicPV || !supportsNativeSidecar {
+			e2eskipper.Skipf("skip for volume type %v", storageframework.DynamicPV)
+		}
+		testCaseReadOnlyFailedWrite(specs.EnableMetadataPrefetchPrefix)
 	})
 
 	testCaseStoreRetainData := func(configPrefix string, uid, gid, fsgroup int) {
@@ -250,6 +263,13 @@ func (t *gcsFuseCSIVolumesTestSuite) DefineTests(driver storageframework.TestDri
 
 	ginkgo.It("[fsgroup delegation][csi-skip-bucket-access-check] should store data and retain the data", func() {
 		testCaseStoreRetainData(specs.SkipCSIBucketAccessCheckPrefix, 1001, 2002, 3003)
+	})
+
+	ginkgo.It("[metadata prefetch] should store data and retain the data", func() {
+		if pattern.VolType == storageframework.DynamicPV || !supportsNativeSidecar {
+			e2eskipper.Skipf("skip for volume type %v", storageframework.DynamicPV)
+		}
+		testCaseStoreRetainData(specs.EnableMetadataPrefetchPrefix, 1001, 2002, 3003)
 	})
 
 	testCaseImplicitDir := func(configPrefix string) {
@@ -316,6 +336,12 @@ func (t *gcsFuseCSIVolumesTestSuite) DefineTests(driver storageframework.TestDri
 	ginkgo.It("[csi-skip-bucket-access-check] should store data using custom sidecar container image", func() {
 		testCaseStoreDataCustomContainerImage(specs.SkipCSIBucketAccessCheckPrefix)
 	})
+	ginkgo.It("[metadata prefetch] should store data using custom sidecar container image", func() {
+		if pattern.VolType == storageframework.DynamicPV || !supportsNativeSidecar {
+			e2eskipper.Skipf("skip for volume type %v", storageframework.DynamicPV)
+		}
+		testCaseStoreDataCustomContainerImage(specs.EnableMetadataPrefetchPrefix)
+	})
 
 	testCaseCustomBufferVol := func(configPrefix string) {
 		init(configPrefix)
@@ -379,5 +405,11 @@ func (t *gcsFuseCSIVolumesTestSuite) DefineTests(driver storageframework.TestDri
 	})
 	ginkgo.It("[csi-skip-bucket-access-check] should store data and retain the data in init container", func() {
 		testCaseStoreDataInitContainer(specs.SkipCSIBucketAccessCheckPrefix)
+	})
+	ginkgo.It("[metadata prefetch] should store data and retain the data in init container", func() {
+		if pattern.VolType == storageframework.DynamicPV || !supportsNativeSidecar {
+			e2eskipper.Skipf("skip for volume type %v", storageframework.DynamicPV)
+		}
+		testCaseStoreDataInitContainer(specs.EnableMetadataPrefetchPrefix)
 	})
 }

--- a/test/e2e/utils/handler.go
+++ b/test/e2e/utils/handler.go
@@ -220,10 +220,13 @@ func generateTestSkip(testParams *TestParameters) string {
 
 	if !testParams.SupportsNativeSidecar {
 		skipTests = append(skipTests, "init.container", "fast.termination")
+		skipTests = append(skipTests, "metadata.prefetch")
 	}
 
 	if testParams.UseGKEManagedDriver {
 		skipTests = append(skipTests, "metrics")
+		// TODO(jaimebz): Skip this test until Managed Driver has changes released.
+		skipTests = append(skipTests, "metadata.prefetch")
 
 		// TODO(saikatroyc) remove this skip when GCSFuse CSI v1.4.3 is back-ported to the below GKE versions.
 		if strings.HasPrefix(testParams.GkeClusterVersion, "1.27") || strings.HasPrefix(testParams.GkeClusterVersion, "1.28") {


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>  
> /kind api-change  
> /kind bug  
> /kind cleanup  
> /kind design  
> /kind documentation  
> /kind failing-test  

/kind feature  

> /kind flake  


**What this PR does / why we need it**:  
Prefill stat/metadata cache as pod starts to reduce number of list calls during workload execution. 

**Which issue(s) this PR fixes**:  
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:  
Yes, this PR adds a new boolean API field within `volumeAttributes` called `gcsfuseMetadataPrefetchOnMount`.

```release-note
Add Cloud Storage FUSE Metadata/Stat cache prefetch from Kubernetes.
```
