### PR TITLE
Add platform flag to Golang binary to honor build platform

### DIFF
--- a/cmd/csi_driver/Dockerfile
+++ b/cmd/csi_driver/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Build driver go binary
-FROM golang:1.22.7 AS driver-builder
+FROM --platform=$BUILDPLATFORM golang:1.22.7 AS driver-builder
 
 ARG STAGINGVERSION
 

--- a/cmd/sidecar_mounter/Dockerfile
+++ b/cmd/sidecar_mounter/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Build sidecar-mounter go binary
-FROM golang:1.22.7 AS sidecar-mounter-builder
+FROM --platform=$BUILDPLATFORM golang:1.22.7 AS sidecar-mounter-builder
 
 ARG STAGINGVERSION
 

--- a/cmd/webhook/Dockerfile
+++ b/cmd/webhook/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Build webhook go binary
-FROM golang:1.22.7 AS webhook-builder
+FROM --platform=$BUILDPLATFORM golang:1.22.7 AS webhook-builder
 
 ARG STAGINGVERSION
 


### PR DESCRIPTION
Adding this flag fixes a specific issue we observed where attempting to build a linux/ARM64 driver would either time out for several hours or produce the error: `.buildkit_qemu_emulator: /bin/sh: Invalid ELF image for this architecture`.

Adding this line ensures that our build platform is honored in our Dockerfile.

More information about this flag: https://docs.docker.com/build/building/multi-platform/#cross-compilation