### PR TITLE
Automated cherry pick of #368: Add platform flag to Golang binary to honor build platform

### DIFF
--- a/cmd/csi_driver/Dockerfile
+++ b/cmd/csi_driver/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Build driver go binary
-FROM golang:1.22.7 AS driver-builder
+FROM --platform=$BUILDPLATFORM golang:1.22.7 AS driver-builder
 
 ARG STAGINGVERSION
 

--- a/cmd/sidecar_mounter/Dockerfile
+++ b/cmd/sidecar_mounter/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Build sidecar-mounter go binary
-FROM golang:1.22.7 AS sidecar-mounter-builder
+FROM --platform=$BUILDPLATFORM golang:1.22.7 AS sidecar-mounter-builder
 
 ARG STAGINGVERSION
 

--- a/cmd/webhook/Dockerfile
+++ b/cmd/webhook/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Build webhook go binary
-FROM golang:1.22.7 AS webhook-builder
+FROM --platform=$BUILDPLATFORM golang:1.22.7 AS webhook-builder
 
 ARG STAGINGVERSION
 


### PR DESCRIPTION
Cherry pick of #368 on release-1.6.

#368: Add platform flag to Golang binary to honor build platform

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```