### PR TITLE
Revert configmap length check to fix e2e tests

### DIFF
--- a/test/e2e/specs/specs.go
+++ b/test/e2e/specs/specs.go
@@ -1151,7 +1151,7 @@ func GetGCSFuseVersion(ctx context.Context, client clientset.Interface) string {
 		FieldSelector: "metadata.name=gcsfusecsi-image-config",
 	})
 	framework.ExpectNoError(err)
-	gomega.Expect(configMaps.Items).To(gomega.HaveLen(2))
+	gomega.Expect(configMaps.Items).To(gomega.HaveLen(1))
 
 	sidecarImageConfig := configMaps.Items[0]
 	image := sidecarImageConfig.Data["sidecar-image"]


### PR DESCRIPTION
The test is checking the number of configmaps in the cluster to be 1. It is not checking for the number of configmap.data entries at this point.