### PR TITLE
Automated cherry pick of #389: Bump golang from 1.22.7 to 1.23.3 in /cmd/metadata_prefetch

### DIFF
--- a/cmd/metadata_prefetch/Dockerfile
+++ b/cmd/metadata_prefetch/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Build metadata-prefetch go binary
-FROM --platform=$BUILDPLATFORM golang:1.22.7 AS metadata-prefetch-builder
+FROM --platform=$BUILDPLATFORM golang:1.23.3 AS metadata-prefetch-builder
 
 ARG STAGINGVERSION
 


### PR DESCRIPTION
Cherry pick of #389 on release-1.8.

#389: Bump golang from 1.22.7 to 1.23.3 in /cmd/metadata_prefetch

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```