### PR TITLE
Automated cherry pick of #394: Set GOARCH through TARGETPLATFORM to correctly build for ARM machines.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,19 +52,19 @@ all: driver sidecar-mounter webhook metadata-prefetch
 
 driver:
 	mkdir -p ${BINDIR}
-	CGO_ENABLED=0 GOOS=linux GOARCH=$(shell dpkg --print-architecture) go build -mod vendor -ldflags "${LDFLAGS}" -o ${BINDIR}/${DRIVER_BINARY} cmd/csi_driver/main.go
+	CGO_ENABLED=0 GOOS=linux go build -mod vendor -ldflags "${LDFLAGS}" -o ${BINDIR}/${DRIVER_BINARY} cmd/csi_driver/main.go
 
 sidecar-mounter:
 	mkdir -p ${BINDIR}
-	CGO_ENABLED=0 GOOS=linux GOARCH=$(shell dpkg --print-architecture) go build -mod vendor -ldflags "${LDFLAGS}" -o ${BINDIR}/${SIDECAR_BINARY} cmd/sidecar_mounter/main.go
+	CGO_ENABLED=0 GOOS=linux go build -mod vendor -ldflags "${LDFLAGS}" -o ${BINDIR}/${SIDECAR_BINARY} cmd/sidecar_mounter/main.go
 
 metadata-prefetch:
 	mkdir -p ${BINDIR}
-	CGO_ENABLED=0 GOOS=linux GOARCH=$(shell dpkg --print-architecture) go build -mod vendor -ldflags "${LDFLAGS}" -o ${BINDIR}/${PREFETCH_BINARY} cmd/metadata_prefetch/main.go
+	CGO_ENABLED=0 GOOS=linux go build -mod vendor -ldflags "${LDFLAGS}" -o ${BINDIR}/${PREFETCH_BINARY} cmd/metadata_prefetch/main.go
 
 webhook:
 	mkdir -p ${BINDIR}
-	CGO_ENABLED=0 GOOS=linux GOARCH=$(shell dpkg --print-architecture) go build -mod vendor -ldflags "${LDFLAGS}" -o ${BINDIR}/${WEBHOOK_BINARY} cmd/webhook/main.go
+	CGO_ENABLED=0 GOOS=linux go build -mod vendor -ldflags "${LDFLAGS}" -o ${BINDIR}/${WEBHOOK_BINARY} cmd/webhook/main.go
 
 download-gcsfuse:
 	mkdir -p ${BINDIR}/linux/amd64 ${BINDIR}/linux/arm64

--- a/cmd/csi_driver/Dockerfile
+++ b/cmd/csi_driver/Dockerfile
@@ -17,10 +17,11 @@
 FROM --platform=$BUILDPLATFORM golang:1.23.3 AS driver-builder
 
 ARG STAGINGVERSION
+ARG TARGETPLATFORM
 
 WORKDIR /gcs-fuse-csi-driver
 ADD . .
-RUN make driver BINDIR=/bin
+RUN GOARCH=$(echo $TARGETPLATFORM | cut -f2 -d '/') make driver BINDIR=/bin
 
 # Start from Kubernetes Debian base.
 FROM gke.gcr.io/debian-base:bookworm-v1.0.2-gke.2 AS debian

--- a/cmd/metadata_prefetch/Dockerfile
+++ b/cmd/metadata_prefetch/Dockerfile
@@ -17,10 +17,11 @@
 FROM --platform=$BUILDPLATFORM golang:1.23.3 AS metadata-prefetch-builder
 
 ARG STAGINGVERSION
+ARG TARGETPLATFORM
 
 WORKDIR /gcs-fuse-csi-driver
 ADD . .
-RUN make metadata-prefetch BINDIR=/bin
+RUN GOARCH=$(echo $TARGETPLATFORM | cut -f2 -d '/') make metadata-prefetch BINDIR=/bin
 
 # go/gke-releasing-policies#base-images
 FROM gke.gcr.io/debian-base:bookworm-v1.0.4-gke.2 AS debian

--- a/cmd/sidecar_mounter/Dockerfile
+++ b/cmd/sidecar_mounter/Dockerfile
@@ -17,10 +17,11 @@
 FROM --platform=$BUILDPLATFORM golang:1.23.3 AS sidecar-mounter-builder
 
 ARG STAGINGVERSION
+ARG TARGETPLATFORM
 
 WORKDIR /gcs-fuse-csi-driver
 ADD . .
-RUN make sidecar-mounter BINDIR=/bin
+RUN GOARCH=$(echo $TARGETPLATFORM | cut -f2 -d '/') make sidecar-mounter BINDIR=/bin
 
 # go/gke-releasing-policies#base-images
 # We use `gcr.io/distroless/base` because it includes glibc.

--- a/cmd/webhook/Dockerfile
+++ b/cmd/webhook/Dockerfile
@@ -17,10 +17,11 @@
 FROM --platform=$BUILDPLATFORM golang:1.23.3 AS webhook-builder
 
 ARG STAGINGVERSION
+ARG TARGETPLATFORM
 
 WORKDIR /gcs-fuse-csi-driver
 ADD . .
-RUN make webhook BINDIR=/bin
+RUN  GOARCH=$(echo $TARGETPLATFORM | cut -f2 -d '/') make webhook BINDIR=/bin
 
 FROM gcr.io/distroless/static
 


### PR DESCRIPTION
Cherry pick of #394 on release-1.8.

#394: Set GOARCH through TARGETPLATFORM to correctly build for ARM machines.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Set GOARCH to TARGETPLATFORM to correctly build for ARM machines.
```