### PR TITLE
Remove setting client-protocol for performance tests.

### DIFF
--- a/test/e2e/testsuites/performance.go
+++ b/test/e2e/testsuites/performance.go
@@ -197,7 +197,7 @@ func (t *gcsFuseCSIPerformanceTestSuite) DefineTests(driver storageframework.Tes
 			tPod.SetImage(specs.UbuntuImage)
 			tPod.SetResource("2", "5Gi", "5Gi")
 			mountPath := "/gcs"
-			tPod.SetupVolume(l.volumeResource, volumeName, mountPath, false, "implicit-dirs", "max-conns-per-host=100", "client-protocol=http1")
+			tPod.SetupVolume(l.volumeResource, volumeName, mountPath, false, "implicit-dirs", "max-conns-per-host=100")
 			tPod.SetAnnotations(map[string]string{
 				"gke-gcsfuse/cpu-limit":               "10",
 				"gke-gcsfuse/memory-limit":            "2Gi",


### PR DESCRIPTION
cc. @saikat-royc 

http1 is the default protocol used, so it is safe to remove as it will still be used by default.