### PR TITLE
Filtering informerFactory to only return relevant PodSpec information

### DIFF
--- a/pkg/cloud_provider/clientset/clientset.go
+++ b/pkg/cloud_provider/clientset/clientset.go
@@ -78,11 +78,48 @@ func New(kubeconfigPath string, informerResyncDurationSec int) (Interface, error
 }
 
 func (c *Clientset) ConfigurePodLister(nodeName string) {
-	trimManagedFields := func(obj interface{}) (interface{}, error) {
+	trim := func(obj interface{}) (interface{}, error) {
 		if accessor, err := meta.Accessor(obj); err == nil {
 			if accessor.GetManagedFields() != nil {
 				accessor.SetManagedFields(nil)
 			}
+		}
+
+		// We are filtering only for relevant PodSpec info to optimize memory usage.
+		// Relevant info is for NodePublishVolume calls:
+		// https://github.com/GoogleCloudPlatform/gcs-fuse-csi-driver/blob/547cab9a9aea4cdbda581885880020fb9266dc03/pkg/csi_driver/node.go#L85
+		podObj, ok := obj.(*corev1.Pod)
+		if !ok {
+			return obj, nil
+		}
+
+		var newContainers []corev1.Container
+		for _, cont := range podObj.Spec.Containers {
+			container := corev1.Container{
+				Name:            cont.Name,
+				SecurityContext: cont.SecurityContext,
+				VolumeMounts:    cont.VolumeMounts,
+			}
+			newContainers = append(newContainers, container)
+		}
+
+		var newInitContainers []corev1.Container
+		for _, cont := range podObj.Spec.InitContainers {
+			container := corev1.Container{
+				Name:            cont.Name,
+				SecurityContext: cont.SecurityContext,
+				VolumeMounts:    cont.VolumeMounts,
+			}
+			newInitContainers = append(newInitContainers, container)
+		}
+
+		nodeName := podObj.Spec.NodeName
+		volumes := podObj.Spec.Volumes
+		podObj.Spec = corev1.PodSpec{
+			NodeName:       nodeName,
+			Volumes:        volumes,
+			Containers:     newContainers,
+			InitContainers: newInitContainers,
 		}
 
 		return obj, nil
@@ -94,7 +131,7 @@ func (c *Clientset) ConfigurePodLister(nodeName string) {
 		informers.WithTweakListOptions(func(options *metav1.ListOptions) {
 			options.FieldSelector = "spec.nodeName=" + nodeName
 		}),
-		informers.WithTransform(trimManagedFields),
+		informers.WithTransform(trim),
 	)
 	podLister := informerFactory.Core().V1().Pods().Lister()
 


### PR DESCRIPTION
Filtering informerFactory to only return relevant PodSpec information to improve GCSFUSE CSI driver memory usage for pods and deployments with larger Pod Specs.