### PR TITLE
Update gcsfuse to v2.5.2

### DIFF
--- a/cmd/sidecar_mounter/gcsfuse_binary
+++ b/cmd/sidecar_mounter/gcsfuse_binary
@@ -1,1 +1,1 @@
-gs://gke-release-staging/gcsfuse/v2.5.1-gke.0/gcsfuse_bin
+gs://gke-release-staging/gcsfuse/v2.5.2-gke.0/gcsfuse_bin


### PR DESCRIPTION
This patch does not release new features. Patch addresses the following CVEs:
- CVE-2024-45337

cc. @saikat-royc 