### PR TITLE
Automated cherry pick of #414: Update gcsfuse to v2.5.2

### DIFF
--- a/cmd/sidecar_mounter/gcsfuse_binary
+++ b/cmd/sidecar_mounter/gcsfuse_binary
@@ -1,1 +1,1 @@
-gs://gke-release-staging/gcsfuse/v2.5.1-gke.0/gcsfuse_bin
+gs://gke-release-staging/gcsfuse/v2.5.2-gke.0/gcsfuse_bin


### PR DESCRIPTION
Cherry pick of #414 on release-1.8.

#414: Update gcsfuse to v2.5.2

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```