### PR TITLE
Track restartPolicy in node pod informer.

### DIFF
--- a/pkg/cloud_provider/clientset/clientset.go
+++ b/pkg/cloud_provider/clientset/clientset.go
@@ -115,11 +115,13 @@ func (c *Clientset) ConfigurePodLister(nodeName string) {
 
 		nodeName := podObj.Spec.NodeName
 		volumes := podObj.Spec.Volumes
+		restartPolicy := podObj.Spec.RestartPolicy
 		podObj.Spec = corev1.PodSpec{
 			NodeName:       nodeName,
 			Volumes:        volumes,
 			Containers:     newContainers,
 			InitContainers: newInitContainers,
+			RestartPolicy:  restartPolicy,
 		}
 
 		return obj, nil


### PR DESCRIPTION
In Kubernetes versions that do not support native sidecar, we put an exit file for the sidecar to read once all the containers in the pod have terminated. This behavior partly depends on the RestartPolicy of the Pod. Tracking of this policy was recently removed in #413. Adding it back to Pod.Spec.RestartPolicy in node server pod informer to fix regression in 1.28.

#### Tested
Ran non-managed driver on cluster running GKE v1.28.15-gke.1020000 and verified auto-termination testsuite succeeds.

cc. @saikat-royc @halimsam 