### PR TITLE
Fix istio tests running on gRPC

### DIFF
--- a/test/e2e/testsuites/istio.go
+++ b/test/e2e/testsuites/istio.go
@@ -107,7 +107,7 @@ func (t *gcsFuseCSIIstioTestSuite) DefineTests(driver storageframework.TestDrive
 		}
 
 		if registryOnly {
-			tPod.SetAnnotations(map[string]string{"traffic.sidecar.istio.io/excludeOutboundIPRanges": "169.254.169.254/32"})
+			tPod.SetAnnotations(map[string]string{"traffic.sidecar.istio.io/excludeOutboundIPRanges": "169.254.169.254/32,209.85.145.95/32"})
 			specs.DeployIstioSidecar(f.Namespace.Name)
 			specs.DeployIstioServiceEntry(f.Namespace.Name)
 		}


### PR DESCRIPTION
Firewall rules is causing test to fail. Still needs investigating as to how exactly the behavior changes with gPRC