### PR TITLE
Support gPRC tests locally.

### DIFF
--- a/test/e2e/run-e2e-ci.sh
+++ b/test/e2e/run-e2e-ci.sh
@@ -36,7 +36,7 @@ readonly gke_cluster_version=${GKE_CLUSTER_VERSION:-latest}
 readonly gke_node_version=${GKE_NODE_VERSION:-}
 readonly node_machine_type=${MACHINE_TYPE:-n2-standard-4}
 readonly number_nodes=${NUMBER_NODES:-3}
-readonly gcsfuse_client_protocol=${GCSFUSE_CLIENT_PROTOCOL:-http}
+readonly gcsfuse_client_protocol=${GCSFUSE_CLIENT_PROTOCOL:-http1}
 
 # Install golang
 version=1.22.7

--- a/test/e2e/run-e2e-local.sh
+++ b/test/e2e/run-e2e-local.sh
@@ -33,6 +33,7 @@ readonly ginkgo_skip="${E2E_TEST_SKIP:-should.succeed.in.performance.test}"
 readonly ginkgo_procs="${E2E_TEST_GINKGO_PROCS:-10}"
 readonly ginkgo_timeout="${E2E_TEST_GINKGO_TIMEOUT:-4h}"
 readonly ginkgo_flake_attempts="${E2E_TEST_GINKGO_FLAKE_ATTEMPTS:-2}"
+readonly gcsfuse_client_protocol=${GCSFUSE_CLIENT_PROTOCOL:-http1}
 
 # Initialize ginkgo.
 export PATH=${PATH}:$(go env GOPATH)/bin
@@ -59,6 +60,7 @@ base_cmd="${PKGDIR}/bin/e2e-test-ci \
             --ginkgo-skip=${ginkgo_skip} \
             --ginkgo-procs=${ginkgo_procs} \
             --ginkgo-timeout=${ginkgo_timeout} \
+            --gcsfuse-client-protocol=${gcsfuse_client_protocol} \
             --ginkgo-flake-attempts=${ginkgo_flake_attempts}"
 
 eval "$base_cmd"


### PR DESCRIPTION
Pass GCSFUSE_CLIENT_PROTOCOL envVar as a flag to testsuite to support gPRC tests locally.

cc. @saikat-royc 