### PR TITLE
Increase sidecar memory limit for gcsfuse integration tests on GKE.

### DIFF
--- a/test/e2e/testsuites/gcsfuse_integration.go
+++ b/test/e2e/testsuites/gcsfuse_integration.go
@@ -171,7 +171,7 @@ func (t *gcsFuseCSIGCSFuseIntegrationTestSuite) DefineTests(driver storageframew
 		tPod := specs.NewTestPod(f.ClientSet, f.Namespace)
 		tPod.SetImage(specs.GolangImage)
 		tPod.SetResource("1", "5Gi", "5Gi")
-		sidecarMemoryLimit := "256Mi"
+		sidecarMemoryLimit := "512Mi"
 
 		if testName == testNameWriteLargeFiles || testName == testNameReadLargeFiles {
 			tPod.SetResource("1", "6Gi", "5Gi")


### PR DESCRIPTION
/cc @saikat-royc 