### PR TITLE
Increase gcsfuse integration e2e test suite sidecar memory request and limits.

### DIFF
--- a/test/e2e/testsuites/gcsfuse_integration.go
+++ b/test/e2e/testsuites/gcsfuse_integration.go
@@ -54,6 +54,9 @@ const (
 	testNamePrefixSucceed = "should succeed in "
 
 	masterBranchName = "master"
+
+	defaultSidecarMemoryLimit   = "1Gi"
+	defaultSidecarMemoryRequest = "512Mi"
 )
 
 var gcsfuseVersionStr = ""
@@ -171,7 +174,7 @@ func (t *gcsFuseCSIGCSFuseIntegrationTestSuite) DefineTests(driver storageframew
 		tPod := specs.NewTestPod(f.ClientSet, f.Namespace)
 		tPod.SetImage(specs.GolangImage)
 		tPod.SetResource("1", "5Gi", "5Gi")
-		sidecarMemoryLimit := "512Mi"
+		sidecarMemoryLimit := defaultSidecarMemoryLimit
 
 		if testName == testNameWriteLargeFiles || testName == testNameReadLargeFiles {
 			tPod.SetResource("1", "6Gi", "5Gi")
@@ -188,6 +191,7 @@ func (t *gcsFuseCSIGCSFuseIntegrationTestSuite) DefineTests(driver storageframew
 		tPod.SetupVolume(l.volumeResource, volumeName, mountPath, readOnly, mountOptions...)
 		tPod.SetAnnotations(map[string]string{
 			"gke-gcsfuse/cpu-limit":               "1",
+			"gke-gcsfuse/memory-request":          defaultSidecarMemoryRequest,
 			"gke-gcsfuse/memory-limit":            sidecarMemoryLimit,
 			"gke-gcsfuse/ephemeral-storage-limit": "2Gi",
 		})

--- a/test/e2e/testsuites/gcsfuse_integration_file_cache.go
+++ b/test/e2e/testsuites/gcsfuse_integration_file_cache.go
@@ -149,7 +149,8 @@ func (t *gcsFuseCSIGCSFuseIntegrationFileCacheTestSuite) DefineTests(driver stor
 		tPod.SetupVolume(l.volumeResource, volumeName, mountPath, readOnly, mountOptions...)
 		tPod.SetAnnotations(map[string]string{
 			"gke-gcsfuse/cpu-limit":               "1",
-			"gke-gcsfuse/memory-limit":            "256Mi",
+			"gke-gcsfuse/memory-request":          defaultSidecarMemoryRequest,
+			"gke-gcsfuse/memory-limit":            defaultSidecarMemoryLimit,
 			"gke-gcsfuse/ephemeral-storage-limit": "2Gi",
 		})
 

--- a/test/e2e/testsuites/gcsfuse_integration_file_cache_parallel_downloads.go
+++ b/test/e2e/testsuites/gcsfuse_integration_file_cache_parallel_downloads.go
@@ -155,7 +155,8 @@ func (t *gcsFuseCSIGCSFuseIntegrationFileCacheParallelDownloadsTestSuite) Define
 		tPod.SetupVolume(l.volumeResource, volumeName, mountPath, readOnly, mountOptions...)
 		tPod.SetAnnotations(map[string]string{
 			"gke-gcsfuse/cpu-limit":               "1",
-			"gke-gcsfuse/memory-limit":            "256Mi",
+			"gke-gcsfuse/memory-request":          defaultSidecarMemoryRequest,
+			"gke-gcsfuse/memory-limit":            defaultSidecarMemoryLimit,
 			"gke-gcsfuse/ephemeral-storage-limit": "2Gi",
 		})
 


### PR DESCRIPTION
Following up from changes in #430. We are continuing to face flakey behavior on gcsfuse integration testsuite on GKE, this time affecting the remaining gcsfuse integration testsuites. We are increasing the minimum sidecar resource request and limit for all gcsfuse integration test suites to prevent OOM when testing gRPC. We are increasing the requested memory to prevent a sidecar from getting evicted in the event too many pods are bursting at the same time in the same node.

/cc @raj-prince 