### PR TITLE
Corrected go version command to use cut command

### DIFF
--- a/test/e2e/testsuites/gcsfuse_integration.go
+++ b/test/e2e/testsuites/gcsfuse_integration.go
@@ -61,7 +61,7 @@ const (
 
 var gcsfuseVersionStr = ""
 
-const gcsfuseGoVersionCommand = "GO_VERSION=$(grep -o 'go[0-9]\\+\\.[0-9]\\+\\.[0-9]\\+' ./gcsfuse/tools/cd_scripts/e2e_test.sh | sed 's/go//')"
+const gcsfuseGoVersionCommand = "GO_VERSION=$(grep -o 'go[0-9]\\+\\.[0-9]\\+\\.[0-9]\\+' ./gcsfuse/tools/cd_scripts/e2e_test.sh | cut -c3-)"
 
 func hnsEnabled(driver storageframework.TestDriver) bool {
 	gcsfuseCSITestDriver, ok := driver.(*specs.GCSFuseCSITestDriver)


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What this PR does / why we need it:**
This is a correction for https://github.com/GoogleCloudPlatform/gcs-fuse-csi-driver/pull/429 
This change corrects the command to grep go version it is needed because it is causing test failures

**Which issue(s) this PR fixes:**
Fixes # https://buganizer.corp.google.com/issues/379879910

**Special notes for your reviewer:**
n/a
**Does this PR introduce a user-facing change?:**
n/a