### PR TITLE
Add backward compatibility for testsuite to fix GKE Managed TestGrid.

### DIFF
--- a/test/e2e/testsuites/failed_mount.go
+++ b/test/e2e/testsuites/failed_mount.go
@@ -130,7 +130,12 @@ func (t *gcsFuseCSIFailedMountTestSuite) DefineTests(driver storageframework.Tes
 
 		ginkgo.By("Checking that the pod has failed mount error")
 		tPod.WaitForFailedMountError(ctx, codes.NotFound.String())
-		if configPrefix == specs.SkipCSIBucketAccessCheckAndFakeVolumePrefix {
+
+		if gcsfuseVersionStr == "" {
+			gcsfuseVersionStr = specs.GetGCSFuseVersion(ctx, f.ClientSet)
+		}
+		v, err := version.ParseSemantic(gcsfuseVersionStr)
+		if err == nil && configPrefix == specs.SkipCSIBucketAccessCheckAndFakeVolumePrefix && v.AtLeast(version.MustParseSemantic("v2.5.0")) {
 			tPod.WaitForLog(ctx, webhook.GcsFuseSidecarName, "bucket does not exist")
 		} else {
 			tPod.WaitForFailedMountError(ctx, "storage: bucket doesn't exist")

--- a/test/e2e/testsuites/gcsfuse_integration.go
+++ b/test/e2e/testsuites/gcsfuse_integration.go
@@ -537,15 +537,26 @@ func (t *gcsFuseCSIGCSFuseIntegrationTestSuite) DefineTests(driver storageframew
 	ginkgo.It(testNamePrefixSucceed+testNameKernelListCache+testNameSuffix(9), func() {
 		init()
 		defer cleanup()
+		testNameByVersion := "TestInfiniteKernelListCacheTest"
+		v, _ := version.ParseSemantic(gcsfuseVersionStr)
+		if v.AtLeast(version.MustParseSemantic("2.7.0")) {
+			testNameByVersion = "TestInfiniteKernelListCacheDeleteDirTest"
+		}
 
-		gcsfuseIntegrationTest(testNameKernelListCache+":TestInfiniteKernelListCacheDeleteDirTest/TestKernelListCache_ListAndDeleteDirectory", false, "implicit-dirs=true", "kernel-list-cache-ttl-secs=-1", "metadata-cache-ttl-secs=0")
+		gcsfuseIntegrationTest(testNameKernelListCache+":"+testNameByVersion+"/TestKernelListCache_ListAndDeleteDirectory", false, "implicit-dirs=true", "kernel-list-cache-ttl-secs=-1", "metadata-cache-ttl-secs=0")
 	})
 
 	ginkgo.It(testNamePrefixSucceed+testNameKernelListCache+testNameSuffix(10), func() {
 		init()
 		defer cleanup()
 
-		gcsfuseIntegrationTest(testNameKernelListCache+":TestInfiniteKernelListCacheDeleteDirTest/TestKernelListCache_DeleteAndListDirectory", false, "implicit-dirs=true", "kernel-list-cache-ttl-secs=-1", "metadata-cache-ttl-secs=0")
+		testNameByVersion := "TestInfiniteKernelListCacheTest"
+		v, _ := version.ParseSemantic(gcsfuseVersionStr)
+		if v.AtLeast(version.MustParseSemantic("2.7.0")) {
+			testNameByVersion = "TestInfiniteKernelListCacheDeleteDirTest"
+		}
+
+		gcsfuseIntegrationTest(testNameKernelListCache+":"+testNameByVersion+"/TestKernelListCache_DeleteAndListDirectory", false, "implicit-dirs=true", "kernel-list-cache-ttl-secs=-1", "metadata-cache-ttl-secs=0")
 	})
 
 	ginkgo.It(testNamePrefixSucceed+testNameKernelListCache+testNameSuffix(11), func() {


### PR DESCRIPTION
On  #443 and #448, we modified testsuite behavior for new versions, but these changes are not backwards compatible with older GKE versions. Adding backward compatibility for testsuite to fix managed TestGrid.