### PR TITLE
Update gcsfuse version that supports InvalidArgument error code to v2.9.0.

### DIFF
--- a/test/e2e/testsuites/failed_mount.go
+++ b/test/e2e/testsuites/failed_mount.go
@@ -180,7 +180,7 @@ func (t *gcsFuseCSIFailedMountTestSuite) DefineTests(driver storageframework.Tes
 			gcsfuseVersionStr = specs.GetGCSFuseVersion(ctx, f.ClientSet)
 		}
 		v, err := version.ParseSemantic(gcsfuseVersionStr)
-		if configPrefix == specs.SkipCSIBucketAccessCheckAndInvalidVolumePrefix && (err != nil || v.AtLeast(version.MustParseSemantic("v2.5.0"))) {
+		if configPrefix == specs.SkipCSIBucketAccessCheckAndInvalidVolumePrefix && (err != nil || v.AtLeast(version.MustParseSemantic("v2.9.0"))) {
 			tPod.WaitForFailedMountError(ctx, codes.InvalidArgument.String())
 			tPod.WaitForFailedMountError(ctx, "name should be a valid bucket resource name")
 		} else {


### PR DESCRIPTION
Update gcsfuse version that supports InvalidArgument error code. We know the version v2.9.0 starts supporting this new error code type, but we had changed it accidentally in #454