### PR TITLE
Update gcsfuse_binary to v2.9.1

### DIFF
--- a/cmd/sidecar_mounter/gcsfuse_binary
+++ b/cmd/sidecar_mounter/gcsfuse_binary
@@ -1,1 +1,1 @@
-gs://gke-release-staging/gcsfuse/v2.9.0-gke.0/gcsfuse_bin
+gs://gke-release-staging/gcsfuse/v2.9.1-gke.0/gcsfuse_bin


### PR DESCRIPTION
Update gcsfuse_binary to v2.9.1 to address bug in v2.9.0

More details on [here](https://github.com/GoogleCloudPlatform/gcsfuse/releases/tag/v2.9.1)