### PR TITLE
Update port used by GCSFuse metrics endpoint.

### DIFF
--- a/pkg/sidecar_mounter/sidecar_mounter_config.go
+++ b/pkg/sidecar_mounter/sidecar_mounter_config.go
@@ -58,7 +58,7 @@ type MountConfig struct {
 	PodShouldUseTokenServer bool                  `json:"-"`
 }
 
-var prometheusPort = 8080
+var prometheusPort = 62990
 
 var disallowedFlags = map[string]bool{
 	"temp-dir":                             true,

--- a/pkg/sidecar_mounter/sidecar_mounter_config_test.go
+++ b/pkg/sidecar_mounter/sidecar_mounter_config_test.go
@@ -235,7 +235,7 @@ func TestPrepareMountArgs(t *testing.T) {
 		},
 	}
 
-	prometheusPort := 8080
+	prometheusPort := 62990
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Update port used by GCSFuse metrics endpoint to reduce likelyhood of running into port coflicts in #392

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Update port used by GCSFuse metrics endpoint to reduce port conflicts.
```