### PR TITLE
Added capability to provide metadata prefetch memory request and limits in pod spec

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -39,21 +39,27 @@ import (
 )
 
 var (
-	port                    = flag.Int("port", 443, "The port that the webhook server serves at.")
-	healthProbeBindAddress  = flag.String("health-probe-bind-address", ":8080", "The TCP address that the controller should bind to for serving health probes.")
-	certDir                 = flag.String("cert-dir", "/etc/tls-certs", "The directory that contains the server key and certificate.")
-	certName                = flag.String("cert-name", "cert.pem", "The server certificate name.")
-	keyName                 = flag.String("key-name", "key.pem", "The server key name.")
-	imagePullPolicy         = flag.String("sidecar-image-pull-policy", "IfNotPresent", "The default image pull policy for gcsfuse sidecar container.")
-	cpuRequest              = flag.String("sidecar-cpu-request", "250m", "The default CPU request for gcsfuse sidecar container.")
-	cpuLimit                = flag.String("sidecar-cpu-limit", "250m", "The default CPU limit for gcsfuse sidecar container.")
-	memoryRequest           = flag.String("sidecar-memory-request", "256Mi", "The default memory request for gcsfuse sidecar container.")
-	memoryLimit             = flag.String("sidecar-memory-limit", "256Mi", "The default memory limit for gcsfuse sidecar container.")
-	ephemeralStorageRequest = flag.String("sidecar-ephemeral-storage-request", "5Gi", "The default ephemeral storage request for gcsfuse sidecar container.")
-	ephemeralStorageLimit   = flag.String("sidecar-ephemeral-storage-limit", "5Gi", "The default ephemeral storage limit for gcsfuse sidecar container.")
-	sidecarImage            = flag.String("sidecar-image", "", "The gcsfuse sidecar container image.")
-	metadataSidecarImage    = flag.String("metadata-sidecar-image", "", "The metadata prefetch sidecar container image.")
-	injectSAVol             = flag.Bool("should-inject-sa-vol", false, "Inject projected service account volume when true")
+	port                                    = flag.Int("port", 443, "The port that the webhook server serves at.")
+	healthProbeBindAddress                  = flag.String("health-probe-bind-address", ":8080", "The TCP address that the controller should bind to for serving health probes.")
+	certDir                                 = flag.String("cert-dir", "/etc/tls-certs", "The directory that contains the server key and certificate.")
+	certName                                = flag.String("cert-name", "cert.pem", "The server certificate name.")
+	keyName                                 = flag.String("key-name", "key.pem", "The server key name.")
+	imagePullPolicy                         = flag.String("sidecar-image-pull-policy", "IfNotPresent", "The default image pull policy for gcsfuse sidecar container.")
+	cpuRequest                              = flag.String("sidecar-cpu-request", "250m", "The default CPU request for gcsfuse sidecar container.")
+	cpuLimit                                = flag.String("sidecar-cpu-limit", "250m", "The default CPU limit for gcsfuse sidecar container.")
+	memoryRequest                           = flag.String("sidecar-memory-request", "256Mi", "The default memory request for gcsfuse sidecar container.")
+	memoryLimit                             = flag.String("sidecar-memory-limit", "256Mi", "The default memory limit for gcsfuse sidecar container.")
+	ephemeralStorageRequest                 = flag.String("sidecar-ephemeral-storage-request", "5Gi", "The default ephemeral storage request for gcsfuse sidecar container.")
+	ephemeralStorageLimit                   = flag.String("sidecar-ephemeral-storage-limit", "5Gi", "The default ephemeral storage limit for gcsfuse sidecar container.")
+	sidecarImage                            = flag.String("sidecar-image", "", "The gcsfuse sidecar container image.")
+	metadataSidecarImage                    = flag.String("metadata-sidecar-image", "", "The metadata prefetch sidecar container image.")
+	injectSAVol                             = flag.Bool("should-inject-sa-vol", false, "Inject projected service account volume when true")
+	metadataMemoryRequest                   = flag.String("metadata-sidecar-memory-request", "10Mi", "Flag to use default value for gcsfuse memory prefetch sidecar container memory request.")
+	metadataMemoryLimit                     = flag.String("metadata-sidecar-memory-limit", "10Mi", "Flag to use default value for gcsfuse memory prefetch sidecar container memory limit.")
+	metadataPrefetchCPURequest              = flag.String("metadata-sidecar-cpu-request", "10m", "The default cpu request for gcsfuse memory prefetch sidecar container cpu request.")
+	metadataPrefetchCPULimit                = flag.String("metadata-sidecar-cpu-request", "50m", "Flag to use default value for gcsfuse memory prefetch sidecar container cpu limit.")
+	metadataPrefetchEphemeralStorageRequest = flag.String("metadata-sidecar-ephemeral-storage-request", "10Mi", "The default value for gcsfuse memory prefetch sidecar ephemeral storage request.")
+	metadataPrefetchEphemeralStorageLimit   = flag.String("metadata-sidecar-ephemeral-storage-request", "10Mi", "The default value for gcsfuse memory prefetch sidecar ephemeral storage limit.")
 	// These are set at compile time.
 	webhookVersion = "unknown"
 )
@@ -73,9 +79,11 @@ func main() {
 	klog.Infof("Running Google Cloud Storage FUSE CSI driver admission webhook version %v, sidecar container image %v", webhookVersion, *sidecarImage)
 
 	// Load webhook config
-	c := wh.LoadConfig(*sidecarImage, *metadataSidecarImage, *imagePullPolicy, *cpuRequest, *cpuLimit, *memoryRequest, *memoryLimit, *ephemeralStorageRequest, *ephemeralStorageLimit)
-	c.ShouldInjectSAVolume = *injectSAVol
-	klog.Infof("Webhook should inject SA volume: %t", c.ShouldInjectSAVolume)
+	fuseSideCarConfig := wh.LoadConfig(*sidecarImage, *imagePullPolicy, *cpuRequest, *cpuLimit, *memoryRequest, *memoryLimit, *ephemeralStorageRequest, *ephemeralStorageLimit)
+	fuseSideCarConfig.ShouldInjectSAVolume = *injectSAVol
+	klog.Infof("Webhook should inject SA volume: %t", fuseSideCarConfig.ShouldInjectSAVolume)
+
+	metadataPrefetchSideCarConfig := wh.LoadConfig(*metadataSidecarImage, *imagePullPolicy, *metadataPrefetchCPURequest, *metadataPrefetchCPULimit, *metadataMemoryRequest, *metadataMemoryLimit, *metadataPrefetchEphemeralStorageRequest, *metadataPrefetchEphemeralStorageLimit)
 
 	// Load config for manager, informers, listers
 	kubeConfig := config.GetConfigOrDie()
@@ -141,13 +149,14 @@ func main() {
 	klog.Info("Registering webhooks to the webhook server.")
 	hookServer.Register("/inject", &webhook.Admission{
 		Handler: &wh.SidecarInjector{
-			Client:        mgr.GetClient(),
-			Config:        c,
-			Decoder:       admission.NewDecoder(runtime.NewScheme()),
-			NodeLister:    nodeLister,
-			PvLister:      pvLister,
-			PvcLister:     pvcLister,
-			ServerVersion: serverVersion,
+			Client:                 mgr.GetClient(),
+			Config:                 fuseSideCarConfig,
+			MetadataPrefetchConfig: metadataPrefetchSideCarConfig,
+			Decoder:                admission.NewDecoder(runtime.NewScheme()),
+			NodeLister:             nodeLister,
+			PvLister:               pvLister,
+			PvcLister:              pvcLister,
+			ServerVersion:          serverVersion,
 		},
 	})
 

--- a/pkg/webhook/config.go
+++ b/pkg/webhook/config.go
@@ -20,6 +20,7 @@ package webhook
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -27,29 +28,27 @@ import (
 )
 
 type Config struct {
-	ShouldInjectSAVolume   bool   `json:"-"`
-	PodHostNetworkSetting  bool   `json:"-"`
-	ContainerImage         string `json:"-"`
-	MetadataContainerImage string `json:"-"`
-	ImagePullPolicy        string `json:"-"`
+	ShouldInjectSAVolume  bool   `json:"-"`
+	PodHostNetworkSetting bool   `json:"-"`
+	ContainerImage        string `json:"-"`
+	ImagePullPolicy       string `json:"-"`
 	//nolint:tagliatelle
-	CPURequest resource.Quantity `json:"gke-gcsfuse/cpu-request,omitempty"`
+	CPURequest resource.Quantity `json:"cpu-request,omitempty"`
 	//nolint:tagliatelle
-	CPULimit resource.Quantity `json:"gke-gcsfuse/cpu-limit,omitempty"`
+	CPULimit resource.Quantity `json:"cpu-limit,omitempty"`
 	//nolint:tagliatelle
-	MemoryRequest resource.Quantity `json:"gke-gcsfuse/memory-request,omitempty"`
+	MemoryRequest resource.Quantity `json:"memory-request,omitempty"`
 	//nolint:tagliatelle
-	MemoryLimit resource.Quantity `json:"gke-gcsfuse/memory-limit,omitempty"`
+	MemoryLimit resource.Quantity `json:"memory-limit,omitempty"`
 	//nolint:tagliatelle
-	EphemeralStorageRequest resource.Quantity `json:"gke-gcsfuse/ephemeral-storage-request,omitempty"`
+	EphemeralStorageRequest resource.Quantity `json:"ephemeral-storage-request,omitempty"`
 	//nolint:tagliatelle
-	EphemeralStorageLimit resource.Quantity `json:"gke-gcsfuse/ephemeral-storage-limit,omitempty"`
+	EphemeralStorageLimit resource.Quantity `json:"ephemeral-storage-limit,omitempty"`
 }
 
-func LoadConfig(containerImage, metadataContainerImage, imagePullPolicy, cpuRequest, cpuLimit, memoryRequest, memoryLimit, ephemeralStorageRequest, ephemeralStorageLimit string) *Config {
+func LoadConfig(containerImage, imagePullPolicy, cpuRequest, cpuLimit, memoryRequest, memoryLimit, ephemeralStorageRequest, ephemeralStorageLimit string) *Config {
 	return &Config{
 		ContainerImage:          containerImage,
-		MetadataContainerImage:  metadataContainerImage,
 		ImagePullPolicy:         imagePullPolicy,
 		CPURequest:              resource.MustParse(cpuRequest),
 		CPULimit:                resource.MustParse(cpuLimit),
@@ -62,9 +61,12 @@ func LoadConfig(containerImage, metadataContainerImage, imagePullPolicy, cpuRequ
 
 func FakeConfig() *Config {
 	fakeImage1 := "fake-repo/fake-sidecar-image:v999.999.999-gke.0@sha256:c9cd4cde857ab8052f416609184e2900c0004838231ebf1c3817baa37f21d847"
-	fakeImage2 := "fake-repo/fake-sidecar-image:v888.888.888-gke.0@sha256:c9cd4cde857ab8052f416609184e2900c0004838231ebf1c3817baa37f21d847"
 
-	return LoadConfig(fakeImage1, fakeImage2, "Always", "250m", "250m", "256Mi", "256Mi", "5Gi", "5Gi")
+	return LoadConfig(fakeImage1, "Always", "250m", "250m", "256Mi", "256Mi", "5Gi", "5Gi")
+}
+
+func FakePrefetchConfig() *Config {
+	return LoadConfig("fake-image", "Always", "10m", "50m", "10Mi", "10Mi", "10Mi", "10Mi")
 }
 
 func prepareResourceList(c *Config) (corev1.ResourceList, corev1.ResourceList) {
@@ -115,30 +117,62 @@ func populateResource(requestQuantity, limitQuantity *resource.Quantity, default
 	}
 }
 
-// prepareConfig overwrittes config values set by user input from pod annotations,
+// prepareConfig overwrites config values set by user input from pod annotations,
 // remaining values that are not specified by user are kept as the default config values.
-func (si *SidecarInjector) prepareConfig(annotations map[string]string) (*Config, error) {
-	config := &Config{
-		ShouldInjectSAVolume:   si.Config.ShouldInjectSAVolume,
-		ContainerImage:         si.Config.ContainerImage,
-		MetadataContainerImage: si.Config.MetadataContainerImage,
-		ImagePullPolicy:        si.Config.ImagePullPolicy,
-	}
-
-	jsonData, err := json.Marshal(annotations)
+func (si *SidecarInjector) prepareConfig(prefix string, pod corev1.Pod) (*Config, error) {
+	defaultConfig, err := si.getDefaultConfig(prefix)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal pod annotations: %w", err)
+		return nil, err
 	}
 
-	if err := json.Unmarshal(jsonData, config); err != nil {
-		return nil, fmt.Errorf("failed to parse sidecar container resource allocation from pod annotations: %w", err)
+	config, err := getConfigFromAnnotation(*defaultConfig, prefix, pod.Annotations)
+	if err != nil {
+		return nil, err
 	}
 
-	populateResource(&config.CPURequest, &config.CPULimit, si.Config.CPURequest, si.Config.CPULimit)
-	populateResource(&config.MemoryRequest, &config.MemoryLimit, si.Config.MemoryRequest, si.Config.MemoryLimit)
-	populateResource(&config.EphemeralStorageRequest, &config.EphemeralStorageLimit, si.Config.EphemeralStorageRequest, si.Config.EphemeralStorageLimit)
+	populateResource(&config.CPURequest, &config.CPULimit, defaultConfig.CPURequest, defaultConfig.CPULimit)
+	populateResource(&config.MemoryRequest, &config.MemoryLimit, defaultConfig.MemoryRequest, defaultConfig.MemoryLimit)
+	populateResource(&config.EphemeralStorageRequest, &config.EphemeralStorageLimit, defaultConfig.EphemeralStorageRequest, defaultConfig.EphemeralStorageLimit)
 
 	return config, nil
+}
+
+func getConfigFromAnnotation(defaultConfig Config, prefix string, annotations map[string]string) (*Config, error) {
+	config := &Config{
+		ShouldInjectSAVolume: defaultConfig.ShouldInjectSAVolume,
+		ContainerImage:       defaultConfig.ContainerImage,
+		ImagePullPolicy:      defaultConfig.ImagePullPolicy,
+	}
+	extractedData := make(map[string]string)
+	for key, value := range annotations {
+		// Check if the key starts with the given prefix
+		if strings.HasPrefix(key, prefix) {
+			// Remove the prefix and keep only the case name
+			newKey := strings.TrimPrefix(key, prefix)
+			extractedData[newKey] = value
+		}
+	}
+	extractedJSON, err := json.Marshal(extractedData)
+	if err != nil {
+		return config, fmt.Errorf("failed to parse sidecar container resource allocation from pod annotations: %w", err)
+	}
+	err = json.Unmarshal(extractedJSON, config)
+	if err != nil {
+		return config, fmt.Errorf("failed to parse sidecar container resource allocation from pod annotations: %w", err)
+	}
+
+	return config, nil
+}
+
+func (si *SidecarInjector) getDefaultConfig(prefix string) (*Config, error) {
+	switch prefix {
+	case sidecarPrefixMap[GcsFuseSidecarName]:
+		return si.Config, nil
+	case sidecarPrefixMap[MetadataPrefetchSidecarName]:
+		return si.MetadataPrefetchConfig, nil
+	default:
+		return nil, fmt.Errorf("invalid sidecar name: %s", prefix)
+	}
 }
 
 func LogPodMutation(pod *corev1.Pod, sidecarConfig *Config) {

--- a/pkg/webhook/injection.go
+++ b/pkg/webhook/injection.go
@@ -24,7 +24,19 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 )
+
+var sidecarPrefixMap = map[string]string{
+	GcsFuseSidecarName:          "gke-gcsfuse/",
+	MetadataPrefetchSidecarName: "gke-gcsfuse/metadata-prefetch/",
+}
+
+// used to guarantee containers start in the correct sequence based on inter-container dependencies.
+var containerIndexOrderMap = map[string]string{
+	GcsFuseSidecarName:          IstioSidecarName,
+	MetadataPrefetchSidecarName: GcsFuseSidecarName,
+}
 
 const IstioSidecarName = "istio-proxy"
 
@@ -86,56 +98,46 @@ func (si *SidecarInjector) supportsNativeSidecar() (bool, error) {
 	return supportsNativeSidecar, nil
 }
 
-func injectSidecarContainer(pod *corev1.Pod, config *Config, injectAsNativeSidecar bool) {
-	if injectAsNativeSidecar {
-		pod.Spec.InitContainers = insert(pod.Spec.InitContainers, GetNativeSidecarContainerSpec(config), getInjectIndex(pod.Spec.InitContainers))
-	} else {
-		pod.Spec.Containers = insert(pod.Spec.Containers, GetSidecarContainerSpec(config), getInjectIndex(pod.Spec.Containers))
-	}
-}
-
-func (si *SidecarInjector) injectMetadataPrefetchSidecarContainer(pod *corev1.Pod, config *Config, injectAsNativeSidecar bool) {
+// InjectSidecarContainer injects a sidecar container into the pod and returns error if unexpected event occurs.
+func (si *SidecarInjector) injectSidecarContainer(containerName string, pod *corev1.Pod, injectAsNativeSidecar bool) error {
 	var containerSpec corev1.Container
 	var index int
-
-	injected, _ := validatePodHasSidecarContainerInjected(MetadataPrefetchSidecarName, pod, []corev1.Volume{}, []corev1.VolumeMount{})
-	if injected {
-		klog.Infof("%s is already injected, skipping injection", MetadataPrefetchSidecarName)
-
-		return
+	config, err := si.prepareConfig(sidecarPrefixMap[containerName], *pod)
+	if err != nil {
+		return err
 	}
+	config.PodHostNetworkSetting = pod.Spec.HostNetwork
 
 	// Extract user provided metadata prefetch sidecar image.
-	userProvidedMetadataPrefetchSidecarImage, err := ExtractImageAndDeleteContainer(&pod.Spec, MetadataPrefetchSidecarName)
-	if err != nil {
-		klog.Errorf("failed to get user provided metadata prefetch image. skipping injection")
-
-		return
-	}
-
-	if userProvidedMetadataPrefetchSidecarImage != "" {
-		config.MetadataContainerImage = userProvidedMetadataPrefetchSidecarImage
-	}
-
-	if injectAsNativeSidecar {
-		containerSpec = si.GetNativeMetadataPrefetchSidecarContainerSpec(pod, config.MetadataContainerImage)
-		index = getInjectIndexAfterContainer(pod.Spec.InitContainers, GcsFuseSidecarName)
+	if userProvidedSidecarImage, err := ExtractImageAndDeleteContainer(&pod.Spec, containerName); err == nil {
+		if userProvidedSidecarImage != "" {
+			config.ContainerImage = userProvidedSidecarImage
+		}
 	} else {
-		containerSpec = si.GetMetadataPrefetchSidecarContainerSpec(pod, config.MetadataContainerImage)
-		index = getInjectIndexAfterContainer(pod.Spec.Containers, GcsFuseSidecarName)
+		return err
 	}
 
-	if len(containerSpec.VolumeMounts) == 0 {
+	// Retrieve container spec and index to inject sidecar for either init containers or regular based on native sidecar support.
+	if injectAsNativeSidecar {
+		containerSpec = si.getNativeContainerSpec(containerName, pod, config)
+		index = getInjectIndexAfterContainer(pod.Spec.InitContainers, containerIndexOrderMap[containerName])
+	} else {
+		containerSpec = si.getContainerSpec(containerName, pod, config)
+		index = getInjectIndexAfterContainer(pod.Spec.Containers, containerIndexOrderMap[containerName])
+	}
+
+	// Skip metadata prefetch sidecar injection if no volumes are requesting metadata prefetch.
+	if containerName == MetadataPrefetchSidecarName && len(containerSpec.VolumeMounts) == 0 {
 		klog.Info("no volumes are requesting metadata prefetch, skipping metadata prefetch sidecar injection")
 
-		return
+		return nil
 	}
 
 	// This should not happen as we always inject the sidecar after injecting our primary gcsfuse sidecar.
-	if index == 0 {
-		klog.Warningf("%s not found when attempting to inject metadata prefetch sidecar. skipping injection", GcsFuseSidecarName)
+	if containerName == MetadataPrefetchSidecarName && index == 0 {
+		klog.Warningf("%s not found when attempting to inject container. skipping injection", containerIndexOrderMap[containerName])
 
-		return
+		return fmt.Errorf("%s", (containerIndexOrderMap[containerName] + "not found when attempting to inject metadata prefetch. skipping injection"))
 	}
 
 	if injectAsNativeSidecar {
@@ -143,6 +145,26 @@ func (si *SidecarInjector) injectMetadataPrefetchSidecarContainer(pod *corev1.Po
 	} else {
 		pod.Spec.Containers = insert(pod.Spec.Containers, containerSpec, index)
 	}
+	// Log pod mutation after fuse sidecar injection.
+	LogPodMutation(pod, config)
+
+	return nil
+}
+
+func (si *SidecarInjector) getNativeContainerSpec(containerName string, pod *corev1.Pod, config *Config) corev1.Container {
+	containerSpec := si.getContainerSpec(containerName, pod, config)
+	containerSpec.Env = append(containerSpec.Env, corev1.EnvVar{Name: "NATIVE_SIDECAR", Value: "TRUE"})
+	containerSpec.RestartPolicy = ptr.To(corev1.ContainerRestartPolicyAlways)
+
+	return containerSpec
+}
+
+func (si *SidecarInjector) getContainerSpec(containerName string, pod *corev1.Pod, config *Config) corev1.Container {
+	if containerName == MetadataPrefetchSidecarName {
+		return si.GetMetadataPrefetchSidecarContainerSpec(pod, config)
+	}
+
+	return GetSidecarContainerSpec(config)
 }
 
 func insert(a []corev1.Container, value corev1.Container, index int) []corev1.Container {

--- a/pkg/webhook/injection_test.go
+++ b/pkg/webhook/injection_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/client-go/informers"
@@ -33,6 +34,19 @@ import (
 )
 
 var UnsupportedVersion = version.MustParseGeneric("1.28.0")
+
+func getDefaultMetadataPrefetchConfig(image string) *Config {
+	return &Config{
+		CPURequest:              resource.MustParse("10m"),
+		CPULimit:                resource.MustParse("50m"),
+		MemoryRequest:           resource.MustParse("10Mi"),
+		MemoryLimit:             resource.MustParse("10Mi"),
+		EphemeralStorageRequest: resource.MustParse("10Mi"),
+		EphemeralStorageLimit:   resource.MustParse("10Mi"),
+		ImagePullPolicy:         "Always",
+		ContainerImage:          image,
+	}
+}
 
 func TestInjectAsNativeSidecar(t *testing.T) {
 	t.Parallel()
@@ -514,7 +528,8 @@ func TestGetInjectIndex(t *testing.T) {
 func TestInjectMetadataPrefetchSidecar(t *testing.T) {
 	t.Parallel()
 
-	limits, requests := prepareResourceList(getMetadataPrefetchConfig("fake-image"))
+	limits, requests := prepareResourceList(getDefaultMetadataPrefetchConfig("fake-image"))
+	customLimits, customRequests := prepareResourceList(LoadConfig("fake-image", "Always", "250m", "250m", "20Mi", "20Mi", "5Gi", "5Gi"))
 
 	testCases := []struct {
 		testName      string
@@ -796,65 +811,6 @@ func TestInjectMetadataPrefetchSidecar(t *testing.T) {
 			},
 		},
 		{
-			testName: "fuse sidecar not present, already injected",
-			pod: &corev1.Pod{
-				Spec: corev1.PodSpec{
-					InitContainers: []corev1.Container{
-						{
-							Name:            MetadataPrefetchSidecarName,
-							Image:           "my-private-image",
-							SecurityContext: GetSecurityContext(),
-						},
-						{
-							Name: "two",
-						},
-						{
-							Name: "three",
-						},
-					},
-					Containers: []corev1.Container{
-						{
-							Name: "workload-one",
-						},
-						{
-							Name: "workload-two",
-						},
-						{
-							Name: "workload-three",
-						},
-					},
-				},
-			},
-			expectedPod: &corev1.Pod{
-				Spec: corev1.PodSpec{
-					InitContainers: []corev1.Container{
-						{
-							Name:            MetadataPrefetchSidecarName,
-							Image:           "my-private-image",
-							SecurityContext: GetSecurityContext(),
-						},
-						{
-							Name: "two",
-						},
-						{
-							Name: "three",
-						},
-					},
-					Containers: []corev1.Container{
-						{
-							Name: "workload-one",
-						},
-						{
-							Name: "workload-two",
-						},
-						{
-							Name: "workload-three",
-						},
-					},
-				},
-			},
-		},
-		{
 			testName: "fuse sidecar not present, privately hosted image",
 			pod: &corev1.Pod{
 				Spec: corev1.PodSpec{
@@ -985,6 +941,8 @@ func TestInjectMetadataPrefetchSidecar(t *testing.T) {
 							Env:             []corev1.EnvVar{{Name: "NATIVE_SIDECAR", Value: "TRUE"}},
 							RestartPolicy:   ptr.To(corev1.ContainerRestartPolicyAlways),
 							SecurityContext: GetSecurityContext(),
+							Image:           FakePrefetchConfig().ContainerImage,
+							ImagePullPolicy: corev1.PullPolicy(FakePrefetchConfig().ImagePullPolicy),
 							Resources: corev1.ResourceRequirements{
 								Requests: requests,
 								Limits:   limits,
@@ -1026,9 +984,236 @@ func TestInjectMetadataPrefetchSidecar(t *testing.T) {
 			},
 		},
 		{
-			testName: "fuse sidecar present with many volumes and config, injection successful",
-			config:   *FakeConfig(),
+			testName: "fuse sidecar present, injection successful, with custom memory limits and requests",
 			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: generateAnnotationsFromConfig(LoadConfig("fake-image", "Always", "250m", "250m", "20Mi", "20Mi", "5Gi", "5Gi"), sidecarPrefixMap[MetadataPrefetchSidecarName]),
+				},
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name: GcsFuseSidecarName,
+						},
+						{
+							Name: "two",
+						},
+						{
+							Name: "three",
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name: "workload-one",
+						},
+						{
+							Name: "workload-two",
+						},
+						{
+							Name: "workload-three",
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "my-volume",
+							VolumeSource: corev1.VolumeSource{
+								CSI: &corev1.CSIVolumeSource{
+									Driver: gcsFuseCsiDriverName,
+									VolumeAttributes: map[string]string{
+										gcsFuseMetadataPrefetchOnMountVolumeAttribute: "true",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"gke-gcsfuse/metadata-prefetch/container-image":           "fake-image",
+						"gke-gcsfuse/metadata-prefetch/cpu-limit":                 "250m",
+						"gke-gcsfuse/metadata-prefetch/cpu-request":               "250m",
+						"gke-gcsfuse/metadata-prefetch/ephemeral-storage-limit":   "5Gi",
+						"gke-gcsfuse/metadata-prefetch/ephemeral-storage-request": "5Gi",
+						"gke-gcsfuse/metadata-prefetch/image-pull-policy":         "Always",
+						"gke-gcsfuse/metadata-prefetch/memory-limit":              "20Mi",
+						"gke-gcsfuse/metadata-prefetch/memory-request":            "20Mi",
+					},
+				},
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name: GcsFuseSidecarName,
+						},
+						{
+							Name:            MetadataPrefetchSidecarName,
+							Image:           "fake-image",
+							ImagePullPolicy: corev1.PullPolicy(FakeConfig().ImagePullPolicy),
+							Env:             []corev1.EnvVar{{Name: "NATIVE_SIDECAR", Value: "TRUE"}},
+							RestartPolicy:   ptr.To(corev1.ContainerRestartPolicyAlways),
+							SecurityContext: GetSecurityContext(),
+							Resources: corev1.ResourceRequirements{
+								Requests: customRequests,
+								Limits:   customLimits,
+							},
+							VolumeMounts: []corev1.VolumeMount{{Name: "my-volume", ReadOnly: true, MountPath: "/volumes/my-volume"}},
+						},
+						{
+							Name: "two",
+						},
+						{
+							Name: "three",
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name: "workload-one",
+						},
+						{
+							Name: "workload-two",
+						},
+						{
+							Name: "workload-three",
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "my-volume",
+							VolumeSource: corev1.VolumeSource{
+								CSI: &corev1.CSIVolumeSource{
+									Driver: gcsFuseCsiDriverName,
+									VolumeAttributes: map[string]string{
+										gcsFuseMetadataPrefetchOnMountVolumeAttribute: "true",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			testName: "fuse sidecar present, injection successful, with custom memory requests no limit provided",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: generateAnnotationsFromConfig(&Config{
+						ContainerImage:          "fake-image",
+						ImagePullPolicy:         "Always",
+						CPURequest:              resource.MustParse("250m"),
+						CPULimit:                resource.MustParse("250m"),
+						MemoryRequest:           resource.MustParse("20Mi"),
+						EphemeralStorageRequest: resource.MustParse("5Gi"),
+						EphemeralStorageLimit:   resource.MustParse("5Gi"),
+					}, sidecarPrefixMap[MetadataPrefetchSidecarName]),
+				},
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name: GcsFuseSidecarName,
+						},
+						{
+							Name: "two",
+						},
+						{
+							Name: "three",
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name: "workload-one",
+						},
+						{
+							Name: "workload-two",
+						},
+						{
+							Name: "workload-three",
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "my-volume",
+							VolumeSource: corev1.VolumeSource{
+								CSI: &corev1.CSIVolumeSource{
+									Driver: gcsFuseCsiDriverName,
+									VolumeAttributes: map[string]string{
+										gcsFuseMetadataPrefetchOnMountVolumeAttribute: "true",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"gke-gcsfuse/metadata-prefetch/container-image":           "fake-image",
+						"gke-gcsfuse/metadata-prefetch/cpu-limit":                 "250m",
+						"gke-gcsfuse/metadata-prefetch/cpu-request":               "250m",
+						"gke-gcsfuse/metadata-prefetch/ephemeral-storage-limit":   "5Gi",
+						"gke-gcsfuse/metadata-prefetch/ephemeral-storage-request": "5Gi",
+						"gke-gcsfuse/metadata-prefetch/image-pull-policy":         "Always",
+						"gke-gcsfuse/metadata-prefetch/memory-request":            "20Mi",
+					},
+				},
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name: GcsFuseSidecarName,
+						},
+						{
+							Name:            MetadataPrefetchSidecarName,
+							Image:           FakePrefetchConfig().ContainerImage,
+							ImagePullPolicy: corev1.PullPolicy(FakeConfig().ImagePullPolicy),
+							Env:             []corev1.EnvVar{{Name: "NATIVE_SIDECAR", Value: "TRUE"}},
+							RestartPolicy:   ptr.To(corev1.ContainerRestartPolicyAlways),
+							SecurityContext: GetSecurityContext(),
+							Resources: corev1.ResourceRequirements{
+								Requests: customRequests,
+								Limits:   customLimits,
+							},
+							VolumeMounts: []corev1.VolumeMount{{Name: "my-volume", ReadOnly: true, MountPath: "/volumes/my-volume"}},
+						},
+						{
+							Name: "two",
+						},
+						{
+							Name: "three",
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name: "workload-one",
+						},
+						{
+							Name: "workload-two",
+						},
+						{
+							Name: "workload-three",
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "my-volume",
+							VolumeSource: corev1.VolumeSource{
+								CSI: &corev1.CSIVolumeSource{
+									Driver: gcsFuseCsiDriverName,
+									VolumeAttributes: map[string]string{
+										gcsFuseMetadataPrefetchOnMountVolumeAttribute: "true",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			testName: "fuse sidecar present with many volumes and config, injection successful",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: generateAnnotationsFromConfig(FakePrefetchConfig(), sidecarPrefixMap[MetadataPrefetchSidecarName]),
+				},
 				Spec: corev1.PodSpec{
 					InitContainers: []corev1.Container{
 						{
@@ -1093,6 +1278,18 @@ func TestInjectMetadataPrefetchSidecar(t *testing.T) {
 				},
 			},
 			expectedPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"gke-gcsfuse/metadata-prefetch/container-image":           "fake-image",
+						"gke-gcsfuse/metadata-prefetch/cpu-limit":                 "50m",
+						"gke-gcsfuse/metadata-prefetch/cpu-request":               "10m",
+						"gke-gcsfuse/metadata-prefetch/ephemeral-storage-limit":   "10Mi",
+						"gke-gcsfuse/metadata-prefetch/ephemeral-storage-request": "10Mi",
+						"gke-gcsfuse/metadata-prefetch/image-pull-policy":         "Always",
+						"gke-gcsfuse/metadata-prefetch/memory-limit":              "10Mi",
+						"gke-gcsfuse/metadata-prefetch/memory-request":            "10Mi",
+					},
+				},
 				Spec: corev1.PodSpec{
 					InitContainers: []corev1.Container{
 						{
@@ -1100,7 +1297,8 @@ func TestInjectMetadataPrefetchSidecar(t *testing.T) {
 						},
 						{
 							Name:            MetadataPrefetchSidecarName,
-							Image:           FakeConfig().MetadataContainerImage,
+							Image:           FakePrefetchConfig().ContainerImage,
+							ImagePullPolicy: corev1.PullPolicy(FakePrefetchConfig().ImagePullPolicy),
 							Env:             []corev1.EnvVar{{Name: "NATIVE_SIDECAR", Value: "TRUE"}},
 							RestartPolicy:   ptr.To(corev1.ContainerRestartPolicyAlways),
 							SecurityContext: GetSecurityContext(),
@@ -1229,8 +1427,9 @@ func TestInjectMetadataPrefetchSidecar(t *testing.T) {
 								Requests: requests,
 								Limits:   limits,
 							},
-							Image:        "my-private-image",
-							VolumeMounts: []corev1.VolumeMount{{Name: "my-volume", ReadOnly: true, MountPath: "/volumes/my-volume"}},
+							Image:           "my-private-image",
+							ImagePullPolicy: corev1.PullPolicy(FakePrefetchConfig().ImagePullPolicy),
+							VolumeMounts:    []corev1.VolumeMount{{Name: "my-volume", ReadOnly: true, MountPath: "/volumes/my-volume"}},
 						},
 						{
 							Name: "two",
@@ -1358,11 +1557,42 @@ func TestInjectMetadataPrefetchSidecar(t *testing.T) {
 			if tc.nativeSidecar == nil {
 				tc.nativeSidecar = ptr.To(true)
 			}
-			si := SidecarInjector{}
-			si.injectMetadataPrefetchSidecarContainer(tc.pod, &tc.config, *tc.nativeSidecar)
+			si := SidecarInjector{MetadataPrefetchConfig: FakePrefetchConfig()}
+			err := si.injectSidecarContainer(MetadataPrefetchSidecarName, tc.pod, *tc.nativeSidecar)
+			t.Logf("%s resulted in %v and error: %v", tc.testName, err == nil, err)
 			if !reflect.DeepEqual(tc.pod, tc.expectedPod) {
 				t.Errorf(`failed to run %s, expected: "%v", but got "%v". Diff: %s`, tc.testName, tc.expectedPod, tc.pod, cmp.Diff(tc.expectedPod, tc.pod))
 			}
 		})
 	}
+}
+
+func generateAnnotationsFromConfig(config *Config, prefix string) map[string]string {
+	annotations := make(map[string]string)
+	if config.ImagePullPolicy != "" {
+		annotations[prefix+"image-pull-policy"] = config.ImagePullPolicy
+	}
+	if config.CPULimit.Format != "" {
+		annotations[prefix+"cpu-limit"] = config.CPULimit.String()
+	}
+	if config.CPURequest.Format != "" {
+		annotations[prefix+"cpu-request"] = config.CPURequest.String()
+	}
+	if config.ContainerImage != "" {
+		annotations[prefix+"container-image"] = config.ContainerImage
+	}
+	if config.MemoryRequest.Format != "" {
+		annotations[prefix+"memory-request"] = config.MemoryRequest.String()
+	}
+	if config.MemoryLimit.Format != "" {
+		annotations[prefix+"memory-limit"] = config.MemoryLimit.String()
+	}
+	if config.EphemeralStorageRequest.Format != "" {
+		annotations[prefix+"ephemeral-storage-request"] = config.EphemeralStorageRequest.String()
+	}
+	if config.EphemeralStorageLimit.Format != "" {
+		annotations[prefix+"ephemeral-storage-limit"] = config.EphemeralStorageLimit.String()
+	}
+
+	return annotations
 }

--- a/pkg/webhook/mutatingwebhook_test.go
+++ b/pkg/webhook/mutatingwebhook_test.go
@@ -48,18 +48,19 @@ func TestPrepareConfig(t *testing.T) {
 
 	testCases := []struct {
 		name        string
+		prefix      string
 		annotations map[string]string
 		wantConfig  *Config
 		expectErr   bool
 	}{
 		{
-			name: "use default values if no annotation is found",
+			name:   "use default values if no annotation is found",
+			prefix: sidecarPrefixMap[GcsFuseSidecarName],
 			annotations: map[string]string{
 				GcsFuseVolumeEnableAnnotation: "true",
 			},
 			wantConfig: &Config{
 				ContainerImage:          FakeConfig().ContainerImage,
-				MetadataContainerImage:  FakeConfig().MetadataContainerImage,
 				ImagePullPolicy:         FakeConfig().ImagePullPolicy,
 				CPULimit:                FakeConfig().CPULimit,
 				CPURequest:              FakeConfig().CPURequest,
@@ -71,7 +72,8 @@ func TestPrepareConfig(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			name: "only limits are specified",
+			name:   "only limits are specified",
+			prefix: sidecarPrefixMap[GcsFuseSidecarName],
 			annotations: map[string]string{
 				GcsFuseVolumeEnableAnnotation:   "true",
 				cpuLimitAnnotation:              "500m",
@@ -80,7 +82,6 @@ func TestPrepareConfig(t *testing.T) {
 			},
 			wantConfig: &Config{
 				ContainerImage:          FakeConfig().ContainerImage,
-				MetadataContainerImage:  FakeConfig().MetadataContainerImage,
 				ImagePullPolicy:         FakeConfig().ImagePullPolicy,
 				CPULimit:                resource.MustParse("500m"),
 				CPURequest:              resource.MustParse("500m"),
@@ -92,7 +93,8 @@ func TestPrepareConfig(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			name: "only requests are specified",
+			name:   "only requests are specified",
+			prefix: sidecarPrefixMap[GcsFuseSidecarName],
 			annotations: map[string]string{
 				GcsFuseVolumeEnableAnnotation:     "true",
 				cpuRequestAnnotation:              "500m",
@@ -101,7 +103,6 @@ func TestPrepareConfig(t *testing.T) {
 			},
 			wantConfig: &Config{
 				ContainerImage:          FakeConfig().ContainerImage,
-				MetadataContainerImage:  FakeConfig().MetadataContainerImage,
 				ImagePullPolicy:         FakeConfig().ImagePullPolicy,
 				CPULimit:                resource.MustParse("500m"),
 				CPURequest:              resource.MustParse("500m"),
@@ -113,7 +114,8 @@ func TestPrepareConfig(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			name: "limits are set to '0'",
+			name:   "limits are set to '0'",
+			prefix: sidecarPrefixMap[GcsFuseSidecarName],
 			annotations: map[string]string{
 				GcsFuseVolumeEnableAnnotation:   "true",
 				cpuLimitAnnotation:              "0",
@@ -122,7 +124,6 @@ func TestPrepareConfig(t *testing.T) {
 			},
 			wantConfig: &Config{
 				ContainerImage:          FakeConfig().ContainerImage,
-				MetadataContainerImage:  FakeConfig().MetadataContainerImage,
 				ImagePullPolicy:         FakeConfig().ImagePullPolicy,
 				CPULimit:                resource.Quantity{},
 				CPURequest:              FakeConfig().CPURequest,
@@ -134,7 +135,8 @@ func TestPrepareConfig(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			name: "requests are set to '0'",
+			name:   "requests are set to '0'",
+			prefix: sidecarPrefixMap[GcsFuseSidecarName],
 			annotations: map[string]string{
 				GcsFuseVolumeEnableAnnotation:     "true",
 				cpuRequestAnnotation:              "0",
@@ -143,7 +145,6 @@ func TestPrepareConfig(t *testing.T) {
 			},
 			wantConfig: &Config{
 				ContainerImage:          FakeConfig().ContainerImage,
-				MetadataContainerImage:  FakeConfig().MetadataContainerImage,
 				ImagePullPolicy:         FakeConfig().ImagePullPolicy,
 				CPULimit:                resource.Quantity{},
 				CPURequest:              resource.Quantity{},
@@ -155,7 +156,8 @@ func TestPrepareConfig(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			name: "requests and limits are explicitly set",
+			name:   "requests and limits are explicitly set",
+			prefix: sidecarPrefixMap[GcsFuseSidecarName],
 			annotations: map[string]string{
 				GcsFuseVolumeEnableAnnotation:     "true",
 				cpuLimitAnnotation:                "500m",
@@ -167,7 +169,6 @@ func TestPrepareConfig(t *testing.T) {
 			},
 			wantConfig: &Config{
 				ContainerImage:          FakeConfig().ContainerImage,
-				MetadataContainerImage:  FakeConfig().MetadataContainerImage,
 				ImagePullPolicy:         FakeConfig().ImagePullPolicy,
 				CPULimit:                resource.MustParse("500m"),
 				CPURequest:              resource.MustParse("100m"),
@@ -179,7 +180,8 @@ func TestPrepareConfig(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			name: "requests and limits are explicitly set with '0' limits",
+			name:   "requests and limits are explicitly set with '0' limits",
+			prefix: sidecarPrefixMap[GcsFuseSidecarName],
 			annotations: map[string]string{
 				GcsFuseVolumeEnableAnnotation:     "true",
 				cpuLimitAnnotation:                "0",
@@ -191,7 +193,6 @@ func TestPrepareConfig(t *testing.T) {
 			},
 			wantConfig: &Config{
 				ContainerImage:          FakeConfig().ContainerImage,
-				MetadataContainerImage:  FakeConfig().MetadataContainerImage,
 				ImagePullPolicy:         FakeConfig().ImagePullPolicy,
 				CPULimit:                resource.Quantity{},
 				CPURequest:              resource.MustParse("100m"),
@@ -203,7 +204,8 @@ func TestPrepareConfig(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			name: "requests and limits are explicitly set with '0' requests",
+			name:   "requests and limits are explicitly set with '0' requests",
+			prefix: sidecarPrefixMap[GcsFuseSidecarName],
 			annotations: map[string]string{
 				GcsFuseVolumeEnableAnnotation:     "true",
 				cpuLimitAnnotation:                "500m",
@@ -215,7 +217,6 @@ func TestPrepareConfig(t *testing.T) {
 			},
 			wantConfig: &Config{
 				ContainerImage:          FakeConfig().ContainerImage,
-				MetadataContainerImage:  FakeConfig().MetadataContainerImage,
 				ImagePullPolicy:         FakeConfig().ImagePullPolicy,
 				CPULimit:                resource.MustParse("500m"),
 				CPURequest:              resource.Quantity{},
@@ -227,7 +228,84 @@ func TestPrepareConfig(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			name: "invalid resource Quantity should throw error",
+			name:   "metadata prefetch requests and limits are provided",
+			prefix: sidecarPrefixMap[MetadataPrefetchSidecarName],
+			annotations: map[string]string{
+				GcsFuseVolumeEnableAnnotation:           "true",
+				cpuLimitAnnotation:                      "500m",
+				memoryLimitAnnotation:                   "1Gi",
+				ephemeralStorageLimitAnnotation:         "50Gi",
+				cpuRequestAnnotation:                    "0",
+				memoryRequestAnnotation:                 "0",
+				ephemeralStorageRequestAnnotation:       "0",
+				metadataPrefetchMemoryLimitAnnotation:   "20Mi",
+				metadataPrefetchMemoryRequestAnnotation: "20Mi",
+			},
+			wantConfig: &Config{
+				ContainerImage:          FakePrefetchConfig().ContainerImage,
+				ImagePullPolicy:         FakePrefetchConfig().ImagePullPolicy,
+				CPULimit:                resource.MustParse("50m"),
+				CPURequest:              resource.MustParse("10m"),
+				MemoryLimit:             resource.MustParse("20Mi"),
+				MemoryRequest:           resource.MustParse("20Mi"),
+				EphemeralStorageLimit:   resource.MustParse("10Mi"),
+				EphemeralStorageRequest: resource.MustParse("10Mi"),
+			},
+			expectErr: false,
+		},
+		{
+			name:   "metadata prefetch memory limits are provided",
+			prefix: sidecarPrefixMap[MetadataPrefetchSidecarName],
+			annotations: map[string]string{
+				GcsFuseVolumeEnableAnnotation:         "true",
+				cpuLimitAnnotation:                    "500m",
+				memoryLimitAnnotation:                 "1Gi",
+				ephemeralStorageLimitAnnotation:       "50Gi",
+				cpuRequestAnnotation:                  "0",
+				memoryRequestAnnotation:               "0",
+				ephemeralStorageRequestAnnotation:     "0",
+				metadataPrefetchMemoryLimitAnnotation: "20Mi",
+			},
+			wantConfig: &Config{
+				ContainerImage:          FakePrefetchConfig().ContainerImage,
+				ImagePullPolicy:         FakePrefetchConfig().ImagePullPolicy,
+				CPULimit:                resource.MustParse("50m"),
+				CPURequest:              resource.MustParse("10m"),
+				MemoryLimit:             resource.MustParse("20Mi"),
+				MemoryRequest:           resource.MustParse("20Mi"),
+				EphemeralStorageLimit:   resource.MustParse("10Mi"),
+				EphemeralStorageRequest: resource.MustParse("10Mi"),
+			},
+			expectErr: false,
+		},
+		{
+			name:   "metadata prefetch memory requests are provided",
+			prefix: sidecarPrefixMap[MetadataPrefetchSidecarName],
+			annotations: map[string]string{
+				GcsFuseVolumeEnableAnnotation:           "true",
+				cpuLimitAnnotation:                      "500m",
+				memoryLimitAnnotation:                   "1Gi",
+				ephemeralStorageLimitAnnotation:         "50Gi",
+				cpuRequestAnnotation:                    "0",
+				memoryRequestAnnotation:                 "0",
+				ephemeralStorageRequestAnnotation:       "0",
+				metadataPrefetchMemoryRequestAnnotation: "20Mi",
+			},
+			wantConfig: &Config{
+				ContainerImage:          FakePrefetchConfig().ContainerImage,
+				ImagePullPolicy:         FakePrefetchConfig().ImagePullPolicy,
+				CPULimit:                resource.MustParse("50m"),
+				CPURequest:              resource.MustParse("10m"),
+				MemoryLimit:             resource.MustParse("20Mi"),
+				MemoryRequest:           resource.MustParse("20Mi"),
+				EphemeralStorageLimit:   resource.MustParse("10Mi"),
+				EphemeralStorageRequest: resource.MustParse("10Mi"),
+			},
+			expectErr: false,
+		},
+		{
+			name:   "invalid resource Quantity should throw error",
+			prefix: sidecarPrefixMap[GcsFuseSidecarName],
 			annotations: map[string]string{
 				GcsFuseVolumeEnableAnnotation: "true",
 				cpuLimitAnnotation:            "invalid",
@@ -239,11 +317,17 @@ func TestPrepareConfig(t *testing.T) {
 
 	for _, tc := range testCases {
 		si := SidecarInjector{
-			Client:  nil,
-			Config:  FakeConfig(),
-			Decoder: admission.NewDecoder(runtime.NewScheme()),
+			Client:                 nil,
+			Config:                 FakeConfig(),
+			MetadataPrefetchConfig: FakePrefetchConfig(),
+			Decoder:                admission.NewDecoder(runtime.NewScheme()),
 		}
-		gotConfig, gotErr := si.prepareConfig(tc.annotations)
+		pod := corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: tc.annotations,
+			},
+		}
+		gotConfig, gotErr := si.prepareConfig(tc.prefix, pod)
 		if tc.expectErr != (gotErr != nil) {
 			t.Errorf(`for "%s", expect error: %v, but got error: %v`, tc.name, tc.expectErr, gotErr)
 		}
@@ -450,6 +534,13 @@ func TestValidateMutatingWebhookResponse(t *testing.T) {
 			nodes:        nativeSupportNodes(),
 		},
 		{
+			name:         "native container injection successful test, with prefetch.",
+			operation:    admissionv1.Create,
+			inputPod:     validInputPodWithPrefetchIncluded(),
+			wantResponse: wantResponseWithPrefetch(t, false, false, true),
+			nodes:        nativeSupportNodes(),
+		},
+		{
 			name:         "Injection with custom sidecar container image successful test with native nodes.",
 			operation:    admissionv1.Create,
 			inputPod:     validInputPodWithCustomImage(false),
@@ -498,10 +589,11 @@ func TestValidateMutatingWebhookResponse(t *testing.T) {
 			lister := informerFactory.Core().V1().Nodes().Lister()
 
 			si := SidecarInjector{
-				Client:     nil,
-				Config:     FakeConfig(),
-				Decoder:    admission.NewDecoder(runtime.NewScheme()),
-				NodeLister: lister,
+				Client:                 nil,
+				Config:                 FakeConfig(),
+				MetadataPrefetchConfig: FakePrefetchConfig(),
+				Decoder:                admission.NewDecoder(runtime.NewScheme()),
+				NodeLister:             lister,
 			}
 
 			stopCh := make(<-chan struct{})
@@ -668,6 +760,18 @@ func validInputPod() *corev1.Pod {
 	return validInputPodWithSettings(false, false)
 }
 
+func validInputPodWithPrefetchIncluded() *corev1.Pod {
+	pod := validInputPodWithSettings(false, false)
+	pod.ObjectMeta.Annotations[GcsFuseNativeSidecarEnableAnnotation] = "true"
+	pod.Spec.InitContainers = append(pod.Spec.InitContainers, corev1.Container{
+		Name:            MetadataPrefetchSidecarName,
+		Image:           "my-private-image",
+		SecurityContext: GetSecurityContext(),
+	})
+
+	return pod
+}
+
 func getWorkloadSpec(name string) corev1.Container {
 	return corev1.Container{
 		Name:  name,
@@ -691,6 +795,14 @@ func wantResponse(t *testing.T, customImage bool, nativeCustomImage bool, native
 	t.Helper()
 	pod := validInputPodWithSettings(customImage, nativeCustomImage)
 	newPod := *modifySpec(*validInputPodWithSettings(customImage, nativeCustomImage), customImage, nativeCustomImage, native)
+
+	return generatePatch(t, pod, &newPod)
+}
+
+func wantResponseWithPrefetch(t *testing.T, customImage bool, nativeCustomImage bool, native bool) admission.Response {
+	t.Helper()
+	pod := validInputPodWithPrefetchIncluded()
+	newPod := *modifySpec(*validInputPodWithPrefetchIncluded(), customImage, nativeCustomImage, native)
 
 	return generatePatch(t, pod, &newPod)
 }

--- a/pkg/webhook/sidecar_spec.go
+++ b/pkg/webhook/sidecar_spec.go
@@ -21,7 +21,6 @@ import (
 	"path/filepath"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 )
@@ -49,14 +48,6 @@ const (
 )
 
 var (
-	// Metadata prefetch container resources.
-	metadataPrefetchCPURequest              = resource.MustParse("10m")
-	metadataPrefetchCPULimit                = resource.MustParse("50m")
-	metadataPrefetchMemoryRequest           = resource.MustParse("10Mi")
-	metadataPrefetchMemoryLimit             = resource.MustParse("10Mi")
-	metadataPrefetchEphemeralStorageRequest = resource.MustParse("10Mi")
-	metadataPrefetchEphemeralStorageLimit   = resource.MustParse("10Mi")
-
 	// gke-gcsfuse-sidecar volumes.
 	tmpVolume = corev1.Volume{
 		Name: SidecarContainerTmpVolumeName,
@@ -155,41 +146,19 @@ func GetSecurityContext() *corev1.SecurityContext {
 	}
 }
 
-func (si *SidecarInjector) GetNativeMetadataPrefetchSidecarContainerSpec(pod *corev1.Pod, image string) corev1.Container {
-	container := si.GetMetadataPrefetchSidecarContainerSpec(pod, image)
-	container.Env = append(container.Env, corev1.EnvVar{Name: "NATIVE_SIDECAR", Value: "TRUE"})
-	container.RestartPolicy = ptr.To(corev1.ContainerRestartPolicyAlways)
-
-	return container
-}
-
-func getMetadataPrefetchConfig(image string) *Config {
-	return &Config{
-		CPURequest:              metadataPrefetchCPURequest,
-		CPULimit:                metadataPrefetchCPULimit,
-		MemoryRequest:           metadataPrefetchMemoryRequest,
-		MemoryLimit:             metadataPrefetchMemoryLimit,
-		EphemeralStorageRequest: metadataPrefetchEphemeralStorageRequest,
-		EphemeralStorageLimit:   metadataPrefetchEphemeralStorageLimit,
-		MetadataContainerImage:  image,
-	}
-}
-
-func (si *SidecarInjector) GetMetadataPrefetchSidecarContainerSpec(pod *corev1.Pod, image string) corev1.Container {
+func (si *SidecarInjector) GetMetadataPrefetchSidecarContainerSpec(pod *corev1.Pod, c *Config) corev1.Container {
 	if pod == nil {
 		klog.Warning("failed to get metadata prefetch container spec: pod is nil")
 
 		return corev1.Container{}
 	}
-
-	c := getMetadataPrefetchConfig(image)
 	limits, requests := prepareResourceList(c)
 
 	// The sidecar container follows Restricted Pod Security Standard,
 	// see https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
 	container := corev1.Container{
 		Name:            MetadataPrefetchSidecarName,
-		Image:           c.MetadataContainerImage,
+		Image:           c.ContainerImage,
 		ImagePullPolicy: corev1.PullPolicy(c.ImagePullPolicy),
 		SecurityContext: GetSecurityContext(),
 		Resources: corev1.ResourceRequirements{


### PR DESCRIPTION
Added capability to provide metadata prefetch memory request and limits in pod spec to fuse csi annotations Additionally added unit tests verifying changes.

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

 /kind feature

> /kind flake

**What this PR does / why we need it**:
This pr adds functionality to allow fuse driver users to provide custom metadata prefetch sidecar memory and limits. The changes add additional annotations and variables to extract prefetch limits and requests if provided and uses those values for the prefetch sidecar config if provided. Otherwise it uses default values

**Which issue(s) this PR fixes**:

Fixes https://b.corp.google.com/issues/385198703

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note Annotations to provide metadataprefetch mem limit and requests are : gke-gcsfuse/metadata-prefetch/memory-request and gke-gcsfuse/metadata-prefetch/memory-limit

```