### PR TITLE
Added Feature to provide a custom Audience in csi driver

### DIFF
--- a/cmd/csi_driver/main.go
+++ b/cmd/csi_driver/main.go
@@ -42,6 +42,7 @@ var (
 	runNode                   = flag.Bool("node", false, "run node service")
 	kubeconfigPath            = flag.String("kubeconfig-path", "", "The kubeconfig path.")
 	identityPool              = flag.String("identity-pool", "", "The Identity Pool to authenticate with GCS API.")
+	customAudience            = flag.String("custom-audience", "", "The custom Identity Pool to authenticate with GCS API.")
 	identityProvider          = flag.String("identity-provider", "", "The Identity Provider to authenticate with GCS API.")
 	enableProfiling           = flag.Bool("enable-profiling", false, "enable the golang pprof at port 6060")
 	informerResyncDurationSec = flag.Int("informer-resync-duration-sec", 1800, "informer resync duration in seconds")
@@ -82,7 +83,7 @@ func main() {
 		klog.Fatalf("Failed to configure k8s client: %v", err)
 	}
 
-	meta, err := metadata.NewMetadataService(*identityPool, *identityProvider)
+	meta, err := metadata.NewMetadataService(*identityPool, *identityProvider, *customAudience)
 	if err != nil {
 		klog.Fatalf("Failed to set up metadata service: %v", err)
 	}

--- a/pkg/cloud_provider/auth/token_sources.go
+++ b/pkg/cloud_provider/auth/token_sources.go
@@ -81,7 +81,6 @@ func (ts *GCPTokenSource) fetchK8sSAToken(ctx context.Context) (*oauth2.Token, e
 				Expiry:      trs.ExpirationTimestamp.Time,
 			}, nil
 		}
-
 		return nil, fmt.Errorf("could not find token for the identity pool %q", ts.meta.GetIdentityPool())
 	}
 
@@ -113,12 +112,18 @@ func (ts *GCPTokenSource) fetchIdentityBindingToken(ctx context.Context, k8sSATo
 	if err != nil {
 		return nil, fmt.Errorf("new STS service error: %w", err)
 	}
+	customAudience := ts.meta.GetCustomAudience()
 
 	audience := fmt.Sprintf(
 		"identitynamespace:%s:%s",
 		ts.meta.GetIdentityPool(),
 		ts.meta.GetIdentityProvider(),
 	)
+
+	if len(customAudience) != 0 {
+		audience = customAudience
+	}
+
 	stsRequest := &sts.GoogleIdentityStsV1ExchangeTokenRequest{
 		Audience:           audience,
 		GrantType:          "urn:ietf:params:oauth:grant-type:token-exchange",

--- a/pkg/cloud_provider/metadata/fake.go
+++ b/pkg/cloud_provider/metadata/fake.go
@@ -33,11 +33,12 @@ type fakeServiceManager struct {
 	projectID        string
 	identityPool     string
 	identityProvider string
+	customAudience   string
 }
 
 var _ Service = &fakeServiceManager{}
 
-func NewFakeService(projectID, location, clusterName, gkeEnv string) (Service, error) {
+func NewFakeService(projectID, location, clusterName, gkeEnv string, customAudience string) (Service, error) {
 	var gkeAPIEndpoint string
 	if _, ok := envAPIMap[gkeEnv]; !ok {
 		if gkeEnv == "sandbox" {
@@ -61,6 +62,20 @@ func NewFakeService(projectID, location, clusterName, gkeEnv string) (Service, e
 		),
 	}
 
+	if len(customAudience) != 0 {
+		s = fakeServiceManager{
+			projectID:    projectID,
+			identityPool: customAudience,
+			identityProvider: fmt.Sprintf(
+				"%sv1/projects/%s/locations/%s/clusters/%s",
+				gkeAPIEndpoint,
+				projectID,
+				location,
+				clusterName,
+			),
+		}
+	}
+
 	return &s, nil
 }
 
@@ -74,4 +89,8 @@ func (manager *fakeServiceManager) GetIdentityPool() string {
 
 func (manager *fakeServiceManager) GetIdentityProvider() string {
 	return manager.identityProvider
+}
+
+func (manager *fakeServiceManager) GetCustomAudience() string {
+	return manager.customAudience
 }

--- a/pkg/cloud_provider/metadata/metadata.go
+++ b/pkg/cloud_provider/metadata/metadata.go
@@ -29,20 +29,30 @@ type Service interface {
 	GetProjectID() string
 	GetIdentityPool() string
 	GetIdentityProvider() string
+	GetCustomAudience() string
 }
 
 type metadataServiceManager struct {
 	projectID        string
 	identityPool     string
 	identityProvider string
+	customAudience   string
 }
 
 var _ Service = &metadataServiceManager{}
 
-func NewMetadataService(identityPool, identityProvider string) (Service, error) {
+func NewMetadataService(identityPool, identityProvider string, customAudience string) (Service, error) {
 	projectID, err := metadata.ProjectIDWithContext(context.Background())
+
 	if err != nil {
 		return nil, fmt.Errorf("failed to get project: %w", err)
+	}
+
+	if len(customAudience) != 0 {
+		projectID, err = metadata.NumericProjectIDWithContext(context.Background())
+		if err != nil {
+			return nil, fmt.Errorf("failed to get project: %w", err)
+		}
 	}
 
 	if identityPool == "" {
@@ -54,11 +64,16 @@ func NewMetadataService(identityPool, identityProvider string) (Service, error) 
 		projectID:        projectID,
 		identityPool:     identityPool,
 		identityProvider: identityProvider,
+		customAudience:   customAudience,
 	}, nil
 }
 
 func (manager *metadataServiceManager) GetProjectID() string {
 	return manager.projectID
+}
+
+func (manager *metadataServiceManager) GetCustomAudience() string {
+	return manager.customAudience
 }
 
 func (manager *metadataServiceManager) GetIdentityPool() string {


### PR DESCRIPTION
Added feature to set a self managed workload identity pool provider as  a custom audience to the csi driver.

**What type of PR is this?**

/kind feature
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

This came out as a requirement when we started using the csi driver to see if we could mount gcs buckets directly to our on-premise Kubernetes clusters. We already had the Workload Identity Federation Pools and providers set in GCP.

After setting the audience as the full resource name of our WIF identity pool provider, we were able to mount the gcs buckets directly into the kubernetes pods running in our on-prem Kubernetes.

**Which issue(s) this PR fixes**:

This is a new feature. It does not have a related issue yet. 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "Yes" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```