### PR TITLE
Disable sidecar metrics server when metrics are disabled.

### DIFF
--- a/pkg/sidecar_mounter/sidecar_mounter.go
+++ b/pkg/sidecar_mounter/sidecar_mounter.go
@@ -132,8 +132,8 @@ func (m *Mounter) Mount(ctx context.Context, mc *MountConfig) error {
 			go logVolumeUsage(ctx, mc.BufferDir, mc.CacheDir)
 		}
 
-		promPort := mc.FlagMap["prometheus-port"]
-		if promPort != "0" {
+		promPort, ok := mc.FlagMap["prometheus-port"]
+		if ok && promPort != "0" {
 			klog.Infof("start to collect metrics from port %v for volume %q", promPort, mc.VolumeName)
 			go collectMetrics(ctx, promPort, mc.TempDir)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
When we disable metrics, we still enable the gke gcsfuse sidecar metrics collector server endpoint to collect metrics. The intended behavior is to disable all metrics serviced. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

Bug found while going through the code.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Disable sidecar metrics server when metrics are disabled.
```

/cc @kislaykishore 