### PR TITLE
Revert "Merge pull request #472 from chrisThePattyEater/fuechr/metadata-prefetch-memory-override"

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -39,27 +39,21 @@ import (
 )
 
 var (
-	port                                    = flag.Int("port", 443, "The port that the webhook server serves at.")
-	healthProbeBindAddress                  = flag.String("health-probe-bind-address", ":8080", "The TCP address that the controller should bind to for serving health probes.")
-	certDir                                 = flag.String("cert-dir", "/etc/tls-certs", "The directory that contains the server key and certificate.")
-	certName                                = flag.String("cert-name", "cert.pem", "The server certificate name.")
-	keyName                                 = flag.String("key-name", "key.pem", "The server key name.")
-	imagePullPolicy                         = flag.String("sidecar-image-pull-policy", "IfNotPresent", "The default image pull policy for gcsfuse sidecar container.")
-	cpuRequest                              = flag.String("sidecar-cpu-request", "250m", "The default CPU request for gcsfuse sidecar container.")
-	cpuLimit                                = flag.String("sidecar-cpu-limit", "250m", "The default CPU limit for gcsfuse sidecar container.")
-	memoryRequest                           = flag.String("sidecar-memory-request", "256Mi", "The default memory request for gcsfuse sidecar container.")
-	memoryLimit                             = flag.String("sidecar-memory-limit", "256Mi", "The default memory limit for gcsfuse sidecar container.")
-	ephemeralStorageRequest                 = flag.String("sidecar-ephemeral-storage-request", "5Gi", "The default ephemeral storage request for gcsfuse sidecar container.")
-	ephemeralStorageLimit                   = flag.String("sidecar-ephemeral-storage-limit", "5Gi", "The default ephemeral storage limit for gcsfuse sidecar container.")
-	sidecarImage                            = flag.String("sidecar-image", "", "The gcsfuse sidecar container image.")
-	metadataSidecarImage                    = flag.String("metadata-sidecar-image", "", "The metadata prefetch sidecar container image.")
-	injectSAVol                             = flag.Bool("should-inject-sa-vol", false, "Inject projected service account volume when true")
-	metadataMemoryRequest                   = flag.String("metadata-sidecar-memory-request", "10Mi", "Flag to use default value for gcsfuse memory prefetch sidecar container memory request.")
-	metadataMemoryLimit                     = flag.String("metadata-sidecar-memory-limit", "10Mi", "Flag to use default value for gcsfuse memory prefetch sidecar container memory limit.")
-	metadataPrefetchCPURequest              = flag.String("metadata-sidecar-cpu-request", "10m", "The default cpu request for gcsfuse memory prefetch sidecar container cpu request.")
-	metadataPrefetchCPULimit                = flag.String("metadata-sidecar-cpu-request", "50m", "Flag to use default value for gcsfuse memory prefetch sidecar container cpu limit.")
-	metadataPrefetchEphemeralStorageRequest = flag.String("metadata-sidecar-ephemeral-storage-request", "10Mi", "The default value for gcsfuse memory prefetch sidecar ephemeral storage request.")
-	metadataPrefetchEphemeralStorageLimit   = flag.String("metadata-sidecar-ephemeral-storage-request", "10Mi", "The default value for gcsfuse memory prefetch sidecar ephemeral storage limit.")
+	port                    = flag.Int("port", 443, "The port that the webhook server serves at.")
+	healthProbeBindAddress  = flag.String("health-probe-bind-address", ":8080", "The TCP address that the controller should bind to for serving health probes.")
+	certDir                 = flag.String("cert-dir", "/etc/tls-certs", "The directory that contains the server key and certificate.")
+	certName                = flag.String("cert-name", "cert.pem", "The server certificate name.")
+	keyName                 = flag.String("key-name", "key.pem", "The server key name.")
+	imagePullPolicy         = flag.String("sidecar-image-pull-policy", "IfNotPresent", "The default image pull policy for gcsfuse sidecar container.")
+	cpuRequest              = flag.String("sidecar-cpu-request", "250m", "The default CPU request for gcsfuse sidecar container.")
+	cpuLimit                = flag.String("sidecar-cpu-limit", "250m", "The default CPU limit for gcsfuse sidecar container.")
+	memoryRequest           = flag.String("sidecar-memory-request", "256Mi", "The default memory request for gcsfuse sidecar container.")
+	memoryLimit             = flag.String("sidecar-memory-limit", "256Mi", "The default memory limit for gcsfuse sidecar container.")
+	ephemeralStorageRequest = flag.String("sidecar-ephemeral-storage-request", "5Gi", "The default ephemeral storage request for gcsfuse sidecar container.")
+	ephemeralStorageLimit   = flag.String("sidecar-ephemeral-storage-limit", "5Gi", "The default ephemeral storage limit for gcsfuse sidecar container.")
+	sidecarImage            = flag.String("sidecar-image", "", "The gcsfuse sidecar container image.")
+	metadataSidecarImage    = flag.String("metadata-sidecar-image", "", "The metadata prefetch sidecar container image.")
+	injectSAVol             = flag.Bool("should-inject-sa-vol", false, "Inject projected service account volume when true")
 	// These are set at compile time.
 	webhookVersion = "unknown"
 )
@@ -79,11 +73,9 @@ func main() {
 	klog.Infof("Running Google Cloud Storage FUSE CSI driver admission webhook version %v, sidecar container image %v", webhookVersion, *sidecarImage)
 
 	// Load webhook config
-	fuseSideCarConfig := wh.LoadConfig(*sidecarImage, *imagePullPolicy, *cpuRequest, *cpuLimit, *memoryRequest, *memoryLimit, *ephemeralStorageRequest, *ephemeralStorageLimit)
-	fuseSideCarConfig.ShouldInjectSAVolume = *injectSAVol
-	klog.Infof("Webhook should inject SA volume: %t", fuseSideCarConfig.ShouldInjectSAVolume)
-
-	metadataPrefetchSideCarConfig := wh.LoadConfig(*metadataSidecarImage, *imagePullPolicy, *metadataPrefetchCPURequest, *metadataPrefetchCPULimit, *metadataMemoryRequest, *metadataMemoryLimit, *metadataPrefetchEphemeralStorageRequest, *metadataPrefetchEphemeralStorageLimit)
+	c := wh.LoadConfig(*sidecarImage, *metadataSidecarImage, *imagePullPolicy, *cpuRequest, *cpuLimit, *memoryRequest, *memoryLimit, *ephemeralStorageRequest, *ephemeralStorageLimit)
+	c.ShouldInjectSAVolume = *injectSAVol
+	klog.Infof("Webhook should inject SA volume: %t", c.ShouldInjectSAVolume)
 
 	// Load config for manager, informers, listers
 	kubeConfig := config.GetConfigOrDie()
@@ -149,14 +141,13 @@ func main() {
 	klog.Info("Registering webhooks to the webhook server.")
 	hookServer.Register("/inject", &webhook.Admission{
 		Handler: &wh.SidecarInjector{
-			Client:                 mgr.GetClient(),
-			Config:                 fuseSideCarConfig,
-			MetadataPrefetchConfig: metadataPrefetchSideCarConfig,
-			Decoder:                admission.NewDecoder(runtime.NewScheme()),
-			NodeLister:             nodeLister,
-			PvLister:               pvLister,
-			PvcLister:              pvcLister,
-			ServerVersion:          serverVersion,
+			Client:        mgr.GetClient(),
+			Config:        c,
+			Decoder:       admission.NewDecoder(runtime.NewScheme()),
+			NodeLister:    nodeLister,
+			PvLister:      pvLister,
+			PvcLister:     pvcLister,
+			ServerVersion: serverVersion,
 		},
 	})
 

--- a/pkg/webhook/mutatingwebhook.go
+++ b/pkg/webhook/mutatingwebhook.go
@@ -34,33 +34,29 @@ import (
 )
 
 const (
-	GcsFuseVolumeEnableAnnotation           = "gke-gcsfuse/volumes"
-	GcsFuseNativeSidecarEnableAnnotation    = "gke-gcsfuse/enable-native-sidecar"
-	cpuLimitAnnotation                      = "gke-gcsfuse/cpu-limit"
-	cpuRequestAnnotation                    = "gke-gcsfuse/cpu-request"
-	memoryLimitAnnotation                   = "gke-gcsfuse/memory-limit"
-	memoryRequestAnnotation                 = "gke-gcsfuse/memory-request"
-	ephemeralStorageLimitAnnotation         = "gke-gcsfuse/ephemeral-storage-limit"
-	ephemeralStorageRequestAnnotation       = "gke-gcsfuse/ephemeral-storage-request"
-	metadataPrefetchMemoryLimitAnnotation   = "gke-gcsfuse/metadata-prefetch/memory-limit"
-	metadataPrefetchMemoryRequestAnnotation = "gke-gcsfuse/metadata-prefetch/memory-request"
+	GcsFuseVolumeEnableAnnotation        = "gke-gcsfuse/volumes"
+	GcsFuseNativeSidecarEnableAnnotation = "gke-gcsfuse/enable-native-sidecar"
+	cpuLimitAnnotation                   = "gke-gcsfuse/cpu-limit"
+	cpuRequestAnnotation                 = "gke-gcsfuse/cpu-request"
+	memoryLimitAnnotation                = "gke-gcsfuse/memory-limit"
+	memoryRequestAnnotation              = "gke-gcsfuse/memory-request"
+	ephemeralStorageLimitAnnotation      = "gke-gcsfuse/ephemeral-storage-limit"
+	ephemeralStorageRequestAnnotation    = "gke-gcsfuse/ephemeral-storage-request"
 )
 
 type SidecarInjector struct {
 	Client client.Client
 	// default sidecar container config values, can be overwritten by the pod annotations
-	Config                 *Config
-	MetadataPrefetchConfig *Config
-	Decoder                admission.Decoder
-	NodeLister             listersv1.NodeLister
-	PvcLister              listersv1.PersistentVolumeClaimLister
-	PvLister               listersv1.PersistentVolumeLister
-	ServerVersion          *version.Version
+	Config        *Config
+	Decoder       admission.Decoder
+	NodeLister    listersv1.NodeLister
+	PvcLister     listersv1.PersistentVolumeClaimLister
+	PvLister      listersv1.PersistentVolumeLister
+	ServerVersion *version.Version
 }
 
 // Handle injects a gcsfuse sidecar container and a emptyDir to incoming qualified pods.
 func (si *SidecarInjector) Handle(ctx context.Context, req admission.Request) admission.Response {
-	// Validate injection request
 	pod := &corev1.Pod{}
 
 	if err := si.Decoder.Decode(req, pod); err != nil {
@@ -93,22 +89,33 @@ func (si *SidecarInjector) Handle(ctx context.Context, req admission.Request) ad
 	if sidecarInjected {
 		return admission.Allowed("The sidecar container was injected, no injection required.")
 	}
+
+	config, err := si.prepareConfig(pod.Annotations)
+	if err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	config.PodHostNetworkSetting = pod.Spec.HostNetwork
+
+	if userProvidedGcsFuseSidecarImage, err := ExtractImageAndDeleteContainer(&pod.Spec, GcsFuseSidecarName); err == nil {
+		if userProvidedGcsFuseSidecarImage != "" {
+			config.ContainerImage = userProvidedGcsFuseSidecarImage
+		}
+	} else {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
 	// Check support for native sidecar.
 	injectAsNativeSidecar, err := si.injectAsNativeSidecar(pod)
 	if err != nil {
 		return admission.Errored(http.StatusInternalServerError, fmt.Errorf("failed to verify native sidecar support: %w", err))
 	}
 
-	// Inject Fuse Side Car container.
-	injected, _ := validatePodHasSidecarContainerInjected(GcsFuseSidecarName, pod, []corev1.Volume{tmpVolume}, []corev1.VolumeMount{TmpVolumeMount})
-	if !injected {
-		err = si.injectSidecarContainer(GcsFuseSidecarName, pod, injectAsNativeSidecar)
-	}
-	if err != nil {
-		return admission.Errored(http.StatusBadRequest, err)
-	}
+	// Inject container.
+	injectSidecarContainer(pod, config, injectAsNativeSidecar)
+
 	// Inject service account volume
-	if si.Config.ShouldInjectSAVolume && pod.Spec.HostNetwork {
+	if config.ShouldInjectSAVolume && pod.Spec.HostNetwork {
 		projectID, err := metadata.ProjectIDWithContext(ctx)
 		if err != nil {
 			return admission.Errored(http.StatusInternalServerError, fmt.Errorf("failed to get project id: %w", err))
@@ -118,14 +125,11 @@ func (si *SidecarInjector) Handle(ctx context.Context, req admission.Request) ad
 
 	pod.Spec.Volumes = append(GetSidecarContainerVolumeSpec(pod.Spec.Volumes...), pod.Spec.Volumes...)
 
+	// Log pod mutation.
+	LogPodMutation(pod, config)
+
 	// Inject metadata prefetch sidecar.
-	injected, _ = validatePodHasSidecarContainerInjected(MetadataPrefetchSidecarName, pod, []corev1.Volume{}, []corev1.VolumeMount{})
-	if !injected {
-		err = si.injectSidecarContainer(MetadataPrefetchSidecarName, pod, injectAsNativeSidecar)
-	}
-	if err != nil {
-		return admission.Errored(http.StatusBadRequest, err)
-	}
+	si.injectMetadataPrefetchSidecarContainer(pod, config, injectAsNativeSidecar)
 
 	marshaledPod, err := json.Marshal(pod)
 	if err != nil {

--- a/pkg/webhook/mutatingwebhook_test.go
+++ b/pkg/webhook/mutatingwebhook_test.go
@@ -48,19 +48,18 @@ func TestPrepareConfig(t *testing.T) {
 
 	testCases := []struct {
 		name        string
-		prefix      string
 		annotations map[string]string
 		wantConfig  *Config
 		expectErr   bool
 	}{
 		{
-			name:   "use default values if no annotation is found",
-			prefix: sidecarPrefixMap[GcsFuseSidecarName],
+			name: "use default values if no annotation is found",
 			annotations: map[string]string{
 				GcsFuseVolumeEnableAnnotation: "true",
 			},
 			wantConfig: &Config{
 				ContainerImage:          FakeConfig().ContainerImage,
+				MetadataContainerImage:  FakeConfig().MetadataContainerImage,
 				ImagePullPolicy:         FakeConfig().ImagePullPolicy,
 				CPULimit:                FakeConfig().CPULimit,
 				CPURequest:              FakeConfig().CPURequest,
@@ -72,8 +71,7 @@ func TestPrepareConfig(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			name:   "only limits are specified",
-			prefix: sidecarPrefixMap[GcsFuseSidecarName],
+			name: "only limits are specified",
 			annotations: map[string]string{
 				GcsFuseVolumeEnableAnnotation:   "true",
 				cpuLimitAnnotation:              "500m",
@@ -82,6 +80,7 @@ func TestPrepareConfig(t *testing.T) {
 			},
 			wantConfig: &Config{
 				ContainerImage:          FakeConfig().ContainerImage,
+				MetadataContainerImage:  FakeConfig().MetadataContainerImage,
 				ImagePullPolicy:         FakeConfig().ImagePullPolicy,
 				CPULimit:                resource.MustParse("500m"),
 				CPURequest:              resource.MustParse("500m"),
@@ -93,8 +92,7 @@ func TestPrepareConfig(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			name:   "only requests are specified",
-			prefix: sidecarPrefixMap[GcsFuseSidecarName],
+			name: "only requests are specified",
 			annotations: map[string]string{
 				GcsFuseVolumeEnableAnnotation:     "true",
 				cpuRequestAnnotation:              "500m",
@@ -103,6 +101,7 @@ func TestPrepareConfig(t *testing.T) {
 			},
 			wantConfig: &Config{
 				ContainerImage:          FakeConfig().ContainerImage,
+				MetadataContainerImage:  FakeConfig().MetadataContainerImage,
 				ImagePullPolicy:         FakeConfig().ImagePullPolicy,
 				CPULimit:                resource.MustParse("500m"),
 				CPURequest:              resource.MustParse("500m"),
@@ -114,8 +113,7 @@ func TestPrepareConfig(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			name:   "limits are set to '0'",
-			prefix: sidecarPrefixMap[GcsFuseSidecarName],
+			name: "limits are set to '0'",
 			annotations: map[string]string{
 				GcsFuseVolumeEnableAnnotation:   "true",
 				cpuLimitAnnotation:              "0",
@@ -124,6 +122,7 @@ func TestPrepareConfig(t *testing.T) {
 			},
 			wantConfig: &Config{
 				ContainerImage:          FakeConfig().ContainerImage,
+				MetadataContainerImage:  FakeConfig().MetadataContainerImage,
 				ImagePullPolicy:         FakeConfig().ImagePullPolicy,
 				CPULimit:                resource.Quantity{},
 				CPURequest:              FakeConfig().CPURequest,
@@ -135,8 +134,7 @@ func TestPrepareConfig(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			name:   "requests are set to '0'",
-			prefix: sidecarPrefixMap[GcsFuseSidecarName],
+			name: "requests are set to '0'",
 			annotations: map[string]string{
 				GcsFuseVolumeEnableAnnotation:     "true",
 				cpuRequestAnnotation:              "0",
@@ -145,6 +143,7 @@ func TestPrepareConfig(t *testing.T) {
 			},
 			wantConfig: &Config{
 				ContainerImage:          FakeConfig().ContainerImage,
+				MetadataContainerImage:  FakeConfig().MetadataContainerImage,
 				ImagePullPolicy:         FakeConfig().ImagePullPolicy,
 				CPULimit:                resource.Quantity{},
 				CPURequest:              resource.Quantity{},
@@ -156,8 +155,7 @@ func TestPrepareConfig(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			name:   "requests and limits are explicitly set",
-			prefix: sidecarPrefixMap[GcsFuseSidecarName],
+			name: "requests and limits are explicitly set",
 			annotations: map[string]string{
 				GcsFuseVolumeEnableAnnotation:     "true",
 				cpuLimitAnnotation:                "500m",
@@ -169,6 +167,7 @@ func TestPrepareConfig(t *testing.T) {
 			},
 			wantConfig: &Config{
 				ContainerImage:          FakeConfig().ContainerImage,
+				MetadataContainerImage:  FakeConfig().MetadataContainerImage,
 				ImagePullPolicy:         FakeConfig().ImagePullPolicy,
 				CPULimit:                resource.MustParse("500m"),
 				CPURequest:              resource.MustParse("100m"),
@@ -180,8 +179,7 @@ func TestPrepareConfig(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			name:   "requests and limits are explicitly set with '0' limits",
-			prefix: sidecarPrefixMap[GcsFuseSidecarName],
+			name: "requests and limits are explicitly set with '0' limits",
 			annotations: map[string]string{
 				GcsFuseVolumeEnableAnnotation:     "true",
 				cpuLimitAnnotation:                "0",
@@ -193,6 +191,7 @@ func TestPrepareConfig(t *testing.T) {
 			},
 			wantConfig: &Config{
 				ContainerImage:          FakeConfig().ContainerImage,
+				MetadataContainerImage:  FakeConfig().MetadataContainerImage,
 				ImagePullPolicy:         FakeConfig().ImagePullPolicy,
 				CPULimit:                resource.Quantity{},
 				CPURequest:              resource.MustParse("100m"),
@@ -204,8 +203,7 @@ func TestPrepareConfig(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			name:   "requests and limits are explicitly set with '0' requests",
-			prefix: sidecarPrefixMap[GcsFuseSidecarName],
+			name: "requests and limits are explicitly set with '0' requests",
 			annotations: map[string]string{
 				GcsFuseVolumeEnableAnnotation:     "true",
 				cpuLimitAnnotation:                "500m",
@@ -217,6 +215,7 @@ func TestPrepareConfig(t *testing.T) {
 			},
 			wantConfig: &Config{
 				ContainerImage:          FakeConfig().ContainerImage,
+				MetadataContainerImage:  FakeConfig().MetadataContainerImage,
 				ImagePullPolicy:         FakeConfig().ImagePullPolicy,
 				CPULimit:                resource.MustParse("500m"),
 				CPURequest:              resource.Quantity{},
@@ -228,84 +227,7 @@ func TestPrepareConfig(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			name:   "metadata prefetch requests and limits are provided",
-			prefix: sidecarPrefixMap[MetadataPrefetchSidecarName],
-			annotations: map[string]string{
-				GcsFuseVolumeEnableAnnotation:           "true",
-				cpuLimitAnnotation:                      "500m",
-				memoryLimitAnnotation:                   "1Gi",
-				ephemeralStorageLimitAnnotation:         "50Gi",
-				cpuRequestAnnotation:                    "0",
-				memoryRequestAnnotation:                 "0",
-				ephemeralStorageRequestAnnotation:       "0",
-				metadataPrefetchMemoryLimitAnnotation:   "20Mi",
-				metadataPrefetchMemoryRequestAnnotation: "20Mi",
-			},
-			wantConfig: &Config{
-				ContainerImage:          FakePrefetchConfig().ContainerImage,
-				ImagePullPolicy:         FakePrefetchConfig().ImagePullPolicy,
-				CPULimit:                resource.MustParse("50m"),
-				CPURequest:              resource.MustParse("10m"),
-				MemoryLimit:             resource.MustParse("20Mi"),
-				MemoryRequest:           resource.MustParse("20Mi"),
-				EphemeralStorageLimit:   resource.MustParse("10Mi"),
-				EphemeralStorageRequest: resource.MustParse("10Mi"),
-			},
-			expectErr: false,
-		},
-		{
-			name:   "metadata prefetch memory limits are provided",
-			prefix: sidecarPrefixMap[MetadataPrefetchSidecarName],
-			annotations: map[string]string{
-				GcsFuseVolumeEnableAnnotation:         "true",
-				cpuLimitAnnotation:                    "500m",
-				memoryLimitAnnotation:                 "1Gi",
-				ephemeralStorageLimitAnnotation:       "50Gi",
-				cpuRequestAnnotation:                  "0",
-				memoryRequestAnnotation:               "0",
-				ephemeralStorageRequestAnnotation:     "0",
-				metadataPrefetchMemoryLimitAnnotation: "20Mi",
-			},
-			wantConfig: &Config{
-				ContainerImage:          FakePrefetchConfig().ContainerImage,
-				ImagePullPolicy:         FakePrefetchConfig().ImagePullPolicy,
-				CPULimit:                resource.MustParse("50m"),
-				CPURequest:              resource.MustParse("10m"),
-				MemoryLimit:             resource.MustParse("20Mi"),
-				MemoryRequest:           resource.MustParse("20Mi"),
-				EphemeralStorageLimit:   resource.MustParse("10Mi"),
-				EphemeralStorageRequest: resource.MustParse("10Mi"),
-			},
-			expectErr: false,
-		},
-		{
-			name:   "metadata prefetch memory requests are provided",
-			prefix: sidecarPrefixMap[MetadataPrefetchSidecarName],
-			annotations: map[string]string{
-				GcsFuseVolumeEnableAnnotation:           "true",
-				cpuLimitAnnotation:                      "500m",
-				memoryLimitAnnotation:                   "1Gi",
-				ephemeralStorageLimitAnnotation:         "50Gi",
-				cpuRequestAnnotation:                    "0",
-				memoryRequestAnnotation:                 "0",
-				ephemeralStorageRequestAnnotation:       "0",
-				metadataPrefetchMemoryRequestAnnotation: "20Mi",
-			},
-			wantConfig: &Config{
-				ContainerImage:          FakePrefetchConfig().ContainerImage,
-				ImagePullPolicy:         FakePrefetchConfig().ImagePullPolicy,
-				CPULimit:                resource.MustParse("50m"),
-				CPURequest:              resource.MustParse("10m"),
-				MemoryLimit:             resource.MustParse("20Mi"),
-				MemoryRequest:           resource.MustParse("20Mi"),
-				EphemeralStorageLimit:   resource.MustParse("10Mi"),
-				EphemeralStorageRequest: resource.MustParse("10Mi"),
-			},
-			expectErr: false,
-		},
-		{
-			name:   "invalid resource Quantity should throw error",
-			prefix: sidecarPrefixMap[GcsFuseSidecarName],
+			name: "invalid resource Quantity should throw error",
 			annotations: map[string]string{
 				GcsFuseVolumeEnableAnnotation: "true",
 				cpuLimitAnnotation:            "invalid",
@@ -317,17 +239,11 @@ func TestPrepareConfig(t *testing.T) {
 
 	for _, tc := range testCases {
 		si := SidecarInjector{
-			Client:                 nil,
-			Config:                 FakeConfig(),
-			MetadataPrefetchConfig: FakePrefetchConfig(),
-			Decoder:                admission.NewDecoder(runtime.NewScheme()),
+			Client:  nil,
+			Config:  FakeConfig(),
+			Decoder: admission.NewDecoder(runtime.NewScheme()),
 		}
-		pod := corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Annotations: tc.annotations,
-			},
-		}
-		gotConfig, gotErr := si.prepareConfig(tc.prefix, pod)
+		gotConfig, gotErr := si.prepareConfig(tc.annotations)
 		if tc.expectErr != (gotErr != nil) {
 			t.Errorf(`for "%s", expect error: %v, but got error: %v`, tc.name, tc.expectErr, gotErr)
 		}
@@ -534,13 +450,6 @@ func TestValidateMutatingWebhookResponse(t *testing.T) {
 			nodes:        nativeSupportNodes(),
 		},
 		{
-			name:         "native container injection successful test, with prefetch.",
-			operation:    admissionv1.Create,
-			inputPod:     validInputPodWithPrefetchIncluded(),
-			wantResponse: wantResponseWithPrefetch(t, false, false, true),
-			nodes:        nativeSupportNodes(),
-		},
-		{
 			name:         "Injection with custom sidecar container image successful test with native nodes.",
 			operation:    admissionv1.Create,
 			inputPod:     validInputPodWithCustomImage(false),
@@ -589,11 +498,10 @@ func TestValidateMutatingWebhookResponse(t *testing.T) {
 			lister := informerFactory.Core().V1().Nodes().Lister()
 
 			si := SidecarInjector{
-				Client:                 nil,
-				Config:                 FakeConfig(),
-				MetadataPrefetchConfig: FakePrefetchConfig(),
-				Decoder:                admission.NewDecoder(runtime.NewScheme()),
-				NodeLister:             lister,
+				Client:     nil,
+				Config:     FakeConfig(),
+				Decoder:    admission.NewDecoder(runtime.NewScheme()),
+				NodeLister: lister,
 			}
 
 			stopCh := make(<-chan struct{})
@@ -760,18 +668,6 @@ func validInputPod() *corev1.Pod {
 	return validInputPodWithSettings(false, false)
 }
 
-func validInputPodWithPrefetchIncluded() *corev1.Pod {
-	pod := validInputPodWithSettings(false, false)
-	pod.ObjectMeta.Annotations[GcsFuseNativeSidecarEnableAnnotation] = "true"
-	pod.Spec.InitContainers = append(pod.Spec.InitContainers, corev1.Container{
-		Name:            MetadataPrefetchSidecarName,
-		Image:           "my-private-image",
-		SecurityContext: GetSecurityContext(),
-	})
-
-	return pod
-}
-
 func getWorkloadSpec(name string) corev1.Container {
 	return corev1.Container{
 		Name:  name,
@@ -795,14 +691,6 @@ func wantResponse(t *testing.T, customImage bool, nativeCustomImage bool, native
 	t.Helper()
 	pod := validInputPodWithSettings(customImage, nativeCustomImage)
 	newPod := *modifySpec(*validInputPodWithSettings(customImage, nativeCustomImage), customImage, nativeCustomImage, native)
-
-	return generatePatch(t, pod, &newPod)
-}
-
-func wantResponseWithPrefetch(t *testing.T, customImage bool, nativeCustomImage bool, native bool) admission.Response {
-	t.Helper()
-	pod := validInputPodWithPrefetchIncluded()
-	newPod := *modifySpec(*validInputPodWithPrefetchIncluded(), customImage, nativeCustomImage, native)
 
 	return generatePatch(t, pod, &newPod)
 }


### PR DESCRIPTION
Revert "Merge pull request #472 from chrisThePattyEater/fuechr/metadata-prefetch-memory-override"

This reverts commit ac9dc7c5cacd37ca6987426e35180d24d1ce4b1a, reversing changes made to 7b906aa74326c1d900da329a4295dcc451515173.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation

/kind failing-test

> /kind feature
> /kind flake

**What this PR does / why we need it**:
Revert "Merge pull request #472 from chrisThePattyEater/fuechr/metadata-prefetch-memory-override", needed due to failing test cases
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```