### PR TITLE
Add identity provider into mount options

### DIFF
--- a/pkg/cloud_provider/auth/fake.go
+++ b/pkg/cloud_provider/auth/fake.go
@@ -31,6 +31,10 @@ func (tm *fakeTokenManager) GetTokenSourceFromK8sServiceAccount(saNamespace, saN
 	return &FakeGCPTokenSource{k8sSAName: saName, k8sSANamespace: saNamespace}
 }
 
+func (tm *fakeTokenManager) GetIdentityProvider() string {
+	return "fake.identity.provider"
+}
+
 type FakeGCPTokenSource struct {
 	k8sSAName      string
 	k8sSANamespace string

--- a/pkg/cloud_provider/auth/token_manager.go
+++ b/pkg/cloud_provider/auth/token_manager.go
@@ -31,6 +31,7 @@ const (
 
 type TokenManager interface {
 	GetTokenSourceFromK8sServiceAccount(saNamespace, saName, saToken string) oauth2.TokenSource
+	GetIdentityProvider() string
 }
 
 type tokenManager struct {
@@ -45,6 +46,10 @@ func NewTokenManager(meta metadata.Service, clientset clientset.Interface) Token
 	}
 
 	return &tm
+}
+
+func (tm *tokenManager) GetIdentityProvider() string {
+	return tm.meta.GetIdentityProvider()
 }
 
 func (tm *tokenManager) GetTokenSourceFromK8sServiceAccount(saNamespace, saName, saToken string) oauth2.TokenSource {

--- a/pkg/sidecar_mounter/sidecar_mounter_config_test.go
+++ b/pkg/sidecar_mounter/sidecar_mounter_config_test.go
@@ -88,7 +88,7 @@ func TestPrepareMountArgs(t *testing.T) {
 				BufferDir:  "test-buffer-dir",
 				CacheDir:   "test-cache-dir",
 				ConfigFile: "test-config-file",
-				Options:    []string{"uid=100", "gid=200", "debug_gcs", "max-conns-per-host=10", "implicit-dirs", "write:create-empty-file:false", "logging:severity:error", "write:create-empty-file:true"},
+				Options:    []string{"uid=100", "gid=200", "token-server-identity-provider=https://fakeresource", "debug_gcs", "max-conns-per-host=10", "implicit-dirs", "write:create-empty-file:false", "logging:severity:error", "write:create-empty-file:true"},
 			},
 			expectedArgs: map[string]string{
 				"implicit-dirs":      "",
@@ -327,7 +327,7 @@ func TestPrepareConfigFile(t *testing.T) {
 					"metadata-cache:type-cache-max-size-mb": "-1",
 					"cache-dir":                             "/gcsfuse-cache/.volumes/volume-name",
 				},
-				PodShouldUseTokenServer: true,
+				TokenServerIdentityProvider: "https://container.googleapis.com/v1/projects/fake-project/locations/us-central1/clusters/fake-cluster",
 			},
 			expectedConfig: map[string]interface{}{
 				"logging": map[string]interface{}{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup

> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
We need environment specific id provider to facilitate sandbox/staging testing.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
Tested:

1) building and installing GCSFuse CSI on a test cluster and created 1) pod with hostnetwork 2) pod without hostnetwork.
2) e2e test 
```
make e2e-test E2E_TEST_USE_GKE_MANAGED_DRIVER=false E2E_TEST_BUILD_DRIVER=true E2E_TEST_FOCUS=should.successfully.mount.for.hostnetwork.enabled.pods STAGINGVERSION=v999.999.007 REGISTRY=gcr.io/shensiyan-joonix
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```