### PR TITLE
Add script to delete leaked autogenerated buckets.

### DIFF
--- a/hack/utils/delete-generated-buckets.sh
+++ b/hack/utils/delete-generated-buckets.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# Copyright 2018 The Kubernetes Authors.
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Script to delete all GCS buckets with a given prefix
+
+BUCKET_PREFIX="gcsfusecsi-testsuite-gen-"
+
+# List all buckets
+BUCKETS=$(gsutil ls)
+
+# Array to store buckets to be deleted
+DELETE_BUCKETS=()
+
+# Identify buckets for deletion and print them
+echo "The following buckets will be deleted:"
+for BUCKET in $BUCKETS; do
+  # Extract the bucket name (remove gs://)
+  BUCKET_NAME=$(echo $BUCKET | sed 's/gs:\/\///')
+
+  # Check if the bucket starts with the specified prefix
+  if [[ "$BUCKET_NAME" == "$BUCKET_PREFIX"* ]]; then
+    echo "- $BUCKET_NAME"
+    DELETE_BUCKETS+=("$BUCKET_NAME") # Add to array
+  fi
+done
+
+# Check if there are any buckets to delete
+if [[ ${#DELETE_BUCKETS[@]} -eq 0 ]]; then
+  echo "No buckets found with the prefix '$BUCKET_PREFIX'. Script exiting."
+  exit 0
+fi
+
+# Prompt for confirmation
+read -p "Are you sure you want to delete ALL the listed buckets? (y/n): " CONFIRM
+
+# If the user confirms, delete the buckets
+if [[ "$CONFIRM" == "y" || "$CONFIRM" == "Y" ]]; then
+  echo "Deleting buckets..."
+  for BUCKET_NAME in "${DELETE_BUCKETS[@]}"; do
+    gsutil -m rm -r "gs://$BUCKET_NAME"
+    echo "Deleted: $BUCKET_NAME"
+  done
+  echo "All specified buckets have been deleted."
+else
+  echo "Deletion cancelled."
+  exit 0
+fi
+
+echo "Script completed."

--- a/test/e2e/specs/testdriver.go
+++ b/test/e2e/specs/testdriver.go
@@ -436,7 +436,7 @@ func (n *GCSFuseCSITestDriver) createBucket(ctx context.Context, serviceAccountN
 	// so there is no need to check if the bucket already exists
 	newBucket := &storage.ServiceBucket{
 		Project:                        n.meta.GetProjectID(),
-		Name:                           uuid.NewString(),
+		Name:                           "gcsfusecsi-testsuite-gen-" + uuid.NewString(),
 		Location:                       n.bucketLocation,
 		EnableUniformBucketLevelAccess: true,
 		EnableHierarchicalNamespace:    n.EnableHierarchicalNamespace,


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
When running the e2e testsuite locally, sometimes you may want to terminate it early. If terminated suddenly, the buckets that were generated wont be deleted. Adding a script that can perform this cleanup.

<img width="845" alt="image" src="https://github.com/user-attachments/assets/77eb0490-1403-4c2c-a102-6e0107ca5ae3" />

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```