### PR TITLE
skip mountOptions test for versions where it is not supported

### DIFF
--- a/test/e2e/utils/cluster.go
+++ b/test/e2e/utils/cluster.go
@@ -34,6 +34,7 @@ var (
 	skipBucketCheckMinimumVersion     = version.MustParseGeneric("1.29.0")
 	kernelReadAheadMinimumVersion     = version.MustParseGeneric("1.32.0")
 	metadataPrefetchMinimumVersion    = version.MustParseGeneric("1.32.0")
+	longMountOptionsMinimumVersion    = version.MustParseGeneric("1.32.0")
 )
 
 func clusterDownGKE(testParams *TestParameters) error {

--- a/test/e2e/utils/handler.go
+++ b/test/e2e/utils/handler.go
@@ -239,6 +239,11 @@ func generateTestSkip(testParams *TestParameters) string {
 		skipTests = append(skipTests, "metadata.prefetch")
 	}
 
+	supportsLongMountOptions, _ := ClusterAtLeastMinVersion(testParams.GkeClusterVersion, testParams.GkeNodeVersion, longMountOptionsMinimumVersion)
+	if !supportsLongMountOptions {
+		skipTests = append(skipTests, "long.mount.options")
+	}
+
 	if testParams.UseGKEManagedDriver {
 		skipTests = append(skipTests, "metrics") // Skipping as these tests are known to be unstable
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation

/kind failing-test

> /kind feature
> /kind flake

**What this PR does / why we need it**:
Skip mount options test for versions where mountOption length hasn't been extended. We are only going to add https://github.com/GoogleCloudPlatform/gcs-fuse-csi-driver/pull/503 into the 1.32 release, so we should skip for versions less than 1.32.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Skip mount options test for versions where mountOption length hasn't been extended
```