### PR TITLE
Skip tests for hostnetwork enabled pods on autopilot clusters

### DIFF
--- a/test/e2e/testsuites/volumes.go
+++ b/test/e2e/testsuites/volumes.go
@@ -346,7 +346,7 @@ func (t *gcsFuseCSIVolumesTestSuite) DefineTests(driver storageframework.TestDri
 	ginkgo.It("should store data using custom sidecar container image", func() {
 		testCaseStoreDataCustomContainerImage("")
 	})
-	ginkgo.It("should gcsfuse process succeed without missing flag error for hostnetwork pods using custom sidecar container image", func() {
+	ginkgo.It("should gcsfuse process succeed without missing flag error for hostnetwork enabled pods using custom sidecar container image", func() {
 		testCaseStoreDataCustomContainerImage(specs.EnableHostNetworkPrefix)
 	})
 	ginkgo.It("[csi-skip-bucket-access-check] should store data using custom sidecar container image", func() {

--- a/test/e2e/utils/handler.go
+++ b/test/e2e/utils/handler.go
@@ -244,6 +244,10 @@ func generateTestSkip(testParams *TestParameters) string {
 		skipTests = append(skipTests, "long.mount.options")
 	}
 
+	if testParams.UseGKEAutopilot {
+		skipTests = append(skipTests, "hostnetwork.enabled.pods")
+	}
+
 	if testParams.UseGKEManagedDriver {
 		skipTests = append(skipTests, "metrics") // Skipping as these tests are known to be unstable
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation

/kind failing-test

> /kind feature
> /kind flake

**What this PR does / why we need it**:
Violations details: {"[denied by autogke-disallow-hostnamespaces]":["enabling hostNetwork is not allowed in Autopilot."]}

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```