### PR TITLE
Automated cherry pick of #530: Skip tests for hostnetwork enabled pods on autopilot clusters

### DIFF
--- a/test/e2e/testsuites/volumes.go
+++ b/test/e2e/testsuites/volumes.go
@@ -346,7 +346,7 @@ func (t *gcsFuseCSIVolumesTestSuite) DefineTests(driver storageframework.TestDri
 	ginkgo.It("should store data using custom sidecar container image", func() {
 		testCaseStoreDataCustomContainerImage("")
 	})
-	ginkgo.It("should gcsfuse process succeed without missing flag error for hostnetwork pods using custom sidecar container image", func() {
+	ginkgo.It("should gcsfuse process succeed without missing flag error for hostnetwork enabled pods using custom sidecar container image", func() {
 		testCaseStoreDataCustomContainerImage(specs.EnableHostNetworkPrefix)
 	})
 	ginkgo.It("[csi-skip-bucket-access-check] should store data using custom sidecar container image", func() {

--- a/test/e2e/utils/handler.go
+++ b/test/e2e/utils/handler.go
@@ -244,6 +244,10 @@ func generateTestSkip(testParams *TestParameters) string {
 		skipTests = append(skipTests, "long.mount.options")
 	}
 
+	if testParams.UseGKEAutopilot {
+		skipTests = append(skipTests, "hostnetwork.enabled.pods")
+	}
+
 	if testParams.UseGKEManagedDriver {
 		skipTests = append(skipTests, "metrics") // Skipping as these tests are known to be unstable
 


### PR DESCRIPTION
Cherry pick of #530 on release-1.13.

#530: Skip tests for hostnetwork enabled pods on autopilot clusters

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```