### PR TITLE
Fail NodePublishVolume with actionable error in case Workload Identity is not yet enabled on node level

### DIFF
--- a/cmd/csi_driver/main.go
+++ b/cmd/csi_driver/main.go
@@ -101,6 +101,7 @@ func main() {
 		}
 
 		clientset.ConfigurePodLister(*nodeID)
+		clientset.ConfigureNodeLister(*nodeID)
 
 		mounter, err = csimounter.New("", *fuseSocketDir)
 		if err != nil {

--- a/deploy/base/node/node_setup.yaml
+++ b/deploy/base/node/node_setup.yaml
@@ -37,6 +37,9 @@ rules:
     resources: ["pods"]
     verbs: ["get", "watch", "list"]
   - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "watch", "list"]
+  - apiGroups: [""]
     resources: ["serviceaccounts"]
     verbs: ["get"]
 ---

--- a/pkg/cloud_provider/clientset/fake.go
+++ b/pkg/cloud_provider/clientset/fake.go
@@ -26,18 +26,21 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-type FakeClientset struct{}
+type FakeClientset struct {
+	fakePod  *corev1.Pod
+	fakeNode *corev1.Node
+}
 
 func (c *FakeClientset) ConfigurePodLister(_ string) {}
 
 func (c *FakeClientset) ConfigureNodeLister(_ string) {}
 
-func (c *FakeClientset) GetPod(namespace, name string) (*corev1.Pod, error) {
+func (c *FakeClientset) CreatePod(hostNetworkEnabled bool) {
 	config := webhook.FakeConfig()
-	pod := &corev1.Pod{
+	c.fakePod = &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
+			Name:      "",
+			Namespace: "",
 		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
@@ -57,17 +60,33 @@ func (c *FakeClientset) GetPod(namespace, name string) (*corev1.Pod, error) {
 		},
 	}
 
-	return pod, nil
+	if hostNetworkEnabled {
+		c.fakePod.Spec.HostNetwork = true
+	}
 }
 
-func (c *FakeClientset) GetNode(name string) (*corev1.Node, error) {
-	node := &corev1.Node{
+func (c *FakeClientset) CreateNode(isWorkloadIdentityEnabled bool) {
+	c.fakeNode = &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
+			Name:   "",
+			Labels: map[string]string{},
 		},
 	}
 
-	return node, nil
+	if isWorkloadIdentityEnabled {
+		c.fakeNode.Labels[GkeMetaDataServerKey] = "true"
+	}
+}
+
+func (c *FakeClientset) GetPod(namespace, name string) (*corev1.Pod, error) {
+	c.fakePod.ObjectMeta.Name = name
+	c.fakePod.ObjectMeta.Namespace = namespace
+	return c.fakePod, nil
+}
+
+func (c *FakeClientset) GetNode(name string) (*corev1.Node, error) {
+	c.fakeNode.ObjectMeta.Name = name
+	return c.fakeNode, nil
 }
 
 func (c *FakeClientset) CreateServiceAccountToken(_ context.Context, _, _ string, _ *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error) {

--- a/pkg/cloud_provider/clientset/fake.go
+++ b/pkg/cloud_provider/clientset/fake.go
@@ -30,6 +30,8 @@ type FakeClientset struct{}
 
 func (c *FakeClientset) ConfigurePodLister(_ string) {}
 
+func (c *FakeClientset) ConfigureNodeLister(_ string) {}
+
 func (c *FakeClientset) GetPod(namespace, name string) (*corev1.Pod, error) {
 	config := webhook.FakeConfig()
 	pod := &corev1.Pod{
@@ -56,6 +58,16 @@ func (c *FakeClientset) GetPod(namespace, name string) (*corev1.Pod, error) {
 	}
 
 	return pod, nil
+}
+
+func (c *FakeClientset) GetNode(name string) (*corev1.Node, error) {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+
+	return node, nil
 }
 
 func (c *FakeClientset) CreateServiceAccountToken(_ context.Context, _, _ string, _ *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error) {

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -141,6 +141,18 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 		fuseMountOptions = joinMountOptions(fuseMountOptions, []string{"token-server-identity-provider=" + identityProvider})
 	}
 
+	node, err := s.k8sClients.GetNode(s.driver.config.NodeID)
+	if err != nil {
+		return nil, status.Errorf(codes.NotFound, "failed to get node: %v", err)
+	}
+
+	val, ok := node.Labels[clientset.GkeMetaDataServerKey]
+	// If Workload Identity is not enabled, the key should be missing; the check for "val == false" is just for extra caution
+	isWorkloadIdentityDisabled := val == "false" || !ok
+	if isWorkloadIdentityDisabled && !pod.Spec.HostNetwork {
+		return nil, status.Errorf(codes.FailedPrecondition, "Workload Identity Federation is not enabled on node. Please make sure this is enabled on both cluster and node pool level.")
+	}
+
 	// Since the webhook mutating ordering is not definitive,
 	// the sidecar position is not checked in the ValidatePodHasSidecarContainerInjected func.
 	shouldInjectedByWebhook := strings.ToLower(pod.Annotations[webhook.GcsFuseVolumeEnableAnnotation]) == util.TrueStr

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -148,9 +148,9 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 
 	val, ok := node.Labels[clientset.GkeMetaDataServerKey]
 	// If Workload Identity is not enabled, the key should be missing; the check for "val == false" is just for extra caution
-	isWorkloadIdentityDisabled := val == "false" || !ok
+	isWorkloadIdentityDisabled := val != "true" || !ok
 	if isWorkloadIdentityDisabled && !pod.Spec.HostNetwork {
-		return nil, status.Errorf(codes.FailedPrecondition, "Workload Identity Federation is not enabled on node. Please make sure this is enabled on both cluster and node pool level.")
+		return nil, status.Errorf(codes.FailedPrecondition, "Workload Identity Federation is not enabled on node. Please make sure this is enabled on both cluster and node pool level (https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity)")
 	}
 
 	// Since the webhook mutating ordering is not definitive,

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -27,6 +27,7 @@ import (
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/clientset"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/storage"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util"
 	"golang.org/x/net/context"
@@ -53,6 +54,21 @@ func initTestNodeServer(t *testing.T) *nodeServerTestEnv {
 	t.Helper()
 	mounter := mount.NewFakeMounter([]mount.MountPoint{})
 	driver := initTestDriver(t, mounter)
+	s, _ := driver.config.StorageServiceManager.SetupService(context.TODO(), nil)
+	if _, err := s.CreateBucket(context.Background(), &storage.ServiceBucket{Name: testVolumeID}); err != nil {
+		t.Fatalf("failed to create the fake bucket: %v", err)
+	}
+
+	return &nodeServerTestEnv{
+		ns: newNodeServer(driver, mounter),
+		fm: mounter,
+	}
+}
+
+func initTestNodeServerWithCustomClientset(t *testing.T, clientSet *clientset.FakeClientset) *nodeServerTestEnv {
+	t.Helper()
+	mounter := mount.NewFakeMounter([]mount.MountPoint{})
+	driver := initTestDriverWithCustomNodeServer(t, mounter, clientSet)
 	s, _ := driver.config.StorageServiceManager.SetupService(context.TODO(), nil)
 	if _, err := s.CreateBucket(context.Background(), &storage.ServiceBucket{Name: testVolumeID}); err != nil {
 		t.Fatalf("failed to create the fake bucket: %v", err)
@@ -165,7 +181,6 @@ func TestNodePublishVolume(t *testing.T) {
 		if test.mounts != nil {
 			testEnv.fm.MountPoints = test.mounts
 		}
-
 		_, err := testEnv.ns.NodePublishVolume(context.TODO(), test.req)
 		if test.expectErr == nil && err != nil {
 			t.Errorf("test %q failed:\ngot error %q,\nexpected error nil", test.name, err)
@@ -175,6 +190,75 @@ func TestNodePublishVolume(t *testing.T) {
 		}
 		validateMountPoint(t, test.name, testEnv.fm, test.expectedMount)
 	}
+}
+
+func TestNodePublishVolumeWIDisabledOnNode(t *testing.T) {
+	defaultPerm := os.FileMode(0o750) + os.ModeDir
+	// Setup mount target path
+	tmpDir := "/tmp/var/lib/kubelet/pods/test-pod-id/volumes/kubernetes.io~csi/"
+	if err := os.MkdirAll(tmpDir, defaultPerm); err != nil {
+		t.Fatalf("failed to setup tmp dir path: %v", err)
+	}
+	base, err := os.MkdirTemp(tmpDir, "node-publish-")
+	if err != nil {
+		t.Fatalf("failed to setup testdir: %v", err)
+	}
+	testTargetPath := filepath.Join(base, "mount")
+	if err = os.MkdirAll(testTargetPath, defaultPerm); err != nil {
+		t.Fatalf("failed to setup target path: %v", err)
+	}
+	defer os.RemoveAll(base)
+
+	req := &csi.NodePublishVolumeRequest{
+		VolumeId:         testVolumeID,
+		TargetPath:       testTargetPath,
+		VolumeCapability: testVolumeCapability,
+	}
+
+	cases := []struct {
+		name                          string
+		hostNetworkEnabledOnPod       bool
+		workloadIdentityEnabledOnNode bool
+		expectErr                     error
+	}{
+		{
+			name:                          "workload identity is enabled on node + pod using hostnetwork",
+			hostNetworkEnabledOnPod:       true,
+			workloadIdentityEnabledOnNode: true,
+		},
+		{
+			name:                          "workload identity is not enabled on node + pod is not using hostnetwork, expecting error",
+			hostNetworkEnabledOnPod:       false,
+			workloadIdentityEnabledOnNode: false,
+			expectErr:                     status.Errorf(codes.FailedPrecondition, "Workload Identity Federation is not enabled on node. Please make sure this is enabled on both cluster and node pool level (https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity)"),
+		},
+		{
+			name:                          "testcase3",
+			hostNetworkEnabledOnPod:       false,
+			workloadIdentityEnabledOnNode: true,
+		},
+		{
+			name:                          "testcase4",
+			hostNetworkEnabledOnPod:       true,
+			workloadIdentityEnabledOnNode: false,
+			// TODO: confirm if this case needs to throw an error (if hostnetwork requires node to have GKE Metadata server enabled) once hostnetwork feature is available for testing
+		},
+	}
+	for _, test := range cases {
+		fakeClientSet := &clientset.FakeClientset{}
+		fakeClientSet.CreateNode( /* workloadIdentityEnabled */ test.workloadIdentityEnabledOnNode)
+		fakeClientSet.CreatePod( /* hostNetworkEnabled */ test.hostNetworkEnabledOnPod)
+		testEnv := initTestNodeServerWithCustomClientset(t, fakeClientSet)
+
+		_, err = testEnv.ns.NodePublishVolume(context.TODO(), req)
+		if test.expectErr == nil && err != nil {
+			t.Errorf("test %q failed:\ngot error %q,\nexpected error nil", test.name, err)
+		}
+		if test.expectErr != nil && !errors.Is(err, test.expectErr) {
+			t.Errorf("test %q failed:\ngot error %q,\nexpected error %q", test.name, err, test.expectErr)
+		}
+	}
+
 }
 
 func TestNodeUnpublishVolume(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:
Add a check for GKE metadata server label on node to fail MountVolume (NodePublishVolume) with an actionable error. The target scenario is when an user enabled Workload Identity on an existing cluster, but didn't update their node pool to use GKE metadata server. Currently, this error takes more effort to debug since NodePublishVolume still succeeds, but we would see R/W errors from the sidecar due to PermissionDenied as the default SA lacks the appropriate permission for the GCS bucket.

Testing documentation with custom driver image: https://paste.googleplex.com/5532151901323264

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fail MountVolume with actionable error in case Workload Identity is not yet enabled on node level
```