### PR TITLE
Replace metadata prefetch prefix with dash instead of slash to keep u…

### DIFF
--- a/pkg/webhook/injection.go
+++ b/pkg/webhook/injection.go
@@ -29,7 +29,7 @@ import (
 
 var sidecarPrefixMap = map[string]string{
 	GcsFuseSidecarName:          "gke-gcsfuse/",
-	MetadataPrefetchSidecarName: "gke-gcsfuse/metadata-prefetch/",
+	MetadataPrefetchSidecarName: "gke-gcsfuse/metadata-prefetch-",
 }
 
 // used to guarantee containers start in the correct sequence based on inter-container dependencies.

--- a/pkg/webhook/injection_test.go
+++ b/pkg/webhook/injection_test.go
@@ -1030,14 +1030,14 @@ func TestInjectMetadataPrefetchSidecar(t *testing.T) {
 			expectedPod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						"gke-gcsfuse/metadata-prefetch/container-image":           "fake-image",
-						"gke-gcsfuse/metadata-prefetch/cpu-limit":                 "250m",
-						"gke-gcsfuse/metadata-prefetch/cpu-request":               "250m",
-						"gke-gcsfuse/metadata-prefetch/ephemeral-storage-limit":   "5Gi",
-						"gke-gcsfuse/metadata-prefetch/ephemeral-storage-request": "5Gi",
-						"gke-gcsfuse/metadata-prefetch/image-pull-policy":         "Always",
-						"gke-gcsfuse/metadata-prefetch/memory-limit":              "20Mi",
-						"gke-gcsfuse/metadata-prefetch/memory-request":            "20Mi",
+						"gke-gcsfuse/metadata-prefetch-container-image":           "fake-image",
+						"gke-gcsfuse/metadata-prefetch-cpu-limit":                 "250m",
+						"gke-gcsfuse/metadata-prefetch-cpu-request":               "250m",
+						"gke-gcsfuse/metadata-prefetch-ephemeral-storage-limit":   "5Gi",
+						"gke-gcsfuse/metadata-prefetch-ephemeral-storage-request": "5Gi",
+						"gke-gcsfuse/metadata-prefetch-image-pull-policy":         "Always",
+						"gke-gcsfuse/metadata-prefetch-memory-limit":              "20Mi",
+						"gke-gcsfuse/metadata-prefetch-memory-request":            "20Mi",
 					},
 				},
 				Spec: corev1.PodSpec{
@@ -1147,13 +1147,13 @@ func TestInjectMetadataPrefetchSidecar(t *testing.T) {
 			expectedPod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						"gke-gcsfuse/metadata-prefetch/container-image":           "fake-image",
-						"gke-gcsfuse/metadata-prefetch/cpu-limit":                 "250m",
-						"gke-gcsfuse/metadata-prefetch/cpu-request":               "250m",
-						"gke-gcsfuse/metadata-prefetch/ephemeral-storage-limit":   "5Gi",
-						"gke-gcsfuse/metadata-prefetch/ephemeral-storage-request": "5Gi",
-						"gke-gcsfuse/metadata-prefetch/image-pull-policy":         "Always",
-						"gke-gcsfuse/metadata-prefetch/memory-request":            "20Mi",
+						"gke-gcsfuse/metadata-prefetch-container-image":           "fake-image",
+						"gke-gcsfuse/metadata-prefetch-cpu-limit":                 "250m",
+						"gke-gcsfuse/metadata-prefetch-cpu-request":               "250m",
+						"gke-gcsfuse/metadata-prefetch-ephemeral-storage-limit":   "5Gi",
+						"gke-gcsfuse/metadata-prefetch-ephemeral-storage-request": "5Gi",
+						"gke-gcsfuse/metadata-prefetch-image-pull-policy":         "Always",
+						"gke-gcsfuse/metadata-prefetch-memory-request":            "20Mi",
 					},
 				},
 				Spec: corev1.PodSpec{
@@ -1280,14 +1280,14 @@ func TestInjectMetadataPrefetchSidecar(t *testing.T) {
 			expectedPod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						"gke-gcsfuse/metadata-prefetch/container-image":           "fake-image",
-						"gke-gcsfuse/metadata-prefetch/cpu-limit":                 "50m",
-						"gke-gcsfuse/metadata-prefetch/cpu-request":               "10m",
-						"gke-gcsfuse/metadata-prefetch/ephemeral-storage-limit":   "10Mi",
-						"gke-gcsfuse/metadata-prefetch/ephemeral-storage-request": "10Mi",
-						"gke-gcsfuse/metadata-prefetch/image-pull-policy":         "Always",
-						"gke-gcsfuse/metadata-prefetch/memory-limit":              "10Mi",
-						"gke-gcsfuse/metadata-prefetch/memory-request":            "10Mi",
+						"gke-gcsfuse/metadata-prefetch-container-image":           "fake-image",
+						"gke-gcsfuse/metadata-prefetch-cpu-limit":                 "50m",
+						"gke-gcsfuse/metadata-prefetch-cpu-request":               "10m",
+						"gke-gcsfuse/metadata-prefetch-ephemeral-storage-limit":   "10Mi",
+						"gke-gcsfuse/metadata-prefetch-ephemeral-storage-request": "10Mi",
+						"gke-gcsfuse/metadata-prefetch-image-pull-policy":         "Always",
+						"gke-gcsfuse/metadata-prefetch-memory-limit":              "10Mi",
+						"gke-gcsfuse/metadata-prefetch-memory-request":            "10Mi",
 					},
 				},
 				Spec: corev1.PodSpec{

--- a/pkg/webhook/mutatingwebhook.go
+++ b/pkg/webhook/mutatingwebhook.go
@@ -42,8 +42,8 @@ const (
 	memoryRequestAnnotation                 = "gke-gcsfuse/memory-request"
 	ephemeralStorageLimitAnnotation         = "gke-gcsfuse/ephemeral-storage-limit"
 	ephemeralStorageRequestAnnotation       = "gke-gcsfuse/ephemeral-storage-request"
-	metadataPrefetchMemoryLimitAnnotation   = "gke-gcsfuse/metadata-prefetch/memory-limit"
-	metadataPrefetchMemoryRequestAnnotation = "gke-gcsfuse/metadata-prefetch/memory-request"
+	metadataPrefetchMemoryLimitAnnotation   = "gke-gcsfuse/metadata-prefetch-memory-limit"
+	metadataPrefetchMemoryRequestAnnotation = "gke-gcsfuse/metadata-prefetch-memory-request"
 )
 
 type SidecarInjector struct {


### PR DESCRIPTION
…p to date with gcw

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This pr enables metadata prefetch annotation using - instead of / 
**Which issue(s) this PR fixes**:
A recent change was merged to enable metadata prefetch annotations for resource limits and requests. However, the Google-managed version of the driver uses hyphens (-) in the annotation keys instead of slashes (/), due to constraints that prevent multiple slashes. To keep things consistent, we've updated our annotations to match the Google-managed format.
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```