### PR TITLE
Pass --machine-type and --disable-autoconfig flags from driver to gcsfuse

### DIFF
--- a/cmd/csi_driver/main.go
+++ b/cmd/csi_driver/main.go
@@ -48,7 +48,7 @@ var (
 	fuseSocketDir             = flag.String("fuse-socket-dir", "/sockets", "FUSE socket directory")
 	metricsEndpoint           = flag.String("metrics-endpoint", "", "The TCP network address where the Prometheus metrics endpoint will listen (example: `:8080`). The default is empty string, which means that the metrics endpoint is disabled.")
 	maximumNumberOfCollectors = flag.Int("max-metric-collectors", -1, "Maximum number of prometheus metric collectors exporting metrics at a time, less than 0 (e.g -1) means no limit.")
-
+	disableAutoconfig         = flag.Bool("disable-autoconfig", false, "Disable gcsfuse's defaulting based on machine type")
 	// These are set at compile time.
 	version = "unknown"
 )
@@ -126,6 +126,7 @@ func main() {
 		Mounter:               mounter,
 		K8sClients:            clientset,
 		MetricsManager:        mm,
+		DisableAutoconfig:     *disableAutoconfig,
 	}
 
 	gcfsDriver, err := driver.NewGCSDriver(config)

--- a/pkg/cloud_provider/clientset/clientset.go
+++ b/pkg/cloud_provider/clientset/clientset.go
@@ -59,6 +59,7 @@ type Clientset struct {
 }
 
 const GkeMetaDataServerKey = "iam.gke.io/gke-metadata-server-enabled"
+const MachineTypeKey = "node.kubernetes.io/instance-type"
 
 func (c *Clientset) ConfigureNodeLister(nodeName string) {
 	trim := func(obj interface{}) (interface{}, error) {
@@ -80,6 +81,10 @@ func (c *Clientset) ConfigureNodeLister(nodeName string) {
 		isGkeMetaDataServerEnabled, ok := nodeObj.ObjectMeta.Labels[GkeMetaDataServerKey]
 		if ok {
 			newLabels[GkeMetaDataServerKey] = isGkeMetaDataServerEnabled
+		}
+		machineType, ok := nodeObj.ObjectMeta.Labels[MachineTypeKey]
+		if ok {
+			newLabels[MachineTypeKey] = machineType
 		}
 
 		nodeObj.Spec = corev1.NodeSpec{}

--- a/pkg/csi_driver/gcs_fuse_driver.go
+++ b/pkg/csi_driver/gcs_fuse_driver.go
@@ -45,6 +45,7 @@ type GCSDriverConfig struct {
 	Mounter               mount.Interface
 	K8sClients            clientset.Interface
 	MetricsManager        metrics.Manager
+	DisableAutoconfig     bool
 }
 
 type GCSDriver struct {

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -247,7 +247,7 @@ func TestNodePublishVolumeWIDisabledOnNode(t *testing.T) {
 	}
 	for _, test := range cases {
 		fakeClientSet := &clientset.FakeClientset{}
-		fakeClientSet.CreateNode( /* workloadIdentityEnabled */ test.workloadIdentityEnabledOnNode)
+		fakeClientSet.CreateNode( /* workloadIdentityEnabled */ clientset.FakeNodeConfig{IsWorkloadIdentityEnabled: test.workloadIdentityEnabledOnNode})
 		fakeClientSet.CreatePod( /* hostNetworkEnabled */ test.hostNetworkEnabledOnPod)
 		testEnv := initTestNodeServerWithCustomClientset(t, fakeClientSet)
 

--- a/pkg/csi_driver/utils_test.go
+++ b/pkg/csi_driver/utils_test.go
@@ -156,6 +156,47 @@ func TestIsSidecarVersionSupportedForTokenServer(t *testing.T) {
 	})
 }
 
+func TestIsSidecarVersionSupportedForDefaultingFlags(t *testing.T) {
+	t.Parallel()
+	t.Run("checking if sidecar version is supported for token server", func(t *testing.T) {
+		t.Parallel()
+		testCases := []struct {
+			name              string
+			imageName         string
+			expectedSupported bool
+		}{
+			{
+				name:              "should return true for supported sidecar version",
+				imageName:         "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gcs-fuse-csi-driver-sidecar-mounter:v1.99.0-gke.2@sha256:abcd",
+				expectedSupported: true,
+			},
+			{
+				name:              "should return true for supported sidecar version in staging gcr",
+				imageName:         "gcr.io/gke-release-staging/gcs-fuse-csi-driver-sidecar-mounter:v1.99.0-gke.0@sha256:abcd",
+				expectedSupported: true,
+			},
+			{
+				name:              "should return false for unsupported sidecar version",
+				imageName:         "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gcs-fuse-csi-driver-sidecar-mounter:v1.14.0-gke.1@sha256:abcd",
+				expectedSupported: false,
+			},
+			{
+				name:              "should return false for private sidecar",
+				imageName:         "customer.gcr.io/dir/gcs-fuse-csi-driver-sidecar-mounter:v1.12.2-gke.0@sha256:abcd",
+				expectedSupported: false,
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Logf("test case: %s", tc.name)
+			actual := isSidecarVersionSupportedForGivenFeature(tc.imageName, AutoconfigDefaultingSidecarMinVersion)
+			if actual != tc.expectedSupported {
+				t.Errorf("Got supported %v, but expected %v", actual, tc.expectedSupported)
+			}
+		}
+	})
+}
+
 func TestParseVolumeAttributes(t *testing.T) {
 	t.Parallel()
 	t.Run("parsing volume attributes into mount options", func(t *testing.T) {

--- a/test/e2e/specs/testdriver.go
+++ b/test/e2e/specs/testdriver.go
@@ -239,6 +239,8 @@ func (n *GCSFuseCSITestDriver) CreateVolume(ctx context.Context, config *storage
 		case EnableMetadataPrefetchAndInvalidMountOptionsVolumePrefix:
 			mountOptions += ",file-system:kernel-list-cache-ttl-secs:-1,invalid-option"
 			v.metadataPrefetch = true
+		case DisableAutoconfig:
+			mountOptions += ",disable-autoconfig"
 		}
 
 		v.mountOptions = mountOptions


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:

This PR bumped gcsfuse binary to v2.12.0-gke-0, where the the new two mountOptions start to be supported. Note that gcsfuse receives these flags but will not turn on the default values until v3.

**Summary of changes:**

As part of GCSFuse's intelligent defaults, new mountOption flags are supported: --machine-type and --disable-autoconfig.
We want to pass these two flags over from the driver to GCSFuse in the following mechanism:
1. --machine-type: The driver has existing mechanism to get Node objects from K8s server starting from [v1.14.0](https://github.com/GoogleCloudPlatform/gcs-fuse-csi-driver/releases/tag/v1.14.0). We're fetching the node object inside NodePublishVolume, get the instance-type label, 
2. --disable-autoconfig: This will be a new driver flag, defaulted to 'false', and added to driver's config, which is accessible from inside NodePublishVolume. This flag denotes whether gcsfuse will apply the machine-type based intelligent defaults.

Both flags are then written as a line-separated map to a temporary file under targetPath, which will be read by the sidecar container upon startup. The sidecar parses the file, reconstructs the map, and merges this map into the config file map. This approach is extensible, allowing us to add  any new flag that we want to pass from the GCSFuse Driver container to the sidecar container and ultimately to the GCSFuse process.

Note that the PR also wraps the flag-writing logic on the driver behind a sidecar version filter, which checks that the sidecar container is a **managed** sidecar and **on a compatible version** (linked to a gcsfuse binary where the new flags are supported). This is to ensure that the file won't be unnecessarily written by the driver if not ultimately consumable by the sidecar (in the case of old/private sidecars). This minimum version is currently using a placeholder of v1.99.0-gke.0 in this PR, and we'll update this with the exact value after we completed the first round of release and get the corresponding sidecar image's version.

**Testing**: 

Flag-passing functionality testing:

The PR has been tested both manually and with two new E2E tests by checking the GCSFuse config logged by the sidecar container:

1. Test that --machine-type and --disable-autoconfig=false (using driver's default value) are passed  correctly to GCSFuse
2. Test that --machine-type and --disable-autoconfig=true (overwritten by the user pod's mountOptions) are passed correctly to GCSFuse

I ran these E2E tests with driver code built without the sidecar version filter, and made sure they're WAI: https://paste.googleplex.com/4777435008335872

Sidecar version filter testing:

1. Added unit tests for sidecar version check for all possible scenarios (compatible managed sidecar, old managed sidecar, private sidecar)
2. Tested that [existing E2E tests](https://github.com/GoogleCloudPlatform/gcs-fuse-csi-driver/blob/6113e07468228144f8c149d523763838741f8bb8/test/e2e/testsuites/volumes.go#L346) for custom sidecars with an older gcsfuse tag are [passing](https://paste.googleplex.com/5805843058262016), and the flag file is not written by the driver (by checking driver's logs).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Pass --machine-type and --disable-autoconfig flags to gcsfuse to enable intelligent defaults on GCSFuse for high-performance machine types.
```