### PR TITLE
Automated cherry pick of #550: fix clientSet error in sanity test setup as part of adding WI check f…
#552: Fix verify test errors on main branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,6 +237,7 @@ unit-test:
 
 sanity-test:
 	go test -v -mod=vendor -timeout 30s "./test/sanity/" -run TestSanity
+	echo $${GITHUB_SHA}
 
 e2e-test:
 	./test/e2e/run-e2e-local.sh

--- a/Makefile
+++ b/Makefile
@@ -237,7 +237,6 @@ unit-test:
 
 sanity-test:
 	go test -v -mod=vendor -timeout 30s "./test/sanity/" -run TestSanity
-	echo $${GITHUB_SHA}
 
 e2e-test:
 	./test/e2e/run-e2e-local.sh

--- a/pkg/cloud_provider/clientset/clientset.go
+++ b/pkg/cloud_provider/clientset/clientset.go
@@ -86,6 +86,7 @@ func (c *Clientset) ConfigureNodeLister(nodeName string) {
 		nodeObj.Status = corev1.NodeStatus{}
 		nodeObj.ObjectMeta.Annotations = nil
 		nodeObj.ObjectMeta.Labels = newLabels
+
 		return obj, nil
 	}
 

--- a/pkg/cloud_provider/clientset/fake.go
+++ b/pkg/cloud_provider/clientset/fake.go
@@ -31,6 +31,14 @@ type FakeClientset struct {
 	fakeNode *corev1.Node
 }
 
+func NewFakeClientset() *FakeClientset {
+	fakeClientSet := &FakeClientset{}
+	// Default setting for most unit tests is pod doesn't use host network & workload identity is enabled on the node
+	fakeClientSet.CreatePod( /*hostNetworkEnabled */ false)
+	fakeClientSet.CreateNode( /* isWorkloadIdentityEnabledOnNode */ true)
+	return fakeClientSet
+}
+
 func (c *FakeClientset) ConfigurePodLister(_ string) {}
 
 func (c *FakeClientset) ConfigureNodeLister(_ string) {}
@@ -81,11 +89,13 @@ func (c *FakeClientset) CreateNode(isWorkloadIdentityEnabled bool) {
 func (c *FakeClientset) GetPod(namespace, name string) (*corev1.Pod, error) {
 	c.fakePod.ObjectMeta.Name = name
 	c.fakePod.ObjectMeta.Namespace = namespace
+
 	return c.fakePod, nil
 }
 
 func (c *FakeClientset) GetNode(name string) (*corev1.Node, error) {
 	c.fakeNode.ObjectMeta.Name = name
+
 	return c.fakeNode, nil
 }
 

--- a/pkg/cloud_provider/clientset/fake.go
+++ b/pkg/cloud_provider/clientset/fake.go
@@ -36,6 +36,7 @@ func NewFakeClientset() *FakeClientset {
 	// Default setting for most unit tests is pod doesn't use host network & workload identity is enabled on the node
 	fakeClientSet.CreatePod( /*hostNetworkEnabled */ false)
 	fakeClientSet.CreateNode( /* isWorkloadIdentityEnabledOnNode */ true)
+
 	return fakeClientSet
 }
 

--- a/pkg/csi_driver/gcs_fuse_driver_test.go
+++ b/pkg/csi_driver/gcs_fuse_driver_test.go
@@ -31,10 +31,6 @@ import (
 
 func initTestDriver(t *testing.T, fm *mount.FakeMounter) *GCSDriver {
 	t.Helper()
-	fakeClientSet := &clientset.FakeClientset{}
-	// Default setting for most unit tests is pod doesn't use host network & workload identity is enabled on the node
-	fakeClientSet.CreatePod( /*hostNetworkEnabled */ false)
-	fakeClientSet.CreateNode( /* isWorkloadIdentityEnabledOnNode */ true)
 	config := &GCSDriverConfig{
 		Name:                  "test-driver",
 		NodeID:                "test-node",
@@ -44,7 +40,7 @@ func initTestDriver(t *testing.T, fm *mount.FakeMounter) *GCSDriver {
 		StorageServiceManager: storage.NewFakeServiceManager(),
 		TokenManager:          auth.NewFakeTokenManager(),
 		Mounter:               fm,
-		K8sClients:            fakeClientSet,
+		K8sClients:            clientset.NewFakeClientset(),
 		MetricsManager:        &metrics.FakeMetricsManager{},
 	}
 	driver, err := NewGCSDriver(config)

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -193,6 +193,7 @@ func TestNodePublishVolume(t *testing.T) {
 }
 
 func TestNodePublishVolumeWIDisabledOnNode(t *testing.T) {
+	t.Parallel()
 	defaultPerm := os.FileMode(0o750) + os.ModeDir
 	// Setup mount target path
 	tmpDir := "/tmp/var/lib/kubelet/pods/test-pod-id/volumes/kubernetes.io~csi/"

--- a/test/sanity/sanity_test.go
+++ b/test/sanity/sanity_test.go
@@ -59,7 +59,6 @@ func TestSanity(t *testing.T) {
 	}
 	defer cleanUp()
 
-	// Set up driver and env
 	driverConfig := &driver.GCSDriverConfig{
 		Name:                  driverName,
 		Version:               driverVersion,
@@ -69,7 +68,7 @@ func TestSanity(t *testing.T) {
 		StorageServiceManager: storage.NewFakeServiceManager(),
 		TokenManager:          auth.NewFakeTokenManager(),
 		Mounter:               mount.NewFakeMounter([]mount.MountPoint{}),
-		K8sClients:            &clientset.FakeClientset{},
+		K8sClients:            clientset.NewFakeClientset(),
 		MetricsManager:        &metrics.FakeMetricsManager{},
 	}
 


### PR DESCRIPTION
Cherry pick of #550 #552 on release-1.13.

#550: fix clientSet error in sanity test setup as part of adding WI check f…
#552: Fix verify test errors on main branch

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note


```