### PR TITLE
Allow multiple volume handles with different mount options

### DIFF
--- a/pkg/csi_driver/controller.go
+++ b/pkg/csi_driver/controller.go
@@ -76,6 +76,9 @@ func (s *controllerServer) ControllerGetCapabilities(_ context.Context, _ *csi.C
 func (s *controllerServer) ValidateVolumeCapabilities(ctx context.Context, req *csi.ValidateVolumeCapabilitiesRequest) (*csi.ValidateVolumeCapabilitiesResponse, error) {
 	// Validate arguments
 	volumeID := req.GetVolumeId()
+	if req.GetVolumeContext()[VolumeContextKeyEphemeral] != util.TrueStr {
+		volumeID = parseVolumeID(volumeID)
+	}
 	if len(volumeID) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "ValidateVolumeCapabilities volumeID must be provided")
 	}

--- a/pkg/csi_driver/utils_test.go
+++ b/pkg/csi_driver/utils_test.go
@@ -29,6 +29,56 @@ const (
 	TraceStr = "trace"
 )
 
+func TestRemoveBucketSuffixIfPresentAndReturnVolumeId(t *testing.T) {
+	t.Parallel()
+	t.Run("removing bucket suffix if present and returning volume id", func(t *testing.T) {
+		t.Parallel()
+		testCases := []struct {
+			name          string
+			bucketName    string
+			expectedValue string
+		}{
+			{
+				name:          "should return bucket name without suffix, no special character",
+				bucketName:    "bucket-name:1234567890123456789",
+				expectedValue: "bucket-name",
+			},
+			{
+				name:          "should return bucket name without suffix, special character",
+				bucketName:    "bucket-name:1234567890123456789@us-central1",
+				expectedValue: "bucket-name",
+			},
+			{
+				name:          "should return bucket name without suffix, no colon with special character",
+				bucketName:    "bucket-name@us-central1",
+				expectedValue: "bucket-name@us-central1",
+			},
+			{
+				name:          "should return bucket name without suffix, two colons",
+				bucketName:    "bucket-name:1234567890123456789:12",
+				expectedValue: "bucket-name",
+			},
+			{
+				name:          "should return bucket name without suffix, no special character and no colon",
+				bucketName:    "bucket-name",
+				expectedValue: "bucket-name",
+			},
+			{
+				name:          "should return bucket name without suffix, no bucket name",
+				bucketName:    ":xyz",
+				expectedValue: "",
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Logf("test case: %s", tc.name)
+			actual := parseVolumeID(tc.bucketName)
+			if actual != tc.expectedValue {
+				t.Errorf("Got value %v, but expected %v", actual, tc.expectedValue)
+			}
+		}
+	})
+}
 func TestJoinMountOptions(t *testing.T) {
 	t.Parallel()
 	t.Run("joining mount options into one", func(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
 /kind feature
> /kind flake

**What this PR does / why we need it**:
When users try to use the same bucket in two different persistent volumes (same value for bucket handle field) and mount these pvs to the same node kubelet does not call node publish volume a second time it treats both volumes as the same which prevents containers from starting (the second volume is not mounted at the expected path). This is a limitation of the gcsfuse csi driver as described [here](https://github.com/GoogleCloudPlatform/gcs-fuse-csi-driver/blob/main/test/e2e/testsuites/multivolume.go#L237)
**Which issue(s) this PR fixes**:
Fixes #395976718
**Does this PR introduce a user-facing change?**:

```release-note
This release introduces support for mounting two persistent volumes to the same node by allowing users to append a custom suffix to the volume handle (e.g., my-bucket:suffix). The suffix is ignored during NodePublishVolume to ensure the correct bucket is mounted, but is retained in earlier stages to let kubelet treat the volumes as unique. Bucket handles a:b:c are valid but recall the [bucket naming conventions](https://cloud.google.com/storage/docs/buckets#:~:text=Bucket%20names%20can%20only%20contain%20lowercase%20letters%2C%20numeric%20characters%2C%20dashes%20(%2D)%2C%20underscores%20(_)%2C%20and%20dots%20(.).%20Spaces%20are%20not%20allowed.%20Names%20containing%20dots%20require%20verification.). In the case of bucket handle "a:b:c" the csi driver will treat it as a bucket name "a"

This unblocks use cases where workloads need to mount the same GCS bucket with distinct persistent volumes. 
For example usage please review PV1 and PV2 under How was this test/validated. Note the different volume handles being used in each persistent volume - volumeHandle: fuechr_fuse_csi_test:1, volumeHandle: fuechr_fuse_csi_test
these will access the same bucket 

To mount the same GCS Bucket with different persistent volumes, use the following syntax for the volumeHandle field in the PersistentVolume object: "BUCKET_NAME:RANDOM_SUFFIX" , where RANDOM_SUFFIX is a random string of your choice and BUCKET_NAME is your bucket name.

For example : "my_bucket:xyz123"
```
**Root Cause - suspected**
This behavior originates from a limitation in the GCS Fuse CSI driver, which currently does not support mounting multiple PVs with the same volume handle (i.e., pointing to the same bucket) on a single node. This restriction aligns with what is documented in the driver’s [test suite](https://github.com/GoogleCloudPlatform/gcs-fuse-csi-driver/blob/main/test/e2e/testsuites/multivolume.go#L237).

**Problem Verification**

To reproduce the issue, a cluster was deployed using the latest version of the GCS Fuse CSI driver. All the resources listed under Resources were applied. During testing, it was observed that NodePublishVolume was invoked only once, resulting in one of the pods failing to start due to the absence of the mounted volume.

To verify that the root cause was the reuse of the same bucket handle across both PVs, a new test was conducted using the same setup, but this time with pv1 and pv2 pointing to different buckets (i.e., using volume handles fuechr_fuse_csi_test and fuechr_fuse_csi_test2, respectively). In this scenario, NodePublishVolume was called twice, and both pods started successfully, confirming that the issue only arises when the same bucket is used in both PVs.

**Proposed Solution**
To resolve the issue where NodePublishVolume is not invoked due to duplicate volume handles referencing the same bucket, we adopted a strategy similar to that used by ParallelStore. This approach introduces a [special suffix](https://cloud.google.com/parallelstore/docs/connect-from-kubernetes-engine-existing-instance#same-instance-different-mount-options) to the volume handle, making each volume unique even if they point to the same underlying bucket.

During the NodePublishVolume operation, the CSI driver strips this suffix from the bucket name before performing the mount. This logic has been implemented in the parseVolumeId function, available in utils.go.

The function works as follows:

Checks for the presence of a suffix, delimited by a colon (:),

Removes the suffix if found,

Returns the base bucket name (volume handle).

Unit tests have been added to verify correct parsing and behavior for volume handles both with and without a suffix.
Importantly, this implementation assumes that bucket handles will contain at most one colon (:). This assumption is safe, as Google Cloud bucket names do not support colons, ensuring that any colon present is introduced solely by the CSI driver for suffixing purposes.

**Solution Verification**

To validate the fix, a custom driver image built from the PR was deployed to a cluster in a Google-managed project. The test pods were re-applied using the same bucket for both PVs, but with unique suffixed volume handles.

As expected:

NodePublishVolume was invoked twice—once for each suffixed volume handle.

Both pods successfully transitioned to the Running state.

Driver logs confirmed that the bucket handle suffixes were properly stripped during mount operations, and the correct underlying bucket was used in both cases.

This confirms that the suffix-handling logic works as intended and allows multiple PVs backed by the same bucket to mount successfully on the same node.

**Resources**:
**PV1:** 
```
apiVersion: v1
kind: PersistentVolume
metadata:
  name: pv1
  annotations:
    gke-gcsfuse/volumes: "true"
spec:
  capacity:
    storage: 1Gi
  accessModes:
    - ReadWriteMany
  persistentVolumeReclaimPolicy: Retain
  csi:
    driver: gcsfuse.csi.storage.gke.io
    **volumeHandle: fuechr_fuse_csi_test:1**
  claimRef:
    name: pvc1  
    namespace: default
``` 

**PVC1:** 
```
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: pvc1
spec:
  accessModes:
    - ReadWriteMany
  resources:
    requests:
      storage: 1Gi
  volumeName: pv1
``` 
**PV2:** 
```
apiVersion: v1
kind: PersistentVolume
metadata:
  name: pv2
  annotations:
    gke-gcsfuse/volumes: "true"
spec:
  capacity:
    storage: 1Gi
  accessModes:
    - ReadWriteMany
  persistentVolumeReclaimPolicy: Retain
  csi:
    driver: gcsfuse.csi.storage.gke.io
    **volumeHandle: fuechr_fuse_csi_test**
  claimRef:
    name: pvc2    
    namespace: default
``` 
**PVC2:** 
```
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: pvc2
spec:
  accessModes:
    - ReadWriteMany
  resources:
    requests:
      storage: 1Gi
  volumeName: pv2
``` 
**Pod spec:** 
``` 
apiVersion: v1
kind: Pod
metadata:
  name: pod
  annotations:
    gke-gcsfuse/volumes: "true"
spec:
  containers:
    - name: gcsfuse-container
      image: google/cloud-sdk:alpine
      command: ["sleep", "3600"]
      volumeMounts:
        - name: gcsfuse-volume-1
          mountPath: /mnt/gcsfuse-1
          subPath: gcsfuse-mount
        - name: gcsfuse-volume-2
          mountPath: /mnt/gcsfuse-2
          subPath: gcsfuse-mount
  volumes:
    - name: gcsfuse-volume-1
      persistentVolumeClaim:
        claimName: pvc1
    - name: gcsfuse-volume-2
      persistentVolumeClaim:
        claimName: pvc2
```