### PR TITLE
Revert "Automated cherry pick of #533: Fail NodePublishVolume with actionable error in case Workload Identity is not yet enabled on node level"

### DIFF
--- a/cmd/csi_driver/main.go
+++ b/cmd/csi_driver/main.go
@@ -101,7 +101,6 @@ func main() {
 		}
 
 		clientset.ConfigurePodLister(*nodeID)
-		clientset.ConfigureNodeLister(*nodeID)
 
 		mounter, err = csimounter.New("", *fuseSocketDir)
 		if err != nil {

--- a/deploy/base/node/node_setup.yaml
+++ b/deploy/base/node/node_setup.yaml
@@ -37,9 +37,6 @@ rules:
     resources: ["pods"]
     verbs: ["get", "watch", "list"]
   - apiGroups: [""]
-    resources: ["nodes"]
-    verbs: ["get", "watch", "list"]
-  - apiGroups: [""]
     resources: ["serviceaccounts"]
     verbs: ["get"]
 ---

--- a/pkg/cloud_provider/clientset/clientset.go
+++ b/pkg/cloud_provider/clientset/clientset.go
@@ -39,11 +39,9 @@ import (
 
 type Interface interface {
 	ConfigurePodLister(nodeName string)
-	ConfigureNodeLister(nodeName string)
 	GetPod(namespace, name string) (*corev1.Pod, error)
 	CreateServiceAccountToken(ctx context.Context, namespace, name string, tokenRequest *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error)
 	GetGCPServiceAccountName(ctx context.Context, namespace, name string) (string, error)
-	GetNode(name string) (*corev1.Node, error)
 }
 
 type PodInfo struct {
@@ -54,56 +52,7 @@ type PodInfo struct {
 type Clientset struct {
 	k8sClients                kubernetes.Interface
 	podLister                 listersv1.PodLister
-	nodeLister                listersv1.NodeLister
 	informerResyncDurationSec int
-}
-
-const GkeMetaDataServerKey = "iam.gke.io/gke-metadata-server-enabled"
-
-func (c *Clientset) ConfigureNodeLister(nodeName string) {
-	trim := func(obj interface{}) (interface{}, error) {
-		if accessor, err := meta.Accessor(obj); err == nil {
-			if accessor.GetManagedFields() != nil {
-				accessor.SetManagedFields(nil)
-			}
-		}
-
-		// We are filtering only for relevant Node annotations to optimize memory usage.
-		// Relevant info is for NodePublishVolume calls:
-		// https://github.com/GoogleCloudPlatform/gcs-fuse-csi-driver/blob/547cab9a9aea4cdbda581885880020fb9266dc03/pkg/csi_driver/node.go#L85
-		nodeObj, ok := obj.(*corev1.Node)
-		if !ok {
-			return obj, nil
-		}
-
-		newLabels := map[string]string{}
-		isGkeMetaDataServerEnabled, ok := nodeObj.ObjectMeta.Labels[GkeMetaDataServerKey]
-		if ok {
-			newLabels[GkeMetaDataServerKey] = isGkeMetaDataServerEnabled
-		}
-
-		nodeObj.Spec = corev1.NodeSpec{}
-		nodeObj.Status = corev1.NodeStatus{}
-		nodeObj.ObjectMeta.Annotations = nil
-		nodeObj.ObjectMeta.Labels = newLabels
-		return obj, nil
-	}
-
-	informerFactory := informers.NewSharedInformerFactoryWithOptions(
-		c.k8sClients,
-		time.Duration(c.informerResyncDurationSec)*time.Second,
-		informers.WithTweakListOptions(func(options *metav1.ListOptions) {
-			options.FieldSelector = "metadata.name=" + nodeName
-		}),
-		informers.WithTransform(trim),
-	)
-	nodeLister := informerFactory.Core().V1().Nodes().Lister()
-
-	ctx := context.Background()
-	informerFactory.Start(ctx.Done())
-	informerFactory.WaitForCacheSync(ctx.Done())
-
-	c.nodeLister = nodeLister
 }
 
 func New(kubeconfigPath string, informerResyncDurationSec int) (Interface, error) {
@@ -209,14 +158,6 @@ func (c *Clientset) GetPod(namespace, name string) (*corev1.Pod, error) {
 	}
 
 	return c.podLister.Pods(namespace).Get(name)
-}
-
-func (c *Clientset) GetNode(name string) (*corev1.Node, error) {
-	if c.nodeLister == nil {
-		return nil, errors.New("node informer is not ready")
-	}
-
-	return c.nodeLister.Get(name)
 }
 
 func (c *Clientset) CreateServiceAccountToken(ctx context.Context, namespace, name string, tokenRequest *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error) {

--- a/pkg/cloud_provider/clientset/fake.go
+++ b/pkg/cloud_provider/clientset/fake.go
@@ -26,21 +26,16 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-type FakeClientset struct {
-	fakePod  *corev1.Pod
-	fakeNode *corev1.Node
-}
+type FakeClientset struct{}
 
 func (c *FakeClientset) ConfigurePodLister(_ string) {}
 
-func (c *FakeClientset) ConfigureNodeLister(_ string) {}
-
-func (c *FakeClientset) CreatePod(hostNetworkEnabled bool) {
+func (c *FakeClientset) GetPod(namespace, name string) (*corev1.Pod, error) {
 	config := webhook.FakeConfig()
-	c.fakePod = &corev1.Pod{
+	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "",
-			Namespace: "",
+			Name:      name,
+			Namespace: namespace,
 		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
@@ -60,33 +55,7 @@ func (c *FakeClientset) CreatePod(hostNetworkEnabled bool) {
 		},
 	}
 
-	if hostNetworkEnabled {
-		c.fakePod.Spec.HostNetwork = true
-	}
-}
-
-func (c *FakeClientset) CreateNode(isWorkloadIdentityEnabled bool) {
-	c.fakeNode = &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   "",
-			Labels: map[string]string{},
-		},
-	}
-
-	if isWorkloadIdentityEnabled {
-		c.fakeNode.Labels[GkeMetaDataServerKey] = "true"
-	}
-}
-
-func (c *FakeClientset) GetPod(namespace, name string) (*corev1.Pod, error) {
-	c.fakePod.ObjectMeta.Name = name
-	c.fakePod.ObjectMeta.Namespace = namespace
-	return c.fakePod, nil
-}
-
-func (c *FakeClientset) GetNode(name string) (*corev1.Node, error) {
-	c.fakeNode.ObjectMeta.Name = name
-	return c.fakeNode, nil
+	return pod, nil
 }
 
 func (c *FakeClientset) CreateServiceAccountToken(_ context.Context, _, _ string, _ *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error) {

--- a/pkg/csi_driver/gcs_fuse_driver_test.go
+++ b/pkg/csi_driver/gcs_fuse_driver_test.go
@@ -31,10 +31,6 @@ import (
 
 func initTestDriver(t *testing.T, fm *mount.FakeMounter) *GCSDriver {
 	t.Helper()
-	fakeClientSet := &clientset.FakeClientset{}
-	// Default setting for most unit tests is pod doesn't use host network & workload identity is enabled on the node
-	fakeClientSet.CreatePod( /*hostNetworkEnabled */ false)
-	fakeClientSet.CreateNode( /* isWorkloadIdentityEnabledOnNode */ true)
 	config := &GCSDriverConfig{
 		Name:                  "test-driver",
 		NodeID:                "test-node",
@@ -44,33 +40,7 @@ func initTestDriver(t *testing.T, fm *mount.FakeMounter) *GCSDriver {
 		StorageServiceManager: storage.NewFakeServiceManager(),
 		TokenManager:          auth.NewFakeTokenManager(),
 		Mounter:               fm,
-		K8sClients:            fakeClientSet,
-		MetricsManager:        &metrics.FakeMetricsManager{},
-	}
-	driver, err := NewGCSDriver(config)
-	if err != nil {
-		t.Fatalf("failed to init driver: %v", err)
-	}
-	if driver == nil {
-		t.Fatalf("driver is nil")
-	}
-
-	return driver
-}
-
-// Helper function for creating node server with a custom FakeClientset
-func initTestDriverWithCustomNodeServer(t *testing.T, fm *mount.FakeMounter, clientSet *clientset.FakeClientset) *GCSDriver {
-	t.Helper()
-	config := &GCSDriverConfig{
-		Name:                  "test-driver",
-		NodeID:                "test-node",
-		Version:               "test-version",
-		RunController:         true,
-		RunNode:               true,
-		StorageServiceManager: storage.NewFakeServiceManager(),
-		TokenManager:          auth.NewFakeTokenManager(),
-		Mounter:               fm,
-		K8sClients:            clientSet,
+		K8sClients:            &clientset.FakeClientset{},
 		MetricsManager:        &metrics.FakeMetricsManager{},
 	}
 	driver, err := NewGCSDriver(config)

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -141,18 +141,6 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 		fuseMountOptions = joinMountOptions(fuseMountOptions, []string{"token-server-identity-provider=" + identityProvider})
 	}
 
-	node, err := s.k8sClients.GetNode(s.driver.config.NodeID)
-	if err != nil {
-		return nil, status.Errorf(codes.NotFound, "failed to get node: %v", err)
-	}
-
-	val, ok := node.Labels[clientset.GkeMetaDataServerKey]
-	// If Workload Identity is not enabled, the key should be missing; the check for "val == false" is just for extra caution
-	isWorkloadIdentityDisabled := val != "true" || !ok
-	if isWorkloadIdentityDisabled && !pod.Spec.HostNetwork {
-		return nil, status.Errorf(codes.FailedPrecondition, "Workload Identity Federation is not enabled on node. Please make sure this is enabled on both cluster and node pool level (https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity)")
-	}
-
 	// Since the webhook mutating ordering is not definitive,
 	// the sidecar position is not checked in the ValidatePodHasSidecarContainerInjected func.
 	shouldInjectedByWebhook := strings.ToLower(pod.Annotations[webhook.GcsFuseVolumeEnableAnnotation]) == util.TrueStr


### PR DESCRIPTION
Reverts GoogleCloudPlatform/gcs-fuse-csi-driver#548 as this is fixing verify test. I'll try chaining this with the PRs https://github.com/GoogleCloudPlatform/gcs-fuse-csi-driver/pull/556 in one cherry-pick PR.