### PR TITLE
Automated cherry pick of #547: Limit the maximum number of registered metric collectors.

### DIFF
--- a/cmd/csi_driver/main.go
+++ b/cmd/csi_driver/main.go
@@ -47,6 +47,7 @@ var (
 	informerResyncDurationSec = flag.Int("informer-resync-duration-sec", 1800, "informer resync duration in seconds")
 	fuseSocketDir             = flag.String("fuse-socket-dir", "/sockets", "FUSE socket directory")
 	metricsEndpoint           = flag.String("metrics-endpoint", "", "The TCP network address where the Prometheus metrics endpoint will listen (example: `:8080`). The default is empty string, which means that the metrics endpoint is disabled.")
+	maximumNumberOfCollectors = flag.Int("max-metric-collectors", -1, "Maximum number of prometheus metric collectors exporting metrics at a time, less than 0 (e.g -1) means no limit.")
 
 	// These are set at compile time.
 	version = "unknown"
@@ -109,7 +110,7 @@ func main() {
 		}
 
 		if *metricsEndpoint != "" {
-			mm = metrics.NewMetricsManager(*metricsEndpoint, *fuseSocketDir, clientset)
+			mm = metrics.NewMetricsManager(*metricsEndpoint, *fuseSocketDir, *maximumNumberOfCollectors, clientset)
 			mm.InitializeHTTPHandler()
 		}
 	}

--- a/deploy/base/node/node.yaml
+++ b/deploy/base/node/node.yaml
@@ -53,6 +53,7 @@ spec:
             - --node=true
             - --identity-provider=$(IDENTITY_PROVIDER)
             - --metrics-endpoint=:9920
+            - --max-metric-collectors=10
           ports:
           - containerPort: 9920
             name: metrics

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -114,7 +114,8 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 			s.volumeStateStore.Store(targetPath, &util.VolumeState{})
 			vs, _ = s.volumeStateStore.Load(targetPath)
 		}
-
+		// volumeState is safe to access for remaining of function since volumeLock prevents
+		// Node Publish/Unpublish Volume calls from running more than once at a time per volume.
 		if !vs.BucketAccessCheckPassed {
 			storageService, err := s.prepareStorageService(ctx, vc)
 			if err != nil {
@@ -165,7 +166,7 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 		return nil, status.Error(codes.FailedPrecondition, "failed to find the sidecar container in Pod spec")
 	}
 
-	// Register metrics collecter.
+	// Register metrics collector.
 	// It is idempotent to register the same collector in node republish calls.
 	if s.driver.config.MetricsManager != nil && !disableMetricsCollection {
 		klog.V(6).Infof("NodePublishVolume enabling metrics collector for target path %q", targetPath)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -26,7 +26,10 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/clientset"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util"
@@ -56,14 +59,21 @@ type manager struct {
 	metricsEndpoint string
 	fuseSocketDir   string
 	clientset       clientset.Interface
+
+	maximumNumberOfCollectors   int
+	volumePublishPathRegistered sets.Set[string]
+	mutex                       sync.Mutex
 }
 
-func NewMetricsManager(metricsEndpoint, fuseSocketDir string, clientset clientset.Interface) Manager {
+func NewMetricsManager(metricsEndpoint, fuseSocketDir string, maximumNumberOfCollectors int, clientset clientset.Interface) Manager {
 	mm := &manager{
-		registry:        prometheus.NewRegistry(),
-		metricsEndpoint: metricsEndpoint,
-		fuseSocketDir:   fuseSocketDir,
-		clientset:       clientset,
+		registry:                    prometheus.NewRegistry(),
+		metricsEndpoint:             metricsEndpoint,
+		fuseSocketDir:               fuseSocketDir,
+		clientset:                   clientset,
+		volumePublishPathRegistered: sets.Set[string]{},
+		maximumNumberOfCollectors:   maximumNumberOfCollectors,
+		mutex:                       sync.Mutex{},
 	}
 
 	return mm
@@ -115,8 +125,43 @@ func (mm *manager) RegisterMetricsCollector(targetPath, podNamespace, podName, b
 		"bucket_name":    bucketName,
 		"pod_uid":        podUID,
 	}, mm.clientset)
-	if err := mm.registry.Register(c); err != nil && !strings.Contains(err.Error(), prometheus.AlreadyRegisteredError{}.Error()) {
-		klog.Errorf("failed to register metrics collector for pod  %v/%v, volume %q, bucket %q: %v", podNamespace, podName, volumeName, bucketName, err)
+
+	// Lock the number of registered collectors while we attempt to register a new collector.
+	mm.mutex.Lock()
+	defer mm.mutex.Unlock()
+
+	if mm.maximumNumberOfCollectors == 0 {
+		klog.Infof("could not register metrics collector: podUID: %s, volume: %s. metrics collector limit is set to zero.", podUID, bucketName)
+
+		return
+	}
+
+	// Check if we need to register collector. We register a collector when the following are met:
+	// 1. There is space on the metrics pipeline for the collector to be registered.
+	// 2. The metrics collector has not previously been registered.
+	if mm.maximumNumberOfCollectors > 0 {
+		// If volume is already registered, do not register again. This flow can get triggered
+		//  since CSI driver has republishVolume capability.
+		if mm.volumePublishPathRegistered.Has(targetPath) {
+			return
+		}
+		// If collector hasn't been registered and there's no space left, log a warning.
+		if mm.volumePublishPathRegistered.Len() >= mm.maximumNumberOfCollectors {
+			klog.V(6).Infof("could not register a metrics collector: podUID: %s, volume: %s. there's already %d collectors registered.", podUID, bucketName, mm.volumePublishPathRegistered.Len())
+
+			return
+		}
+	}
+
+	// Attempt to register new metrics collector and record success.
+	err = mm.registry.Register(c)
+	if err != nil {
+		if !strings.Contains(err.Error(), prometheus.AlreadyRegisteredError{}.Error()) {
+			klog.Errorf("failed to register metrics collector for pod  %v/%v, volume %q, bucket %q: %v", podNamespace, podName, volumeName, bucketName, err)
+		}
+	} else {
+		mm.volumePublishPathRegistered.Insert(targetPath)
+		klog.Infof("successfully registered a new metrics collector: podUID: %s, volume: %s. there's %d collectors registered.", podUID, bucketName, mm.volumePublishPathRegistered.Len())
 	}
 }
 
@@ -126,8 +171,16 @@ func (mm *manager) UnregisterMetricsCollector(targetPath string) {
 
 	// metricsCollector uses a hash of pod UID and volume name as an identifier.
 	c := NewMetricsCollector("", "", "", "", podUID, volumeName, nil, nil)
+
+	// Lock the number of registered collectors while we attempt to unregister a collector.
+	mm.mutex.Lock()
+	defer mm.mutex.Unlock()
+
 	if ok := mm.registry.Unregister(c); !ok {
 		klog.Infof("Unregister metrics collector for targetPath %q is not needed since the collector is not registered", targetPath)
+	} else {
+		mm.volumePublishPathRegistered.Delete(targetPath)
+		klog.Infof("successfully unregistered a metrics collector: podUID: %s, volume: %s. there's %d collectors registered.", podUID, volumeName, mm.volumePublishPathRegistered.Len())
 	}
 }
 

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/clientset"
+)
+
+func TestNewMetricsManager(t *testing.T) {
+	t.Run("test the metrics manager creation", func(t *testing.T) {
+		t.Parallel()
+		testCases := []struct {
+			name          string
+			endpoint      string
+			socketDir     string
+			maxCollectors int
+		}{
+			{
+				name:          "basic options test",
+				endpoint:      "/test/metrics",
+				socketDir:     "/tmp/test-sockets",
+				maxCollectors: 5,
+			},
+			{
+				name:          "no collectors test",
+				endpoint:      ":9920",
+				socketDir:     "/gcsfuse-tmp/socket",
+				maxCollectors: 0,
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Logf("test case: %s", tc.name)
+
+			clientset := clientset.NewFakeClientset()
+			manager := NewMetricsManager(tc.endpoint, tc.socketDir, tc.maxCollectors, clientset).(*manager)
+
+			if manager.metricsEndpoint != tc.endpoint {
+				t.Errorf("NewMetricsManager did not set metricsEndpoint correctly. Got %q, want %q", manager.metricsEndpoint, tc.endpoint)
+			}
+			if manager.fuseSocketDir != tc.socketDir {
+				t.Errorf("NewMetricsManager did not set fuseSocketDir correctly. Got %q, want %q", manager.fuseSocketDir, tc.socketDir)
+			}
+			if manager.maximumNumberOfCollectors != tc.maxCollectors {
+				t.Errorf("NewMetricsManager did not set maximumNumberOfCollectors correctly. Got %d, want %d", manager.maximumNumberOfCollectors, tc.maxCollectors)
+			}
+			if manager.registry == nil {
+				t.Errorf("NewMetricsManager did not initialize registry")
+			}
+			if manager.volumePublishPathRegistered == nil {
+				t.Errorf("NewMetricsManager did not initialize volumePublishPathRegistered")
+			}
+		}
+	})
+}


### PR DESCRIPTION
Cherry pick of #547 on release-1.14.

#547: Limit the maximum number of registered metric collectors.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Limit the maximum number of registered metric collectors.
```