### PR TITLE
Automated cherry pick of #569: Enable metrics collection by default

### DIFF
--- a/pkg/csi_driver/utils.go
+++ b/pkg/csi_driver/utils.go
@@ -191,7 +191,7 @@ func parseVolumeAttributes(fuseMountOptions []string, volumeContext map[string]s
 		fuseMountOptions = joinMountOptions(fuseMountOptions, strings.Split(mountOptions, ","))
 	}
 	skipCSIBucketAccessCheck := false
-	disableMetricsCollection := true
+	disableMetricsCollection := false
 	for volumeAttribute, mountOption := range volumeAttributesToMountOptionsMapping {
 		value, ok := volumeContext[volumeAttribute]
 		if !ok {

--- a/pkg/csi_driver/utils_test.go
+++ b/pkg/csi_driver/utils_test.go
@@ -111,12 +111,12 @@ func TestParseVolumeAttributes(t *testing.T) {
 	t.Run("parsing volume attributes into mount options", func(t *testing.T) {
 		t.Parallel()
 		testCases := []struct {
-			name                            string
-			volumeContext                   map[string]string
-			expectedMountOptions            []string
-			expectedSkipBucketAccessCheck   bool
-			expectedEnableMetricsCollection bool
-			expectedErr                     bool
+			name                             string
+			volumeContext                    map[string]string
+			expectedMountOptions             []string
+			expectedSkipBucketAccessCheck    bool
+			expectedDisableMetricsCollection bool
+			expectedErr                      bool
 		}{
 			{
 				name:                 "should return correct fileCacheCapacity 1",
@@ -420,16 +420,16 @@ func TestParseVolumeAttributes(t *testing.T) {
 				expectedErr:   true,
 			},
 			{
-				name:                            "value set to true for VolumeContextKeyDisableMetrics",
-				volumeContext:                   map[string]string{VolumeContextKeyDisableMetrics: util.TrueStr},
-				expectedMountOptions:            []string{volumeAttributesToMountOptionsMapping[VolumeContextKeyDisableMetrics] + util.TrueStr},
-				expectedEnableMetricsCollection: false,
+				name:                             "value set to true for VolumeContextKeyDisableMetrics",
+				volumeContext:                    map[string]string{VolumeContextKeyDisableMetrics: util.TrueStr},
+				expectedMountOptions:             []string{volumeAttributesToMountOptionsMapping[VolumeContextKeyDisableMetrics] + util.TrueStr},
+				expectedDisableMetricsCollection: true,
 			},
 			{
-				name:                            "value set to false for VolumeContextKeyDisableMetrics",
-				volumeContext:                   map[string]string{VolumeContextKeyDisableMetrics: util.FalseStr},
-				expectedMountOptions:            []string{volumeAttributesToMountOptionsMapping[VolumeContextKeyDisableMetrics] + util.FalseStr},
-				expectedEnableMetricsCollection: true,
+				name:                             "value set to false for VolumeContextKeyDisableMetrics",
+				volumeContext:                    map[string]string{VolumeContextKeyDisableMetrics: util.FalseStr},
+				expectedMountOptions:             []string{volumeAttributesToMountOptionsMapping[VolumeContextKeyDisableMetrics] + util.FalseStr},
+				expectedDisableMetricsCollection: false,
 			},
 		}
 
@@ -440,7 +440,6 @@ func TestParseVolumeAttributes(t *testing.T) {
 				if (err != nil) != tc.expectedErr {
 					t.Errorf("Got error %v, but expected error %v", err, tc.expectedErr)
 				}
-				enableMetricsCollection := !disableMetricsCollection
 
 				if tc.expectedErr {
 					return
@@ -448,8 +447,8 @@ func TestParseVolumeAttributes(t *testing.T) {
 				if tc.expectedSkipBucketAccessCheck != skipCSIBucketAccessCheck {
 					t.Errorf("Got skipBucketAccessCheck %v, but expected %v", skipCSIBucketAccessCheck, tc.expectedSkipBucketAccessCheck)
 				}
-				if tc.expectedEnableMetricsCollection != enableMetricsCollection {
-					t.Errorf("Got disableMetricsCollection %v, but expected %v", enableMetricsCollection, tc.expectedEnableMetricsCollection)
+				if tc.expectedDisableMetricsCollection != disableMetricsCollection {
+					t.Errorf("Got disableMetricsCollection %v, but expected %v", disableMetricsCollection, tc.expectedDisableMetricsCollection)
 				}
 
 				less := func(a, b string) bool { return a > b }


### PR DESCRIPTION
Cherry pick of #569 on release-1.14.

#569: Enable metrics collection by default

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Enable GCSFuse metrics collection by default
```