### PR TITLE
Enable metrics collection by default on gcsfusecsi sidecar.

### DIFF
--- a/pkg/sidecar_mounter/sidecar_mounter_config.go
+++ b/pkg/sidecar_mounter/sidecar_mounter_config.go
@@ -154,13 +154,16 @@ func NewMountConfig(sp string) *MountConfig {
 
 func (mc *MountConfig) prepareMountArgs() {
 	flagMap := map[string]string{
-		"app-name":    GCSFuseAppName,
-		"temp-dir":    mc.BufferDir + TempDir,
-		"config-file": mc.ConfigFile,
-		"foreground":  "",
-		"uid":         "0",
-		"gid":         "0",
+		"app-name":        GCSFuseAppName,
+		"temp-dir":        mc.BufferDir + TempDir,
+		"config-file":     mc.ConfigFile,
+		"foreground":      "",
+		"uid":             "0",
+		"gid":             "0",
+		"prometheus-port": strconv.Itoa(prometheusPort),
 	}
+	// Use a new port each gcsfuse instance that we start.
+	prometheusPort++
 
 	configFileFlagMap := map[string]string{
 		"logging:file-path": "/dev/fd/1", // redirect the output to cmd stdout
@@ -176,10 +179,8 @@ func (mc *MountConfig) prepareMountArgs() {
 			f, v := arg[:i], arg[i+1:]
 
 			if f == util.DisableMetricsForGKE {
-				if v == util.FalseStr {
-					flagMap["prometheus-port"] = strconv.Itoa(prometheusPort)
-					// Use a new port each gcsfuse instance that we start.
-					prometheusPort++
+				if v == util.TrueStr {
+					flagMap["prometheus-port"] = "0"
 				}
 
 				continue

--- a/pkg/sidecar_mounter/sidecar_mounter_config_test.go
+++ b/pkg/sidecar_mounter/sidecar_mounter_config_test.go
@@ -20,6 +20,7 @@ package sidecarmounter
 import (
 	"os"
 	"reflect"
+	"slices"
 	"strconv"
 	"testing"
 
@@ -220,7 +221,7 @@ func TestPrepareMountArgs(t *testing.T) {
 				BufferDir:  "test-buffer-dir",
 				CacheDir:   "test-cache-dir",
 				ConfigFile: "test-config-file",
-				Options:    []string{util.DisableMetricsForGKE + ":false"},
+				Options:    []string{util.DisableMetricsForGKE + ":true"},
 			},
 			expectedArgs: map[string]string{
 				"app-name":        GCSFuseAppName,
@@ -233,25 +234,37 @@ func TestPrepareMountArgs(t *testing.T) {
 			},
 			expectedConfigMapArgs: defaultConfigFileFlagMap,
 		},
+		{
+			name: "should return valid args when metrics is enabled",
+			mc: &MountConfig{
+				BucketName: "test-bucket",
+				BufferDir:  "test-buffer-dir",
+				CacheDir:   "test-cache-dir",
+				ConfigFile: "test-config-file",
+				Options:    []string{util.DisableMetricsForGKE + ":false"},
+			},
+			expectedArgs: map[string]string{
+				"app-name":    GCSFuseAppName,
+				"temp-dir":    "test-buffer-dir/temp-dir",
+				"config-file": "test-config-file",
+				"foreground":  "",
+				"uid":         "0",
+				"gid":         "0",
+			},
+			expectedConfigMapArgs: defaultConfigFileFlagMap,
+		},
 	}
 
-	prometheusPort := 62990
+	testPrometheusPort := prometheusPort
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			found := false
-			for _, o := range tc.mc.Options {
-				if o == util.DisableMetricsForGKE+":false" {
-					found = true
-
-					break
-				}
+			// Do not parallelize [e.g t.Parallel()] because all testcases share testPrometheusPort.
+			found := slices.Contains(tc.mc.Options, util.DisableMetricsForGKE+":true")
+			if !found {
+				tc.expectedArgs["prometheus-port"] = strconv.Itoa(testPrometheusPort)
 			}
-
-			if found {
-				tc.expectedArgs["prometheus-port"] = strconv.Itoa(prometheusPort)
-				prometheusPort++
-			}
+			// Increase port value to match behavior of prepareMountArgs()
+			testPrometheusPort++
 
 			tc.mc.prepareMountArgs()
 			if !reflect.DeepEqual(tc.mc.FlagMap, tc.expectedArgs) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
On #569 we enabled metrics by default by changing the value (passed when `disableMetrics` VolumeAttribute(VA) is not present) of the `disable-metrics-on-gke` mountOption (which are passed to the sidecar) from true to false. We also need to handle the defaulting behavior on the sidecar side. This PR enables metrics collection by default on the sidecar.

**Which issue(s) this PR fixes**:
Currently the metrics collection is not set unless the `disableMetrics` VA is set. Intended behavior is for prometheus port to be set on sidecar even if VA is not present.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Enable metrics collection by default on gcsfusecsi sidecar.
```