### PR TITLE
Automated cherry pick of #574: Enable metrics collection by default on gcsfusecsi sidecar.

### DIFF
--- a/pkg/sidecar_mounter/sidecar_mounter_config.go
+++ b/pkg/sidecar_mounter/sidecar_mounter_config.go
@@ -154,13 +154,16 @@ func NewMountConfig(sp string) *MountConfig {
 
 func (mc *MountConfig) prepareMountArgs() {
 	flagMap := map[string]string{
-		"app-name":    GCSFuseAppName,
-		"temp-dir":    mc.BufferDir + TempDir,
-		"config-file": mc.ConfigFile,
-		"foreground":  "",
-		"uid":         "0",
-		"gid":         "0",
+		"app-name":        GCSFuseAppName,
+		"temp-dir":        mc.BufferDir + TempDir,
+		"config-file":     mc.ConfigFile,
+		"foreground":      "",
+		"uid":             "0",
+		"gid":             "0",
+		"prometheus-port": strconv.Itoa(prometheusPort),
 	}
+	// Use a new port each gcsfuse instance that we start.
+	prometheusPort++
 
 	configFileFlagMap := map[string]string{
 		"logging:file-path": "/dev/fd/1", // redirect the output to cmd stdout
@@ -176,10 +179,8 @@ func (mc *MountConfig) prepareMountArgs() {
 			f, v := arg[:i], arg[i+1:]
 
 			if f == util.DisableMetricsForGKE {
-				if v == util.FalseStr {
-					flagMap["prometheus-port"] = strconv.Itoa(prometheusPort)
-					// Use a new port each gcsfuse instance that we start.
-					prometheusPort++
+				if v == util.TrueStr {
+					flagMap["prometheus-port"] = "0"
 				}
 
 				continue

--- a/pkg/sidecar_mounter/sidecar_mounter_config_test.go
+++ b/pkg/sidecar_mounter/sidecar_mounter_config_test.go
@@ -20,6 +20,7 @@ package sidecarmounter
 import (
 	"os"
 	"reflect"
+	"slices"
 	"strconv"
 	"testing"
 
@@ -220,7 +221,7 @@ func TestPrepareMountArgs(t *testing.T) {
 				BufferDir:  "test-buffer-dir",
 				CacheDir:   "test-cache-dir",
 				ConfigFile: "test-config-file",
-				Options:    []string{util.DisableMetricsForGKE + ":false"},
+				Options:    []string{util.DisableMetricsForGKE + ":true"},
 			},
 			expectedArgs: map[string]string{
 				"app-name":        GCSFuseAppName,
@@ -233,25 +234,37 @@ func TestPrepareMountArgs(t *testing.T) {
 			},
 			expectedConfigMapArgs: defaultConfigFileFlagMap,
 		},
+		{
+			name: "should return valid args when metrics is enabled",
+			mc: &MountConfig{
+				BucketName: "test-bucket",
+				BufferDir:  "test-buffer-dir",
+				CacheDir:   "test-cache-dir",
+				ConfigFile: "test-config-file",
+				Options:    []string{util.DisableMetricsForGKE + ":false"},
+			},
+			expectedArgs: map[string]string{
+				"app-name":    GCSFuseAppName,
+				"temp-dir":    "test-buffer-dir/temp-dir",
+				"config-file": "test-config-file",
+				"foreground":  "",
+				"uid":         "0",
+				"gid":         "0",
+			},
+			expectedConfigMapArgs: defaultConfigFileFlagMap,
+		},
 	}
 
-	prometheusPort := 62990
+	testPrometheusPort := prometheusPort
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			found := false
-			for _, o := range tc.mc.Options {
-				if o == util.DisableMetricsForGKE+":false" {
-					found = true
-
-					break
-				}
+			// Do not parallelize [e.g t.Parallel()] because all testcases share testPrometheusPort.
+			found := slices.Contains(tc.mc.Options, util.DisableMetricsForGKE+":true")
+			if !found {
+				tc.expectedArgs["prometheus-port"] = strconv.Itoa(testPrometheusPort)
 			}
-
-			if found {
-				tc.expectedArgs["prometheus-port"] = strconv.Itoa(prometheusPort)
-				prometheusPort++
-			}
+			// Increase port value to match behavior of prepareMountArgs()
+			testPrometheusPort++
 
 			tc.mc.prepareMountArgs()
 			if !reflect.DeepEqual(tc.mc.FlagMap, tc.expectedArgs) {


### PR DESCRIPTION
Cherry pick of #574 on release-1.14.

#574: Enable metrics collection by default on gcsfusecsi sidecar.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Enable metrics collection by default on gcsfusecsi sidecar.
```