### PR TITLE
Revert "Enable metrics collection by default on gcsfusecsi sidecar."

### DIFF
--- a/pkg/sidecar_mounter/sidecar_mounter_config.go
+++ b/pkg/sidecar_mounter/sidecar_mounter_config.go
@@ -154,16 +154,13 @@ func NewMountConfig(sp string) *MountConfig {
 
 func (mc *MountConfig) prepareMountArgs() {
 	flagMap := map[string]string{
-		"app-name":        GCSFuseAppName,
-		"temp-dir":        mc.BufferDir + TempDir,
-		"config-file":     mc.ConfigFile,
-		"foreground":      "",
-		"uid":             "0",
-		"gid":             "0",
-		"prometheus-port": strconv.Itoa(prometheusPort),
+		"app-name":    GCSFuseAppName,
+		"temp-dir":    mc.BufferDir + TempDir,
+		"config-file": mc.ConfigFile,
+		"foreground":  "",
+		"uid":         "0",
+		"gid":         "0",
 	}
-	// Use a new port each gcsfuse instance that we start.
-	prometheusPort++
 
 	configFileFlagMap := map[string]string{
 		"logging:file-path": "/dev/fd/1", // redirect the output to cmd stdout
@@ -179,8 +176,10 @@ func (mc *MountConfig) prepareMountArgs() {
 			f, v := arg[:i], arg[i+1:]
 
 			if f == util.DisableMetricsForGKE {
-				if v == util.TrueStr {
-					flagMap["prometheus-port"] = "0"
+				if v == util.FalseStr {
+					flagMap["prometheus-port"] = strconv.Itoa(prometheusPort)
+					// Use a new port each gcsfuse instance that we start.
+					prometheusPort++
 				}
 
 				continue


### PR DESCRIPTION
Reverts GoogleCloudPlatform/gcs-fuse-csi-driver#574 until GCSFuse e2e test failures are resolved.

Issue is visible on https://github.com/GoogleCloudPlatform/gcsfuse/pull/3239 as presubmit e2e tests fail.