### PR TITLE
Automated cherry pick of #602: Add minimum sidecar version for intelligent defaults and enable E2E tests

### DIFF
--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -350,7 +350,7 @@ func (s *nodeServer) shouldPassDefaultingFlags(pod *corev1.Pod) bool {
 	var sidecarVersionSupported bool
 	for _, container := range pod.Spec.InitContainers {
 		if container.Name == webhook.GcsFuseSidecarName {
-			sidecarVersionSupported = isSidecarVersionSupportedForGivenFeature(container.Image, AutoconfigDefaultingSidecarMinVersion)
+			sidecarVersionSupported = isSidecarVersionSupportedForGivenFeature(container.Image, MachineTypeAutoConfigSidecarMinVersion)
 
 			break
 		}

--- a/pkg/csi_driver/utils.go
+++ b/pkg/csi_driver/utils.go
@@ -60,15 +60,14 @@ const (
 
 	VolumeContextKeyServiceAccountName = "csi.storage.k8s.io/serviceAccount.name"
 	//nolint:gosec
-	VolumeContextKeyServiceAccountToken = "csi.storage.k8s.io/serviceAccount.tokens"
-	VolumeContextKeyPodName             = "csi.storage.k8s.io/pod.name"
-	VolumeContextKeyPodNamespace        = "csi.storage.k8s.io/pod.namespace"
-	VolumeContextKeyEphemeral           = "csi.storage.k8s.io/ephemeral"
-	VolumeContextKeyBucketName          = "bucketName"
-	tokenServerSidecarMinVersion        = "v1.12.2-gke.0" // #nosec G101
-	// TODO: Update with actual minimum sidecar version after the first feature release
-	AutoconfigDefaultingSidecarMinVersion = "v1.99.0-gke.0"
-	FlagFileForDefaultingPath             = "flags-for-defaulting"
+	VolumeContextKeyServiceAccountToken    = "csi.storage.k8s.io/serviceAccount.tokens"
+	VolumeContextKeyPodName                = "csi.storage.k8s.io/pod.name"
+	VolumeContextKeyPodNamespace           = "csi.storage.k8s.io/pod.namespace"
+	VolumeContextKeyEphemeral              = "csi.storage.k8s.io/ephemeral"
+	VolumeContextKeyBucketName             = "bucketName"
+	tokenServerSidecarMinVersion           = "v1.12.2-gke.0" // #nosec G101
+	MachineTypeAutoConfigSidecarMinVersion = "v1.15.1-gke.0" // #nosec G101
+	FlagFileForDefaultingPath              = "flags-for-defaulting"
 )
 
 var volumeIDRegEx = regexp.MustCompile(`:.*$`)

--- a/pkg/csi_driver/utils_test.go
+++ b/pkg/csi_driver/utils_test.go
@@ -189,7 +189,7 @@ func TestIsSidecarVersionSupportedForDefaultingFlags(t *testing.T) {
 
 		for _, tc := range testCases {
 			t.Logf("test case: %s", tc.name)
-			actual := isSidecarVersionSupportedForGivenFeature(tc.imageName, AutoconfigDefaultingSidecarMinVersion)
+			actual := isSidecarVersionSupportedForGivenFeature(tc.imageName, MachineTypeAutoConfigSidecarMinVersion)
 			if actual != tc.expectedSupported {
 				t.Errorf("Got supported %v, but expected %v", actual, tc.expectedSupported)
 			}

--- a/test/e2e/testsuites/mount.go
+++ b/test/e2e/testsuites/mount.go
@@ -64,11 +64,18 @@ func (t *gcsFuseCSIMountTestSuite) SkipUnsupportedTests(_ storageframework.TestD
 }
 
 func (t *gcsFuseCSIMountTestSuite) DefineTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {
-	envVar := os.Getenv(utils.TestWithSAVolumeInjectionEnvVar)
-	supportSAVolInjection, err := strconv.ParseBool(envVar)
+	supportSAVolInjectionEnvVar := os.Getenv(utils.TestWithSAVolumeInjectionEnvVar)
+	supportSAVolInjection, err := strconv.ParseBool(supportSAVolInjectionEnvVar)
 	if err != nil {
-		klog.Fatalf(`env variable "%s" could not be converted to boolean`, envVar)
+		klog.Fatalf("env variable %q could not be converted to boolean", supportSAVolInjectionEnvVar)
 	}
+
+	supportMachineTypeAutoConfigEnvVar := os.Getenv(utils.TestWithMachineTypeAutoConfigEnvVar)
+	supportMachineTypeAutoconfig, err := strconv.ParseBool(supportMachineTypeAutoConfigEnvVar)
+	if err != nil {
+		klog.Fatalf("env variable %q could not be converted to boolean", supportMachineTypeAutoConfigEnvVar)
+	}
+
 	type local struct {
 		config         *storageframework.PerTestConfig
 		volumeResource *storageframework.VolumeResource
@@ -211,15 +218,11 @@ func (t *gcsFuseCSIMountTestSuite) DefineTests(driver storageframework.TestDrive
 		tPod.Cleanup(ctx)
 	}
 
-	ginkgo.It("should pass --machine-type and --disable-autoconfig=false from driver to gcsfuse ", func() {
-		// TODO: remove this skip after we've updated the minimum sidecar version that supports the feature
-		e2eskipper.Skipf("skipping machine type defaulting test while new sidecar version is not known")
-		testDefaultingFlags()
+	ginkgo.It("should pass --machine-type and --disable-autoconfig=false from driver to gcsfuse", func() {
+		testDefaultingFlags(specs.DisableAutoconfig)
 	})
 
 	ginkgo.It("should pass --disable-autoconfig=true as a user-specified mountOption to gcsfuse", func() {
-		// TODO: remove this skip after we've updated the minimum sidecar version that supports the feature
-		e2eskipper.Skipf("skipping machine type defaulting test while new sidecar version is not known")
 		testDefaultingFlags(specs.DisableAutoconfig)
 	})
 

--- a/test/e2e/utils/cluster.go
+++ b/test/e2e/utils/cluster.go
@@ -29,12 +29,13 @@ import (
 )
 
 var (
-	nativeSidecarMinimumVersion       = version.MustParseGeneric("1.29.0")
-	saTokenVolInjectionMinimumVersion = version.MustParseGeneric("1.33.0")
-	skipBucketCheckMinimumVersion     = version.MustParseGeneric("1.29.0")
-	kernelReadAheadMinimumVersion     = version.MustParseGeneric("1.32.0")
-	metadataPrefetchMinimumVersion    = version.MustParseGeneric("1.32.0")
-	longMountOptionsMinimumVersion    = version.MustParseGeneric("1.32.0")
+	nativeSidecarMinimumVersion                 = version.MustParseGeneric("1.29.0")
+	saTokenVolInjectionMinimumVersion           = version.MustParseGeneric("1.33.0")
+	skipBucketCheckMinimumVersion               = version.MustParseGeneric("1.29.0")
+	kernelReadAheadMinimumVersion               = version.MustParseGeneric("1.32.0")
+	metadataPrefetchMinimumVersion              = version.MustParseGeneric("1.32.0")
+	longMountOptionsMinimumVersion              = version.MustParseGeneric("1.32.0")
+	supportsMachineTypeAutoConfigMinimumVersion = version.MustParseGeneric("1.33.0")
 )
 
 func clusterDownGKE(testParams *TestParameters) error {

--- a/test/e2e/utils/handler.go
+++ b/test/e2e/utils/handler.go
@@ -68,10 +68,11 @@ type TestParameters struct {
 	GinkgoFlakeAttempts string
 	GinkgoSkipGcpSaTest bool
 
-	SupportsNativeSidecar bool
-	SupportSAVolInjection bool
-	IstioVersion          string
-	GcsfuseClientProtocol string
+	SupportsNativeSidecar        bool
+	SupportSAVolInjection        bool
+	SupportMachineTypeAutoconfig bool
+	IstioVersion                 string
+	GcsfuseClientProtocol        string
 }
 
 const (
@@ -190,6 +191,12 @@ func Handle(testParams *TestParameters) error {
 		klog.Fatalf(`env variable "%s" could not be set: %v`, TestWithSAVolumeInjectionEnvVar, err)
 	}
 
+	supportsMachineTypeAutoConfig, err := ClusterAtLeastMinVersion(testParams.GkeClusterVersion, testParams.GkeNodeVersion, supportsMachineTypeAutoConfigMinimumVersion)
+	if err != nil {
+		klog.Fatalf(`support for intelligent defaults on high-performance machine types could not be determined: %v`, err)
+	}
+	testParams.SupportMachineTypeAutoconfig = supportsMachineTypeAutoConfig
+
 	testSkipStr := generateTestSkip(testParams)
 	if !strings.Contains(testSkipStr, "istio") && (len(testFocusStr) == 0 || strings.Contains(testFocusStr, "istio")) {
 		installIstio(testParams.IstioVersion)
@@ -266,6 +273,10 @@ func generateTestSkip(testParams *TestParameters) string {
 		if !supportsSkipBucketAccessCheck {
 			skipTests = append(skipTests, "csi-skip-bucket-access-check")
 		}
+	}
+
+	if !testParams.SupportMachineTypeAutoconfig {
+		skipTests = append(skipTests, "disable-autoconfig")
 	}
 
 	skipTests = append(skipTests, "flaky")


### PR DESCRIPTION
Cherry pick of #602 on release-1.15.

#602: Add minimum sidecar version for intelligent defaults and enable E2E tests

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Add minimum sidecar version for intelligent defaults on high-performance machine types and enable corresponding E2E tests
```