### PR TITLE
Add retry logic while fetching STS token in sidecar mounter

### DIFF
--- a/cmd/csi_driver/main.go
+++ b/cmd/csi_driver/main.go
@@ -40,28 +40,30 @@ import (
 )
 
 var (
-	endpoint                     = flag.String("endpoint", "unix:/tmp/csi.sock", "CSI endpoint")
-	nodeID                       = flag.String("nodeid", "", "node id")
-	runController                = flag.Bool("controller", false, "run controller service")
-	runNode                      = flag.Bool("node", false, "run node service")
-	kubeconfigPath               = flag.String("kubeconfig-path", "", "The kubeconfig path.")
-	kubeAPIQPS                   = flag.Float64("kube-api-qps", 5, "QPS to use while communicating with the kubernetes apiserver. Defaults to 5.0.")
-	kubeAPIBurst                 = flag.Int("kube-api-burst", 10, "Burst to use while communicating with the kubernetes apiserver. Defaults to 10.")
-	identityPool                 = flag.String("identity-pool", "", "The Identity Pool to authenticate with GCS API.")
-	identityProvider             = flag.String("identity-provider", "", "The Identity Provider to authenticate with GCS API.")
-	enableProfiling              = flag.Bool("enable-profiling", false, "enable the golang pprof at port 6060")
-	enableBucketScanner          = flag.Bool("enable-bucket-scanner", false, "enable the bucket scanner feature")
-	datafluxParallelism          = flag.Int("dataflux-parallelism", 0, "number of go routines for Dataflux lister. Defaults to 0 (10X number of available vCPUs)")
-	datafluxBatchSize            = flag.Int("dataflux-batch-size", 25000, "batch size for Dataflux lister. Defaults to 25000")
-	datafluxSkipDirectoryObjects = flag.Bool("dataflux-skip-directory-objects", false, "set to true to skip Dataflux listing objects that include files with names ending in '/'")
-	informerResyncDurationSec    = flag.Int("informer-resync-duration-sec", 1800, "informer resync duration in seconds")
-	retryIntervalStart           = flag.Duration("retry-interval-start", time.Second, "Initial retry interval for a failed PV processing operation. It doubles with each failure, up to retry-interval-max.")
-	retryIntervalMax             = flag.Duration("retry-interval-max", 5*time.Minute, "Maximum retry interval for a failed PV processing operation.")
-	fuseSocketDir                = flag.String("fuse-socket-dir", "/sockets", "FUSE socket directory")
-	metricsEndpoint              = flag.String("metrics-endpoint", "", "The TCP network address where the Prometheus metrics endpoint will listen (example: `:8080`). The default is empty string, which means that the metrics endpoint is disabled.")
-	maximumNumberOfCollectors    = flag.Int("max-metric-collectors", -1, "Maximum number of prometheus metric collectors exporting metrics at a time, less than 0 (e.g -1) means no limit.")
-	disableAutoconfig            = flag.Bool("disable-autoconfig", false, "Disable gcsfuse's defaulting based on machine type")
-	wiNodeLabelCheck             = flag.Bool("wi-node-label-check", true, "Workload Identity node label check")
+	endpoint                       = flag.String("endpoint", "unix:/tmp/csi.sock", "CSI endpoint")
+	nodeID                         = flag.String("nodeid", "", "node id")
+	runController                  = flag.Bool("controller", false, "run controller service")
+	runNode                        = flag.Bool("node", false, "run node service")
+	kubeconfigPath                 = flag.String("kubeconfig-path", "", "The kubeconfig path.")
+	kubeAPIQPS                     = flag.Float64("kube-api-qps", 5, "QPS to use while communicating with the kubernetes apiserver. Defaults to 5.0.")
+	kubeAPIBurst                   = flag.Int("kube-api-burst", 10, "Burst to use while communicating with the kubernetes apiserver. Defaults to 10.")
+	identityPool                   = flag.String("identity-pool", "", "The Identity Pool to authenticate with GCS API.")
+	identityProvider               = flag.String("identity-provider", "", "The Identity Provider to authenticate with GCS API.")
+	enableProfiling                = flag.Bool("enable-profiling", false, "enable the golang pprof at port 6060")
+	enableBucketScanner            = flag.Bool("enable-bucket-scanner", false, "enable the bucket scanner feature")
+	datafluxParallelism            = flag.Int("dataflux-parallelism", 0, "number of go routines for Dataflux lister. Defaults to 0 (10X number of available vCPUs)")
+	datafluxBatchSize              = flag.Int("dataflux-batch-size", 25000, "batch size for Dataflux lister. Defaults to 25000")
+	datafluxSkipDirectoryObjects   = flag.Bool("dataflux-skip-directory-objects", false, "set to true to skip Dataflux listing objects that include files with names ending in '/'")
+	informerResyncDurationSec      = flag.Int("informer-resync-duration-sec", 1800, "informer resync duration in seconds")
+	retryIntervalStart             = flag.Duration("retry-interval-start", time.Second, "Initial retry interval for a failed PV processing operation. It doubles with each failure, up to retry-interval-max.")
+	retryIntervalMax               = flag.Duration("retry-interval-max", 5*time.Minute, "Maximum retry interval for a failed PV processing operation.")
+	fuseSocketDir                  = flag.String("fuse-socket-dir", "/sockets", "FUSE socket directory")
+	metricsEndpoint                = flag.String("metrics-endpoint", "", "The TCP network address where the Prometheus metrics endpoint will listen (example: `:8080`). The default is empty string, which means that the metrics endpoint is disabled.")
+	maximumNumberOfCollectors      = flag.Int("max-metric-collectors", -1, "Maximum number of prometheus metric collectors exporting metrics at a time, less than 0 (e.g -1) means no limit.")
+	disableAutoconfig              = flag.Bool("disable-autoconfig", false, "Disable gcsfuse's defaulting based on machine type")
+	wiNodeLabelCheck               = flag.Bool("wi-node-label-check", true, "Workload Identity node label check")
+	enableSidecarBucketAccessCheck = flag.Bool("enable-sidecar-bucket-access-check", false, "Enable bucket access check on sidecar, this does not disable bucket access check in node driver")
+
 	enableCloudProfilerForDriver = flag.Bool("enable-cloud-profiler-for-driver", false, "Enable cloud profiler to collect analysis data")
 	// These are set at compile time.
 	version = "unknown"
@@ -163,19 +165,20 @@ func main() {
 	}
 
 	config := &driver.GCSDriverConfig{
-		Name:                  driver.DefaultName,
-		Version:               version,
-		NodeID:                *nodeID,
-		RunController:         *runController,
-		RunNode:               *runNode,
-		StorageServiceManager: ssm,
-		TokenManager:          tm,
-		Mounter:               mounter,
-		K8sClients:            clientset,
-		MetricsManager:        mm,
-		DisableAutoconfig:     *disableAutoconfig,
-		WINodeLabelCheck:      *wiNodeLabelCheck,
-		FeatureOptions:        featureOptions,
+		Name:                           driver.DefaultName,
+		Version:                        version,
+		NodeID:                         *nodeID,
+		RunController:                  *runController,
+		RunNode:                        *runNode,
+		StorageServiceManager:          ssm,
+		TokenManager:                   tm,
+		Mounter:                        mounter,
+		K8sClients:                     clientset,
+		MetricsManager:                 mm,
+		DisableAutoconfig:              *disableAutoconfig,
+		WINodeLabelCheck:               *wiNodeLabelCheck,
+		EnableSidecarBucketAccessCheck: *enableSidecarBucketAccessCheck,
+		FeatureOptions:                 featureOptions,
 	}
 
 	gcfsDriver, err := driver.NewGCSDriver(config)

--- a/deploy/base/node/node.yaml
+++ b/deploy/base/node/node.yaml
@@ -56,6 +56,7 @@ spec:
             - --metrics-endpoint=:9920
             - --max-metric-collectors=10
             - --enable-cloud-profiler-for-driver=false
+            - --enable-sidecar-bucket-access-check=true
           ports:
           - containerPort: 9920
             name: metrics

--- a/pkg/cloud_provider/auth/fake.go
+++ b/pkg/cloud_provider/auth/fake.go
@@ -27,12 +27,16 @@ func NewFakeTokenManager() TokenManager {
 	return &fakeTokenManager{}
 }
 
-func (tm *fakeTokenManager) GetTokenSourceFromK8sServiceAccount(saNamespace, saName, _ string) oauth2.TokenSource {
+func (tm *fakeTokenManager) GetTokenSourceFromK8sServiceAccount(saNamespace, saName, _, _ string, _ bool) oauth2.TokenSource {
 	return &FakeGCPTokenSource{k8sSAName: saName, k8sSANamespace: saNamespace}
 }
 
 func (tm *fakeTokenManager) GetIdentityProvider() string {
 	return "fake.identity.provider"
+}
+
+func (tm *fakeTokenManager) GetIdentityPool() string {
+	return "fake.identity.pool"
 }
 
 type FakeGCPTokenSource struct {

--- a/pkg/cloud_provider/auth/token_manager.go
+++ b/pkg/cloud_provider/auth/token_manager.go
@@ -30,8 +30,9 @@ const (
 )
 
 type TokenManager interface {
-	GetTokenSourceFromK8sServiceAccount(saNamespace, saName, saToken string) oauth2.TokenSource
+	GetTokenSourceFromK8sServiceAccount(saNamespace, saName, saToken, audience string, fetchFromFile bool) oauth2.TokenSource
 	GetIdentityProvider() string
+	GetIdentityPool() string
 }
 
 type tokenManager struct {
@@ -52,12 +53,18 @@ func (tm *tokenManager) GetIdentityProvider() string {
 	return tm.meta.GetIdentityProvider()
 }
 
-func (tm *tokenManager) GetTokenSourceFromK8sServiceAccount(saNamespace, saName, saToken string) oauth2.TokenSource {
+func (tm *tokenManager) GetIdentityPool() string {
+	return tm.meta.GetIdentityPool()
+}
+
+func (tm *tokenManager) GetTokenSourceFromK8sServiceAccount(saNamespace, saName, saToken, audience string, fetchFromFile bool) oauth2.TokenSource {
 	return &GCPTokenSource{
-		meta:           tm.meta,
-		k8sSAName:      saName,
-		k8sSANamespace: saNamespace,
-		k8sSAToken:     saToken,
-		k8sClients:     tm.k8sClients,
+		meta:               tm.meta,
+		k8sSAName:          saName,
+		k8sSANamespace:     saNamespace,
+		k8sSAToken:         saToken,
+		k8sClients:         tm.k8sClients,
+		audience:           audience,
+		fetchTokenfromFile: fetchFromFile,
 	}
 }

--- a/pkg/cloud_provider/storage/fake.go
+++ b/pkg/cloud_provider/storage/fake.go
@@ -50,6 +50,10 @@ func (manager *fakeServiceManager) SetupServiceWithDefaultCredential(_ context.C
 	return &fakeService{sm: *manager}, nil
 }
 
+func (manager *fakeServiceManager) SetupStorageServiceForSidecar(_ context.Context, _ oauth2.TokenSource) (Service, error) {
+	return &fakeService{sm: *manager}, nil
+}
+
 func NewFakeServiceManager() ServiceManager {
 	return &fakeServiceManager{createdBuckets: map[string]*ServiceBucket{}}
 }

--- a/pkg/csi_driver/controller.go
+++ b/pkg/csi_driver/controller.go
@@ -237,7 +237,7 @@ func (s *controllerServer) prepareStorageService(ctx context.Context, secrets ma
 		return nil, status.Error(codes.InvalidArgument, "serviceAccountNamespace must be provided in secret")
 	}
 
-	ts := s.driver.config.TokenManager.GetTokenSourceFromK8sServiceAccount(serviceAccountNamespace, serviceAccountName, "")
+	ts := s.driver.config.TokenManager.GetTokenSourceFromK8sServiceAccount(serviceAccountNamespace, serviceAccountName, "", "" /*audience*/, false)
 	storageService, err := s.storageServiceManager.SetupService(ctx, ts)
 	if err != nil {
 		return nil, fmt.Errorf("storage service manager failed to setup service: %w", err)

--- a/pkg/csi_driver/gcs_fuse_driver.go
+++ b/pkg/csi_driver/gcs_fuse_driver.go
@@ -47,20 +47,21 @@ type GCSDriverFeatureOptions struct {
 }
 
 type GCSDriverConfig struct {
-	Name                          string // Driver name
-	Version                       string // Driver version
-	NodeID                        string // Node name
-	RunController                 bool   // Run CSI controller service
-	RunNode                       bool   // Run CSI node service
-	StorageServiceManager         storage.ServiceManager
-	TokenManager                  auth.TokenManager
-	Mounter                       mount.Interface
-	K8sClients                    clientset.Interface
-	MetricsManager                metrics.Manager
-	DisableAutoconfig             bool
-	WINodeLabelCheck              bool
-	EnableCloudProfilerForSidecar bool
-	FeatureOptions                *GCSDriverFeatureOptions
+	Name                           string // Driver name
+	Version                        string // Driver version
+	NodeID                         string // Node name
+	RunController                  bool   // Run CSI controller service
+	RunNode                        bool   // Run CSI node service
+	StorageServiceManager          storage.ServiceManager
+	TokenManager                   auth.TokenManager
+	Mounter                        mount.Interface
+	K8sClients                     clientset.Interface
+	MetricsManager                 metrics.Manager
+	DisableAutoconfig              bool
+	EnableSidecarBucketAccessCheck bool
+	WINodeLabelCheck               bool
+	EnableCloudProfilerForSidecar  bool
+	FeatureOptions                 *GCSDriverFeatureOptions
 }
 
 type GCSDriver struct {

--- a/pkg/csi_driver/utils.go
+++ b/pkg/csi_driver/utils.go
@@ -56,6 +56,7 @@ const (
 	VolumeContextKeyHostNetworkPodKSA          = "hostNetworkPodKSA"
 	VolumeContextKeyIdentityProvider           = "identityProvider"
 	VolumeContextKeyDisableMetrics             = "disableMetrics"
+	VolumeContextKeyIdentityPool               = "identityPool"
 	VolumeContextEnableCloudProfilerForSidecar = "enableCloudProfilerForSidecar"
 
 	//nolint:revive,stylecheck

--- a/pkg/csi_driver/utils_test.go
+++ b/pkg/csi_driver/utils_test.go
@@ -603,6 +603,13 @@ func TestParseVolumeAttributes(t *testing.T) {
 				expectedMountOptions:                  []string{},
 				expectedEnableCloudProfilerForSidecar: true,
 			},
+			{
+				name:                     "value set to true for VolumeContextKeyIdentityProvider",
+				volumeContext:            map[string]string{VolumeContextKeyIdentityProvider: "some-string"},
+				expectedErr:              false,
+				expectedMountOptions:     []string{},
+				expectedIdentityProvider: "some-string",
+			},
 		}
 
 		for _, tc := range testCases {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -37,7 +37,14 @@ const (
 	FalseStr = "false"
 
 	// mount options that both CSI mounter and sidecar mounter should understand.
-	DisableMetricsForGKE = "disable-metrics-for-gke"
+	DisableMetricsForGKE                = "disable-metrics-for-gke"
+	EnableSidecarBucketAccessCheckConst = "enable-sidecar-bucket-access-check"
+	TokenServerIdentityPoolConst        = "token-server-identity-pool"
+	ServiceAccountNameConst             = "service-account-name"
+	PodNamespaceConst                   = "pod-namespace"
+	TokenServerIdentityProviderConst    = "token-server-identity-provider"
+	OptInHnw                            = "hnw-ksa"
+	EnableCloudProfilerForSidecarConst  = "enable-cloud-profiler-for-sidecar"
 )
 
 var (
@@ -205,6 +212,15 @@ func CheckAndDeleteStaleFile(dirPath, fileName string) error {
 	klog.Infof("Stale file '%s' successfully deleted", fileName)
 
 	return nil
+}
+
+func FetchK8sTokenFromFile(tokenPath string) (string, error) {
+	token, err := os.ReadFile(tokenPath)
+	if err != nil {
+		return "", fmt.Errorf("error reading token file: %w", err)
+	}
+
+	return strings.TrimSpace(string(token)), nil
 }
 
 // The format allows customers to specify a fake volume handle for static provisioning,

--- a/pkg/webhook/mutatingwebhook.go
+++ b/pkg/webhook/mutatingwebhook.go
@@ -110,7 +110,7 @@ func (si *SidecarInjector) Handle(ctx context.Context, req admission.Request) ad
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 	// Inject service account volume
-	if si.Config.ShouldInjectSAVolume && pod.Spec.HostNetwork {
+	if si.Config.ShouldInjectSAVolume {
 		projectID, err := metadata.ProjectIDWithContext(ctx)
 		if err != nil {
 			return admission.Errored(http.StatusInternalServerError, fmt.Errorf("failed to get project id: %w", err))

--- a/pkg/webhook/sidecar_spec.go
+++ b/pkg/webhook/sidecar_spec.go
@@ -123,7 +123,7 @@ func GetSidecarContainerSpec(c *Config) corev1.Container {
 	limits, requests := prepareResourceList(c)
 
 	volumeMounts := []corev1.VolumeMount{TmpVolumeMount, buffVolumeMount, cacheVolumeMount}
-	if c.PodHostNetworkSetting && c.ShouldInjectSAVolume {
+	if c.ShouldInjectSAVolume {
 		volumeMounts = append(volumeMounts, saTokenVolumeMount)
 	}
 

--- a/test/e2e/specs/specs.go
+++ b/test/e2e/specs/specs.go
@@ -159,7 +159,7 @@ func NewTestPod(c clientset.Interface, ns *corev1.Namespace) *TestPod {
 				},
 				RestartPolicy:                corev1.RestartPolicyAlways,
 				Volumes:                      make([]corev1.Volume, 0),
-				AutomountServiceAccountToken: ptr.To(false),
+				AutomountServiceAccountToken: ptr.To(true),
 				Tolerations: []corev1.Toleration{
 					{Operator: corev1.TolerationOpExists},
 				},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

 /kind feature
> /kind flake

**What this PR does / why we need it**:
The PR performs bucket access check in GCS Fuse sidecar. This check is currently performed in CSI node driver but that consumes additional STS quota hence it is being moved to sidecar. The STS quota benefits can be seen only for Workload Identity pods while HostNetwork pods will see ad additional STS quota request per pod.
Since the bucket access check is being performed in sidecar with this PR it can be skipped in node by setting `--skipCSIBucketAccessCheck=true`

***Workload Identity***
1. Performs bucket access check in sidecar
2. STS quota savings as WI serves any recurring request from same pod through its cached token.
3. Ensure `--skipCSIBucketAccessCheck=true` to save STS quota

***Host Network***
1. Performs bucket access check in sidecar
2. Sidecar makes an additional STS request to the token server to perform bucket access check.

***Metrics to view STS requests and quota***
STS quota consumption can be found in Metrics explorer page `service=sts.googleapis.com` and metric `Consumed API - Request Count`
<img width="6016" height="3140" alt="image" src="https://github.com/user-attachments/assets/fed02ef8-f7ef-46f2-8fb2-13d79c94ded3" />

***Testing***
Ran full test suite locally, some of the failing tests succeeded on re-run with E2E_TEST_FOCUS, the tests were failing in earlier attempt due to unrelated issues (tag naming - needed `prow-gob-internal-boskos` in tag name)
```
============================= gcsfuseIntegrationTests focused =============================

------------------------------
[ReportAfterSuite] PASSED [0.081 seconds]
[ReportAfterSuite] Autogenerated ReportAfterSuite for --junit-report
autogenerated by Ginkgo
------------------------------

Ran 76 of 434 Specs in 2376.885 seconds
SUCCESS! -- 76 Passed | 0 Failed | 0 Pending | 358 Skipped


==================== Volumes focused ===============
make e2e-test E2E_TEST_FOCUS="volumes.should.*" E2E_TEST_USE_GKE_MANAGED_DRIVER=false E2E_TEST_BUILD_DRIVER=false BUILD_GCSFUSE_FROM_SOURCE=false STAGINGVERSION=$STAGINGVERSION  REGISTRY=$REGISTRY
PROJECT is snehaaradhey-gke-dev
OVERLAY is stable
STAGINGVERSION is test-bucket-access-check-debugging-prow-gob-internal-boskos-29
DRIVER_IMAGE is us-central1-docker.pkg.dev/snehaaradhey-gke-dev/csi-dev/gcs-fuse-csi-driver
SIDECAR_IMAGE is us-central1-docker.pkg.dev/snehaaradhey-gke-dev/csi-dev/gcs-fuse-csi-driver-sidecar-mounter
WEBHOOK_IMAGE is us-central1-docker.pkg.dev/snehaaradhey-gke-dev/csi-dev/gcs-fuse-csi-driver-webhook
........


Ran 12 of 434 Specs in 32.093 seconds
SUCCESS! -- 12 Passed | 0 Failed | 0 Pending | 422 Skipped

===================== Mount focused ================
OVERLAY is stable
STAGINGVERSION is test-bucket-access-check-debugging-prow-gob-internal-boskos-29
DRIVER_IMAGE is us-central1-docker.pkg.dev/snehaaradhey-gke-dev/csi-dev/gcs-fuse-csi-driver
SIDECAR_IMAGE is us-central1-docker.pkg.dev/snehaaradhey-gke-dev/csi-dev/gcs-fuse-csi-driver-sidecar-mounter
WEBHOOK_IMAGE is us-central1-docker.pkg.dev/snehaaradhey-gke-dev/csi-dev/gcs-fuse-csi-driver-webhook

.......
Ran 7 of 434 Specs in 19.492 seconds
SUCCESS! -- 7 Passed | 0 Failed | 0 Pending | 427 Skipped


========================== All the failing tests were re-run with E2E_TEST_FOCUS captured above, the tests were failing due to unrelated issues (tag naming)  ====================
make e2e-test E2E_TEST_USE_GKE_MANAGED_DRIVER=false E2E_TEST_BUILD_DRIVER=false BUILD_GCSFUSE_FROM_SOURCE=false STAGINGVERSION=$STAGINGVERSION  REGISTRY=$REGISTRY
PROJECT is snehaaradhey-gke-dev
OVERLAY is stable
STAGINGVERSION is test-bucket-access-check-debugging-29
DRIVER_IMAGE is us-central1-docker.pkg.dev/snehaaradhey-gke-dev/csi-dev/gcs-fuse-csi-driver
SIDECAR_IMAGE is us-central1-docker.pkg.dev/snehaaradhey-gke-dev/csi-dev/gcs-fuse-csi-driver-sidecar-mounter
WEBHOOK_IMAGE is us-central1-docker.pkg.dev/snehaaradhey-gke-dev/csi-dev/gcs-fuse-csi-driver-webhook
.......
Ran 324 of 434 Specs in 8333.466 seconds
FAIL! -- 307 Passed | 17 Failed | 8 Flaked | 0 Pending | 110 Skipped
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Enhances sidecar to perform bucket access check before mounting any bucket
```