### PR TITLE
Fix build issues with E2E tests

### DIFF
--- a/pkg/csi_driver/utils.go
+++ b/pkg/csi_driver/utils.go
@@ -488,9 +488,8 @@ func isSidecarVersionSupportedForGivenFeature(imageName string, sidecarMinSuppor
 		return false
 	}
 	imageVersion := strings.Split(strings.Split(imageName, ":")[1], "@")[0]
-	klog.Infof("sidecar image version: %v", imageVersion)
 	if semver.Compare(imageVersion, sidecarMinSupportedVersion) >= 0 {
-		klog.Infof("sidecar version is supported for token server")
+		klog.Infof("sidecar version is supported for intelligent defaults on high-performance machine types")
 		return true
 	}
 

--- a/test/e2e/testsuites/mount.go
+++ b/test/e2e/testsuites/mount.go
@@ -70,12 +70,6 @@ func (t *gcsFuseCSIMountTestSuite) DefineTests(driver storageframework.TestDrive
 		klog.Fatalf("env variable %q could not be converted to boolean", supportSAVolInjectionEnvVar)
 	}
 
-	supportMachineTypeAutoConfigEnvVar := os.Getenv(utils.TestWithMachineTypeAutoConfigEnvVar)
-	supportMachineTypeAutoconfig, err := strconv.ParseBool(supportMachineTypeAutoConfigEnvVar)
-	if err != nil {
-		klog.Fatalf("env variable %q could not be converted to boolean", supportMachineTypeAutoConfigEnvVar)
-	}
-
 	type local struct {
 		config         *storageframework.PerTestConfig
 		volumeResource *storageframework.VolumeResource

--- a/test/e2e/utils/handler.go
+++ b/test/e2e/utils/handler.go
@@ -195,6 +195,7 @@ func Handle(testParams *TestParameters) error {
 	if err != nil {
 		klog.Fatalf(`support for intelligent defaults on high-performance machine types could not be determined: %v`, err)
 	}
+
 	testParams.SupportMachineTypeAutoconfig = supportsMachineTypeAutoConfig
 
 	testSkipStr := generateTestSkip(testParams)
@@ -273,6 +274,9 @@ func generateTestSkip(testParams *TestParameters) string {
 		if !supportsSkipBucketAccessCheck {
 			skipTests = append(skipTests, "csi-skip-bucket-access-check")
 		}
+
+		// TODO(hungpnguyen): remove this skip once we do 1.15.3 release or 1.16 since sidecar version filter will work correctly by then
+		skipTests = append(skipTests, "disable-autoconfig")
 	}
 
 	if !testParams.SupportMachineTypeAutoconfig {


### PR DESCRIPTION
Fix build issues with E2E tests while enabling e2e tests for high-performance machine types.

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation

/kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
https://github.com/GoogleCloudPlatform/gcs-fuse-csi-driver/pull/602 introduced a build error with E2E test, so this PR is meant to fix that. I also modified the test-skip logic to skip managed drivers for now since the target tests for intelligent defaults will still fail for managed drivers until we complete the next release and the minimum sidecar version in https://github.com/GoogleCloudPlatform/gcs-fuse-csi-driver/pull/602 gets shipped.

Testing: I verified that the sidecar version filter is working as intended with local E2E test runs.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix build issues with E2E tests while enabling e2e tests for high-performance machine types.
```