### PR TITLE
Automated cherry pick of #606: Fix build issues with E2E tests

### DIFF
--- a/pkg/csi_driver/utils.go
+++ b/pkg/csi_driver/utils.go
@@ -488,9 +488,8 @@ func isSidecarVersionSupportedForGivenFeature(imageName string, sidecarMinSuppor
 		return false
 	}
 	imageVersion := strings.Split(strings.Split(imageName, ":")[1], "@")[0]
-	klog.Infof("sidecar image version: %v", imageVersion)
 	if semver.Compare(imageVersion, sidecarMinSupportedVersion) >= 0 {
-		klog.Infof("sidecar version is supported for token server")
+		klog.Infof("sidecar version is supported for intelligent defaults on high-performance machine types")
 		return true
 	}
 

--- a/test/e2e/testsuites/mount.go
+++ b/test/e2e/testsuites/mount.go
@@ -70,12 +70,6 @@ func (t *gcsFuseCSIMountTestSuite) DefineTests(driver storageframework.TestDrive
 		klog.Fatalf("env variable %q could not be converted to boolean", supportSAVolInjectionEnvVar)
 	}
 
-	supportMachineTypeAutoConfigEnvVar := os.Getenv(utils.TestWithMachineTypeAutoConfigEnvVar)
-	supportMachineTypeAutoconfig, err := strconv.ParseBool(supportMachineTypeAutoConfigEnvVar)
-	if err != nil {
-		klog.Fatalf("env variable %q could not be converted to boolean", supportMachineTypeAutoConfigEnvVar)
-	}
-
 	type local struct {
 		config         *storageframework.PerTestConfig
 		volumeResource *storageframework.VolumeResource

--- a/test/e2e/utils/handler.go
+++ b/test/e2e/utils/handler.go
@@ -195,6 +195,7 @@ func Handle(testParams *TestParameters) error {
 	if err != nil {
 		klog.Fatalf(`support for intelligent defaults on high-performance machine types could not be determined: %v`, err)
 	}
+
 	testParams.SupportMachineTypeAutoconfig = supportsMachineTypeAutoConfig
 
 	testSkipStr := generateTestSkip(testParams)
@@ -273,6 +274,9 @@ func generateTestSkip(testParams *TestParameters) string {
 		if !supportsSkipBucketAccessCheck {
 			skipTests = append(skipTests, "csi-skip-bucket-access-check")
 		}
+
+		// TODO(hungpnguyen): remove this skip once we do 1.15.3 release or 1.16 since sidecar version filter will work correctly by then
+		skipTests = append(skipTests, "disable-autoconfig")
 	}
 
 	if !testParams.SupportMachineTypeAutoconfig {


### PR DESCRIPTION
Cherry pick of #606 on release-1.15.

#606: Fix build issues with E2E tests

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fix build issues with E2E tests while enabling e2e tests for high-performance machine types.
```