### PR TITLE
Filtering informerFactory to return relevant PodSpec information [Cherrypick main --> 1.8]

### DIFF
--- a/pkg/cloud_provider/clientset/clientset.go
+++ b/pkg/cloud_provider/clientset/clientset.go
@@ -78,11 +78,48 @@ func New(kubeconfigPath string, informerResyncDurationSec int) (Interface, error
 }
 
 func (c *Clientset) ConfigurePodLister(nodeName string) {
-	trimManagedFields := func(obj interface{}) (interface{}, error) {
+	trim := func(obj interface{}) (interface{}, error) {
 		if accessor, err := meta.Accessor(obj); err == nil {
 			if accessor.GetManagedFields() != nil {
 				accessor.SetManagedFields(nil)
 			}
+		}
+
+		// We are filtering only for relevant PodSpec info to optimize memory usage.
+		// Relevant info is for NodePublishVolume calls:
+		// https://github.com/GoogleCloudPlatform/gcs-fuse-csi-driver/blob/547cab9a9aea4cdbda581885880020fb9266dc03/pkg/csi_driver/node.go#L85
+		podObj, ok := obj.(*corev1.Pod)
+		if !ok {
+			return obj, nil
+		}
+
+		var newContainers []corev1.Container
+		for _, cont := range podObj.Spec.Containers {
+			container := corev1.Container{
+				Name:            cont.Name,
+				SecurityContext: cont.SecurityContext,
+				VolumeMounts:    cont.VolumeMounts,
+			}
+			newContainers = append(newContainers, container)
+		}
+
+		var newInitContainers []corev1.Container
+		for _, cont := range podObj.Spec.InitContainers {
+			container := corev1.Container{
+				Name:            cont.Name,
+				SecurityContext: cont.SecurityContext,
+				VolumeMounts:    cont.VolumeMounts,
+			}
+			newInitContainers = append(newInitContainers, container)
+		}
+
+		nodeName := podObj.Spec.NodeName
+		volumes := podObj.Spec.Volumes
+		podObj.Spec = corev1.PodSpec{
+			NodeName:       nodeName,
+			Volumes:        volumes,
+			Containers:     newContainers,
+			InitContainers: newInitContainers,
 		}
 
 		return obj, nil
@@ -94,7 +131,7 @@ func (c *Clientset) ConfigurePodLister(nodeName string) {
 		informers.WithTweakListOptions(func(options *metav1.ListOptions) {
 			options.FieldSelector = "spec.nodeName=" + nodeName
 		}),
-		informers.WithTransform(trimManagedFields),
+		informers.WithTransform(trim),
 	)
 	podLister := informerFactory.Core().V1().Pods().Lister()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Cherrypick/backport informer filtering to GKE versions 1.31.
Original PR: https://github.com/GoogleCloudPlatform/gcs-fuse-csi-driver/pull/413
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```