### PR TITLE
Re-enable E2E tests for defaults on high-performance machine types on managed drivers

### DIFF
--- a/test/e2e/utils/handler.go
+++ b/test/e2e/utils/handler.go
@@ -274,9 +274,6 @@ func generateTestSkip(testParams *TestParameters) string {
 		if !supportsSkipBucketAccessCheck {
 			skipTests = append(skipTests, "csi-skip-bucket-access-check")
 		}
-
-		// TODO(hungpnguyen): remove this skip once we do 1.15.3 release or 1.16 since sidecar version filter will work correctly by then
-		skipTests = append(skipTests, "disable-autoconfig")
 	}
 
 	if !testParams.SupportMachineTypeAutoconfig {


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:
Previously, we [skipped](https://github.com/GoogleCloudPlatform/gcs-fuse-csi-driver/pull/606) E2E tests on high-performance machine types for our managed test grid since our 1.33 testgrid was on an older GKE version with a placeholder sidecar version.  Now the testgrid has been updated to use [1.33.0-gke.2248000](https://screenshot.googleplex.com/JjuWxpnLfkdzN2Y), which is [mapped](https://paste.googleplex.com/4726408225751040) to [our 1.15.2 upstream release ](https://github.com/GoogleCloudPlatform/gcs-fuse-csi-driver/releases/tag/v1.15.2)with the complete sidecar version filter logic. These tests should therefore be runnable now for 1.33 managed drivers.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Re-enable E2E tests for defaults on high-performance machine types on managed drivers
```