### PR TITLE
Automated cherry pick of #610: Allow sidecar filter logic to accept non-managed image built for internal test grids

### DIFF
--- a/pkg/csi_driver/utils.go
+++ b/pkg/csi_driver/utils.go
@@ -479,6 +479,11 @@ func isSidecarVersionSupportedForTokenServer(imageName string) bool {
 }
 
 func isSidecarVersionSupportedForGivenFeature(imageName string, sidecarMinSupportedVersion string) bool {
+	// If the image is from our non-managed testgrid, just assume the sidecar version is supported
+	// since it's built off latest code in main
+	if strings.Contains(imageName, "prow-gob-internal-boskos") {
+		return true
+	}
 	managedSidecarPattern := `.*/gke-release(-staging)?/gcs-fuse-csi-driver-sidecar-mounter:v\d+.\d+.\d+-gke\.\d+.*`
 	re := regexp.MustCompile(managedSidecarPattern)
 	isManagedSidecar := re.MatchString(imageName)

--- a/pkg/csi_driver/utils_test.go
+++ b/pkg/csi_driver/utils_test.go
@@ -166,13 +166,18 @@ func TestIsSidecarVersionSupportedForDefaultingFlags(t *testing.T) {
 			expectedSupported bool
 		}{
 			{
-				name:              "should return true for supported sidecar version",
+				name:              "should return true for supported sidecar version (managed driver image)",
 				imageName:         "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gcs-fuse-csi-driver-sidecar-mounter:v1.99.0-gke.2@sha256:abcd",
 				expectedSupported: true,
 			},
 			{
 				name:              "should return true for supported sidecar version in staging gcr",
 				imageName:         "gcr.io/gke-release-staging/gcs-fuse-csi-driver-sidecar-mounter:v1.99.0-gke.0@sha256:abcd",
+				expectedSupported: true,
+			},
+			{
+				name:              "should return true for supported sidecar version (non-managed driver image)",
+				imageName:         "gcr.io/prow-gob-internal-boskos-447/gcs-fuse-csi-driver/gcs-fuse-csi-driver-sidecar-mounter:v1.15.1-gke.0-14-gf752039e_linux_amd64@sha:abcd",
 				expectedSupported: true,
 			},
 			{


### PR DESCRIPTION
Cherry pick of #610 on release-1.15.

#610: Allow sidecar filter logic to accept non-managed image built for internal test grids

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```