### PR TITLE
Cherrypick #615 to release-1.15

### DIFF
--- a/pkg/sidecar_mounter/sidecar_mounter_config.go
+++ b/pkg/sidecar_mounter/sidecar_mounter_config.go
@@ -125,8 +125,9 @@ func NewMountConfig(sp string, flagMapFromDriver map[string]string) *MountConfig
 	}
 	// as we got all the information from the socket, closing the connection and deleting the socket
 	c.Close()
-	if err = syscall.Unlink(sp); err != nil {
-		klog.Errorf("failed to close socket %q: %v", sp, err)
+	if err = syscall.Unlink(sp); err != nil && err != syscall.ENOENT {
+		// ENOENT suggests, the file may have already been unliked and removed, since the listener is closed on the csi node driver when it has successfully responsed to the sidecar
+		klog.Errorf("failed to unlink socket %q: %v", sp, err)
 	}
 
 	mc.FileDescriptor = fd


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Cherrypick #615 to release-1.15

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
log error to unlink socket path only if the error is not ENOENT
```