### PR TITLE
Automated cherry pick of #654: Bump gcsfuse to v2.12.2 for CVE fix

### DIFF
--- a/cmd/sidecar_mounter/gcsfuse_binary
+++ b/cmd/sidecar_mounter/gcsfuse_binary
@@ -1,1 +1,1 @@
-gs://gke-release-staging/gcsfuse/v2.12.1-gke.0/gcsfuse_bin
+gs://gke-release-staging/gcsfuse/v2.12.2-gke.0/gcsfuse_bin


### PR DESCRIPTION
Cherry pick of #654 on release-1.15.

#654: Bump gcsfuse to v2.12.2 for CVE fix

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Bump gcsfuse to v2.12.2 for CVE fix
```