### PR TITLE
Add support for node restarts.

### DIFF
--- a/cmd/sidecar_mounter/main.go
+++ b/cmd/sidecar_mounter/main.go
@@ -69,6 +69,7 @@ func main() {
 	}
 
 	for _, sp := range socketPaths {
+		klog.V(4).Infof("in sidecar mounter, found socket path %s", sp)
 		// sleep 1.5 seconds before launch the next gcsfuse to avoid
 		// 1. different gcsfuse logs mixed together.
 		// 2. memory usage peak.
@@ -123,6 +124,7 @@ func main() {
 	klog.Info("received SIGTERM signal, waiting for all the gcsfuse processes exit...")
 
 	if isNativeSidecar {
+		klog.V(4).Info("the sidecar mounter is calling ctx.cancel")
 		cancel()
 	}
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -437,6 +437,13 @@ See GKE documentation [Storage for GKE clusters overview](https://cloud.google.c
 
 If the sidecar container (`gke-gcsfuse-sidecar`) hosting the gcsfuse process, crashes for some reason (e.g OOM Kill, or fatals), and kubelet decides to inplace restart the container, gcsfusecsi driver does not handle this scenario gracefully. This is because in the CSI NodePublishVolume the driver [checks the last known state](https://github.com/GoogleCloudPlatform/gcs-fuse-csi-driver/blob/v1.15.4/pkg/csi_driver/utils.go#L431) of the container and fails fast. To mitigate this, delete and create the pod.
 
+### Node level restarts
+
+GCSFuse CSI Driver can now manage node restarts without impacting pods using GCSFuse-backed volumes. The driver ensures a clean slate by clearing stale files or sockets, and re-establishing the gcsfuse /dev/fuse file descriptor during the NodePublishVolume phase after a restart.
+
+Known issues after a node restart:
+- Metrics will not be visible on Cloud Monitoring after node restart. If they become visible, assume that they will be malformed.
+- Metrics after a restart will only look at the time period after the node restart.
 
 ### enabling debug logs
 


### PR DESCRIPTION
<!-- ***Please note I will update the description before I mark the PR as ready*** -->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:
This PR allows the GCSFuse CSI Driver to handle Node restarts. We are currently seeing more demand for this feature as the restarts become increasingly common the scale of the cluster increases. Certain nodes (e.g. TPU and GPU VMs) perform restarts for more scenarios compared to a traditional GKE node/nodepool (e.g. host error, maintenance preemption, etc.)

**Restart scenarios tested**:
We've manually verified select features of the GCSFuse CSI Driver against node restarts. 
Each feature was verified against both graceful and ungraceful node restart. The testing steps are as follows:
1. Deploy workload on GKE Cluster
2. Verify feature works by: running IOPS against volume, check logs for errors
3. Perform node restart
5. Verify feature works by: running IOPS against volume, check logs for errors

Graceful node restart command
`sudo systemctl reboot`

Ungraceful node restart command (node crash)
`sudo su \ echo 1 > /proc/sys/kernel/sysrq & echo "c" > /proc/sysrq-trigger`

**Verified the following features:**
- Defaulting flags for GCSFuse
- HostNetworking
- Metrics (only addressing metrics endpoint health)

**Breakdown of PR**
Stale sockets that are cleaned up:
- Mount
  - Socket used to transfer the /dev/fuse file descriptor, bucket name, and GCSFuse configurations from csi driver to sidecar mounter
  - Stale socket is reached when the Node crashes after the NodePublishVolume call succeeds, but before the sidecar starts up.
  - <img width="824" alt="image" src="https://github.com/user-attachments/assets/60456141-0191-49b9-b097-9bd742a9e975" />
- Hostnetwork
  - Socket used by token server to process requests from GCSFuse
  - <img width="778" alt="image" src="https://github.com/user-attachments/assets/2d916810-82fa-4df5-ae60-b23bb437ae7e" />

- Metrics
  - Socket used by metrics process running in sidecar mounter to scrape metrics from GCSFuse
  - <img width="835" alt="image" src="https://github.com/user-attachments/assets/7d5972ad-bf06-4364-84de-84d0171ccd08" />

Files used by GCSFuse CSI Driver:
- `config.yaml`
  - This file is created by sidecar and it is read by GCSFuse process.
  - cleaned up to avoid permission issues while reading file after restart.
- `error`
  - created by gcsfuse process when failure occurs
  - cleaned up to avoid storing stale errors after node restart
- `flags-for-defaulting`
  - created by csi driver and used by sidecar mounter at startup to create `config.yaml`
  - Did not encounter permission or startup issues by having stale file after restart.
- `exit`
  - Only used on clusters that don't support native sidecar
  - This file is placed on sidecar tmp volume once all workload containers terminate.
  - No action required. Once exit file is placed, pod is not expected to restart. Kubelet does not restart pods that are in terminating state in the event of a restart.

**Local tests:**
<img width="667" alt="image" src="https://github.com/user-attachments/assets/ac1ad6ff-223e-419f-82a5-459c0302bef0" />


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This PR also adds retries to the WaitForLog function used in e2e testing, as too many tests calling this function can cause temporary failures.

**Does this PR introduce a user-facing change?**:

```release-note
Add node restart support to GCSFuse CSI driver.
```
<!-- h i--> 