### PR TITLE
Added ZB support during e2e tests

### DIFF
--- a/pkg/cloud_provider/storage/storage.go
+++ b/pkg/cloud_provider/storage/storage.go
@@ -42,6 +42,7 @@ type ServiceBucket struct {
 	Labels                         map[string]string
 	EnableUniformBucketLevelAccess bool
 	EnableHierarchicalNamespace    bool
+	EnableZB 					   bool // Enable Zonal Buckets
 }
 
 type Service interface {
@@ -109,6 +110,12 @@ func (service *gcsService) CreateBucket(ctx context.Context, obj *ServiceBucket)
 		Labels:                   obj.Labels,
 		UniformBucketLevelAccess: storage.UniformBucketLevelAccess{Enabled: obj.EnableUniformBucketLevelAccess},
 		HierarchicalNamespace:    &storage.HierarchicalNamespace{Enabled: obj.EnableHierarchicalNamespace},
+	}
+	if obj.EnableZB {
+		bktAttrs.CustomPlacementConfig = &storage.CustomPlacementConfig{
+			DataLocations: []string{obj.Location + "-c"},
+		}
+		bktAttrs.StorageClass = "RAPID"
 	}
 	if err := bkt.Create(ctx, obj.Project, bktAttrs); err != nil {
 		return nil, fmt.Errorf("CreateBucket operation failed for bucket %q: %w", obj.Name, err)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -116,11 +116,14 @@ var _ = ginkgo.Describe("E2E Test Suite", func() {
 		testsuites.InitGcsFuseMountTestSuite,
 	}
 
-	testDriver := specs.InitGCSFuseCSITestDriver(c, m, *bucketLocation, *skipGcpSaTest, false, *clientProtocol)
+	//ZB is only valid for HNS enabled buckets
+	if !*enableZB {
+	testDriver := specs.InitGCSFuseCSITestDriver(c, m, *bucketLocation, *skipGcpSaTest, false, *clientProtocol, *enableZB)
 
 	ginkgo.Context(fmt.Sprintf("[Driver: %s]", testDriver.GetDriverInfo().Name), func() {
 		storageframework.DefineTestSuites(testDriver, GCSFuseCSITestSuites)
 	})
+	}
 
 	GCSFuseCSITestSuitesHNS := []func() storageframework.TestSuite{
 		testsuites.InitGcsFuseCSIGCSFuseIntegrationTestSuite,
@@ -128,7 +131,7 @@ var _ = ginkgo.Describe("E2E Test Suite", func() {
 		testsuites.InitGcsFuseCSIGCSFuseIntegrationFileCacheParallelDownloadsTestSuite,
 	}
 
-	testDriverHNS := specs.InitGCSFuseCSITestDriver(c, m, *bucketLocation, *skipGcpSaTest, true, *clientProtocol)
+	testDriverHNS := specs.InitGCSFuseCSITestDriver(c, m, *bucketLocation, *skipGcpSaTest, true, *clientProtocol, *enableZB)
 
 	ginkgo.Context(fmt.Sprintf("[Driver: %s HNS]", testDriverHNS.GetDriverInfo().Name), func() {
 		storageframework.DefineTestSuites(testDriverHNS, GCSFuseCSITestSuitesHNS)

--- a/test/e2e/main.go
+++ b/test/e2e/main.go
@@ -39,6 +39,7 @@ var (
 	apiEndpointOverride = flag.String("api-endpoint-override", "https://container.googleapis.com/", "CloudSDK API endpoint override to use for the cluster environment")
 	nodeImageType       = flag.String("node-image-type", "cos_containerd", "image type to use for the cluster")
 	istioVersion        = flag.String("istio-version", "1.23.0", "istio version to install on the cluster")
+	enableZB 	   = flag.Bool("enable-zb", false, "use GKE Zonal Buckets in US-Central1-c for the tests")
 
 	// Test infrastructure flags.
 	inProw             = flag.Bool("run-in-prow", false, "whether or not to run the test in PROW")
@@ -105,6 +106,7 @@ func main() {
 		GinkgoSkipGcpSaTest:    *ginkgoSkipGcpSaTest,
 		IstioVersion:           *istioVersion,
 		GcsfuseClientProtocol:  *gcsfuseClientProtocol,
+		EnableZB: 			    *enableZB,
 	}
 
 	if strings.Contains(testParams.GinkgoFocus, "performance") {

--- a/test/e2e/run-e2e-ci.sh
+++ b/test/e2e/run-e2e-ci.sh
@@ -38,6 +38,7 @@ readonly node_machine_type=${MACHINE_TYPE:-n2-standard-4}
 readonly number_nodes=${NUMBER_NODES:-3}
 readonly gcsfuse_client_protocol=${GCSFUSE_CLIENT_PROTOCOL:-http1}
 readonly build_gcsfuse_from_source=${BUILD_GCSFUSE_FROM_SOURCE:-false}
+readonly enable_zb=${ENABLE_ZB:-false}
 
 # Install golang
 version=1.22.7
@@ -76,6 +77,7 @@ base_cmd="${PKGDIR}/bin/e2e-test-ci \
             --gke-node-version=${gke_node_version} \
             --node-machine-type=${node_machine_type} \
             --gcsfuse-client-protocol=${gcsfuse_client_protocol} \
-            --number-nodes=${number_nodes}"
+            --number-nodes=${number_nodes} \
+            --enable-zb=${enable_zb} \"
 
 eval "$base_cmd"

--- a/test/e2e/specs/testdriver.go
+++ b/test/e2e/specs/testdriver.go
@@ -48,6 +48,7 @@ type GCSFuseCSITestDriver struct {
 	ClientProtocol              string
 	skipGcpSaTest               bool
 	EnableHierarchicalNamespace bool
+	EnableZB					bool // Enable Zonal Buckets
 }
 
 type gcsVolume struct {
@@ -63,7 +64,7 @@ type gcsVolume struct {
 }
 
 // InitGCSFuseCSITestDriver returns GCSFuseCSITestDriver that implements TestDriver interface.
-func InitGCSFuseCSITestDriver(c clientset.Interface, m metadata.Service, bl string, skipGcpSaTest, enableHierarchicalNamespace bool, clientProtocol string) storageframework.TestDriver {
+func InitGCSFuseCSITestDriver(c clientset.Interface, m metadata.Service, bl string, skipGcpSaTest, enableHierarchicalNamespace bool, clientProtocol string, enableZB bool) storageframework.TestDriver {
 	ssm, err := storage.NewGCSServiceManager()
 	if err != nil {
 		e2eframework.Failf("Failed to set up storage service manager: %v", err)
@@ -89,6 +90,7 @@ func InitGCSFuseCSITestDriver(c clientset.Interface, m metadata.Service, bl stri
 		skipGcpSaTest:               skipGcpSaTest,
 		ClientProtocol:              clientProtocol,
 		EnableHierarchicalNamespace: enableHierarchicalNamespace,
+		EnableZB: 					 enableZB, // Enable Zonal Buckets
 	}
 }
 
@@ -440,6 +442,7 @@ func (n *GCSFuseCSITestDriver) createBucket(ctx context.Context, serviceAccountN
 		Location:                       n.bucketLocation,
 		EnableUniformBucketLevelAccess: true,
 		EnableHierarchicalNamespace:    n.EnableHierarchicalNamespace,
+		EnableZB: 				 		n.EnableZB,	
 	}
 
 	ginkgo.By(fmt.Sprintf("Creating bucket %q", newBucket.Name))

--- a/test/e2e/utils/handler.go
+++ b/test/e2e/utils/handler.go
@@ -71,6 +71,7 @@ type TestParameters struct {
 	SupportSAVolInjection bool
 	IstioVersion          string
 	GcsfuseClientProtocol string
+	EnableZB 			  bool 
 }
 
 const (
@@ -208,6 +209,7 @@ func Handle(testParams *TestParameters) error {
 		"--client-protocol", testParams.GcsfuseClientProtocol,
 		"--provider", "skeleton",
 		"--test-bucket-location", testParams.GkeClusterRegion,
+		"--enable-zb", strconv.FormatBool(testParams.EnableZB),
 		"--skip-gcp-sa-test", strconv.FormatBool(testParams.GinkgoSkipGcpSaTest),
 		"--api-env", envAPIMap[testParams.APIEndpointOverride],
 	)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:
This pr introduces support for Zonal Buckets during e2e gcsfuse tests. Specifically it makes it so when passing the optional argument ENABLE_ZB the bucket created during tests is set to be a ZB created in the region provided -c. For example if the regional cluster was created in us-central1 then the zb would be created in us-central1-c. US-central1-c is the only zone we currently support for zb e2e testing.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```