### PR TITLE
Added ZB support during e2e tests

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -95,7 +95,8 @@ You can control the test through the following make parameters, eg `make e2e-tes
 - `E2E_TEST_GINKGO_PROCS`: default value is `5`. The value will be passed to `ginkgo run --procs` flag.
 - `E2E_TEST_GINKGO_TIMEOUT`: default value is `2h`. The value will be passed to `ginkgo run --timeout` flag.
 - `E2E_TEST_GINKGO_FLAKE_ATTEMPTS`: default value is `2`. The value will be passed to `ginkgo run --flake-attempts` flag.
-
+- `ENABLE_ZB`: default value is `false`. Change it to `true` if you want the bucket used during testing to be a Zonal Bucket created in the zone -> "$(location provided)" + "-c".
+- `GCSFUSE_CLIENT_PROTOCOL`: default value is 'http1'. Change to 'grpc' to alter the type of protocol gcsfuse uses to communicate with gcs
 ```bash
 # Run the test on an Autopilot cluster with the GcsFuseCsiDriver add-on enabled.
 make e2e-test E2E_TEST_USE_GKE_MANAGED_DRIVER=true E2E_TEST_USE_GKE_AUTOPILOT=true

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -116,11 +116,14 @@ var _ = ginkgo.Describe("E2E Test Suite", func() {
 		testsuites.InitGcsFuseMountTestSuite,
 	}
 
-	testDriver := specs.InitGCSFuseCSITestDriver(c, m, *bucketLocation, *skipGcpSaTest, false, *clientProtocol)
+	//Disabling non hns tests because ZB is only valid for HNS enabled buckets
+	if !*enableZB {
+		testDriver := specs.InitGCSFuseCSITestDriver(c, m, *bucketLocation, *skipGcpSaTest, false, *clientProtocol, *enableZB)
 
-	ginkgo.Context(fmt.Sprintf("[Driver: %s]", testDriver.GetDriverInfo().Name), func() {
-		storageframework.DefineTestSuites(testDriver, GCSFuseCSITestSuites)
-	})
+		ginkgo.Context(fmt.Sprintf("[Driver: %s]", testDriver.GetDriverInfo().Name), func() {
+			storageframework.DefineTestSuites(testDriver, GCSFuseCSITestSuites)
+		})
+	}
 
 	GCSFuseCSITestSuitesHNS := []func() storageframework.TestSuite{
 		testsuites.InitGcsFuseCSIGCSFuseIntegrationTestSuite,
@@ -128,7 +131,7 @@ var _ = ginkgo.Describe("E2E Test Suite", func() {
 		testsuites.InitGcsFuseCSIGCSFuseIntegrationFileCacheParallelDownloadsTestSuite,
 	}
 
-	testDriverHNS := specs.InitGCSFuseCSITestDriver(c, m, *bucketLocation, *skipGcpSaTest, true, *clientProtocol)
+	testDriverHNS := specs.InitGCSFuseCSITestDriver(c, m, *bucketLocation, *skipGcpSaTest, true, *clientProtocol, *enableZB)
 
 	ginkgo.Context(fmt.Sprintf("[Driver: %s HNS]", testDriverHNS.GetDriverInfo().Name), func() {
 		storageframework.DefineTestSuites(testDriverHNS, GCSFuseCSITestSuitesHNS)

--- a/test/e2e/main.go
+++ b/test/e2e/main.go
@@ -41,6 +41,7 @@ var (
 	apiEndpointOverride = flag.String("api-endpoint-override", "https://container.googleapis.com/", "CloudSDK API endpoint override to use for the cluster environment")
 	nodeImageType       = flag.String("node-image-type", "cos_containerd", "image type to use for the cluster")
 	istioVersion        = flag.String("istio-version", "1.23.0", "istio version to install on the cluster")
+	enableZB            = flag.Bool("enable-zb", false, "use GKE Zonal Buckets in US-Central1-c for the tests")
 
 	// Test infrastructure flags.
 	inProw             = flag.Bool("run-in-prow", false, "whether or not to run the test in PROW")
@@ -109,6 +110,7 @@ func main() {
 		GinkgoSkipGcpSaTest:    *ginkgoSkipGcpSaTest,
 		IstioVersion:           *istioVersion,
 		GcsfuseClientProtocol:  *gcsfuseClientProtocol,
+		EnableZB:               *enableZB,
 	}
 
 	if strings.Contains(testParams.GinkgoFocus, "performance") {

--- a/test/e2e/run-e2e-ci.sh
+++ b/test/e2e/run-e2e-ci.sh
@@ -39,6 +39,7 @@ readonly node_machine_type=${MACHINE_TYPE:-n2-standard-4}
 readonly number_nodes=${NUMBER_NODES:-3}
 readonly gcsfuse_client_protocol=${GCSFUSE_CLIENT_PROTOCOL:-http1}
 readonly build_gcsfuse_from_source=${BUILD_GCSFUSE_FROM_SOURCE:-false}
+readonly enable_zb=${ENABLE_ZB:-false}
 
 # Install golang
 version=1.22.7
@@ -78,6 +79,7 @@ base_cmd="${PKGDIR}/bin/e2e-test-ci \
             --gke-node-version=${gke_node_version} \
             --node-machine-type=${node_machine_type} \
             --gcsfuse-client-protocol=${gcsfuse_client_protocol} \
-            --number-nodes=${number_nodes}"
+            --number-nodes=${number_nodes} \
+            --enable-zb=${enable_zb}"
 
 eval "$base_cmd"

--- a/test/e2e/run-e2e-local.sh
+++ b/test/e2e/run-e2e-local.sh
@@ -37,6 +37,7 @@ readonly ginkgo_procs="${E2E_TEST_GINKGO_PROCS:-10}"
 readonly ginkgo_timeout="${E2E_TEST_GINKGO_TIMEOUT:-4h}"
 readonly ginkgo_flake_attempts="${E2E_TEST_GINKGO_FLAKE_ATTEMPTS:-2}"
 readonly gcsfuse_client_protocol=${GCSFUSE_CLIENT_PROTOCOL:-http1}
+readonly enable_zb=${ENABLE_ZB:-false}
 
 # Initialize ginkgo.
 export PATH=${PATH}:$(go env GOPATH)/bin
@@ -70,6 +71,6 @@ base_cmd="${PKGDIR}/bin/e2e-test-ci \
             --ginkgo-procs=${ginkgo_procs} \
             --ginkgo-timeout=${ginkgo_timeout} \
             --gcsfuse-client-protocol=${gcsfuse_client_protocol} \
-            --ginkgo-flake-attempts=${ginkgo_flake_attempts}"
-
+            --ginkgo-flake-attempts=${ginkgo_flake_attempts} \
+            --enable-zb=${enable_zb}"
 eval "$base_cmd"

--- a/test/e2e/specs/testdriver.go
+++ b/test/e2e/specs/testdriver.go
@@ -48,6 +48,7 @@ type GCSFuseCSITestDriver struct {
 	ClientProtocol              string
 	skipGcpSaTest               bool
 	EnableHierarchicalNamespace bool
+	EnableZB                    bool // Enable Zonal Buckets
 }
 
 type gcsVolume struct {
@@ -63,7 +64,7 @@ type gcsVolume struct {
 }
 
 // InitGCSFuseCSITestDriver returns GCSFuseCSITestDriver that implements TestDriver interface.
-func InitGCSFuseCSITestDriver(c clientset.Interface, m metadata.Service, bl string, skipGcpSaTest, enableHierarchicalNamespace bool, clientProtocol string) storageframework.TestDriver {
+func InitGCSFuseCSITestDriver(c clientset.Interface, m metadata.Service, bl string, skipGcpSaTest, enableHierarchicalNamespace bool, clientProtocol string, enableZB bool) storageframework.TestDriver {
 	ssm, err := storage.NewGCSServiceManager()
 	if err != nil {
 		e2eframework.Failf("Failed to set up storage service manager: %v", err)
@@ -89,6 +90,7 @@ func InitGCSFuseCSITestDriver(c clientset.Interface, m metadata.Service, bl stri
 		skipGcpSaTest:               skipGcpSaTest,
 		ClientProtocol:              clientProtocol,
 		EnableHierarchicalNamespace: enableHierarchicalNamespace,
+		EnableZB:                    enableZB, // Enable Zonal Buckets
 	}
 }
 
@@ -442,6 +444,7 @@ func (n *GCSFuseCSITestDriver) createBucket(ctx context.Context, serviceAccountN
 		Location:                       n.bucketLocation,
 		EnableUniformBucketLevelAccess: true,
 		EnableHierarchicalNamespace:    n.EnableHierarchicalNamespace,
+		EnableZB:                       n.EnableZB,
 	}
 
 	ginkgo.By(fmt.Sprintf("Creating bucket %q", newBucket.Name))

--- a/test/e2e/testsuites/gcsfuse_integration.go
+++ b/test/e2e/testsuites/gcsfuse_integration.go
@@ -71,6 +71,16 @@ func hnsEnabled(driver storageframework.TestDriver) bool {
 	return gcsfuseCSITestDriver.EnableHierarchicalNamespace
 }
 
+// zbEnabled checks if the Zonal Buckets feature is enabled for the given driver.
+// It is needs to be used in the integration test commands because gcsfuse tests parallelize and disabled tests based on this --zonal flag.
+// Gcsfuse team adds this in this commit https://github.com/GoogleCloudPlatform/gcsfuse/commit/c9a273daf6028ac90dd18f35e74014763d5aa03c.
+func zbEnabled(driver storageframework.TestDriver) bool {
+	gcsfuseCSITestDriver, ok := driver.(*specs.GCSFuseCSITestDriver)
+	gomega.Expect(ok).To(gomega.BeTrue(), "failed to cast storageframework.TestDriver to *specs.GCSFuseCSITestDriver")
+
+	return gcsfuseCSITestDriver.EnableZB
+}
+
 func getClientProtocol(driver storageframework.TestDriver) string {
 	gcsfuseCSITestDriver, ok := driver.(*specs.GCSFuseCSITestDriver)
 	gomega.Expect(ok).To(gomega.BeTrue(), "failed to cast storageframework.TestDriver to *specs.GCSFuseCSITestDriver")
@@ -256,7 +266,7 @@ func (t *gcsFuseCSIGCSFuseIntegrationTestSuite) DefineTests(driver storageframew
 
 		ginkgo.By("Checking that the gcsfuse integration tests exits with no error")
 
-		baseTestCommand := fmt.Sprintf("export GOTOOLCHAIN=go%v && export PATH=$PATH:/usr/local/go/bin && cd %v/%v && GODEBUG=asyncpreemptoff=1 go test . -p 1 --integrationTest -v --mountedDirectory=%v", gcsfuseTestSuiteVersion, gcsfuseIntegrationTestsBasePath, testName, mountPath)
+		baseTestCommand := fmt.Sprintf("export GOTOOLCHAIN=go%v && export PATH=$PATH:/usr/local/go/bin && cd %v/%v && GODEBUG=asyncpreemptoff=1 go test . -p 1 --integrationTest -v --zonal=%t --mountedDirectory=%v", gcsfuseTestSuiteVersion, gcsfuseIntegrationTestsBasePath, testName, zbEnabled(driver), mountPath)
 		baseTestCommandWithTestBucket := baseTestCommand + fmt.Sprintf(" --testbucket=%v", bucketName)
 
 		var finalTestCommand string

--- a/test/e2e/testsuites/gcsfuse_integration_file_cache.go
+++ b/test/e2e/testsuites/gcsfuse_integration_file_cache.go
@@ -174,7 +174,7 @@ func (t *gcsFuseCSIGCSFuseIntegrationFileCacheTestSuite) DefineTests(driver stor
 		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("git clone --branch %v https://github.com/GoogleCloudPlatform/gcsfuse.git", gcsfuseTestBranch))
 		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, "ln -s /usr/bin/python3 /usr/bin/python")
 
-		baseTestCommand := fmt.Sprintf("export GO_VERSION=$(%v) && export GOTOOLCHAIN=go$GO_VERSION && export PATH=$PATH:/usr/local/go/bin && cd %v/read_cache && GODEBUG=asyncpreemptoff=1 go test . -p 1 --integrationTest -v --mountedDirectory=%v --testbucket=%v -run %v", gcsfuseGoVersionCommand, gcsfuseIntegrationTestsBasePath, mountPath, bucketName, testName)
+		baseTestCommand := fmt.Sprintf("export GO_VERSION=$(%v) && export GOTOOLCHAIN=go$GO_VERSION && export PATH=$PATH:/usr/local/go/bin && cd %v/read_cache && GODEBUG=asyncpreemptoff=1 go test . -p 1 --integrationTest -v --mountedDirectory=%v --testbucket=%v --zonal=%t -run %v", gcsfuseGoVersionCommand, gcsfuseIntegrationTestsBasePath, mountPath, bucketName, zbEnabled(driver), testName)
 		tPod.VerifyExecInPodSucceedWithFullOutput(f, specs.TesterContainerName, baseTestCommand)
 	}
 

--- a/test/e2e/testsuites/gcsfuse_integration_file_cache_parallel_downloads.go
+++ b/test/e2e/testsuites/gcsfuse_integration_file_cache_parallel_downloads.go
@@ -180,7 +180,7 @@ func (t *gcsFuseCSIGCSFuseIntegrationFileCacheParallelDownloadsTestSuite) Define
 		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("git clone --branch %v https://github.com/GoogleCloudPlatform/gcsfuse.git", gcsfuseTestBranch))
 		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, "ln -s /usr/bin/python3 /usr/bin/python")
 
-		baseTestCommand := fmt.Sprintf("export GO_VERSION=$(%v) && export GOTOOLCHAIN=go$GO_VERSION && export PATH=$PATH:/usr/local/go/bin && cd %v/read_cache && GODEBUG=asyncpreemptoff=1 go test . -p 1 --integrationTest -v --mountedDirectory=%v --testbucket=%v -run %v", gcsfuseGoVersionCommand, gcsfuseIntegrationTestsBasePath, mountPath, bucketName, testName)
+		baseTestCommand := fmt.Sprintf("export GO_VERSION=$(%v) && export GOTOOLCHAIN=go$GO_VERSION && export PATH=$PATH:/usr/local/go/bin && cd %v/read_cache && GODEBUG=asyncpreemptoff=1 go test . -p 1 --integrationTest -v --mountedDirectory=%v --testbucket=%v --zonal=%t -run %v", gcsfuseGoVersionCommand, gcsfuseIntegrationTestsBasePath, mountPath, bucketName, zbEnabled(driver), testName)
 		tPod.VerifyExecInPodSucceedWithFullOutput(f, specs.TesterContainerName, baseTestCommand)
 	}
 

--- a/test/e2e/utils/handler.go
+++ b/test/e2e/utils/handler.go
@@ -73,6 +73,7 @@ type TestParameters struct {
 	SupportMachineTypeAutoconfig bool
 	IstioVersion                 string
 	GcsfuseClientProtocol        string
+	EnableZB                     bool
 }
 
 const (
@@ -81,6 +82,12 @@ const (
 )
 
 func Handle(testParams *TestParameters) error {
+	// Validating the test parameters.
+	// ZB uses gRPC as the client protocol, so if ZB is enabled, the client protocol must be gRPC.
+	if testParams.GcsfuseClientProtocol != "grpc" && testParams.EnableZB {
+		klog.Fatalf("EnableZB %t is not supported with GcsfuseClientProtocol %q. Zonal buckets only supports GcsfuseClientProtocol grpc", testParams.EnableZB, testParams.GcsfuseClientProtocol)
+	}
+
 	oldMask := syscall.Umask(0o000)
 	defer syscall.Umask(oldMask)
 
@@ -217,6 +224,7 @@ func Handle(testParams *TestParameters) error {
 		"--client-protocol", testParams.GcsfuseClientProtocol,
 		"--provider", "skeleton",
 		"--test-bucket-location", testParams.GkeClusterRegion,
+		"--enable-zb", strconv.FormatBool(testParams.EnableZB),
 		"--skip-gcp-sa-test", strconv.FormatBool(testParams.GinkgoSkipGcpSaTest),
 		"--api-env", envAPIMap[testParams.APIEndpointOverride],
 	)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:
This pr introduces support for Zonal Buckets during e2e gcsfuse tests. Specifically it makes it so when passing the optional argument ENABLE_ZB the bucket created during tests is set to be a ZB created in the region provided -c. For example if the regional cluster was created in us-central1 then the zb would be created in us-central1-c. US-central1-c is the only zone we currently support for zb e2e testing.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```