### PR TITLE
Cherry pick #668 Clean up node restart support logging and comments into main branch.

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -439,11 +439,10 @@ If the sidecar container (`gke-gcsfuse-sidecar`) hosting the gcsfuse process, cr
 
 ### Node level restarts
 
-GCSFuse CSI Driver can now manage node restarts without impacting pods using GCSFuse-backed volumes. The driver ensures a clean slate by clearing stale files or sockets, and re-establishing the gcsfuse /dev/fuse file descriptor during the NodePublishVolume phase after a restart.
+If the GKE Node, that is running a pod/volume that's backed by GCSFuse CSI Driver, performs a restart (either due to a crash or a minor graceful restart), the pod within that GKE node will be able to start back up and will continue to have access to all GCS backed volumes once runnning. The GCSFuse CSI Driver will ensure a clean slate after a restart by clearing stale files or sockets, and re-establishing the gcsfuse /dev/fuse file descriptor during the NodePublishVolume phase after a restart. Since GCSFuse had to restart, file and metadata caches will be empty.
 
 Known issues after a node restart:
-- Metrics will not be visible on Cloud Monitoring after node restart. If they become visible, assume that they will be malformed.
-- Metrics after a restart will only look at the time period after the node restart.
+- Metrics will not be visible on Cloud Monitoring after node restart. If they become visible, the metrics will always be malformed and should not be used. You will need to redeploy your pod if you want to continue collecting reliable metrics in the event of a restart.
 
 ### enabling debug logs
 

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -206,6 +206,9 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 	// Skip mount if the mount on target path already exists.
 	if mounted {
 		// Check if there is any error from the gcsfuse
+		// We only check for sidecar liveliness if the path is reported as mounted.
+		// This indicates the initial kernel mount is complete, and gcsfuse is ready to proceed.
+		// With this approach, NodePublishVolume will still report an error if gcsfuse itself fails.
 		code, err := checkGcsFuseErr(isInitContainer, pod, targetPath)
 		if code != codes.OK {
 			if code == codes.Canceled {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -201,7 +201,7 @@ func CheckAndDeleteStaleFile(dirPath, fileName string) error {
 	if deleteErr := os.Remove(filePath); deleteErr != nil {
 		return fmt.Errorf("failed to delete file '%s': %w", filePath, deleteErr)
 	}
-	klog.Infof("Stale file '%s' successfully deleted.", fileName)
+	klog.Infof("Stale file '%s' successfully deleted", fileName)
 
 	return nil
 }


### PR DESCRIPTION
Cherry pick #668: Clean up node restart support logging and comments, into main branch.