### PR TITLE
Cherrypick #675 onto release-1.15: Clean up node restart support logging and comments.

### DIFF
--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -206,6 +206,9 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 	// Skip mount if the mount on target path already exists.
 	if mounted {
 		// Check if there is any error from the gcsfuse
+		// We only check for sidecar liveliness if the path is reported as mounted.
+		// This indicates the initial kernel mount is complete, and gcsfuse is ready to proceed.
+		// With this approach, NodePublishVolume will still report an error if gcsfuse itself fails.
 		code, err := checkGcsFuseErr(isInitContainer, pod, targetPath)
 		if code != codes.OK {
 			if code == codes.Canceled {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -201,7 +201,7 @@ func CheckAndDeleteStaleFile(dirPath, fileName string) error {
 	if deleteErr := os.Remove(filePath); deleteErr != nil {
 		return fmt.Errorf("failed to delete file '%s': %w", filePath, deleteErr)
 	}
-	klog.Infof("Stale file '%s' successfully deleted.", fileName)
+	klog.Infof("Stale file '%s' successfully deleted", fileName)
 
 	return nil
 }


### PR DESCRIPTION
Cherrypick #675 onto release-1.15: Clean up node restart support logging and comments.