### PR TITLE
bump to gcsfuse v3 and add new flag to streaming_writes tests

### DIFF
--- a/cmd/sidecar_mounter/gcsfuse_binary
+++ b/cmd/sidecar_mounter/gcsfuse_binary
@@ -1,1 +1,1 @@
-gs://gke-release-staging/gcsfuse/v2.12.2-gke.0/gcsfuse_bin
+gs://gke-release-staging/gcsfuse/v3.0.0-gke.0/gcsfuse_bin

--- a/test/e2e/testsuites/gcsfuse_integration.go
+++ b/test/e2e/testsuites/gcsfuse_integration.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"strings"
 
+	"local/test/e2e/specs"
+
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -31,7 +33,6 @@ import (
 	e2evolume "k8s.io/kubernetes/test/e2e/framework/volume"
 	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
 	admissionapi "k8s.io/pod-security-admission/api"
-	"local/test/e2e/specs"
 )
 
 const (
@@ -620,7 +621,7 @@ func (t *gcsFuseCSIGCSFuseIntegrationTestSuite) DefineTests(driver storageframew
 		if getClientProtocol(driver) == "grpc" {
 			e2eskipper.Skipf("skip gcsfuse integration grpc test %v with enable-streaming-writes", testNameEnableStreamingWrites)
 		} else {
-			gcsfuseIntegrationTest(testNameEnableStreamingWrites, false, "rename-dir-limit=3", "implicit-dirs=true", "enable-streaming-writes", "write-block-size-mb=1", "write-max-blocks-per-file=2")
+			gcsfuseIntegrationTest(testNameEnableStreamingWrites, false, "rename-dir-limit=3", "implicit-dirs=true", "enable-streaming-writes", "write-block-size-mb=1", "write-max-blocks-per-file=2", "write-global-max-blocks=-1")
 		}
 	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:
This bumps the GCSFuse binary to GCSFuse v3.0.0, and passes an additional flag, `write-global-max-blocks=-1` to the streaming_writes tests, which is required now that streaming writes is enabled by default in GCSFuse v3.  The cloud_profiler tests will be added in a [follow up PR](https://github.com/GoogleCloudPlatform/gcs-fuse-csi-driver/pull/740), as they are only for debugging purposes, and aren't release blocking.

Manually tested: 
```
gcloud container clusters create test-gcsfusev3-new \
    --zone=us-central1-a \
    --workload-pool=amacaskill-gke-dev.svc.id.goog --machine-type=c3-standard-44
gcloud container clusters get-credentials test-gcsfusev3-new --zone us-central1-a
# build and push image to registry
make build-image-and-push-multi-arch REGISTRY=us-central1-docker.pkg.dev/amacaskill-gke-dev/csi-dev STAGINGVERSION=v999.999.999
# install non-managed driver on GKE cluster
make install REGISTRY=us-central1-docker.pkg.dev/amacaskill-gke-dev/csi-dev STAGINGVERSION=v999.999.999 PROJECT=amacaskill-gke-dev

#Confirm that the driver is up and running
kubectl get CSIDriver,Deployment,DaemonSet,Pods -n gcs-fuse-csi-driver


# run tests on that cluster.
make e2e-test E2E_TEST_USE_GKE_MANAGED_DRIVER=false E2E_TEST_BUILD_DRIVER=false BUILD_GCSFUSE_FROM_SOURCE=false E2E_TEST_FOCUS="streaming_writes" STAGINGVERSION=v999.999.999 REGISTRY=us-central1-docker.pkg.dev/amacaskill-gke-dev/csi-dev
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Update GCSFuse binary to v3.0.0
```