### PR TITLE
Revert "bump to gcsfuse v3 and add new flag to streaming_writes tests"

### DIFF
--- a/cmd/sidecar_mounter/gcsfuse_binary
+++ b/cmd/sidecar_mounter/gcsfuse_binary
@@ -1,1 +1,1 @@
-gs://gke-release-staging/gcsfuse/v3.0.0-gke.0/gcsfuse_bin
+gs://gke-release-staging/gcsfuse/v2.12.2-gke.0/gcsfuse_bin

--- a/test/e2e/testsuites/gcsfuse_integration.go
+++ b/test/e2e/testsuites/gcsfuse_integration.go
@@ -22,8 +22,6 @@ import (
 	"fmt"
 	"strings"
 
-	"local/test/e2e/specs"
-
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -33,6 +31,7 @@ import (
 	e2evolume "k8s.io/kubernetes/test/e2e/framework/volume"
 	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
 	admissionapi "k8s.io/pod-security-admission/api"
+	"local/test/e2e/specs"
 )
 
 const (
@@ -621,7 +620,7 @@ func (t *gcsFuseCSIGCSFuseIntegrationTestSuite) DefineTests(driver storageframew
 		if getClientProtocol(driver) == "grpc" {
 			e2eskipper.Skipf("skip gcsfuse integration grpc test %v with enable-streaming-writes", testNameEnableStreamingWrites)
 		} else {
-			gcsfuseIntegrationTest(testNameEnableStreamingWrites, false, "rename-dir-limit=3", "implicit-dirs=true", "enable-streaming-writes", "write-block-size-mb=1", "write-max-blocks-per-file=2", "write-global-max-blocks=-1")
+			gcsfuseIntegrationTest(testNameEnableStreamingWrites, false, "rename-dir-limit=3", "implicit-dirs=true", "enable-streaming-writes", "write-block-size-mb=1", "write-max-blocks-per-file=2")
 		}
 	})
 }


### PR DESCRIPTION
 Reverts GoogleCloudPlatform/gcs-fuse-csi-driver#757

Now several other tests are failing. I ran streaming_writes tests  but now metrics and some other tests are failing too. Will debug locally, then remerge.