### PR TITLE
Re-apply zb flag

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -46,6 +46,7 @@ var (
 	bucketLocation = flag.String("test-bucket-location", "us-central1", "the test bucket location")
 	skipGcpSaTest  = flag.Bool("skip-gcp-sa-test", true, "skip GCP SA test")
 	apiEnv         = flag.String("api-env", "prod", "cluster API env")
+	zbFlag         = *enableZB
 )
 
 var _ = func() bool {
@@ -116,10 +117,10 @@ var _ = ginkgo.Describe("E2E Test Suite", func() {
 		testsuites.InitGcsFuseCSIMetadataPrefetchTestSuite,
 		testsuites.InitGcsFuseMountTestSuite,
 	}
-	enableZB := false
+
 	//Disabling non hns tests because ZB is only valid for HNS enabled buckets
-	if !enableZB {
-		testDriver := specs.InitGCSFuseCSITestDriver(c, m, *bucketLocation, *skipGcpSaTest, false, *clientProtocol, enableZB)
+	if !zbFlag {
+		testDriver := specs.InitGCSFuseCSITestDriver(c, m, *bucketLocation, *skipGcpSaTest, false, *clientProtocol, zbFlag)
 
 		ginkgo.Context(fmt.Sprintf("[Driver: %s]", testDriver.GetDriverInfo().Name), func() {
 			storageframework.DefineTestSuites(testDriver, GCSFuseCSITestSuites)
@@ -132,7 +133,7 @@ var _ = ginkgo.Describe("E2E Test Suite", func() {
 		testsuites.InitGcsFuseCSIGCSFuseIntegrationFileCacheParallelDownloadsTestSuite,
 	}
 
-	testDriverHNS := specs.InitGCSFuseCSITestDriver(c, m, *bucketLocation, *skipGcpSaTest, true, *clientProtocol, enableZB)
+	testDriverHNS := specs.InitGCSFuseCSITestDriver(c, m, *bucketLocation, *skipGcpSaTest, true, *clientProtocol, zbFlag)
 
 	ginkgo.Context(fmt.Sprintf("[Driver: %s HNS]", testDriverHNS.GetDriverInfo().Name), func() {
 		storageframework.DefineTestSuites(testDriverHNS, GCSFuseCSITestSuitesHNS)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation

/kind failing-test

> /kind feature
> /kind flake

**What this PR does / why we need it**:
Summary:
Reinstates zb flag , we had disabled due to incorrect passing of value.

Problem:
The issue was that package-level variables in Go are initialized during package loading, which happens before flag.Parse() is called.
This meant that when we dereferenced our CLI flag (e.g., *enableZB) during package initialization — for example, by assigning it to a var at the top level — it captured the default value, not the one passed via command-line arguments.
Even though the flag's value is correctly set later (after flag.Parse() runs), our variable had already been assigned, so its value was "frozen" incorrectly.

Documents from go: 
https://golang.org/ref/spec#Package_initialization
Package initialization:
1 The package's imported packages are initialized.
2 Then the package-level variables are initialized in the order in which they appear in the source. <---our value set wrong
3 Finally, any init() functions are called in the order they appear in the source.

Solution: 
The fix was to defer reading the flag value until runtime, by evaluating *enableZB inside a function or test block. This ensures the flag has already been parsed and reflects the correct CLI value.

How was this tested: Reran all tests using personal dev project, verifying that when zonal is set to false the values passed to integration are set to false, also printed values at point in question in e2e_test to verify value of flag is correctly set.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```