### PR TITLE
Stop testing renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
   "prConcurrentLimit": 0,
   "packageRules": [
     {
-      "enabled": true,
+      "enabled": false,
       "matchPackagePatterns": ["*"]
     }
   ],


### PR DESCRIPTION
Renovate is adding additional toil to release czar and cluttering PR count.

Will also close all PRs created and not merged by renovate-bot 

Reverts GoogleCloudPlatform/gcs-fuse-csi-driver#502