### PR TITLE
Update token server sidecar min version

### DIFF
--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -139,6 +139,7 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 	}
 
 	if s.shouldPopulateIdentifyProvider(pod, optInHostnetworkKSA, userSpecifiedIdentityProvider != "") {
+		klog.V(4).Infof("NodePublishVolume populating identity provider in mount options")
 		identityProvider := ""
 		if userSpecifiedIdentityProvider != "" {
 			identityProvider = userSpecifiedIdentityProvider

--- a/pkg/csi_driver/utils.go
+++ b/pkg/csi_driver/utils.go
@@ -62,14 +62,13 @@ const (
 
 	VolumeContextKeyServiceAccountName = "csi.storage.k8s.io/serviceAccount.name"
 	//nolint:gosec
-	VolumeContextKeyServiceAccountToken = "csi.storage.k8s.io/serviceAccount.tokens"
-	VolumeContextKeyPodName             = "csi.storage.k8s.io/pod.name"
-	VolumeContextKeyPodNamespace        = "csi.storage.k8s.io/pod.namespace"
-	VolumeContextKeyEphemeral           = "csi.storage.k8s.io/ephemeral"
-	VolumeContextKeyBucketName          = "bucketName"
-	// TODO(@siyanshen): update the minimum version when the sidecar image is updated.
-	tokenServerSidecarMinVersion           = "v1.100.2-gke.0" // #nosec G101
-	MachineTypeAutoConfigSidecarMinVersion = "v1.15.1-gke.0"  // #nosec G101
+	VolumeContextKeyServiceAccountToken    = "csi.storage.k8s.io/serviceAccount.tokens"
+	VolumeContextKeyPodName                = "csi.storage.k8s.io/pod.name"
+	VolumeContextKeyPodNamespace           = "csi.storage.k8s.io/pod.namespace"
+	VolumeContextKeyEphemeral              = "csi.storage.k8s.io/ephemeral"
+	VolumeContextKeyBucketName             = "bucketName"
+	tokenServerSidecarMinVersion           = "v1.17.0-gke.0" // #nosec G101
+	MachineTypeAutoConfigSidecarMinVersion = "v1.15.1-gke.0" // #nosec G101
 	FlagFileForDefaultingPath              = "flags-for-defaulting"
 )
 

--- a/pkg/csi_driver/utils_test.go
+++ b/pkg/csi_driver/utils_test.go
@@ -126,22 +126,22 @@ func TestIsSidecarVersionSupportedForTokenServer(t *testing.T) {
 		}{
 			{
 				name:              "should return true for supported sidecar version",
-				imageName:         "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gcs-fuse-csi-driver-sidecar-mounter:v1.200.3-gke.2@sha256:abcd",
+				imageName:         "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gcs-fuse-csi-driver-sidecar-mounter:v1.18.3-gke.2@sha256:abcd",
 				expectedSupported: true,
 			},
 			{
 				name:              "should return true for supported sidecar version in staging gcr",
-				imageName:         "gcr.io/gke-release-staging/gcs-fuse-csi-driver-sidecar-mounter:v1.200.2-gke.0@sha256:abcd",
+				imageName:         "gcr.io/gke-release-staging/gcs-fuse-csi-driver-sidecar-mounter:v1.17.2-gke.0@sha256:abcd",
 				expectedSupported: true,
 			},
 			{
 				name:              "should return false for unsupported sidecar version",
-				imageName:         "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gcs-fuse-csi-driver-sidecar-mounter:v1.8.7-gke.1@sha256:abcd",
+				imageName:         "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gcs-fuse-csi-driver-sidecar-mounter:v1.16.7-gke.1@sha256:abcd",
 				expectedSupported: false,
 			},
 			{
 				name:              "should return false for private sidecar",
-				imageName:         "customer.gcr.io/dir/gcs-fuse-csi-driver-sidecar-mounter:v1.12.2-gke.0@sha256:abcd",
+				imageName:         "customer.gcr.io/dir/gcs-fuse-csi-driver-sidecar-mounter:v1.17.2-gke.0@sha256:abcd",
 				expectedSupported: false,
 			},
 		}

--- a/test/e2e/testsuites/failed_mount.go
+++ b/test/e2e/testsuites/failed_mount.go
@@ -279,7 +279,7 @@ func (t *gcsFuseCSIFailedMountTestSuite) DefineTests(driver storageframework.Tes
 		if supportSAVolInjection {
 			testCaseSAInsufficientAccess(specs.EnableHostNetworkPrefix, specs.OptInHnwKSAPrefix)
 		} else {
-			ginkgo.By("Skipping the hostnetwork test for cluster version <  " + utils.SaTokenVolInjectionMinimumVersion.String())
+			ginkgo.By("Skipping the hostnetwork test for managed cluster version <  " + utils.SaTokenVolInjectionMinimumVersion.String() + " or cluster without init container support")
 		}
 	})
 

--- a/test/e2e/testsuites/mount.go
+++ b/test/e2e/testsuites/mount.go
@@ -241,7 +241,7 @@ func (t *gcsFuseCSIMountTestSuite) DefineTests(driver storageframework.TestDrive
 		if supportSAVolInjection {
 			testCaseHostNetworkEnabledAndKSAOptIn()
 		} else {
-			ginkgo.By("Skipping the hostnetwork test for cluster version < " + utils.SaTokenVolInjectionMinimumVersion.String())
+			ginkgo.By("Skipping the hostnetwork test for cluster version < " + utils.SaTokenVolInjectionMinimumVersion.String() + " or cluster without init container support")
 		}
 	})
 

--- a/test/e2e/utils/handler.go
+++ b/test/e2e/utils/handler.go
@@ -192,7 +192,7 @@ func Handle(testParams *TestParameters) error {
 	if err != nil {
 		klog.Fatalf(`managed driver version for host network token server support could not be determined: %v`, err)
 	}
-	supportSAVolInjection := !testParams.UseGKEManagedDriver || managedDriverVersionForHostNetworkTokenServerSatisfied
+	supportSAVolInjection := (supportsNativeSidecar && !testParams.UseGKEManagedDriver) || managedDriverVersionForHostNetworkTokenServerSatisfied
 	testParams.SupportSAVolInjection = supportSAVolInjection
 
 	if err = os.Setenv(TestWithSAVolumeInjectionEnvVar, strconv.FormatBool(supportSAVolInjection)); err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature


> /kind flake

**What this PR does / why we need it**:
We need to specify the minimum sidecar version that supports the host network ksa token feature. It is needed because sidecars with versions lower than the min is not compatible with the (internal only) mount options.

This PR also skips OSS tests for clusters without support for native sidecars.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
Ran e2e tests on 1.28 cluster and confirmed it is not failing any more.
```
make e2e-test E2E_TEST_USE_GKE_MANAGED_DRIVER=false E2E_TEST_BUILD_DRIVER=true E2E_TEST_FOCUS=should.successfully.mount.for.hostnetwork.enabled.pods STAGINGVERSION=prow-gob-internal-boskos-0630-4 REGISTRY=gcr.io/shensiyan-joonix
```

STEP: Skipping the hostnetwork test for cluster version < 1.100.0 or cluster without init container support @ 06/30/25 22:05:22.694

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NA
```