### PR TITLE
Automated cherry pick of #867: Update token server sidecar min version

### DIFF
--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -139,6 +139,7 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 	}
 
 	if s.shouldPopulateIdentifyProvider(pod, optInHostnetworkKSA, userSpecifiedIdentityProvider != "") {
+		klog.V(4).Infof("NodePublishVolume populating identity provider in mount options")
 		identityProvider := ""
 		if userSpecifiedIdentityProvider != "" {
 			identityProvider = userSpecifiedIdentityProvider

--- a/pkg/csi_driver/utils.go
+++ b/pkg/csi_driver/utils.go
@@ -62,14 +62,13 @@ const (
 
 	VolumeContextKeyServiceAccountName = "csi.storage.k8s.io/serviceAccount.name"
 	//nolint:gosec
-	VolumeContextKeyServiceAccountToken = "csi.storage.k8s.io/serviceAccount.tokens"
-	VolumeContextKeyPodName             = "csi.storage.k8s.io/pod.name"
-	VolumeContextKeyPodNamespace        = "csi.storage.k8s.io/pod.namespace"
-	VolumeContextKeyEphemeral           = "csi.storage.k8s.io/ephemeral"
-	VolumeContextKeyBucketName          = "bucketName"
-	// TODO(@siyanshen): update the minimum version when the sidecar image is updated.
-	tokenServerSidecarMinVersion           = "v1.100.2-gke.0" // #nosec G101
-	MachineTypeAutoConfigSidecarMinVersion = "v1.15.1-gke.0"  // #nosec G101
+	VolumeContextKeyServiceAccountToken    = "csi.storage.k8s.io/serviceAccount.tokens"
+	VolumeContextKeyPodName                = "csi.storage.k8s.io/pod.name"
+	VolumeContextKeyPodNamespace           = "csi.storage.k8s.io/pod.namespace"
+	VolumeContextKeyEphemeral              = "csi.storage.k8s.io/ephemeral"
+	VolumeContextKeyBucketName             = "bucketName"
+	tokenServerSidecarMinVersion           = "v1.17.0-gke.0" // #nosec G101
+	MachineTypeAutoConfigSidecarMinVersion = "v1.15.1-gke.0" // #nosec G101
 	FlagFileForDefaultingPath              = "flags-for-defaulting"
 )
 

--- a/pkg/csi_driver/utils_test.go
+++ b/pkg/csi_driver/utils_test.go
@@ -126,22 +126,22 @@ func TestIsSidecarVersionSupportedForTokenServer(t *testing.T) {
 		}{
 			{
 				name:              "should return true for supported sidecar version",
-				imageName:         "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gcs-fuse-csi-driver-sidecar-mounter:v1.200.3-gke.2@sha256:abcd",
+				imageName:         "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gcs-fuse-csi-driver-sidecar-mounter:v1.18.3-gke.2@sha256:abcd",
 				expectedSupported: true,
 			},
 			{
 				name:              "should return true for supported sidecar version in staging gcr",
-				imageName:         "gcr.io/gke-release-staging/gcs-fuse-csi-driver-sidecar-mounter:v1.200.2-gke.0@sha256:abcd",
+				imageName:         "gcr.io/gke-release-staging/gcs-fuse-csi-driver-sidecar-mounter:v1.17.2-gke.0@sha256:abcd",
 				expectedSupported: true,
 			},
 			{
 				name:              "should return false for unsupported sidecar version",
-				imageName:         "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gcs-fuse-csi-driver-sidecar-mounter:v1.8.7-gke.1@sha256:abcd",
+				imageName:         "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gcs-fuse-csi-driver-sidecar-mounter:v1.16.7-gke.1@sha256:abcd",
 				expectedSupported: false,
 			},
 			{
 				name:              "should return false for private sidecar",
-				imageName:         "customer.gcr.io/dir/gcs-fuse-csi-driver-sidecar-mounter:v1.12.2-gke.0@sha256:abcd",
+				imageName:         "customer.gcr.io/dir/gcs-fuse-csi-driver-sidecar-mounter:v1.17.2-gke.0@sha256:abcd",
 				expectedSupported: false,
 			},
 		}

--- a/test/e2e/testsuites/failed_mount.go
+++ b/test/e2e/testsuites/failed_mount.go
@@ -279,7 +279,7 @@ func (t *gcsFuseCSIFailedMountTestSuite) DefineTests(driver storageframework.Tes
 		if supportSAVolInjection {
 			testCaseSAInsufficientAccess(specs.EnableHostNetworkPrefix, specs.OptInHnwKSAPrefix)
 		} else {
-			ginkgo.By("Skipping the hostnetwork test for cluster version <  " + utils.SaTokenVolInjectionMinimumVersion.String())
+			ginkgo.By("Skipping the hostnetwork test for managed cluster version <  " + utils.SaTokenVolInjectionMinimumVersion.String() + " or cluster without init container support")
 		}
 	})
 

--- a/test/e2e/testsuites/mount.go
+++ b/test/e2e/testsuites/mount.go
@@ -241,7 +241,7 @@ func (t *gcsFuseCSIMountTestSuite) DefineTests(driver storageframework.TestDrive
 		if supportSAVolInjection {
 			testCaseHostNetworkEnabledAndKSAOptIn()
 		} else {
-			ginkgo.By("Skipping the hostnetwork test for cluster version < " + utils.SaTokenVolInjectionMinimumVersion.String())
+			ginkgo.By("Skipping the hostnetwork test for cluster version < " + utils.SaTokenVolInjectionMinimumVersion.String() + " or cluster without init container support")
 		}
 	})
 

--- a/test/e2e/utils/handler.go
+++ b/test/e2e/utils/handler.go
@@ -192,7 +192,7 @@ func Handle(testParams *TestParameters) error {
 	if err != nil {
 		klog.Fatalf(`managed driver version for host network token server support could not be determined: %v`, err)
 	}
-	supportSAVolInjection := !testParams.UseGKEManagedDriver || managedDriverVersionForHostNetworkTokenServerSatisfied
+	supportSAVolInjection := (supportsNativeSidecar && !testParams.UseGKEManagedDriver) || managedDriverVersionForHostNetworkTokenServerSatisfied
 	testParams.SupportSAVolInjection = supportSAVolInjection
 
 	if err = os.Setenv(TestWithSAVolumeInjectionEnvVar, strconv.FormatBool(supportSAVolInjection)); err != nil {


### PR DESCRIPTION
Cherry pick of #867 on release-1.17.

#867: Update token server sidecar min version

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NA
```