### PR TITLE
Automated cherry pick of #874: Update gcsfuse binary patch to resolve vulnerability

### DIFF
--- a/cmd/sidecar_mounter/gcsfuse_binary
+++ b/cmd/sidecar_mounter/gcsfuse_binary
@@ -1,1 +1,1 @@
-gs://gke-release-staging/gcsfuse/v3.0.0-gke.0/gcsfuse_bin
+gs://gke-release-staging/gcsfuse/v3.0.1-gke.0/gcsfuse_bin


### PR DESCRIPTION
Cherry pick of #874 on release-1.17.

#874: Update gcsfuse binary patch to resolve vulnerability

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```