### PR TITLE
Add gke.gcr.io as a managed sidecar image registry format

### DIFF
--- a/pkg/csi_driver/utils_test.go
+++ b/pkg/csi_driver/utils_test.go
@@ -130,6 +130,21 @@ func TestIsSidecarVersionSupportedForTokenServer(t *testing.T) {
 				expectedSupported: true,
 			},
 			{
+				name:              "should return true for supported sidecar version with container registory gke.gcr.io",
+				imageName:         "gke.gcr.io/gcs-fuse-csi-driver-sidecar-mounter:v1.18.3-gke.2@sha256:abcd",
+				expectedSupported: true,
+			},
+			{
+				name:              "should return false for unmanaged container registory with substring gke.gcr.io",
+				imageName:         "random-gke.gcr.io/gcs-fuse-csi-driver-sidecar-mounter:v1.18.3-gke.2@sha256:abcd",
+				expectedSupported: false,
+			},
+			{
+				name:              "should return false for unmanaged container registory with subdir gke.gcr.io",
+				imageName:         "randomhost.gcr.io/gke.gcr.io/gcs-fuse-csi-driver-sidecar-mounter:v1.18.3-gke.2@sha256:abcd",
+				expectedSupported: false,
+			},
+			{
 				name:              "should return true for supported sidecar version in staging gcr",
 				imageName:         "gcr.io/gke-release-staging/gcs-fuse-csi-driver-sidecar-mounter:v1.17.2-gke.0@sha256:abcd",
 				expectedSupported: true,
@@ -158,7 +173,7 @@ func TestIsSidecarVersionSupportedForTokenServer(t *testing.T) {
 
 func TestIsSidecarVersionSupportedForDefaultingFlags(t *testing.T) {
 	t.Parallel()
-	t.Run("checking if sidecar version is supported for token server", func(t *testing.T) {
+	t.Run("checking if sidecar version is supported for defaulting flags", func(t *testing.T) {
 		t.Parallel()
 		testCases := []struct {
 			name              string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR adds gke.gcr.io as a managed sidecar image registry format. We recently found out some customers using managed sidecar has gke.gcr.io as the registry name instead of "`.*-artifactregistry.gcr.io/gke-release/.*"

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
1. Valid gcr host names are retrieved from go/gke-release-infra#gcr-container-images
2. Also updated min sidecar version for token server so that we support users with gke.gcr.io registry with host network pod ksa feature. Machine intelligent defaults should consider doing the same

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Support gke.gcr.io as a managed sidecar image registry format. We recently found out some customers using managed sidecar has gke.gcr.io as the registry name instead of "`.-artifactregistry.gcr.io/gke-release/."
```