### PR TITLE
release gcsfuse 3.1.0 and enable inactive_stream_timeout tests

### DIFF
--- a/cmd/sidecar_mounter/gcsfuse_binary
+++ b/cmd/sidecar_mounter/gcsfuse_binary
@@ -1,1 +1,1 @@
-gs://gke-release-staging/gcsfuse/v3.0.1-gke.0/gcsfuse_bin
+gs://gke-release-staging/gcsfuse/v3.1.0-gke.0/gcsfuse_bin

--- a/test/e2e/testsuites/gcsfuse_integration_file_cache.go
+++ b/test/e2e/testsuites/gcsfuse_integration_file_cache.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"strings"
 
+	"local/test/e2e/specs"
+
 	"github.com/onsi/ginkgo/v2"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/version"
@@ -30,7 +32,6 @@ import (
 	e2evolume "k8s.io/kubernetes/test/e2e/framework/volume"
 	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
 	admissionapi "k8s.io/pod-security-admission/api"
-	"local/test/e2e/specs"
 )
 
 type gcsFuseCSIGCSFuseIntegrationFileCacheTestSuite struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

 /kind feature

> /kind flake

**What this PR does / why we need it**:
Bumps GCSFuse binary to  v3.1.0

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

Tested via: 
```
gcloud container clusters create test-gcsfusev3-new \
    --zone=us-central1-a \
    --workload-pool=amacaskill-gke-dev.svc.id.goog --machine-type=c3-standard-44
gcloud container clusters get-credentials test-gcsfusev3-new --zone us-central1-a
# build and push image to registry
make build-image-and-push-multi-arch REGISTRY=us-central1-docker.pkg.dev/amacaskill-gke-dev/csi-dev STAGINGVERSION=v999.999.999
# install non-managed driver on GKE cluster
make install REGISTRY=us-central1-docker.pkg.dev/amacaskill-gke-dev/csi-dev STAGINGVERSION=v999.999.999 PROJECT=amacaskill-gke-dev

#Confirm that the driver is up and running
kubectl get CSIDriver,Deployment,DaemonSet,Pods -n gcs-fuse-csi-driver


# run inactive_stream_timeout tests on that cluster.
make e2e-test E2E_TEST_USE_GKE_MANAGED_DRIVER=false E2E_TEST_BUILD_DRIVER=false BUILD_GCSFUSE_FROM_SOURCE=false E2E_TEST_FOCUS="inactive_stream_timeout" STAGINGVERSION=v999.999.999 REGISTRY=us-central1-docker.pkg.dev/amacaskill-gke-dev/csi-dev

# also run all tests on the cluster: 
make e2e-test E2E_TEST_USE_GKE_MANAGED_DRIVER=false E2E_TEST_BUILD_DRIVER=false BUILD_GCSFUSE_FROM_SOURCE=false E2E_TEST_SKIP="should.succeed.in.performance.test" STAGINGVERSION=v999.999.999 REGISTRY=us-central1-docker.pkg.dev/amacaskill-gke-dev/csi-dev
```
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Bumps GCSFuse binary to  v3.1.0
```