### PR TITLE
Automated cherry pick of #880: Add gke.gcr.io as a managed sidecar image registry format

### DIFF
--- a/pkg/csi_driver/utils_test.go
+++ b/pkg/csi_driver/utils_test.go
@@ -130,6 +130,21 @@ func TestIsSidecarVersionSupportedForTokenServer(t *testing.T) {
 				expectedSupported: true,
 			},
 			{
+				name:              "should return true for supported sidecar version with container registory gke.gcr.io",
+				imageName:         "gke.gcr.io/gcs-fuse-csi-driver-sidecar-mounter:v1.18.3-gke.2@sha256:abcd",
+				expectedSupported: true,
+			},
+			{
+				name:              "should return false for unmanaged container registory with substring gke.gcr.io",
+				imageName:         "random-gke.gcr.io/gcs-fuse-csi-driver-sidecar-mounter:v1.18.3-gke.2@sha256:abcd",
+				expectedSupported: false,
+			},
+			{
+				name:              "should return false for unmanaged container registory with subdir gke.gcr.io",
+				imageName:         "randomhost.gcr.io/gke.gcr.io/gcs-fuse-csi-driver-sidecar-mounter:v1.18.3-gke.2@sha256:abcd",
+				expectedSupported: false,
+			},
+			{
 				name:              "should return true for supported sidecar version in staging gcr",
 				imageName:         "gcr.io/gke-release-staging/gcs-fuse-csi-driver-sidecar-mounter:v1.17.2-gke.0@sha256:abcd",
 				expectedSupported: true,
@@ -158,7 +173,7 @@ func TestIsSidecarVersionSupportedForTokenServer(t *testing.T) {
 
 func TestIsSidecarVersionSupportedForDefaultingFlags(t *testing.T) {
 	t.Parallel()
-	t.Run("checking if sidecar version is supported for token server", func(t *testing.T) {
+	t.Run("checking if sidecar version is supported for defaulting flags", func(t *testing.T) {
 		t.Parallel()
 		testCases := []struct {
 			name              string


### PR DESCRIPTION
Cherry pick of #880 on release-1.17.

#880: Add gke.gcr.io as a managed sidecar image registry format

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Support gke.gcr.io as a managed sidecar image registry format. We recently found out some customers using managed sidecar has gke.gcr.io as the registry name instead of "`.-artifactregistry.gcr.io/gke-release/."
```