### PR TITLE
Automated cherry pick of #885: release gcsfuse 3.1.0 and enable inactive_stream_timeout tests

### DIFF
--- a/cmd/sidecar_mounter/gcsfuse_binary
+++ b/cmd/sidecar_mounter/gcsfuse_binary
@@ -1,1 +1,1 @@
-gs://gke-release-staging/gcsfuse/v3.0.1-gke.0/gcsfuse_bin
+gs://gke-release-staging/gcsfuse/v3.1.0-gke.0/gcsfuse_bin

--- a/test/e2e/testsuites/gcsfuse_integration_file_cache.go
+++ b/test/e2e/testsuites/gcsfuse_integration_file_cache.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"strings"
 
+	"local/test/e2e/specs"
+
 	"github.com/onsi/ginkgo/v2"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/version"
@@ -30,7 +32,6 @@ import (
 	e2evolume "k8s.io/kubernetes/test/e2e/framework/volume"
 	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
 	admissionapi "k8s.io/pod-security-admission/api"
-	"local/test/e2e/specs"
 )
 
 type gcsFuseCSIGCSFuseIntegrationFileCacheTestSuite struct {


### PR DESCRIPTION
Cherry pick of #885 on release-1.17.

#885: release gcsfuse 3.1.0 and enable inactive_stream_timeout tests

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Bumps GCSFuse binary to  v3.1.0
```