### PR TITLE
Fix for disabled zb test

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -46,7 +46,7 @@ var (
 	bucketLocation = flag.String("test-bucket-location", "us-central1", "the test bucket location")
 	skipGcpSaTest  = flag.Bool("skip-gcp-sa-test", true, "skip GCP SA test")
 	apiEnv         = flag.String("api-env", "prod", "cluster API env")
-	zbFlag         = *enableZB
+	zbFlag         = flag.Bool("enable-zb", false, "use GKE Zonal Buckets in US-Central1-c for the tests")
 )
 
 var _ = func() bool {
@@ -119,8 +119,9 @@ var _ = ginkgo.Describe("E2E Test Suite", func() {
 	}
 
 	//Disabling non hns tests because ZB is only valid for HNS enabled buckets
-	if !zbFlag {
-		testDriver := specs.InitGCSFuseCSITestDriver(c, m, *bucketLocation, *skipGcpSaTest, false, *clientProtocol, zbFlag)
+	fmt.Sprintf("ZB flag is set to %v, skipping non HNS tests", *zbFlag)
+	if !*zbFlag {
+		testDriver := specs.InitGCSFuseCSITestDriver(c, m, *bucketLocation, *skipGcpSaTest, false, *clientProtocol, *zbFlag)
 
 		ginkgo.Context(fmt.Sprintf("[Driver: %s]", testDriver.GetDriverInfo().Name), func() {
 			storageframework.DefineTestSuites(testDriver, GCSFuseCSITestSuites)
@@ -133,7 +134,7 @@ var _ = ginkgo.Describe("E2E Test Suite", func() {
 		testsuites.InitGcsFuseCSIGCSFuseIntegrationFileCacheParallelDownloadsTestSuite,
 	}
 
-	testDriverHNS := specs.InitGCSFuseCSITestDriver(c, m, *bucketLocation, *skipGcpSaTest, true, *clientProtocol, zbFlag)
+	testDriverHNS := specs.InitGCSFuseCSITestDriver(c, m, *bucketLocation, *skipGcpSaTest, true, *clientProtocol, *zbFlag)
 
 	ginkgo.Context(fmt.Sprintf("[Driver: %s HNS]", testDriverHNS.GetDriverInfo().Name), func() {
 		storageframework.DefineTestSuites(testDriverHNS, GCSFuseCSITestSuitesHNS)

--- a/test/e2e/main.go
+++ b/test/e2e/main.go
@@ -41,7 +41,7 @@ var (
 	apiEndpointOverride = flag.String("api-endpoint-override", "https://container.googleapis.com/", "CloudSDK API endpoint override to use for the cluster environment")
 	nodeImageType       = flag.String("node-image-type", "cos_containerd", "image type to use for the cluster")
 	istioVersion        = flag.String("istio-version", "1.23.0", "istio version to install on the cluster")
-	enableZB            = flag.Bool("enable-zb", false, "use GKE Zonal Buckets in US-Central1-c for the tests")
+	gcsfuseEnableZB     = flag.Bool("gcsfuse-enable-zb", false, "use GKE Zonal Buckets in US-Central1-c for the tests")
 
 	// Test infrastructure flags.
 	inProw             = flag.Bool("run-in-prow", false, "whether or not to run the test in PROW")
@@ -110,7 +110,7 @@ func main() {
 		GinkgoSkipGcpSaTest:    *ginkgoSkipGcpSaTest,
 		IstioVersion:           *istioVersion,
 		GcsfuseClientProtocol:  *gcsfuseClientProtocol,
-		EnableZB:               *enableZB,
+		EnableZB:               *gcsfuseEnableZB,
 	}
 
 	if strings.Contains(testParams.GinkgoFocus, "performance") {

--- a/test/e2e/run-e2e-ci.sh
+++ b/test/e2e/run-e2e-ci.sh
@@ -80,6 +80,6 @@ base_cmd="${PKGDIR}/bin/e2e-test-ci \
             --node-machine-type=${node_machine_type} \
             --gcsfuse-client-protocol=${gcsfuse_client_protocol} \
             --number-nodes=${number_nodes} \
-            --enable-zb=${enable_zb}"
+            --gcsfuse-enable-zb=${enable_zb}"
 
 eval "$base_cmd"

--- a/test/e2e/run-e2e-local.sh
+++ b/test/e2e/run-e2e-local.sh
@@ -72,5 +72,5 @@ base_cmd="${PKGDIR}/bin/e2e-test-ci \
             --ginkgo-timeout=${ginkgo_timeout} \
             --gcsfuse-client-protocol=${gcsfuse_client_protocol} \
             --ginkgo-flake-attempts=${ginkgo_flake_attempts} \
-            --enable-zb=${enable_zb}"
+            --gcsfuse-enable-zb=${enable_zb}"
 eval "$base_cmd"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation

/kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Recently we added tests to our tests grid that incorporate the new zonal bucket feature, unfortunately it seems that one of the flags being parsed defaults to false and never gets updated. This means that tests ran do not actually run using ZB. This fix implements a separate flag similare to other ones in the same file to ensure there is no run time discrepancies. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
How was this tested

make build-image-and-push-multi-arch REGISTRY=gcr.io/prow-gob-internal-boskos-02 STAGINGVERSION=v999.999.999

make install REGISTRY=gcr.io/prow-gob-internal-boskos-02 STAGINGVERSION=v999.999.999 PROJECT=gcr.io/prow-gob-internal-boskos-02

make e2e-test E2E_TEST_USE_GKE_MANAGED_DRIVER=false E2E_TEST_BUILD_DRIVER=false BUILD_GCSFUSE_FROM_SOURCE=true E2E_TEST_SKIP="should.succeed.in.performance.test" STAGINGVERSION=v999.999.999 REGISTRY=gcr.io/prow-gob-internal-boskos-02  ENABLE_ZB=true GCSFUSE_CLIENT_PROTOCOL=grpc 


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```