### PR TITLE
Automated cherry pick of #896: Add filter for killed process from GCSFuse.

### DIFF
--- a/pkg/sidecar_mounter/sidecar_mounter.go
+++ b/pkg/sidecar_mounter/sidecar_mounter.go
@@ -149,6 +149,8 @@ func (m *Mounter) Mount(ctx context.Context, mc *MountConfig) error {
 			errMsg := fmt.Sprintf("gcsfuse exited with error: %v\n", err)
 			if strings.Contains(errMsg, "signal: terminated") {
 				klog.Infof("[%v] gcsfuse was terminated.", mc.VolumeName)
+			} else if strings.Contains(errMsg, "signal: killed") {
+				klog.Infof("[%v] gcsfuse was killed.", mc.VolumeName)
 			} else {
 				mc.ErrWriter.WriteMsg(errMsg)
 			}


### PR DESCRIPTION
Cherry pick of #896 on release-1.17.

#896: Add filter for killed process from GCSFuse.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
The error encounter `signal: killed` when ending gcsfusecsi will be degraded from an error to a info log.
```