### PR TITLE
ZB Test refactoring

### DIFF
--- a/test/e2e/specs/testdriver.go
+++ b/test/e2e/specs/testdriver.go
@@ -214,8 +214,12 @@ func (n *GCSFuseCSITestDriver) CreateVolume(ctx context.Context, config *storage
 			mountOptions += ",implicit-dirs"
 		case SubfolderInBucketPrefix:
 			dirPath := uuid.NewString()
-			n.CreateImplicitDirInBucket(ctx, dirPath, bucketName)
-			mountOptions += ",only-dir=" + dirPath
+
+			//Temporarily disable only-dir mount option zonal bucket tests as it is not supported in gcsfuse tests yet.
+			if !n.EnableZB {
+				n.CreateImplicitDirInBucket(ctx, dirPath, bucketName)
+				mountOptions += ",only-dir=" + dirPath
+			}
 		case EnableFileCachePrefix, EnableFileCacheForceNewBucketPrefix:
 			v.fileCacheCapacity = "100Mi"
 		case EnableFileCacheAndMetricsPrefix, EnableFileCacheForceNewBucketAndMetricsPrefix:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation

/kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This pr implements a change relating to failing tests introduced during the enablement of gcsfusexzonal buckets tests.

The change introduced in commit -  7753a057a0dce11582d8453414712a99d7bd26e0
This commit disabled the only-dir mount option (a flag used to communicate to gcsfuse that we have mounted our bucket in a subdirectory) for zb tests, this is needed because as mentioned in this ticket gcsfuse team does not currently support it 
https://github.com/GoogleCloudPlatform/gcsfuse/pull/3612

**Special notes for your reviewer**:
These changes have been tested both manually as mentioned above and by running the e2e tests for "gcsfuseIntegration.should.succeed.in.imp
licit_dir" both with gcsfuse zb enabled and disabled