### PR TITLE
Revert disabling of Mount Options in Zonal buckets tests

### DIFF
--- a/test/e2e/specs/testdriver.go
+++ b/test/e2e/specs/testdriver.go
@@ -214,12 +214,8 @@ func (n *GCSFuseCSITestDriver) CreateVolume(ctx context.Context, config *storage
 			mountOptions += ",implicit-dirs"
 		case SubfolderInBucketPrefix:
 			dirPath := uuid.NewString()
-
-			//Temporarily disable only-dir mount option zonal bucket tests as it is not supported in gcsfuse tests yet.
-			if !n.EnableZB {
-				n.CreateImplicitDirInBucket(ctx, dirPath, bucketName)
-				mountOptions += ",only-dir=" + dirPath
-			}
+			n.CreateImplicitDirInBucket(ctx, dirPath, bucketName)
+			mountOptions += ",only-dir=" + dirPath
 		case EnableFileCachePrefix, EnableFileCacheForceNewBucketPrefix:
 			v.fileCacheCapacity = "100Mi"
 		case EnableFileCacheAndMetricsPrefix, EnableFileCacheForceNewBucketAndMetricsPrefix:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation

/kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
We recently added commit - which disabled a failing test, the fix has now been submitted in [https://github.com/GoogleCloudPlatform/gcsfuse/commit/c414fda04f577cf770b709bc1c5584926f8e8da7]. Reenabling

tested with 
make e2e-test E2E_TEST_USE_GKE_MANAGED_DRIVER=false E2E_TEST_BUILD_DRIVER=true BUILD_GCSFUSE_FROM_SOURCE=false E2E_TEST_SKIP="should.succeed.in.performance.test" STAGINGVERSION=v999.999.996 REGISTRY=gcr.io/prow-gob-internal-boskos-01 E2E_TEST_FOCUS="gcsfuseIntegration.should.succeed.in.implicit_dir" ENABLE_ZB=true GCSFUSE_CLIENT_PROTOCOL=grpc 
