### PR TITLE
Automated cherry pick of #908: Downgrade bootstrap config error to warning

### DIFF
--- a/pkg/csi_driver/utils.go
+++ b/pkg/csi_driver/utils.go
@@ -447,6 +447,11 @@ func checkGcsFuseErr(isInitContainer bool, pod *corev1.Pod, targetPath string) (
 			code = codes.NotFound
 		}
 
+		// Special case for harmless error message from gcsfuse stderr, gcsfuse cannot mute this because it stems from a needed library.
+		if strings.Contains(errMsgStr, "[xds] Attempt to set a bootstrap configuration even though one is already set via environment variables.") {
+			return codes.Unavailable, fmt.Errorf("benign grpc error: %s", errMsgStr)
+		}
+
 		return code, fmt.Errorf("gcsfuse failed with error: %v", errMsgStr)
 	}
 


### PR DESCRIPTION
Cherry pick of #908 on release-1.17.

#908: Downgrade bootstrap config error to warning

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```