### PR TITLE
Automated cherry pick of #921: bump gcsfuse version to v3.2

### DIFF
--- a/cmd/sidecar_mounter/gcsfuse_binary
+++ b/cmd/sidecar_mounter/gcsfuse_binary
@@ -1,1 +1,1 @@
-gs://gke-release-staging/gcsfuse/v3.1.0-gke.0/gcsfuse_bin
+gs://gke-release-staging/gcsfuse/v3.2.0-gke.0/gcsfuse_bin


### PR DESCRIPTION
Cherry pick of #921 on release-1.17.

#921: bump gcsfuse version to v3.2

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Bump GCSFuse version to v3.2
```