### PR TITLE
update gcsfuse binary from v2.11.3 to v2.11.4 to fix symlink issue

### DIFF
--- a/cmd/sidecar_mounter/gcsfuse_binary
+++ b/cmd/sidecar_mounter/gcsfuse_binary
@@ -1,1 +1,1 @@
-gs://gke-release-staging/gcsfuse/v2.11.3-gke.0/gcsfuse_bin
+gs://gke-release-staging/gcsfuse/v2.11.4-gke.0/gcsfuse_bin


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
update gcsfuse binary from v2.11.3 to v2.11.4 to fix symlink issue

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
Steps to manually test: 

```
# I recommend a cluster with bigger than normal machines, so you don't have flaky tests
gcloud container clusters create test-gcsfusev3-new \
    --zone=us-central1-a \
    --workload-pool=$USER-gke-dev.svc.id.goog --machine-type=c3-standard-44
gcloud container clusters get-credentials test-gcsfusev3-new --zone us-central1-a
# build and push image to registry
make build-image-and-push-multi-arch REGISTRY=us-central1-docker.pkg.dev/$USER-gke-dev/csi-dev STAGINGVERSION=v999.999.999
# install non-managed driver on GKE cluster
make install REGISTRY=us-central1-docker.pkg.dev/$USER-gke-dev/csi-dev STAGINGVERSION=v999.999.999 PROJECT=$USER-gke-dev

#Confirm that the driver is up and running
kubectl get CSIDriver,Deployment,DaemonSet,Pods -n gcs-fuse-csi-driver


# run tests on that cluster. For Sanity check, run one test to make sure your test setup works. 
make e2e-test E2E_TEST_USE_GKE_MANAGED_DRIVER=false E2E_TEST_BUILD_DRIVER=false BUILD_GCSFUSE_FROM_SOURCE=false E2E_TEST_FOCUS="gcsfuseIntegration.should.succeed.in.explicit_dir.test.1" STAGINGVERSION=v999.999.999 REGISTRY=us-central1-docker.pkg.dev/$USER-gke-dev/csi-dev

# Then if that test passes, run the rest of the tests. If GCSFuse team says we have to run a subset of tests, use the E2E_TEST_FOCUS string to filter tests that are run. 
make e2e-test E2E_TEST_USE_GKE_MANAGED_DRIVER=false E2E_TEST_BUILD_DRIVER=false BUILD_GCSFUSE_FROM_SOURCE=false STAGINGVERSION=v999.999.999 REGISTRY=us-central1-docker.pkg.dev/$USER-gke-dev/csi-dev
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
update gcsfuse binary from v2.11.3 to v2.11.4 to fix symlink issue
```