### PR TITLE
Update ZB Tests: Added increase memorylimits, n2-standard-8, included…

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -118,15 +118,11 @@ var _ = ginkgo.Describe("E2E Test Suite", func() {
 		testsuites.InitGcsFuseMountTestSuite,
 	}
 
-	//Disabling non hns tests because ZB is only valid for HNS enabled buckets
-	fmt.Sprintf("ZB flag is set to %v, skipping non HNS tests", *zbFlag)
-	if !*zbFlag {
-		testDriver := specs.InitGCSFuseCSITestDriver(c, m, *bucketLocation, *skipGcpSaTest, false, *clientProtocol, *zbFlag)
+	testDriver := specs.InitGCSFuseCSITestDriver(c, m, *bucketLocation, *skipGcpSaTest, false, *clientProtocol, *zbFlag)
 
-		ginkgo.Context(fmt.Sprintf("[Driver: %s]", testDriver.GetDriverInfo().Name), func() {
-			storageframework.DefineTestSuites(testDriver, GCSFuseCSITestSuites)
-		})
-	}
+	ginkgo.Context(fmt.Sprintf("[Driver: %s]", testDriver.GetDriverInfo().Name), func() {
+		storageframework.DefineTestSuites(testDriver, GCSFuseCSITestSuites)
+	})
 
 	GCSFuseCSITestSuitesHNS := []func() storageframework.TestSuite{
 		testsuites.InitGcsFuseCSIGCSFuseIntegrationTestSuite,

--- a/test/e2e/main.go
+++ b/test/e2e/main.go
@@ -119,6 +119,9 @@ func main() {
 		testParams.NumNodes = 1
 		testParams.NodeMachineType = "n2-standard-32"
 	}
+	if *gcsfuseEnableZB {
+		testParams.NodeMachineType = "n2-standard-8"
+	}
 
 	if err := utils.Handle(testParams); err != nil {
 		klog.Fatalf("Failed to run e2e test: %v", err)

--- a/test/e2e/testsuites/gcsfuse_integration.go
+++ b/test/e2e/testsuites/gcsfuse_integration.go
@@ -227,10 +227,15 @@ func (t *gcsFuseCSIGCSFuseIntegrationTestSuite) DefineTests(driver storageframew
 		tPod.SetImage(specs.GolangImage)
 		tPod.SetResource("1", "5Gi", "5Gi")
 		sidecarMemoryLimit := defaultSidecarMemoryLimit
+		sidecarMemoryRequest := defaultSidecarMemoryRequest
 
 		if testName == testNameWriteLargeFiles || testName == testNameReadLargeFiles {
 			tPod.SetResource("1", "6Gi", "5Gi")
 			sidecarMemoryLimit = "1Gi"
+			if zbEnabled(driver) {
+				sidecarMemoryRequest = "1Gi"
+				sidecarMemoryLimit = "2Gi"
+			}
 		}
 
 		mo := l.volumeResource.VolSource.CSI.VolumeAttributes["mountOptions"]
@@ -243,7 +248,7 @@ func (t *gcsFuseCSIGCSFuseIntegrationTestSuite) DefineTests(driver storageframew
 		tPod.SetupVolume(l.volumeResource, volumeName, mountPath, readOnly, mountOptions...)
 		tPod.SetAnnotations(map[string]string{
 			"gke-gcsfuse/cpu-limit":               "1",
-			"gke-gcsfuse/memory-request":          defaultSidecarMemoryRequest,
+			"gke-gcsfuse/memory-request":          sidecarMemoryRequest,
 			"gke-gcsfuse/memory-limit":            sidecarMemoryLimit,
 			"gke-gcsfuse/ephemeral-storage-limit": "2Gi",
 		})

--- a/test/e2e/utils/handler.go
+++ b/test/e2e/utils/handler.go
@@ -83,10 +83,6 @@ const (
 
 func Handle(testParams *TestParameters) error {
 	// Validating the test parameters.
-	// ZB uses gRPC as the client protocol, so if ZB is enabled, the client protocol must be gRPC.
-	if testParams.GcsfuseClientProtocol != "grpc" && testParams.EnableZB {
-		klog.Fatalf("EnableZB %t is not supported with GcsfuseClientProtocol %q. Zonal buckets only supports GcsfuseClientProtocol grpc", testParams.EnableZB, testParams.GcsfuseClientProtocol)
-	}
 
 	oldMask := syscall.Umask(0o000)
 	defer syscall.Umask(oldMask)


### PR DESCRIPTION
… http tests

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation

/kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This pr introduced three modifications to the way we run tests targeted for Rapid Storage
Bug to track resource related issue for zb - https://b.corp.google.com/issues/436372553
Bug to track enablement of http tests for zb - https://buganizer.corp.google.com/issues/439891073
1 - 
Change - Added increase memory limits for write_large_files when ZB is enabled, the default values for this test are 1gb limit and 512Mi request, after this change if ZB is enabled then the test will run with 2gb limit and 1gb request. 
Why - The gcsfuse zb test grid has been flaking this test for some time, after further investigation we encountered two kinds of failures. The first being OOMs on the gcsfuse process and the second being time out for waiting for the node to schedule the pod successfully. Both of these issues were fixed while testing with n2-standard-8 machine and the increased resource settings mentioned above. 

**GCSFuse team runs their tests one n2-standard-64 machines, which is why they never run into similar resource bottle necks
** GCSFuse team has made it clear that GRPC itself has increased memory requirements compared to http, these increased memory requirements in conjunction with the heavy operations performed in write_large_file are likely the reason we see these failures on zb and not the regular http test grid. Note that grpc test grid is also extremely flakey.
**We also tried just a larger machine and just increased resources but both result in similar flakiness albeit with better results than what is currently set in the test grid

2 - 
Change - If running zb tests use n2-standard-8 (add zb check in test/e2e/main.go)
Why - Same reasoning as before, these tests need a larger machine

3 - 
Change - Add all http tests to zb test grid (remove the filter for zb in e2e_test.go)
Why - The original plan for testing zb with gcsfuse was to test using only grpc tests, this is because ZB is only supported with grpc enabled. That said the tests we currently run for grpc do not test all scenarios of functionality for gcsfuse meaning there are fundamental/core functionalities that are not being verified if only testing using grpc tests. This is fine for non zb because in the case that grpc fails to provide these core functionalities, customers can fall back to http as the client protocol. Unfortunately this is not an option for zb, therefore in order to confidently validate gcsfuse with zb we must test ALL functionalities required for gcsfuse usage.
**Even though we are making the zb tests run all tests including the ones that default to http, know that when hooked up to a zb gcsfuse will internally switch the protocol to grpc 

**How was this tested**
Two forms of validation were performed for these changes, 
For write_large_file resource related changes: 
The following command was run with the only tests enabled was 60 runs for write_large_files, this made it so we could see the rate at which the tests fail and flake at scale. With these large scale runs with no resource limit changes we see 20% flake rate. With the changes no failures or flakes. These results are further explained in https://b.corp.google.com/issues/436372553#comment34
```make e2e-test E2E_TEST_USE_GKE_MANAGED_DRIVER=false E2E_TEST_BUILD_DRIVER=true BUILD_GCSFUSE_FROM_SOURCE=false E2E_TEST_SKIP="should.succeed.in.performance.test" STAGINGVERSION=v999.999.996 REGISTRY=gcr.io/prow-gob-internal-boskos-03 E2E_TEST_FOCUS="gcsfuseIntegration.should.succeed.in.write_large_files" ENABLE_ZB=true GCSFUSE_CLIENT_PROTOCOL=grpc```


For http test suite enablement: 
All tests were ran with the following command, manual verification was done to ensure all the correct test suites were being inclueded
```make e2e-test E2E_TEST_USE_GKE_MANAGED_DRIVER=false E2E_TEST_BUILD_DRIVER=true BUILD_GCSFUSE_FROM_SOURCE=false E2E_TEST_SKIP="should.succeed.in.performance.test" STAGINGVERSION=v999.999.996 REGISTRY=gcr.io/prow-gob-internal-boskos-03 ENABLE_ZB=true```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
https://b.corp.google.com/issues/439891073
**Special notes for your reviewer**:
These changes have been scoped to only impact zb tests, if it is determined that resources are the reason our grpc test grid is also flaking as much as it is we will make the change later, this is because we have not done the investigations required to verify that this is the root cause of regular grpc (no zb) test grid
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```