### PR TITLE
Bucket scanner controller - PersistentVolume creation trigger

### DIFF
--- a/examples/gcsfuse-profiles/pv-pvc.yaml
+++ b/examples/gcsfuse-profiles/pv-pvc.yaml
@@ -27,6 +27,14 @@ spec:
   csi:
     driver: gcsfuse.csi.storage.gke.io
     volumeHandle: test-bucket
+    volumeAttributes:
+      # Optional: The timeout for the bucket scan operation before giving up and delivering
+      # partial results. The default is 2m.
+      # bucketScanTimeout: 2m 
+      # Optional: The TTL for the the bucket scan operation. New PV / Pod creation events won't
+      # trigger the scanner until at least this amount of time has passed since the previous
+      # scan. The default is 168h (7 days).
+      # bucketScanTTL: 168h
   mountOptions:
   - only-dir=/my-folder/
 ---

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -19,9 +19,15 @@ package scanner
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"strconv"
+	"strings"
+	"sync"
 	"time"
 
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
@@ -36,22 +42,64 @@ import (
 	"k8s.io/klog/v2"
 
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	storagelisters "k8s.io/client-go/listers/storage/v1"
 )
 
 const (
-	scannerComponentName = "gke-gcsfuse-scanner"
+	scannerComponentName              = "gke-gcsfuse-scanner"
+	csiDriverName                     = "gcsfuse.csi.storage.gke.io"
+	paramWorkloadTypeKey              = "workloadType"
+	paramWorkloadTypeInferenceKey     = "inference"
+	paramWorkloadTypeTrainingKey      = "training"
+	paramWorkloadTypeCheckpointingKey = "checkpointing"
+	volumeAttributeScanTimeoutKey     = "bucketScanTimeout"
+	volumeAttributeScanTTLKey         = "bucketScanTTL"
+
+	// Annotation keys
+	annotationPrefix          = "gke-gcsfuse"
+	annotationStatus          = annotationPrefix + "/bucket-scan-status"
+	annotationNumObjects      = annotationPrefix + "/bucket-scan-num-objects"
+	annotationTotalSize       = annotationPrefix + "/bucket-scan-total-size-bytes"
+	annotationLastUpdatedTime = annotationPrefix + "/bucket-scan-last-updated-time"
+	annotationHNSEnabled      = annotationPrefix + "/bucket-scan-hns-enabled"
 
 	// Event reasons
-	ReasonScannerStarted              = "ScannerStarted"
-	ReasonScanOperationStartError     = "ScanOperationStartError"
-	ReasonScanOperationStartSucceeded = "ScanOperationStartSucceeded"
-	ReasonScanOperationFailed         = "ScanOperationFailed"
-	ReasonScanOperationSucceeded      = "ScanOperationSucceeded"
-	ReasonScanOperationTimedOut       = "ScanOperationTimedOut"
-	ReasonScannerFinished             = "ScannerFinished"
+	reasonScanOperationStartError     = "ScanOperationStartError"
+	reasonScanOperationStartSucceeded = "ScanOperationStartSucceeded"
+	reasonScanOperationFailed         = "ScanOperationFailed"
+	reasonScanOperationSucceeded      = "ScanOperationSucceeded"
+	reasonScanOperationTimedOut       = "ScanOperationTimedOut"
+
+	// Bucket scan status values
+	scanCompleted = "completed"
+	scanTimeout   = "timeout"
 )
+
+var (
+	// defaultScanTimeoutDuration is the default timeout for a single bucket scan.
+	defaultScanTimeoutDuration = 2 * time.Minute
+
+	// defaultScanTTLDuration is the default TTL for skipping bucket scans.
+	defaultScanTTLDuration = 168 * time.Hour // 7 days
+
+	// To allow mocking time in tests
+	timeNow = time.Now
+
+	// scanBucket is a function to scan the bucket, can be overridden in tests.
+	scanBucket = defaultScanBucket
+)
+
+// stringPtr returns a pointer to the passed string.
+func stringPtr(s string) *string { return &s }
+
+// boolPtr returns a pointer to the string representation of the passed bool.
+func boolPtr(b bool) *string { return stringPtr(strconv.FormatBool(b)) }
+
+// int64Ptr returns a pointer to the string representation of the passed int64.
+func int64Ptr(i int64) *string { return stringPtr(strconv.FormatInt(i, 10)) }
 
 // ScannerConfig holds the configuration for the Scanner.
 type ScannerConfig struct {
@@ -60,6 +108,15 @@ type ScannerConfig struct {
 	ResyncPeriod   time.Duration // Resync period for informers.
 	KubeConfigPath string        // Optional: Path to kubeconfig file. If empty, InClusterConfig is used.
 	RateLimiter    workqueue.TypedRateLimiter[string]
+}
+
+// bucketInfo holds the results of a bucket scan.
+type bucketInfo struct {
+	name           string
+	dir            string
+	numObjects     int64
+	totalSizeBytes int64
+	isHNSEnabled   bool
 }
 
 // Scanner is the main controller structure.
@@ -72,6 +129,12 @@ type Scanner struct {
 	factory       informers.SharedInformerFactory
 	queue         workqueue.TypedRateLimitingInterface[string]
 	eventRecorder record.EventRecorder
+	// Set of PV names being tracked/processed. This is
+	// used to avoid reprocessing if multiple user Pods
+	// trigger a PV addition to the queue.
+	trackedPVs map[string]struct{}
+	// Mutex to protect trackedPVs.
+	pvMutex sync.RWMutex
 }
 
 // buildConfig creates a Kubernetes rest.Config for the client.
@@ -128,15 +191,20 @@ func NewScanner(config *ScannerConfig) (*Scanner, error) {
 		pvSynced:      pvInformer.Informer().HasSynced,
 		scSynced:      scInformer.Informer().HasSynced,
 		queue:         workqueue.NewTypedRateLimitingQueue(rateLimiter),
+		trackedPVs:    make(map[string]struct{}),
 		eventRecorder: eventRecorder,
 	}
 
 	klog.Info("Setting up event handlers for PersistentVolumes")
 	pvInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    scanner.addPV,
-		UpdateFunc: scanner.updatePV,
 		DeleteFunc: scanner.deletePV,
+		// UpdateFunc is not required because subsequent Pod creation events
+		// will trigger the scanner.
 	})
+
+	// TODO(urielguzman): Add logic to make Pod creation events trigger the scanner
+	// and remove the scheduling gates.
 
 	return scanner, nil
 }
@@ -182,11 +250,15 @@ func (s *Scanner) processNextWorkItem(ctx context.Context) bool {
 	defer s.queue.Done(key)
 
 	klog.V(6).Infof("Processing PV %q", key)
-	// TODO(urielguzman): Get PV object
-	// TODO(urielguzman): Implement syncPV for actual logic
 	err := s.syncPV(ctx, key)
 	if err == nil {
 		s.queue.Forget(key)
+		s.pvMutex.Lock()
+		if _, exists := s.trackedPVs[key]; exists {
+			klog.V(6).Infof("PV %s finished processing, removing from tracking", key)
+			delete(s.trackedPVs, key)
+		}
+		s.pvMutex.Unlock()
 		klog.V(6).Infof("Successfully synced PV %q", key)
 	} else {
 		klog.Errorf("Error syncing PV %q: %v", key, err)
@@ -195,14 +267,271 @@ func (s *Scanner) processNextWorkItem(ctx context.Context) bool {
 	return true
 }
 
-// syncPV is the main reconciliation function for a PV.
-// Currently, it's a placeholder.
-func (s *Scanner) syncPV(_ context.Context, key string) error {
-	klog.V(6).Infof("syncPV called for %q", key)
-	// TODO(urielguzman): Add relevance check
-	// TODO(urielguzman): Add scanning logic
-	// TODO(urielguzman): Add annotation logic
+func (s *Scanner) getDurationAttribute(pv *v1.PersistentVolume, attributeKey string, defaultDuration time.Duration) (*time.Duration, error) {
+	if pv.Spec.CSI != nil && pv.Spec.CSI.VolumeAttributes != nil {
+		if durationStr, ok := pv.Spec.CSI.VolumeAttributes[attributeKey]; ok {
+			parsedDuration, err := time.ParseDuration(durationStr)
+			if err != nil {
+				return nil, fmt.Errorf("invalid duration format for %s: %q, error: %w", attributeKey, durationStr, err)
+			}
+			if parsedDuration <= 0 {
+				return nil, fmt.Errorf("non-positive duration for %s: %q", attributeKey, durationStr)
+			}
+			klog.Infof("PV %s: Using %q key from VolumeAttributes: %s", pv.Name, attributeKey, parsedDuration)
+			return &parsedDuration, nil
+		}
+	}
+	klog.V(6).Infof("PV %s: No %q key in VolumeAttributes. Using default %s", pv.Name, attributeKey, defaultDuration)
+	return &defaultDuration, nil
+}
+
+// syncPV is the core reconciliation function for a PersistentVolume.
+// It checks if the PV is relevant, performs the bucket scan, and updates the PV annotations.
+func (s *Scanner) syncPV(ctx context.Context, key string) error {
+	syncStartTime := timeNow()
+	klog.Infof("Started syncing PV %q", key)
+
+	pv, err := s.pvLister.Get(key)
+	if err != nil {
+		// The PV may have already been deleted. This is normal and we should remove it from tracking.
+		if apierrors.IsNotFound(err) {
+			klog.Infof("PV %q has been deleted, removing from tracking", key)
+			return nil
+		}
+		klog.Errorf("Failed to get PV %q from lister: %v", key, err)
+		return err
+	}
+
+	// Skip PVs that are not relevant, e.g. PVs that don't use the gcsfuse profiles feature or
+	// that have been scanned too recently.
+	bucketInfo, err := s.checkPVRelevance(pv)
+	if err != nil {
+		klog.Errorf("Relevance check failed for PV %s: %v", pv.Name, err)
+		s.eventRecorder.Eventf(pv, v1.EventTypeWarning, reasonScanOperationStartError, "Relevance check failed: %v", err)
+		return fmt.Errorf("relevance check failed for PV %s: %w", pv.Name, err)
+	}
+	if bucketInfo == nil {
+		klog.V(6).Infof("PV %q is no longer relevant, skipping sync", key)
+		return nil // Remove irrelevant PV from queue
+	}
+	klog.Infof("PV %q is relevant, bucket: %s, dir: %s", key, bucketInfo.name, bucketInfo.dir)
+
+	// ----- At this stage, the PV has been considered eligible for a scan. -----
+
+	// Get the bucket scan timeout limit. This may have been overriden by the customer.
+	currentScanTimeout, err := s.getDurationAttribute(pv, volumeAttributeScanTimeoutKey, defaultScanTimeoutDuration)
+	if err != nil {
+		s.eventRecorder.Eventf(pv, v1.EventTypeWarning, reasonScanOperationStartError, "Bucket scan timeout configuration error: %v", err)
+		return nil // Avoid re-queueing on static customer misconfig.
+	}
+
+	s.eventRecorder.Eventf(pv, v1.EventTypeNormal, reasonScanOperationStartSucceeded, "Started bucket scan for PV %s, bucket %s, directory '%s', with timeout %s", pv.Name, bucketInfo.name, bucketInfo.dir, currentScanTimeout)
+	klog.Infof("Bucket scan operation starting for PV %s, bucket %s, dir %s, timeout %s", pv.Name, bucketInfo.name, bucketInfo.dir, currentScanTimeout)
+
+	info, err := scanBucket(ctx, bucketInfo, *currentScanTimeout)
+
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			// A bucket scan timeout is benign and expected if the bucket has a large number of objects.
+			// We send a warning only to inform the customer about the timeout.
+			duration := timeNow().Sub(syncStartTime)
+			s.eventRecorder.Eventf(pv, v1.EventTypeWarning, reasonScanOperationTimedOut, "Bucket scan timed out after %s for bucket %s, directory '%s' (%v). Updating with partial results. Consider increasing timeout if bucket size is big", currentScanTimeout, bucketInfo.name, bucketInfo.dir, duration)
+			if patchErr := s.updatePVScanResult(ctx, pv, info, scanTimeout); patchErr != nil {
+				return fmt.Errorf("failed to patch PV %s after timeout, err: %w", pv.Name, patchErr)
+			}
+			return nil // Remove since we still consider this a successful scan.
+		}
+		// For any other error, re-queue.
+		klog.Errorf("Error scanning bucket for PV %s: %v", pv.Name, err)
+		s.eventRecorder.Eventf(pv, v1.EventTypeWarning, reasonScanOperationFailed, "Bucket scan failed for bucket %s, directory '%s': %v", bucketInfo.name, bucketInfo.dir, err)
+		return fmt.Errorf("error scanning bucket for PV %s: %w", pv.Name, err)
+	}
+
+	// The scan has been successful and complete results have been used.
+	duration := timeNow().Sub(syncStartTime)
+	s.eventRecorder.Eventf(pv, v1.EventTypeNormal, reasonScanOperationSucceeded, "Bucket scan completed successfully for bucket %s, directory '%s' (%v)", bucketInfo.name, bucketInfo.dir, duration)
+	if patchErr := s.updatePVScanResult(ctx, pv, info, scanCompleted); patchErr != nil {
+		return fmt.Errorf("failed to patch PV %s results, err: %w", pv.Name, patchErr)
+	}
+	return nil // Remove since this is a complete and successful scan.
+}
+
+// defaultScanBucket simulates scanning a GCS bucket to gather metadata.
+// It collects the number of objects, total size, and HNS status.
+// This function respects the provided context and the scanTimeout.
+// It returns partial results if the timeout is reached (context.DeadlineExceeded).
+// TODO(urielguzman): Add real Dataflux and bucket metrics fallback logic in subsequent PR.
+func defaultScanBucket(ctx context.Context, info *bucketInfo, scanTimeout time.Duration) (*bucketInfo, error) {
+	klog.Infof("Simulating scan for bucket: %s, dir: %s, timeout: %s", info.name, info.dir, scanTimeout)
+	scanCtx, cancel := context.WithTimeout(ctx, scanTimeout)
+	defer cancel()
+
+	result := &bucketInfo{
+		name:         info.name,
+		dir:          info.dir,
+		isHNSEnabled: true, // Example
+	}
+
+	// Simulate work in ticks
+	tickDuration := 200 * time.Millisecond
+	ticker := time.NewTicker(tickDuration)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-scanCtx.Done():
+			// This is the scanTimeout
+			klog.Warningf("Scan for bucket %s, dir %s timed out after %s. Returning partial results: %+v", result.name, result.dir, scanTimeout, result)
+			return result, context.DeadlineExceeded
+		case <-ctx.Done():
+			// This means the caller cancelled the operation.
+			klog.Infof("Scan for bucket %s, dir %s cancelled by caller", result.name, result.dir)
+			return nil, ctx.Err()
+		case <-ticker.C:
+			// Simulate incremental discovery of objects and size
+			result.numObjects += 1000
+			result.totalSizeBytes += 1000000
+		}
+	}
+}
+
+// patchPVAnnotations updates the annotations for a given PV.
+// annotationsToUpdate should contain the desired state of the annotations to be patched.
+func (s *Scanner) patchPVAnnotations(ctx context.Context, pvName string, annotationsToUpdate map[string]*string) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("context cancelled: %w", err)
+	}
+	patchData := map[string]any{
+		"metadata": map[string]any{"annotations": annotationsToUpdate},
+	}
+	patchBytes, err := json.Marshal(patchData)
+	if err != nil {
+		return fmt.Errorf("failed to marshal annotation patch data for PV %s: %w", pvName, err)
+	}
+	klog.V(6).Infof("Patching PV %s annotations with: %s", pvName, string(patchBytes))
+	_, err = s.kubeClient.CoreV1().PersistentVolumes().Patch(ctx, pvName, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			klog.Warningf("Failed to patch PV %s because it was not found", pvName)
+			return nil
+		}
+		return fmt.Errorf("failed to patch PV %s annotations: %w", pvName, err)
+	}
+	klog.V(6).Infof("Successfully patched annotations for PV %s", pvName)
 	return nil
+}
+
+// updatePVScanResult updates the PV annotations with the results of a bucket scan.
+// It sets the status, number of objects, total size, HNS status, and last updated time.
+func (s *Scanner) updatePVScanResult(ctx context.Context, pv *v1.PersistentVolume, info *bucketInfo, status string) error {
+	annotationsToUpdate := map[string]*string{
+		annotationStatus:          stringPtr(status),
+		annotationNumObjects:      int64Ptr(info.numObjects),
+		annotationTotalSize:       int64Ptr(info.totalSizeBytes),
+		annotationLastUpdatedTime: stringPtr(timeNow().UTC().Format(time.RFC3339)),
+		annotationHNSEnabled:      boolPtr(info.isHNSEnabled),
+	}
+	klog.Infof("Updating PV %s with scan result: %+v, status: %s", pv.Name, info, status)
+	err := s.patchPVAnnotations(ctx, pv.Name, annotationsToUpdate)
+	if err != nil {
+		klog.Errorf("Failed to update annotations on PV %s with status %s: %v", pv.Name, status, err)
+		return err
+	}
+	klog.Infof("Successfully updated annotations on PV %s with status %s", pv.Name, status)
+	return nil
+}
+
+// checkPVRelevance determines if a PersistentVolume is relevant for scanning.
+// A PV is relevant if it uses the gcsfuse CSI driver and its StorageClass
+// has a workloadType parameter set to inference, training, or checkpointing.
+// The PV is relevant if the current time - last scan time > scan TTL
+// This function returns a bucketInfo with the bucket name and the directory if
+// relevant, otherwise, it will return nil and any error.
+func (s *Scanner) checkPVRelevance(pv *v1.PersistentVolume) (*bucketInfo, error) {
+	if pv == nil {
+		return nil, nil
+	}
+	if pv.Spec.CSI == nil || pv.Spec.CSI.Driver != csiDriverName || pv.Spec.CSI.VolumeHandle == "" {
+		return nil, nil
+	}
+
+	scName := pv.Spec.StorageClassName
+	if scName == "" {
+		return nil, nil
+	}
+	sc, err := s.scLister.Get(scName)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("failed to get StorageClass %s: %w", scName, err)
+		}
+		// If the customer specifies a "dummy" StorageClass, this must be handled gracefully. Example:
+		// https://cloud.google.com/kubernetes-engine/docs/how-to/cloud-storage-fuse-csi-driver-pv#create-a-persistentvolume
+		klog.Warningf("StorageClass %s not found for PV %s", scName, pv.Name)
+		return nil, nil
+	}
+
+	scParams := sc.Parameters
+	if scParams == nil {
+		return nil, nil
+	}
+	workloadType, ok := scParams[paramWorkloadTypeKey]
+	if !ok {
+		klog.V(6).Infof("Workload type parameter key %s was not found in StorageClass %s for PV %s", paramWorkloadTypeKey, scName, pv.Name)
+		return nil, nil
+	}
+
+	// ---- At this stage, there is clearly a customer intent to use the scanner feature, so we start logging warnings -----
+
+	switch workloadType {
+	case paramWorkloadTypeInferenceKey, paramWorkloadTypeTrainingKey, paramWorkloadTypeCheckpointingKey:
+	default:
+		s.eventRecorder.Eventf(pv, v1.EventTypeWarning, reasonScanOperationStartError, "Found invalid '%s' parameter %q in StorageClass %s for PV %s", paramWorkloadTypeKey, workloadType, scName, pv.Name)
+		return nil, nil // Avoid re-queuing on static customer misconfig.
+	}
+
+	// Check if the scan should be skipped based on TTL
+	currentScanTTL, err := s.getDurationAttribute(pv, volumeAttributeScanTTLKey, defaultScanTTLDuration)
+	if err != nil {
+		s.eventRecorder.Eventf(pv, v1.EventTypeWarning, reasonScanOperationStartError, "Bucket scan TTL configuration error: %v", err)
+		return nil, nil // Avoid re-queuing on static customer misconfig.
+	}
+	if lastUpdatedTimeStr, ok := pv.Annotations[annotationLastUpdatedTime]; ok {
+		lastUpdatedTime, err := time.Parse(time.RFC3339, lastUpdatedTimeStr)
+		if err != nil {
+			klog.Warningf("PV %s: Failed to parse annotation %s value %q: %v. Proceeding with scan", pv.Name, annotationLastUpdatedTime, lastUpdatedTimeStr, err)
+		} else {
+			elapsed := timeNow().Sub(lastUpdatedTime)
+			if elapsed < *currentScanTTL {
+				klog.Infof("PV %s: Skipping scan, only %s elapsed since last scan, which is less than TTL %s", pv.Name, elapsed.Round(time.Second), currentScanTTL)
+				return nil, nil
+			}
+			klog.V(6).Infof("PV %s: Proceeding with scan, %s elapsed since last scan, TTL is %s", pv.Name, elapsed.Round(time.Second), currentScanTTL)
+		}
+	} else {
+		klog.V(6).Infof("PV %s: No last updated time annotation found. Proceeding with scan", pv.Name)
+	}
+
+	bucketName := pv.Spec.CSI.VolumeHandle
+	var dir string
+	for _, mountOption := range pv.Spec.MountOptions {
+		if val, ok := getOnlyDirValue(mountOption); ok {
+			dir = val
+			break
+		}
+	}
+	return &bucketInfo{
+		name: bucketName,
+		dir:  dir}, nil
+}
+
+// getOnlyDirValue parses a mount option string to extract the value of "only-dir".
+// It returns the directory value and true if the prefix is found, otherwise empty string and false.
+func getOnlyDirValue(s string) (string, bool) {
+	prefix := "only-dir="
+	if strings.HasPrefix(s, prefix) {
+		return strings.TrimPrefix(s, prefix), true
+	}
+	return "", false
 }
 
 // enqueuePV enqueues a PersistentVolume.
@@ -223,30 +552,36 @@ func (s *Scanner) addPV(obj any) {
 		klog.Errorf("AddFunc PV: Expected PersistentVolume but got %T", obj)
 		return
 	}
-	klog.V(6).Infof("PV ADDED: %s", pv.Name)
-	s.enqueuePV(pv)
+	s.handlePVEvent(pv, "ADD")
 }
 
-// updatePV is the update event handler for PersistentVolumes.
-func (s *Scanner) updatePV(oldObj, newObj any) {
-	oldPV, ok := oldObj.(*v1.PersistentVolume)
-	if !ok {
-		klog.Errorf("UpdateFunc PV: old object is not a PersistentVolume, got %T", oldObj)
+// This function is called by addPV and updatePV event handlers.
+func (s *Scanner) handlePVEvent(pv *v1.PersistentVolume, eventType string) {
+	bucketInfo, err := s.checkPVRelevance(pv)
+	if err != nil {
+		klog.Errorf("PV %s: Error checking relevance for %s: %v", eventType, pv.Name, err)
 		return
 	}
-	newPV, ok := newObj.(*v1.PersistentVolume)
-	if !ok {
-		klog.Errorf("UpdateFunc PV: new object is not a PersistentVolume, got %T", newObj)
+
+	if bucketInfo == nil {
+		klog.V(6).Infof("PV %s: %s - Not relevant", eventType, pv.Name)
 		return
 	}
-	if oldPV.ResourceVersion == newPV.ResourceVersion {
-		return
+
+	s.pvMutex.Lock()
+	defer s.pvMutex.Unlock()
+
+	if _, isTracked := s.trackedPVs[pv.Name]; !isTracked {
+		s.trackedPVs[pv.Name] = struct{}{}
+		klog.V(6).Infof("PV %s: %s - New relevant PV. Enqueuing for scan", eventType, pv.Name)
+		s.enqueuePV(pv)
+	} else {
+		klog.V(6).Infof("PV %s: %s - Already tracked. No action", eventType, pv.Name)
 	}
-	klog.V(6).Infof("PV UPDATED: %s", newPV.Name)
-	s.enqueuePV(newPV)
 }
 
-// deletePV is the delete event handler for PersistentVolumes.
+// deletePV is the event handler for PersistentVolume Delete events.
+// It removes the PV from the workqueue and the internal tracking map.
 func (s *Scanner) deletePV(obj any) {
 	pv, ok := obj.(*v1.PersistentVolume)
 	if !ok {
@@ -264,5 +599,14 @@ func (s *Scanner) deletePV(obj any) {
 	} else {
 		klog.V(6).Infof("PV DELETED: %s", pv.Name)
 	}
-	s.enqueuePV(pv) // Enqueue on delete to handle any cleanup if necessary
+
+	key, err := cache.MetaNamespaceKeyFunc(pv)
+	if err != nil {
+		klog.Errorf("DeleteFunc PV: Error mapping key from object: %v", err)
+	} else {
+		s.pvMutex.Lock()
+		delete(s.trackedPVs, key)
+		s.pvMutex.Unlock()
+		s.queue.Forget(key)
+	}
 }

--- a/pkg/scanner/scanner_test.go
+++ b/pkg/scanner/scanner_test.go
@@ -18,100 +18,687 @@ limitations under the License.
 package scanner
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
 	"testing"
+	"time"
 
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
+
+	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	storagelisters "k8s.io/client-go/listers/storage/v1"
+	k8stesting "k8s.io/client-go/testing"
 )
 
-// Helper to create a basic PV for tests
-func createTestPV(name string) *v1.PersistentVolume {
+const (
+	testSCName            = "test-storage-class"
+	testPVName            = "test-pv"
+	testBucketName        = "test-bucket"
+	testDirName           = "test-dir"
+	oldAnnotationKey      = "old"
+	newAnnotationKey      = "new"
+	newAnnotationVal      = "newval"
+	onlyDirMountOptPrefix = "only-dir="
+)
+
+var (
+	validSCParams = map[string]string{paramWorkloadTypeKey: paramWorkloadTypeInferenceKey}
+	validSC       = createStorageClass(testSCName, validSCParams)
+)
+
+// mockTime allows controlling the time in tests.
+// This is useful for testing time-dependent logic, such as TTLs.
+type mockTime struct {
+	currentTime time.Time
+}
+
+// Now returns the current mocked time.
+func (m *mockTime) Now() time.Time {
+	return m.currentTime
+}
+
+// fakeScanBucketFunc provides a mock implementation of the scanBucket function.
+// It allows simulating different scan outcomes, including errors and timeouts.
+type fakeScanBucketFunc struct {
+	info *bucketInfo
+	err  error
+}
+
+// Scan is the mock implementation of the scanBucket function.
+// It checks for context cancellation (like timeouts) before returning the predefined info and error.
+func (f *fakeScanBucketFunc) Scan(ctx context.Context, bucketInfo *bucketInfo, scanTimeout time.Duration) (*bucketInfo, error) {
+	select {
+	case <-ctx.Done():
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return f.info, context.DeadlineExceeded
+		}
+		return nil, ctx.Err()
+	default:
+		return f.info, f.err
+	}
+}
+
+// testFixture holds the necessary components for testing the Scanner.
+// It encapsulates the fake Kubernetes client, listers, recorders, and mock functions.
+type testFixture struct {
+	scanner      *Scanner
+	kubeClient   *fake.Clientset
+	pvLister     corelisters.PersistentVolumeLister
+	scLister     storagelisters.StorageClassLister
+	recorder     *record.FakeRecorder
+	mockTimeImpl *mockTime
+	scanBucketFn *fakeScanBucketFunc
+	stopCh       chan struct{}
+}
+
+// newTestFixture initializes a new testFixture.
+func newTestFixture(t *testing.T, initialObjects ...runtime.Object) *testFixture {
+	t.Helper()
+
+	kubeClient := fake.NewSimpleClientset(initialObjects...)
+	factory := informers.NewSharedInformerFactory(kubeClient, 0 /* no resync period */)
+	pvInformer := factory.Core().V1().PersistentVolumes()
+	scInformer := factory.Storage().V1().StorageClasses()
+
+	// Manually add initial objects to the informer indexers to ensure they are available in listers.
+	for _, obj := range initialObjects {
+		switch obj := obj.(type) {
+		case *v1.PersistentVolume:
+			if err := pvInformer.Informer().GetIndexer().Add(obj); err != nil {
+				t.Fatalf("Failed to add PV to indexer: %v", err)
+			}
+		case *storagev1.StorageClass:
+			if err := scInformer.Informer().GetIndexer().Add(obj); err != nil {
+				t.Fatalf("Failed to add SC to indexer: %v", err)
+			}
+		}
+	}
+
+	recorder := record.NewFakeRecorder(30)
+	mt := &mockTime{currentTime: time.Date(2025, time.August, 27, 0, 0, 0, 0, time.UTC)}
+	origTimeNow := timeNow
+	timeNow = mt.Now
+
+	fsb := &fakeScanBucketFunc{}
+	origScanBucket := scanBucket
+	scanBucket = fsb.Scan
+	stopCh := make(chan struct{})
+
+	t.Cleanup(func() {
+		timeNow = origTimeNow
+		scanBucket = origScanBucket
+		close(stopCh)
+	})
+
+	// Create the Scanner instance with fake/mock components.
+	s := &Scanner{
+		kubeClient:    kubeClient,
+		pvLister:      pvInformer.Lister(),
+		scLister:      scInformer.Lister(),
+		pvSynced:      pvInformer.Informer().HasSynced,
+		scSynced:      scInformer.Informer().HasSynced,
+		factory:       factory,
+		queue:         workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()),
+		eventRecorder: recorder,
+		trackedPVs:    make(map[string]struct{}),
+	}
+
+	factory.Start(stopCh)
+	if !cache.WaitForCacheSync(stopCh, s.pvSynced, s.scSynced) {
+		t.Fatalf("Failed to sync caches")
+	}
+
+	return &testFixture{
+		scanner:      s,
+		kubeClient:   kubeClient,
+		pvLister:     pvInformer.Lister(),
+		scLister:     scInformer.Lister(),
+		recorder:     recorder,
+		mockTimeImpl: mt,
+		scanBucketFn: fsb,
+		stopCh:       stopCh,
+	}
+}
+
+// createStorageClass is a helper function to create a StorageClass object.
+func createStorageClass(name string, params map[string]string) *storagev1.StorageClass {
+	return &storagev1.StorageClass{
+		ObjectMeta:  metav1.ObjectMeta{Name: name},
+		Provisioner: csiDriverName,
+		Parameters:  params,
+	}
+}
+
+// createPV is a helper function to create a PersistentVolume object.
+func createPV(name, scName, volumeHandle, driver string, mountOptions []string, annotations map[string]string, volAttributes map[string]string) *v1.PersistentVolume {
 	return &v1.PersistentVolume{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
+		ObjectMeta: metav1.ObjectMeta{Name: name, Annotations: annotations},
+		Spec: v1.PersistentVolumeSpec{
+			StorageClassName: scName,
+			MountOptions:     mountOptions,
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				CSI: &v1.CSIPersistentVolumeSource{
+					Driver:           driver,
+					VolumeHandle:     volumeHandle,
+					VolumeAttributes: volAttributes,
+				},
+			},
 		},
 	}
 }
 
-// newTestScanner creates a Scanner instance with a fake Kubernetes client for testing.
-func newTestScanner(t *testing.T) *Scanner {
-	t.Helper()
-	client := fake.NewSimpleClientset()
-	factory := informers.NewSharedInformerFactory(client, 0)
-	pvInformer := factory.Core().V1().PersistentVolumes()
-	scInformer := factory.Storage().V1().StorageClasses()
+// TestCheckPVRelevance tests the checkPVRelevance function.
+// This function determines if a PersistentVolume is relevant for scanning based on its StorageClass,
+// annotations, and other properties.
+func TestCheckPVRelevance(t *testing.T) {
+	now := time.Date(2025, time.August, 27, 0, 0, 0, 0, time.UTC)
+	ttl := defaultScanTTLDuration
+	lastUpdateTimeWithinTTL := now.Add(-ttl / 2).Format(time.RFC3339)
+	lastUpdateTimeOutsideTTL := now.Add(-ttl * 2).Format(time.RFC3339)
 
-	recorder := record.NewFakeRecorder(10) // Buffer size 10
-
-	scanner := &Scanner{
-		kubeClient:    client,
-		factory:       factory,
-		pvLister:      pvInformer.Lister(),
-		scLister:      scInformer.Lister(),
-		pvSynced:      func() bool { return true }, // Assume synced for tests
-		scSynced:      func() bool { return true }, // Assume synced for tests
-		queue:         workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()),
-		eventRecorder: recorder,
+	testCases := []struct {
+		name         string
+		pv           *v1.PersistentVolume
+		scs          []*storagev1.StorageClass
+		wantRelevant bool
+		wantErr      bool
+		wantBucket   string
+		wantDir      string
+	}{
+		{
+			name:         "Relevant PV",
+			pv:           createPV(testPVName, testSCName, testBucketName, csiDriverName, []string{onlyDirMountOptPrefix + testDirName}, nil, nil),
+			scs:          []*storagev1.StorageClass{validSC},
+			wantRelevant: true,
+			wantBucket:   testBucketName,
+			wantDir:      testDirName,
+		},
+		{
+			name: "Relevant PV - Training",
+			pv:   createPV(testPVName, testSCName, testBucketName, csiDriverName, nil, nil, nil),
+			scs: []*storagev1.StorageClass{
+				createStorageClass(testSCName, map[string]string{paramWorkloadTypeKey: paramWorkloadTypeTrainingKey}),
+			},
+			wantRelevant: true,
+			wantBucket:   testBucketName,
+		},
+		{
+			name: "Relevant PV - Inference",
+			pv:   createPV(testPVName, testSCName, testBucketName, csiDriverName, nil, nil, nil),
+			scs: []*storagev1.StorageClass{
+				createStorageClass(testSCName, map[string]string{paramWorkloadTypeKey: paramWorkloadTypeInferenceKey}),
+			},
+			wantRelevant: true,
+			wantBucket:   testBucketName,
+		},
+		{
+			name: "Relevant PV - Checkpointing",
+			pv:   createPV(testPVName, testSCName, testBucketName, csiDriverName, nil, nil, nil),
+			scs: []*storagev1.StorageClass{
+				createStorageClass(testSCName, map[string]string{paramWorkloadTypeKey: paramWorkloadTypeCheckpointingKey}),
+			},
+			wantRelevant: true,
+			wantBucket:   testBucketName,
+		},
+		{
+			name: "Irrelevant - Wrong Driver",
+			pv:   createPV(testPVName, testSCName, testBucketName, "blah", nil, nil, nil),
+			scs: []*storagev1.StorageClass{
+				createStorageClass(testSCName, map[string]string{paramWorkloadTypeKey: paramWorkloadTypeCheckpointingKey}),
+			},
+			wantRelevant: false,
+		},
+		{
+			name:         "Irrelevant - SC Not Found",
+			pv:           createPV(testPVName, "blah", testBucketName, csiDriverName, nil, nil, nil),
+			scs:          []*storagev1.StorageClass{validSC},
+			wantRelevant: false,
+		},
+		{
+			name: "Error - Invalid Workload Type",
+			pv:   createPV(testPVName, testSCName, testBucketName, csiDriverName, nil, nil, nil),
+			scs: []*storagev1.StorageClass{
+				createStorageClass(testSCName, map[string]string{paramWorkloadTypeKey: "blah"}),
+			},
+			wantErr: false,
+		},
+		{
+			name: "Irrelevant - Within TTL",
+			pv: createPV(testPVName, testSCName, testBucketName, csiDriverName, nil, map[string]string{
+				annotationLastUpdatedTime: lastUpdateTimeWithinTTL,
+			}, nil),
+			scs:          []*storagev1.StorageClass{validSC},
+			wantRelevant: false,
+		},
+		{
+			name: "Relevant - Outside TTL",
+			pv: createPV(testPVName, testSCName, testBucketName, csiDriverName, nil, map[string]string{
+				annotationLastUpdatedTime: lastUpdateTimeOutsideTTL,
+			}, nil),
+			scs:          []*storagev1.StorageClass{validSC},
+			wantRelevant: true,
+			wantBucket:   testBucketName,
+		},
 	}
-	return scanner
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var objs []runtime.Object
+			if tc.pv != nil {
+				objs = append(objs, tc.pv)
+			}
+			for _, sc := range tc.scs {
+				objs = append(objs, sc)
+			}
+			f := newTestFixture(t, objs...)
+			f.mockTimeImpl.currentTime = now
+			info, err := f.scanner.checkPVRelevance(tc.pv)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("checkPVRelevance(%v) = %v, nil, want error", tc.pv.Name, info)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("checkPVRelevance(%v) = %v, %v, want no error", tc.pv.Name, info, err)
+				}
+			}
+
+			isRelevant := info != nil
+			if isRelevant != tc.wantRelevant {
+				t.Errorf("checkPVRelevance(%v) relevant = %v, want %v", tc.pv.Name, isRelevant, tc.wantRelevant)
+			}
+
+			if tc.wantRelevant && info != nil {
+				if info.name != tc.wantBucket {
+					t.Errorf("checkPVRelevance(%v) bucket = %q, want %q", tc.pv.Name, info.name, tc.wantBucket)
+				}
+				if info.dir != tc.wantDir {
+					t.Errorf("checkPVRelevance(%v) dir = %q, want %q", tc.pv.Name, info.dir, tc.wantDir)
+				}
+			}
+		})
+	}
 }
 
-func TestEnqueuePV(t *testing.T) {
-	s := newTestScanner(t)
-	pv := createTestPV("test-pv")
-	s.enqueuePV(pv)
+// TestProcessNextWorkItem tests the processNextWorkItem function.
+// This function processes items from the work queue, triggering the scan and update logic.
+func TestProcessNextWorkItem(t *testing.T) {
+	pvName := testPVName
+	scName := testSCName
+	bucketName := testBucketName
+	basePV := createPV(pvName, scName, bucketName, csiDriverName, nil, nil, nil)
+	relevantSC := createStorageClass(scName, validSCParams)
 
-	if s.queue.Len() != 1 {
-		t.Errorf("queue.Len() = %d, want 1", s.queue.Len())
+	scanResult := &bucketInfo{
+		name:           bucketName,
+		numObjects:     1234,
+		totalSizeBytes: 567890,
+		isHNSEnabled:   true,
 	}
 
-	key, _ := cache.MetaNamespaceKeyFunc(pv)
-	item, quit := s.queue.Get()
-	if quit {
-		t.Errorf("s.queue.Get() quit = true, want false")
+	testCases := []struct {
+		name           string
+		initialPV      *v1.PersistentVolume
+		scanInfo       *bucketInfo
+		scanErr        error
+		timeoutErr     bool
+		patchErr       error
+		expectRequeue  bool
+		expectAnnotate bool
+		expectedStatus string
+	}{
+		{
+			name:           "Successful Sync",
+			initialPV:      basePV.DeepCopy(),
+			scanInfo:       scanResult,
+			expectRequeue:  false,
+			expectAnnotate: true,
+			expectedStatus: scanCompleted,
+		},
+		{
+			name:          "Sync Failure - Scan Error",
+			initialPV:     basePV.DeepCopy(),
+			scanErr:       fmt.Errorf("scan failed"),
+			expectRequeue: true,
+		},
+		{
+			name:           "Sync Failure - Scan Timeout",
+			initialPV:      basePV.DeepCopy(),
+			scanInfo:       scanResult,
+			timeoutErr:     true,
+			expectRequeue:  false,
+			expectAnnotate: true,
+			expectedStatus: scanTimeout,
+		},
+		{
+			name:          "Sync Failure - Patch Error",
+			initialPV:     basePV.DeepCopy(),
+			scanInfo:      scanResult,
+			patchErr:      fmt.Errorf("patch failed"),
+			expectRequeue: true,
+		},
 	}
-	if item != key {
-		t.Errorf("s.queue.Get() item = %v, want %v", item, key)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var objs []runtime.Object
+			objs = append(objs, relevantSC)
+			if tc.initialPV != nil {
+				objs = append(objs, tc.initialPV)
+			}
+			f := newTestFixture(t, objs...)
+
+			f.scanBucketFn.info = tc.scanInfo
+			if tc.timeoutErr {
+				f.scanBucketFn.err = context.DeadlineExceeded
+			} else {
+				f.scanBucketFn.err = tc.scanErr
+			}
+
+			if tc.patchErr != nil {
+				f.kubeClient.PrependReactor("patch", "persistentvolumes", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, nil, tc.patchErr
+				})
+			}
+
+			key, _ := cache.MetaNamespaceKeyFunc(tc.initialPV)
+			f.scanner.enqueuePV(tc.initialPV)
+
+			if !f.scanner.processNextWorkItem(context.Background()) {
+				t.Errorf("processNextWorkItem returned false, expected true")
+			}
+
+			// Check if the item was requeued as expected.
+			numRequeues := f.scanner.queue.NumRequeues(key)
+			if tc.expectRequeue {
+				if numRequeues == 0 {
+					t.Errorf("Expected key %q to be requeued, got %d requeues", key, numRequeues)
+				}
+			} else {
+				if numRequeues > 0 {
+					t.Errorf("Expected key %q not to be requeued, got %d requeues", key, numRequeues)
+				}
+			}
+
+			// Check if PV annotations were updated as expected.
+			if tc.expectAnnotate {
+				updatedPV, err := f.kubeClient.CoreV1().PersistentVolumes().Get(context.Background(), pvName, metav1.GetOptions{})
+				if err != nil {
+					t.Fatalf("Failed to get PV: %v", err)
+				}
+				if updatedPV.Annotations == nil {
+					t.Errorf("Expected annotations to be set")
+				}
+				if status := updatedPV.Annotations[annotationStatus]; status != tc.expectedStatus {
+					t.Errorf("Annotation %s: got %v, want %v", annotationStatus, status, tc.expectedStatus)
+				}
+				if _, exists := updatedPV.Annotations[annotationLastUpdatedTime]; !exists {
+					t.Errorf("Annotation %s not found", annotationLastUpdatedTime)
+				}
+			}
+		})
 	}
-	s.queue.Done(item)
 }
 
+// TestAddPV tests the addPV function, which handles new PV additions.
 func TestAddPV(t *testing.T) {
-	s := newTestScanner(t)
-	pv := createTestPV("add-pv")
-	s.addPV(pv)
-	if s.queue.Len() != 1 {
-		t.Errorf("queue.Len() after addPV = %d, want 1", s.queue.Len())
+	pvRelevant := createPV(testPVName, testSCName, testBucketName, csiDriverName, nil, nil, nil)
+	scValid := createStorageClass(testSCName, validSCParams)
+	f := newTestFixture(t, pvRelevant, scValid)
+
+	f.scanner.addPV(pvRelevant)
+
+	// Expect the PV to be added to the queue and tracked.
+	if f.scanner.queue.Len() != 1 {
+		t.Errorf("Queue length: got %d, want 1", f.scanner.queue.Len())
+	}
+	key, _ := cache.MetaNamespaceKeyFunc(pvRelevant)
+	if _, exists := f.scanner.trackedPVs[key]; !exists {
+		t.Errorf("PV %s not tracked after add", key)
+	}
+
+	// Adding the same PV again should not change the queue length (it's a set).
+	f.scanner.addPV(pvRelevant)
+	if f.scanner.queue.Len() != 1 {
+		t.Errorf("Queue length after duplicate add: got %d, want 1", f.scanner.queue.Len())
 	}
 }
 
-func TestUpdatePV(t *testing.T) {
-	s := newTestScanner(t)
-	oldPV := createTestPV("update-pv")
-	newPV := oldPV.DeepCopy()
-	newPV.ResourceVersion = "2"
-	s.updatePV(oldPV, newPV)
-	if s.queue.Len() != 1 {
-		t.Errorf("queue.Len() after updatePV = %d, want 1", s.queue.Len())
-	}
-
-	// Test no enqueue if resource version is same
-	s.updatePV(newPV, newPV)
-	if s.queue.Len() != 1 {
-		t.Errorf("queue.Len() after no-op updatePV = %d, want 1", s.queue.Len())
-	}
-}
-
+// TestDeletePV tests the deletePV function.
 func TestDeletePV(t *testing.T) {
-	s := newTestScanner(t)
-	pv := createTestPV("delete-pv")
-	s.deletePV(pv)
-	if s.queue.Len() != 1 {
-		t.Errorf("queue.Len() after deletePV = %d, want 1", s.queue.Len())
+	pvName := testPVName
+	key := pvName
+	pv := createPV(pvName, testSCName, testBucketName, csiDriverName, nil, nil, nil)
+
+	f := newTestFixture(t)
+	f.scanner.queue.Add(key)
+	f.scanner.trackedPVs[pvName] = struct{}{}
+	f.scanner.deletePV(pv)
+
+	// PV should no longer be in the tracked set.
+	if _, exists := f.scanner.trackedPVs[pvName]; exists {
+		t.Errorf("PV %s still tracked after deletePV() call", pvName)
+	}
+
+	// The item is still in the queue, deletePV doesn't remove it from the queue.
+	if f.scanner.queue.Len() != 1 {
+		t.Errorf("Queue length after deletePV(): got %d, want 1", f.scanner.queue.Len())
+	}
+
+	// Simulate the worker picking up the item.
+	// processNextWorkItem will call syncPV.
+	// Since the PV is not in the fake client, pvLister.Get() will return NotFound.
+	if !f.scanner.processNextWorkItem(context.Background()) {
+		t.Errorf("processNextWorkItem returned false unexpectedly")
+	}
+
+	// After processing, the queue should be empty and the item not re-queued
+	// because the PV was not found, simulating a successful handle of the deletion.
+	if f.scanner.queue.Len() != 0 {
+		t.Errorf("Queue length after processNextWorkItem: got %d, want 0", f.scanner.queue.Len())
+	}
+	if f.scanner.queue.NumRequeues(key) > 0 {
+		t.Errorf("Key %s was requeued unexpectedly, NumRequeues: %d", key, f.scanner.queue.NumRequeues(key))
+	}
+}
+
+// TestGetScanTimeout tests the getDurationAttribute function.
+func TestGetDurationAttribute(t *testing.T) {
+	customScanTimeoutDuration := time.Duration(42 * time.Minute)
+	customScanTTLDuration := time.Duration(5 * time.Minute)
+	testCases := []struct {
+		name            string
+		attributeKey    string
+		attributes      map[string]string
+		defaultDuration time.Duration
+		wantTimeout     *time.Duration
+		wantErr         bool
+	}{
+		{
+			name:            "No bucket scan timeout attribute - Use default",
+			attributeKey:    volumeAttributeScanTimeoutKey,
+			defaultDuration: defaultScanTimeoutDuration,
+			wantTimeout:     &defaultScanTimeoutDuration,
+			wantErr:         false,
+		},
+		{
+			name:            "No bucket scan TTL attribute - Use default",
+			attributeKey:    volumeAttributeScanTTLKey,
+			defaultDuration: defaultScanTTLDuration,
+			wantTimeout:     &defaultScanTTLDuration,
+			wantErr:         false,
+		},
+		{
+			name:            "Valid bucket scan timeout attribute - Override",
+			attributes:      map[string]string{volumeAttributeScanTimeoutKey: "42m"},
+			defaultDuration: defaultScanTimeoutDuration,
+			attributeKey:    volumeAttributeScanTimeoutKey,
+			wantTimeout:     &customScanTimeoutDuration,
+			wantErr:         false,
+		},
+		{
+			name:            "Valid bucket scan TTL attribute - Override",
+			attributes:      map[string]string{volumeAttributeScanTTLKey: "5m"},
+			defaultDuration: defaultScanTTLDuration,
+			attributeKey:    volumeAttributeScanTTLKey,
+			wantTimeout:     &customScanTTLDuration,
+			wantErr:         false,
+		},
+		{
+			name:            "Invalid duration - Error",
+			attributes:      map[string]string{volumeAttributeScanTimeoutKey: "5min"},
+			attributeKey:    volumeAttributeScanTimeoutKey,
+			defaultDuration: defaultScanTimeoutDuration,
+			wantErr:         true,
+		},
+		{
+			name:            "Non-positive duration - Error",
+			attributes:      map[string]string{volumeAttributeScanTimeoutKey: "0s"},
+			attributeKey:    volumeAttributeScanTimeoutKey,
+			defaultDuration: defaultScanTimeoutDuration,
+			wantErr:         true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pv := createPV(testPVName, testSCName, testBucketName, csiDriverName, nil, nil, tc.attributes)
+			f := newTestFixture(t)
+			timeout, err := f.scanner.getDurationAttribute(pv, tc.attributeKey, tc.defaultDuration)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("getDurationAttribute() error = %v, wantErr %v", err, tc.wantErr)
+				}
+			} else {
+				if *timeout != *tc.wantTimeout {
+					t.Errorf("getDurationAttribute() = %v, want %v", timeout, tc.wantTimeout)
+				}
+			}
+		})
+	}
+}
+
+// TestUpdatePVScanResult tests the updatePVScanResult function.
+// This function updates the PV annotations with the scan results.
+func TestUpdatePVScanResult(t *testing.T) {
+	pv := createPV(testPVName, testSCName, testBucketName, csiDriverName, nil, nil, nil)
+	f := newTestFixture(t, pv)
+	now := time.Date(2025, 9, 1, 10, 0, 0, 0, time.UTC)
+	f.mockTimeImpl.currentTime = now
+
+	info := &bucketInfo{
+		numObjects:     999,
+		totalSizeBytes: 8888,
+		isHNSEnabled:   true,
+	}
+	status := scanCompleted
+
+	// Call the function to update annotations.
+	if err := f.scanner.updatePVScanResult(context.Background(), pv, info, status); err != nil {
+		t.Fatalf("updatePVScanResult() returned error: %v", err)
+	}
+
+	// Get the updated PV from the fake client.
+	updatedPV, err := f.kubeClient.CoreV1().PersistentVolumes().Get(context.Background(), testPVName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get PV: %v", err)
+	}
+
+	annotations := updatedPV.Annotations
+	if annotations == nil {
+		t.Fatalf("Annotations are nil")
+	}
+
+	// Define the expected annotations.
+	expectedAnnotations := map[string]string{
+		annotationStatus:          status,
+		annotationNumObjects:      "999",
+		annotationTotalSize:       "8888",
+		annotationHNSEnabled:      "true",
+		annotationLastUpdatedTime: now.UTC().Format(time.RFC3339),
+	}
+
+	// Verify each expected annotation.
+	for key, want := range expectedAnnotations {
+		got := annotations[key]
+		if got != want {
+			t.Errorf("Annotation %s: got %v, want %v", key, got, want)
+		}
+	}
+}
+
+// TestPatchPVAnnotations tests the patchPVAnnotations function.
+// This function patches specific annotations on a PV.
+func TestPatchPVAnnotations(t *testing.T) {
+	pv := createPV(testPVName, testSCName, testBucketName, csiDriverName, nil, map[string]string{oldAnnotationKey: "val"}, nil)
+	f := newTestFixture(t, pv)
+
+	// Annotations to update: "new" to add, "old" to remove (by setting value to nil).
+	annotationsToUpdate := map[string]*string{
+		newAnnotationKey: stringPtr(newAnnotationVal),
+		oldAnnotationKey: nil,
+	}
+
+	if err := f.scanner.patchPVAnnotations(context.Background(), testPVName, annotationsToUpdate); err != nil {
+		t.Fatalf("patchPVAnnotations() returned error: %v", err)
+	}
+
+	// Get the updated PV.
+	updatedPV, err := f.kubeClient.CoreV1().PersistentVolumes().Get(context.Background(), testPVName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get PV: %v", err)
+	}
+	// Expected annotations after the patch.
+	expectedAnnotations := map[string]string{newAnnotationKey: newAnnotationVal}
+	if !reflect.DeepEqual(updatedPV.Annotations, expectedAnnotations) {
+		t.Errorf("Annotations: got %v, want %v", updatedPV.Annotations, expectedAnnotations)
+	}
+}
+
+// TestGetOnlyDirValue tests the getOnlyDirValue function.
+// This function extracts the directory name from a mount option string.
+func TestGetOnlyDirValue(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+		ok    bool
+	}{
+		{
+			name:  "Valid mount option with dir name",
+			input: onlyDirMountOptPrefix + testDirName,
+			want:  testDirName,
+			ok:    true,
+		},
+		{
+			name:  "Valid mount option without dir name",
+			input: onlyDirMountOptPrefix,
+			want:  "",
+			ok:    true,
+		},
+		{
+			name:  "Invalid mount option",
+			input: "blah=" + testDirName,
+			want:  "",
+			ok:    false,
+		},
+	}
+	for _, tc := range tests {
+		got, ok := getOnlyDirValue(tc.input)
+		if ok != tc.ok || got != tc.want {
+			t.Errorf("getOnlyDirValue(%q) = %q, %v, want %q, %v", tc.input, got, ok, tc.want, tc.ok)
+		}
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR builds on top of the existing Bucket Scanner controller skeleton (https://github.com/GoogleCloudPlatform/gcs-fuse-csi-driver/pull/948) within the GCSFuse CSI driver. This controller watches PersistentVolumes (PVs) managed by `gcsfuse.csi.storage.gke.io` and, when relevant, performs simulated metadata scans on the associated GCS buckets. The results are stored as annotations on the PV.

Key features implemented in this PR:

*   **PV Event Handling**: Reacts to Add and Delete PV events.
*   **Relevance Checks**:
    *   Ensures the PV uses the `gcsfuse.csi.storage.gke.io` driver.
    *   Verifies the StorageClass has a valid `workloadType` parameter (`inference`, `training`, or `checkpointing`).
    *   Implements a Time-To-Live (TTL) logic: re-scans only if the time since the `bucket-scan-last-updated-time` annotation exceeds the configured TTL.
*   **Configurable Scan Behavior**:
    *   Scan Timeout and TTL can be customized via PV VolumeAttributes (`bucketScanTimeout`, `bucketScanTTL`). Defaults are 2 minutes and 7 days, respectively.
*   **Simulated Bucket Scan**:
    *   The current version simulates the scanning process. It does not yet interact with Google Cloud Storage.
    *   It respects context cancellation and the configured scan timeout, returning partial results upon timeout.
*   **PV Annotation Updates**:
    *   Patches the PV with annotations prefixed `gke-gcsfuse/bucket-scan-`:
        *   `status` (e.g., `completed`, `timeout`)
        *   `num-objects`
        *   `total-size-bytes`
        *   `hns-enabled`
        *   `last-updated-time`
*   **Kubernetes Events**: Emits events to the PV to indicate scan status and errors.
*   **Unit Tests**: Expands the existing test suite (`scanner_test.go`) to validate:
    *   PV relevance logic (including TTL).
    *   Queue processing and error handling in `syncPV`.
    *   PV event handlers (add/delete).
    *   Annotation patching.
    *   Timeout/TTL parsing from VolumeAttributes.

**Manual Verification**:
1. Scan timeout w/ custom `bucketScanTTL` and `bucketScanTimeout` volumeAttributes (this will always time out because the mock infinetely scans for objects) :
```
Name:            my-pv
Labels:          <none>
Annotations:     gke-gcsfuse/bucket-scan-hns-enabled: true
                 gke-gcsfuse/bucket-scan-last-updated-time: 2025-08-27T23:53:30Z
                 gke-gcsfuse/bucket-scan-num-objects: 150000
                 gke-gcsfuse/bucket-scan-status: timeout
                 gke-gcsfuse/bucket-scan-total-size-bytes: 150000000
                 pv.kubernetes.io/bound-by-controller: yes
Finalizers:      [kubernetes.io/pv-protection]
StorageClass:    gcsfusecsi-inference
Status:          Bound
Claim:           default/my-pvc
Reclaim Policy:  Retain
Access Modes:    RWX
VolumeMode:      Filesystem
Capacity:        10Gi
Node Affinity:   <none>
Message:         
Source:
    Type:              CSI (a Container Storage Interface (CSI) volume source)
    Driver:            gcsfuse.csi.storage.gke.io
    FSType:            
    VolumeHandle:      test-bucket
    ReadOnly:          false
    VolumeAttributes:      bucketScanTTL=1m
                           bucketScanTimeout=30s
Events:
  Type     Reason                       Age   From                 Message
  ----     ------                       ----  ----                 -------
  Normal   ScanOperationStartSucceeded  40s   gke-gcsfuse-scanner  Bucket scan operation starting for PV my-pv, bucket test-bucket, directory '/my-folder/', timeout 30s
  Warning  ScanOperationTimedOut        10s   gke-gcsfuse-scanner  Bucket scan timed out after 30s for bucket test-bucket, directory '/my-folder/'. Updating with partial results. Consider increasing timeout if bucket size is big.
  Normal   ScannerFinished              10s   gke-gcsfuse-scanner  Scanner finished processing PV my-pv, took 30.024545895s
```
2. Invalid `bucketScanTimeout` format informs customer once and blocks scanning:
```
  Warning  ScanOperationStartError  4s    gke-gcsfuse-scanner  Bucket scan timeout configuration error: invalid duration format for bucketScanTimeout: "2x", error: time: unknown unit "x" in duration "2x".
```
3. Invalid `bucketScanTTL` informs customer once and blocks scanning:
```
  Warning  ScanOperationStartError  3m    gke-gcsfuse-scanner  Bucket scan TTL configuration error: invalid duration format for bucketScanTTL: "1x". Error: time: unknown unit "x" in duration "1x".
```


*Expected behavior with this PR*: The controller will log relevance checks, scan operations (simulated), and annotation updates. PVs will be annotated with scan results.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
*   This PR establishes the core logic for the Bucket Scanner, including PV tracking, relevance checks, configurable timeout/TTL, and result annotation.
*   The actual GCS bucket interaction (e.g., using Dataflux or GCS client) is **not yet implemented**; `defaultScanBucket` is a placeholder. This will be added in a follow-up PR.
*   The Pod creation event triggers and leader election features are **not yet implemented**. These will be implemented in subsequent PRs and have TODOs where needed.
*   The feature is intended to be flag-gated (flag not shown in the provided code, but is in the main driver).
*   The provided `scanner.go` and `scanner_test.go` files contain the full implementation and tests for this feature.
*   The next PR will handle "Pod creation trigger", as well as the removal of the scheduling gates. PRs are split to facilitate the review process.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
