### PR TITLE
Bucket scanner controller - Pod creation trigger

### DIFF
--- a/examples/gcsfuse-profiles/pv-pvc-deployment.yaml
+++ b/examples/gcsfuse-profiles/pv-pvc-deployment.yaml
@@ -50,3 +50,45 @@ spec:
       storage: 10Gi
   volumeName: my-pv
   storageClassName: gcsfusecsi-inference 
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-deployment
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: my-app
+  template:
+    metadata:
+      labels:
+        app: my-app
+        # TODO(urielguzman): Remove when mutating webhook injects this.
+        gke-gcsfuse/profile-managed: "true"
+      annotations:
+        gke-gcsfuse/volumes: "true"
+        # Feature flag
+        gke-gcsfuse/profiles: "true"
+    spec:
+      serviceAccountName: my-ksa
+      containers:
+      - name: my-container
+        image: nginx:latest
+        volumeMounts:
+        - name: my-gcs-volume
+          mountPath: "/data/gcs"
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+          requests:
+            cpu: 10m
+            memory: 80Mi
+      volumes:
+      - name: my-gcs-volume
+        persistentVolumeClaim:
+          claimName: my-pvc
+      schedulingGates:
+        # TODO(urielguzman): Remove when mutating webhook injects this.
+        - name: "gke-gcsfuse/bucket-scan-pending"

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -27,13 +27,13 @@ import (
 	"sync"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
-	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
@@ -44,7 +44,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	corev1listers "k8s.io/client-go/listers/core/v1"
+	typedv1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	v1listers "k8s.io/client-go/listers/core/v1"
 	storagelisters "k8s.io/client-go/listers/storage/v1"
 )
 
@@ -76,6 +77,17 @@ const (
 	// Bucket scan status values
 	scanCompleted = "completed"
 	scanTimeout   = "timeout"
+
+	// Key prefixes for workqueue
+	pvPrefix  = "pv/"
+	podPrefix = "pod/"
+
+	// Scheduling Gate
+	schedulingGateName = "gke-gcsfuse/bucket-scan-pending"
+
+	// Label for filtering Pods
+	profileManagedLabelKey   = "gke-gcsfuse/profile-managed"
+	profileManagedLabelValue = "true"
 )
 
 var (
@@ -90,6 +102,9 @@ var (
 
 	// scanBucket is a function to scan the bucket, can be overridden in tests.
 	scanBucket = defaultScanBucket
+
+	// Fake error to signal worker to re-queue the Pod without emitting an error log.
+	errRequeuePod = errors.New("requeuing pod")
 )
 
 // stringPtr returns a pointer to the passed string.
@@ -122,19 +137,34 @@ type bucketInfo struct {
 // Scanner is the main controller structure.
 type Scanner struct {
 	kubeClient    kubernetes.Interface
-	pvLister      corev1listers.PersistentVolumeLister
+	pvLister      v1listers.PersistentVolumeLister
+	pvcLister     v1listers.PersistentVolumeClaimLister
 	scLister      storagelisters.StorageClassLister
+	podLister     v1listers.PodLister
 	pvSynced      cache.InformerSynced
+	pvcSynced     cache.InformerSynced
 	scSynced      cache.InformerSynced
+	podSynced     cache.InformerSynced
 	factory       informers.SharedInformerFactory
+	podFactory    informers.SharedInformerFactory
 	queue         workqueue.TypedRateLimitingInterface[string]
 	eventRecorder record.EventRecorder
+
+	// pvMutex protects trackedPVs.
+	pvMutex sync.RWMutex
 	// Set of PV names being tracked/processed. This is
 	// used to avoid reprocessing if multiple user Pods
 	// trigger a PV addition to the queue.
 	trackedPVs map[string]struct{}
-	// Mutex to protect trackedPVs.
-	pvMutex sync.RWMutex
+
+	// scanMutex protects lastSuccessfulScan.
+	scanMutex sync.RWMutex
+	// Map to track the last successful scan time for each PV in this instance.
+	// This is required because there exists a non-zero time window where a PV
+	// patch may not be reflected in the informer's cache after syncPV processes
+	// and removes the key from trackedPVs, potentially resulting in multiple
+	// scans not seeing the PV's annotationLastUpdatedTime.
+	lastSuccessfulScan map[string]time.Time
 }
 
 // buildConfig creates a Kubernetes rest.Config for the client.
@@ -153,6 +183,35 @@ func buildConfig(kubeconfigPath string) (*rest.Config, error) {
 	}
 	klog.Info("Using In-Cluster Kubeconfig")
 	return cfg, nil
+}
+
+// trimPodObject is a transform function for the Pod informer to reduce memory usage.
+// It keeps only the fields relevant to the scanner logic.
+func trimPodObject(obj any) (any, error) {
+	if accessor, err := meta.Accessor(obj); err == nil {
+		accessor.SetManagedFields(nil)
+	} else {
+		klog.Warningf("Failed to get meta accessor for object: %v", err)
+	}
+
+	podObj, ok := obj.(*v1.Pod)
+	if !ok {
+		return obj, nil
+	}
+
+	// Create a new Pod object with only the fields we need.
+	trimmedPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podObj.ObjectMeta.Name,      // Needed for workqueue key.
+			Namespace: podObj.ObjectMeta.Namespace, // Needed for workqueue key.
+		},
+		Spec: v1.PodSpec{
+			Volumes:         podObj.Spec.Volumes,         // Needed to check PVs requiring scans.
+			SchedulingGates: podObj.Spec.SchedulingGates, // Needed to remove scheduling gates.
+		},
+	}
+
+	return trimmedPod, nil
 }
 
 // NewScanner creates a new Scanner instance.
@@ -174,25 +233,49 @@ func NewScanner(config *ScannerConfig) (*Scanner, error) {
 	if rateLimiter == nil {
 		rateLimiter = workqueue.DefaultTypedControllerRateLimiter[string]()
 	}
+
+	// Factory for PV, PVC and SC informers
 	factory := informers.NewSharedInformerFactory(kubeClient, config.ResyncPeriod)
 	pvInformer := factory.Core().V1().PersistentVolumes()
+	pvcInformer := factory.Core().V1().PersistentVolumeClaims()
 	scInformer := factory.Storage().V1().StorageClasses()
+
+	// Factory for Pod informer with label selector and transform
+	// The label is patched by the mutating webhook.
+	podLabelSelector := fmt.Sprintf("%s=%s", profileManagedLabelKey, profileManagedLabelValue)
+	tweakFunc := func(options *metav1.ListOptions) {
+		options.LabelSelector = podLabelSelector
+	}
+	podFactory := informers.NewSharedInformerFactoryWithOptions(
+		kubeClient,
+		config.ResyncPeriod,
+		informers.WithTweakListOptions(tweakFunc),
+		informers.WithTransform(trimPodObject),
+	)
+	podInformer := podFactory.Core().V1().Pods()
+	klog.Infof("Pod informer configured with label selector: %q and a transform function", podLabelSelector)
 
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartStructuredLogging(0)
-	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: kubeClient.CoreV1().Events("")})
+	eventBroadcaster.StartRecordingToSink(&typedv1.EventSinkImpl{Interface: kubeClient.CoreV1().Events("")})
 	eventRecorder := eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: scannerComponentName})
 
 	scanner := &Scanner{
-		kubeClient:    kubeClient,
-		factory:       factory,
-		pvLister:      pvInformer.Lister(),
-		scLister:      scInformer.Lister(),
-		pvSynced:      pvInformer.Informer().HasSynced,
-		scSynced:      scInformer.Informer().HasSynced,
-		queue:         workqueue.NewTypedRateLimitingQueue(rateLimiter),
-		trackedPVs:    make(map[string]struct{}),
-		eventRecorder: eventRecorder,
+		kubeClient:         kubeClient,
+		factory:            factory,
+		podFactory:         podFactory,
+		pvLister:           pvInformer.Lister(),
+		pvcLister:          pvcInformer.Lister(),
+		scLister:           scInformer.Lister(),
+		podLister:          podInformer.Lister(),
+		pvSynced:           pvInformer.Informer().HasSynced,
+		pvcSynced:          pvcInformer.Informer().HasSynced,
+		scSynced:           scInformer.Informer().HasSynced,
+		podSynced:          podInformer.Informer().HasSynced,
+		queue:              workqueue.NewTypedRateLimitingQueue(rateLimiter),
+		trackedPVs:         make(map[string]struct{}),
+		lastSuccessfulScan: make(map[string]time.Time),
+		eventRecorder:      eventRecorder,
 	}
 
 	klog.Info("Setting up event handlers for PersistentVolumes")
@@ -203,8 +286,11 @@ func NewScanner(config *ScannerConfig) (*Scanner, error) {
 		// will trigger the scanner.
 	})
 
-	// TODO(urielguzman): Add logic to make Pod creation events trigger the scanner
-	// and remove the scheduling gates.
+	klog.Info("Setting up event handlers for Pods")
+	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    scanner.addPod,
+		DeleteFunc: scanner.deletePod,
+	})
 
 	return scanner, nil
 }
@@ -218,9 +304,10 @@ func (s *Scanner) Run(ctx context.Context) {
 
 	klog.Info("Starting informers")
 	s.factory.Start(stopCh)
+	s.podFactory.Start(stopCh)
 
 	klog.Info("Waiting for informer caches to sync")
-	if !cache.WaitForCacheSync(stopCh, s.pvSynced, s.scSynced) {
+	if !cache.WaitForCacheSync(stopCh, s.pvSynced, s.pvcSynced, s.scSynced, s.podSynced) {
 		klog.Error("Failed to wait for caches to sync")
 		return
 	}
@@ -249,22 +336,186 @@ func (s *Scanner) processNextWorkItem(ctx context.Context) bool {
 	}
 	defer s.queue.Done(key)
 
-	klog.V(6).Infof("Processing PV %q", key)
-	err := s.syncPV(ctx, key)
+	var err error
+	syncType := "Unknown"
+	itemKey := key
+
+	if strings.HasPrefix(key, podPrefix) {
+		syncType = "Pod"
+		itemKey = strings.TrimPrefix(key, podPrefix)
+		klog.V(6).Infof("Processing %s %q", syncType, itemKey)
+		err = s.syncPod(ctx, itemKey)
+	} else if strings.HasPrefix(key, pvPrefix) {
+		syncType = "PV"
+		itemKey = strings.TrimPrefix(key, pvPrefix)
+		klog.V(6).Infof("Processing %s %q", syncType, itemKey)
+		err = s.syncPV(ctx, itemKey)
+
+		// PV specific tracking removal
+		if err == nil {
+			s.pvMutex.Lock()
+			if _, exists := s.trackedPVs[itemKey]; exists {
+				klog.V(6).Infof("PV %s finished processing, removing from tracking", itemKey)
+				delete(s.trackedPVs, itemKey)
+			}
+			s.pvMutex.Unlock()
+		}
+	} else {
+		klog.Errorf("Unknown key prefix for %q", key)
+		s.queue.Forget(key)
+		return true
+	}
+
 	if err == nil {
 		s.queue.Forget(key)
-		s.pvMutex.Lock()
-		if _, exists := s.trackedPVs[key]; exists {
-			klog.V(6).Infof("PV %s finished processing, removing from tracking", key)
-			delete(s.trackedPVs, key)
-		}
-		s.pvMutex.Unlock()
-		klog.V(6).Infof("Successfully synced PV %q", key)
+		klog.V(6).Infof("Successfully synced %s %q", syncType, itemKey)
+	} else if errors.Is(err, errRequeuePod) {
+		// Specific requeue signal for Pods waiting on PV scans or PVC binds.
+		// This is not a "true" error, so it doesn't need to be logged as such.
+		klog.Infof("Requeuing %s %q: %v", syncType, itemKey, err)
+		s.queue.AddRateLimited(key)
 	} else {
-		klog.Errorf("Error syncing PV %q: %v", key, err)
+		// All other errors will be requeued with exponential back-off and
+		// logged as errors, e.g. Kubernetes API server or transient errors.
+		klog.Errorf("Error syncing %s %q: %v", syncType, itemKey, err)
 		s.queue.AddRateLimited(key)
 	}
 	return true
+}
+
+// syncPod is the core reconciliation function for a Pod. It checks if any of the
+// Pod's PVs require scanning and removes the Pod's scheduling gate:
+//  1. If any PV requires scanning, both the PVs and the Pod are enqueued to be
+//     handled later. This eventually results in the PV being scanned by syncPV,
+//     and the Pod's scheduling gate being removed by syncPod (step #2).
+//  2. If none of the PVs require scanning, the Pod's scheduling gate is removed,
+//     allowing the Kubernetes scheduler to find a Node for the Pod.
+//
+// The function returns the error `errRequeuePod` if the Pod should be requeued
+// but the error doesn't need to be logged, for example: If the PVC is unbound
+// or the volumes are not scanned yet.
+func (s *Scanner) syncPod(ctx context.Context, key string) error {
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		klog.Errorf("Failed to split meta namespace key %q: %v", key, err)
+		return nil // Don't re-queue bad keys
+	}
+
+	pod, err := s.podLister.Pods(namespace).Get(name)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			klog.Infof("Pod %q in namespace %q has been deleted", name, namespace)
+			return nil
+		}
+		klog.Errorf("Failed to get Pod %q in namespace %q: %v", name, namespace, err)
+		return err
+	}
+
+	klog.Infof("Syncing Pod: %s/%s", pod.Namespace, pod.Name)
+
+	var anyPVRelevant bool
+	var needsRequeue bool
+
+	for _, vol := range pod.Spec.Volumes {
+		if vol.PersistentVolumeClaim == nil {
+			continue
+		}
+
+		pvcName := vol.PersistentVolumeClaim.ClaimName
+		pvc, err := s.pvcLister.PersistentVolumeClaims(namespace).Get(pvcName)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				klog.Warningf("PVC %s/%s for Pod %s not found, will recheck Pod later", namespace, pvcName, key)
+				needsRequeue = true
+				continue
+			}
+			klog.Errorf("Failed to get PVC %s/%s for Pod %s: %v", namespace, pvcName, key, err)
+			return fmt.Errorf("failed to get PVC %s/%s: %w", namespace, pvcName, err) // API server error, retry with backoff
+		}
+
+		pvName := pvc.Spec.VolumeName
+		if pvName == "" {
+			klog.Infof("PVC %s/%s for Pod %s is not bound to a PV yet, requeue Pod to evaluate later", namespace, pvcName, key)
+			needsRequeue = true
+			continue
+		}
+
+		pv, err := s.pvLister.Get(pvName)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				klog.Warningf("PV %s (from PVC %s/%s) for Pod %s not found, this should not happen if PVC is bound", pvName, namespace, pvcName, key)
+				// This state is unexpected, but treat as transient.
+				return fmt.Errorf("PV %s not found: %w", pvName, err)
+			}
+			klog.Errorf("Failed to get PV %s for Pod %s (from PVC %s/%s): %v", pvName, key, namespace, pvcName, err)
+			return fmt.Errorf("failed to get PV %s: %w", pvName, err) // API server error, retry with backoff
+		}
+
+		bucketInfo, err := s.checkPVRelevance(pv)
+		if err != nil {
+			return fmt.Errorf("error checking PV %s relevance for Pod %s: %v", pvName, key, err)
+		}
+
+		if bucketInfo != nil {
+			klog.Infof("Pod %s uses relevant PV %s (PVC %s/%s)", key, pvName, namespace, pvcName)
+			anyPVRelevant = true
+			s.enqueuePVIfNotTracked(pv) // Enqueue the PV for scanning if not already tracked
+		}
+	}
+
+	if anyPVRelevant {
+		klog.Infof("Pod %s uses one or more relevant PVs, will recheck Pod later to ensure scans complete", key)
+		return fmt.Errorf("%w: waiting for PV scans to complete for Pod %s", errRequeuePod, key)
+	}
+
+	if needsRequeue {
+		klog.Infof("Pod %s has unbound or missing PVCs, will recheck Pod later", key)
+		return fmt.Errorf("%w: waiting for PVCs to be ready for Pod %s", errRequeuePod, key)
+	}
+
+	// If no PVs are relevant and no other reason to requeue, remove the scheduling gate
+	return s.removeSchedulingGate(ctx, pod)
+}
+
+func (s *Scanner) removeSchedulingGate(ctx context.Context, pod *v1.Pod) error {
+	var newGates []v1.PodSchedulingGate
+	gateFound := false
+	for _, gate := range pod.Spec.SchedulingGates {
+		if gate.Name == schedulingGateName {
+			gateFound = true
+		} else {
+			newGates = append(newGates, gate)
+		}
+	}
+
+	if !gateFound {
+		klog.V(6).Infof("Scheduling gate %s not found on Pod %s/%s", schedulingGateName, pod.Namespace, pod.Name)
+		return nil // Nothing to do
+	}
+
+	klog.Infof("Removing scheduling gate %s from Pod %s/%s", schedulingGateName, pod.Namespace, pod.Name)
+
+	patchData := map[string]any{
+		"spec": map[string]any{
+			"schedulingGates": newGates,
+		},
+	}
+	patchBytes, err := json.Marshal(patchData)
+	if err != nil {
+		return fmt.Errorf("failed to marshal patch data for Pod %s/%s: %w", pod.Namespace, pod.Name, err)
+	}
+
+	_, err = s.kubeClient.CoreV1().Pods(pod.Namespace).Patch(ctx, pod.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			klog.Warningf("Failed to patch Pod %s/%s because it was not found", pod.Namespace, pod.Name)
+			return nil
+		}
+		return fmt.Errorf("failed to patch Pod %s/%s to remove scheduling gate: %w", pod.Namespace, pod.Name, err)
+	}
+
+	klog.Infof("Successfully removed scheduling gate %s from Pod %s/%s", schedulingGateName, pod.Namespace, pod.Name)
+	return nil
 }
 
 func (s *Scanner) getDurationAttribute(pv *v1.PersistentVolume, attributeKey string, defaultDuration time.Duration) (*time.Duration, error) {
@@ -423,12 +674,14 @@ func (s *Scanner) patchPVAnnotations(ctx context.Context, pvName string, annotat
 
 // updatePVScanResult updates the PV annotations with the results of a bucket scan.
 // It sets the status, number of objects, total size, HNS status, and last updated time.
+// It also updates the in-memory lastSuccessfulScan map.
 func (s *Scanner) updatePVScanResult(ctx context.Context, pv *v1.PersistentVolume, info *bucketInfo, status string) error {
+	currentTime := timeNow()
 	annotationsToUpdate := map[string]*string{
 		annotationStatus:          stringPtr(status),
 		annotationNumObjects:      int64Ptr(info.numObjects),
 		annotationTotalSize:       int64Ptr(info.totalSizeBytes),
-		annotationLastUpdatedTime: stringPtr(timeNow().UTC().Format(time.RFC3339)),
+		annotationLastUpdatedTime: stringPtr(currentTime.UTC().Format(time.RFC3339)),
 		annotationHNSEnabled:      boolPtr(info.isHNSEnabled),
 	}
 	klog.Infof("Updating PV %s with scan result: %+v, status: %s", pv.Name, info, status)
@@ -438,6 +691,14 @@ func (s *Scanner) updatePVScanResult(ctx context.Context, pv *v1.PersistentVolum
 		return err
 	}
 	klog.Infof("Successfully updated annotations on PV %s with status %s", pv.Name, status)
+
+	// Update in-memory map only on terminal state updates.
+	if status == scanCompleted || status == scanTimeout {
+		s.scanMutex.Lock()
+		s.lastSuccessfulScan[pv.Name] = currentTime
+		s.scanMutex.Unlock()
+		klog.V(6).Infof("Updated lastSuccessfulScan map for PV %s to %s", pv.Name, currentTime)
+	}
 	return nil
 }
 
@@ -495,20 +756,43 @@ func (s *Scanner) checkPVRelevance(pv *v1.PersistentVolume) (*bucketInfo, error)
 		s.eventRecorder.Eventf(pv, v1.EventTypeWarning, reasonScanOperationStartError, "Bucket scan TTL configuration error: %v", err)
 		return nil, nil // Avoid re-queuing on static customer misconfig.
 	}
-	if lastUpdatedTimeStr, ok := pv.Annotations[annotationLastUpdatedTime]; ok {
-		lastUpdatedTime, err := time.Parse(time.RFC3339, lastUpdatedTimeStr)
-		if err != nil {
-			klog.Warningf("PV %s: Failed to parse annotation %s value %q: %v. Proceeding with scan", pv.Name, annotationLastUpdatedTime, lastUpdatedTimeStr, err)
-		} else {
-			elapsed := timeNow().Sub(lastUpdatedTime)
-			if elapsed < *currentScanTTL {
-				klog.Infof("PV %s: Skipping scan, only %s elapsed since last scan, which is less than TTL %s", pv.Name, elapsed.Round(time.Second), currentScanTTL)
-				return nil, nil
+
+	var lastScanTime time.Time
+	found := false
+	source := ""
+
+	s.scanMutex.RLock()
+	if lastTime, ok := s.lastSuccessfulScan[pv.Name]; ok {
+		lastScanTime = lastTime
+		found = true
+		source = "memory"
+		klog.V(6).Infof("PV %s: Found last scan time in memory: %s", pv.Name, lastScanTime)
+	}
+	s.scanMutex.RUnlock()
+
+	if !found {
+		if lastUpdatedTimeStr, ok := pv.Annotations[annotationLastUpdatedTime]; ok {
+			parsedTime, err := time.Parse(time.RFC3339, lastUpdatedTimeStr)
+			if err != nil {
+				klog.Warningf("PV %s: Failed to parse annotation %s value %q: %v. Assuming no recent scan", pv.Name, annotationLastUpdatedTime, lastUpdatedTimeStr, err)
+			} else {
+				lastScanTime = parsedTime
+				found = true
+				source = "annotation"
+				klog.V(6).Infof("PV %s: Found last scan time in annotations: %s", pv.Name, lastScanTime)
 			}
-			klog.V(6).Infof("PV %s: Proceeding with scan, %s elapsed since last scan, TTL is %s", pv.Name, elapsed.Round(time.Second), currentScanTTL)
 		}
+	}
+
+	if found {
+		elapsed := timeNow().Sub(lastScanTime)
+		if elapsed < *currentScanTTL {
+			klog.Infof("PV %s: Skipping scan, only %s elapsed since last scan (source: %s), which is less than TTL %s", pv.Name, elapsed.Round(time.Second), source, currentScanTTL)
+			return nil, nil
+		}
+		klog.V(6).Infof("PV %s: Proceeding with scan, %s elapsed since last scan (source: %s), TTL is %s", pv.Name, elapsed.Round(time.Second), source, currentScanTTL)
 	} else {
-		klog.V(6).Infof("PV %s: No last updated time annotation found. Proceeding with scan", pv.Name)
+		klog.V(6).Infof("PV %s: No last scan time found in memory or annotations. Proceeding with scan", pv.Name)
 	}
 
 	bucketName := pv.Spec.CSI.VolumeHandle
@@ -542,7 +826,21 @@ func (s *Scanner) enqueuePV(pv *v1.PersistentVolume) {
 		return
 	}
 	klog.V(6).Infof("Enqueuing PV %q", key)
-	s.queue.Add(key)
+	s.queue.Add(pvPrefix + key)
+}
+
+// enqueuePVIfNotTracked enqueues a PersistentVolume if it's not already tracked.
+func (s *Scanner) enqueuePVIfNotTracked(pv *v1.PersistentVolume) {
+	s.pvMutex.Lock()
+	defer s.pvMutex.Unlock()
+
+	if _, isTracked := s.trackedPVs[pv.Name]; !isTracked {
+		s.trackedPVs[pv.Name] = struct{}{}
+		klog.V(6).Infof("PV %s: Not tracked, enqueuing for scan", pv.Name)
+		s.enqueuePV(pv)
+	} else {
+		klog.V(6).Infof("PV %s: Already tracked, skipping enqueue", pv.Name)
+	}
 }
 
 // addPV is the add event handler for PersistentVolumes.
@@ -568,16 +866,7 @@ func (s *Scanner) handlePVEvent(pv *v1.PersistentVolume, eventType string) {
 		return
 	}
 
-	s.pvMutex.Lock()
-	defer s.pvMutex.Unlock()
-
-	if _, isTracked := s.trackedPVs[pv.Name]; !isTracked {
-		s.trackedPVs[pv.Name] = struct{}{}
-		klog.V(6).Infof("PV %s: %s - New relevant PV. Enqueuing for scan", eventType, pv.Name)
-		s.enqueuePV(pv)
-	} else {
-		klog.V(6).Infof("PV %s: %s - Already tracked. No action", eventType, pv.Name)
-	}
+	s.enqueuePVIfNotTracked(pv)
 }
 
 // deletePV is the event handler for PersistentVolume Delete events.
@@ -607,6 +896,62 @@ func (s *Scanner) deletePV(obj any) {
 		s.pvMutex.Lock()
 		delete(s.trackedPVs, key)
 		s.pvMutex.Unlock()
-		s.queue.Forget(key)
+
+		s.scanMutex.Lock()
+		delete(s.lastSuccessfulScan, key)
+		s.scanMutex.Unlock()
+		klog.V(6).Infof("Removed PV %s from lastSuccessfulScan map", key)
+
+		s.queue.Forget(pvPrefix + key)
 	}
+}
+
+// addPod is the add event handler for Pods.
+func (s *Scanner) addPod(obj any) {
+	pod, ok := obj.(*v1.Pod)
+	if !ok {
+		klog.Errorf("AddFunc Pod: Expected Pod but got %T", obj)
+		return
+	}
+	klog.V(6).Infof("Pod ADDED: %s/%s", pod.Namespace, pod.Name)
+	s.enqueuePod(pod)
+}
+
+// deletePod is the event handler for Pod Delete events.
+func (s *Scanner) deletePod(obj any) {
+	pod, ok := obj.(*v1.Pod)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			klog.Errorf("DeleteFunc Pod: Expected Pod or Tombstone but got %T", obj)
+			return
+		}
+		pod, ok = tombstone.Obj.(*v1.Pod)
+		if !ok {
+			klog.Errorf("DeleteFunc Pod: Expected Pod in Tombstone but got %T", tombstone.Obj)
+			return
+		}
+		klog.V(6).Infof("Pod TOMBSTONE: %s/%s", pod.Namespace, pod.Name)
+	} else {
+		klog.V(6).Infof("Pod DELETED: %s/%s", pod.Namespace, pod.Name)
+	}
+
+	key, err := cache.MetaNamespaceKeyFunc(pod)
+	if err != nil {
+		klog.Errorf("DeleteFunc Pod: Error mapping key from object: %v", err)
+		return
+	}
+	klog.V(6).Infof("Forgetting Pod %q from queue", key)
+	s.queue.Forget(podPrefix + key)
+}
+
+// enqueuePod enqueues a Pod.
+func (s *Scanner) enqueuePod(pod *v1.Pod) {
+	key, err := cache.MetaNamespaceKeyFunc(pod)
+	if err != nil {
+		runtime.HandleError(fmt.Errorf("couldn't get key for object %#v: %w", pod, err))
+		return
+	}
+	klog.V(6).Infof("Enqueuing Pod %q", key)
+	s.queue.Add(podPrefix + key)
 }

--- a/pkg/scanner/scanner_test.go
+++ b/pkg/scanner/scanner_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
@@ -34,6 +35,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	storagelisters "k8s.io/client-go/listers/storage/v1"
@@ -43,6 +45,9 @@ import (
 const (
 	testSCName            = "test-storage-class"
 	testPVName            = "test-pv"
+	testPVCName           = "test-pvc"
+	testPodName           = "test-pod"
+	testNamespace         = "default"
 	testBucketName        = "test-bucket"
 	testDirName           = "test-dir"
 	oldAnnotationKey      = "old"
@@ -54,6 +59,13 @@ const (
 var (
 	validSCParams = map[string]string{paramWorkloadTypeKey: paramWorkloadTypeInferenceKey}
 	validSC       = createStorageClass(testSCName, validSCParams)
+	podLabels     = map[string]string{profileManagedLabelKey: profileManagedLabelValue}
+	scanResult    = &bucketInfo{
+		name:           testBucketName,
+		numObjects:     1234,
+		totalSizeBytes: 567890,
+		isHNSEnabled:   true,
+	}
 )
 
 // mockTime allows controlling the time in tests.
@@ -94,7 +106,9 @@ type testFixture struct {
 	scanner      *Scanner
 	kubeClient   *fake.Clientset
 	pvLister     corelisters.PersistentVolumeLister
+	pvcLister    corelisters.PersistentVolumeClaimLister
 	scLister     storagelisters.StorageClassLister
+	podLister    corelisters.PodLister
 	recorder     *record.FakeRecorder
 	mockTimeImpl *mockTime
 	scanBucketFn *fakeScanBucketFunc
@@ -106,9 +120,25 @@ func newTestFixture(t *testing.T, initialObjects ...runtime.Object) *testFixture
 	t.Helper()
 
 	kubeClient := fake.NewSimpleClientset(initialObjects...)
+
+	// Factory for PV, PVC and SC informers
 	factory := informers.NewSharedInformerFactory(kubeClient, 0 /* no resync period */)
 	pvInformer := factory.Core().V1().PersistentVolumes()
+	pvcInformer := factory.Core().V1().PersistentVolumeClaims()
 	scInformer := factory.Storage().V1().StorageClasses()
+
+	// Factory for Pod informer
+	podLabelSelector := fmt.Sprintf("%s=%s", profileManagedLabelKey, profileManagedLabelValue)
+	tweakFunc := func(options *metav1.ListOptions) {
+		options.LabelSelector = podLabelSelector
+	}
+	podFactory := informers.NewSharedInformerFactoryWithOptions(
+		kubeClient,
+		0, // No resync period for tests
+		informers.WithTweakListOptions(tweakFunc),
+		informers.WithTransform(trimPodObject),
+	)
+	podInformer := podFactory.Core().V1().Pods()
 
 	// Manually add initial objects to the informer indexers to ensure they are available in listers.
 	for _, obj := range initialObjects {
@@ -117,9 +147,22 @@ func newTestFixture(t *testing.T, initialObjects ...runtime.Object) *testFixture
 			if err := pvInformer.Informer().GetIndexer().Add(obj); err != nil {
 				t.Fatalf("Failed to add PV to indexer: %v", err)
 			}
+		case *v1.PersistentVolumeClaim:
+			if err := pvcInformer.Informer().GetIndexer().Add(obj); err != nil {
+				t.Fatalf("Failed to add PVC to indexer: %v", err)
+			}
 		case *storagev1.StorageClass:
 			if err := scInformer.Informer().GetIndexer().Add(obj); err != nil {
 				t.Fatalf("Failed to add SC to indexer: %v", err)
+			}
+		case *v1.Pod:
+			// Must apply transform before adding to indexer to mimic real behavior
+			trimmedObj, err := trimPodObject(obj)
+			if err != nil {
+				t.Fatalf("Failed to transform Pod: %v", err)
+			}
+			if err := podInformer.Informer().GetIndexer().Add(trimmedObj); err != nil {
+				t.Fatalf("Failed to add Pod to indexer: %v", err)
 			}
 		}
 	}
@@ -142,19 +185,26 @@ func newTestFixture(t *testing.T, initialObjects ...runtime.Object) *testFixture
 
 	// Create the Scanner instance with fake/mock components.
 	s := &Scanner{
-		kubeClient:    kubeClient,
-		pvLister:      pvInformer.Lister(),
-		scLister:      scInformer.Lister(),
-		pvSynced:      pvInformer.Informer().HasSynced,
-		scSynced:      scInformer.Informer().HasSynced,
-		factory:       factory,
-		queue:         workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()),
-		eventRecorder: recorder,
-		trackedPVs:    make(map[string]struct{}),
+		kubeClient:         kubeClient,
+		pvLister:           pvInformer.Lister(),
+		pvcLister:          pvcInformer.Lister(),
+		scLister:           scInformer.Lister(),
+		podLister:          podInformer.Lister(),
+		pvSynced:           pvInformer.Informer().HasSynced,
+		pvcSynced:          pvcInformer.Informer().HasSynced,
+		scSynced:           scInformer.Informer().HasSynced,
+		podSynced:          podInformer.Informer().HasSynced,
+		factory:            factory,
+		podFactory:         podFactory,
+		queue:              workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()),
+		eventRecorder:      recorder,
+		trackedPVs:         make(map[string]struct{}),
+		lastSuccessfulScan: make(map[string]time.Time),
 	}
 
 	factory.Start(stopCh)
-	if !cache.WaitForCacheSync(stopCh, s.pvSynced, s.scSynced) {
+	podFactory.Start(stopCh)
+	if !cache.WaitForCacheSync(stopCh, s.pvSynced, s.pvcSynced, s.scSynced, s.podSynced) {
 		t.Fatalf("Failed to sync caches")
 	}
 
@@ -162,7 +212,9 @@ func newTestFixture(t *testing.T, initialObjects ...runtime.Object) *testFixture
 		scanner:      s,
 		kubeClient:   kubeClient,
 		pvLister:     pvInformer.Lister(),
+		pvcLister:    pvcInformer.Lister(),
 		scLister:     scInformer.Lister(),
+		podLister:    podInformer.Lister(),
 		recorder:     recorder,
 		mockTimeImpl: mt,
 		scanBucketFn: fsb,
@@ -197,9 +249,50 @@ func createPV(name, scName, volumeHandle, driver string, mountOptions []string, 
 	}
 }
 
-// TestCheckPVRelevance tests the checkPVRelevance function.
-// This function determines if a PersistentVolume is relevant for scanning based on its StorageClass,
-// annotations, and other properties.
+// createPVC is a helper function to create a PersistentVolumeClaim object.
+func createPVC(name, namespace, pvName, scName string) *v1.PersistentVolumeClaim {
+	spec := v1.PersistentVolumeClaimSpec{
+		AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteMany},
+		Resources: v1.VolumeResourceRequirements{
+			Requests: v1.ResourceList{
+				v1.ResourceStorage: *resource.NewQuantity(1, resource.BinarySI),
+			},
+		},
+	}
+	if pvName != "" {
+		spec.VolumeName = pvName
+	}
+	if scName != "" {
+		spec.StorageClassName = &scName
+	}
+
+	return &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: spec,
+	}
+}
+
+// createPod is a helper function to create a Pod object.
+func createPod(name, namespace string, volumes []v1.Volume, labels map[string]string, withGate bool) *v1.Pod {
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Spec: v1.PodSpec{
+			Volumes: volumes,
+		},
+	}
+	if withGate {
+		pod.Spec.SchedulingGates = []v1.PodSchedulingGate{{Name: schedulingGateName}}
+	}
+	return pod
+}
+
 func TestCheckPVRelevance(t *testing.T) {
 	now := time.Date(2025, time.August, 27, 0, 0, 0, 0, time.UTC)
 	ttl := defaultScanTTLDuration
@@ -331,80 +424,82 @@ func TestCheckPVRelevance(t *testing.T) {
 	}
 }
 
-// TestProcessNextWorkItem tests the processNextWorkItem function.
-// This function processes items from the work queue, triggering the scan and update logic.
-func TestProcessNextWorkItem(t *testing.T) {
+// TestSyncPV tests the syncPV function.
+func TestSyncPV(t *testing.T) {
 	pvName := testPVName
 	scName := testSCName
 	bucketName := testBucketName
 	basePV := createPV(pvName, scName, bucketName, csiDriverName, nil, nil, nil)
 	relevantSC := createStorageClass(scName, validSCParams)
-
-	scanResult := &bucketInfo{
-		name:           bucketName,
-		numObjects:     1234,
-		totalSizeBytes: 567890,
-		isHNSEnabled:   true,
-	}
+	irrelevantSC := createStorageClass("irrelevant-sc", map[string]string{"some": "param"})
+	pvIrrelevantSC := createPV("irrelevant-pv", "irrelevant-sc", bucketName, csiDriverName, nil, nil, nil)
 
 	testCases := []struct {
 		name           string
-		initialPV      *v1.PersistentVolume
+		key            string
+		initialObjects []runtime.Object
 		scanInfo       *bucketInfo
 		scanErr        error
-		timeoutErr     bool
 		patchErr       error
-		expectRequeue  bool
+		wantErr        bool
 		expectAnnotate bool
 		expectedStatus string
 	}{
 		{
 			name:           "Successful Sync",
-			initialPV:      basePV.DeepCopy(),
+			key:            pvName,
+			initialObjects: []runtime.Object{basePV.DeepCopy(), relevantSC},
 			scanInfo:       scanResult,
-			expectRequeue:  false,
+			wantErr:        false,
 			expectAnnotate: true,
 			expectedStatus: scanCompleted,
 		},
 		{
-			name:          "Sync Failure - Scan Error",
-			initialPV:     basePV.DeepCopy(),
-			scanErr:       fmt.Errorf("scan failed"),
-			expectRequeue: true,
+			name:           "Scan Error",
+			key:            pvName,
+			initialObjects: []runtime.Object{basePV.DeepCopy(), relevantSC},
+			scanErr:        fmt.Errorf("scan failed"),
+			wantErr:        true,
 		},
 		{
-			name:           "Sync Failure - Scan Timeout",
-			initialPV:      basePV.DeepCopy(),
+			name:           "Scan Timeout",
+			key:            pvName,
+			initialObjects: []runtime.Object{basePV.DeepCopy(), relevantSC},
 			scanInfo:       scanResult,
-			timeoutErr:     true,
-			expectRequeue:  false,
+			scanErr:        context.DeadlineExceeded,
+			wantErr:        false,
 			expectAnnotate: true,
 			expectedStatus: scanTimeout,
 		},
 		{
-			name:          "Sync Failure - Patch Error",
-			initialPV:     basePV.DeepCopy(),
-			scanInfo:      scanResult,
-			patchErr:      fmt.Errorf("patch failed"),
-			expectRequeue: true,
+			name:           "Patch Error",
+			key:            pvName,
+			initialObjects: []runtime.Object{basePV.DeepCopy(), relevantSC},
+			scanInfo:       scanResult,
+			patchErr:       fmt.Errorf("patch failed"),
+			wantErr:        true,
+		},
+		{
+			name:           "PV Not Found",
+			key:            pvName,
+			initialObjects: []runtime.Object{relevantSC},
+			wantErr:        false, // Not found is not an error for syncPV, just stops processing.
+		},
+		{
+			name:           "PV Not Relevant",
+			key:            "irrelevant-pv",
+			initialObjects: []runtime.Object{pvIrrelevantSC, irrelevantSC},
+			wantErr:        false,
+			expectAnnotate: false,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			var objs []runtime.Object
-			objs = append(objs, relevantSC)
-			if tc.initialPV != nil {
-				objs = append(objs, tc.initialPV)
-			}
-			f := newTestFixture(t, objs...)
+			f := newTestFixture(t, tc.initialObjects...)
 
 			f.scanBucketFn.info = tc.scanInfo
-			if tc.timeoutErr {
-				f.scanBucketFn.err = context.DeadlineExceeded
-			} else {
-				f.scanBucketFn.err = tc.scanErr
-			}
+			f.scanBucketFn.err = tc.scanErr
 
 			if tc.patchErr != nil {
 				f.kubeClient.PrependReactor("patch", "persistentvolumes", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
@@ -412,28 +507,14 @@ func TestProcessNextWorkItem(t *testing.T) {
 				})
 			}
 
-			key, _ := cache.MetaNamespaceKeyFunc(tc.initialPV)
-			f.scanner.enqueuePV(tc.initialPV)
+			err := f.scanner.syncPV(context.Background(), tc.key)
 
-			if !f.scanner.processNextWorkItem(context.Background()) {
-				t.Errorf("processNextWorkItem returned false, expected true")
+			if tc.wantErr != (err != nil) {
+				t.Errorf("syncPV(%s) returned error: %v, wantErr: %v", tc.key, err, tc.wantErr)
 			}
 
-			// Check if the item was requeued as expected.
-			numRequeues := f.scanner.queue.NumRequeues(key)
-			if tc.expectRequeue {
-				if numRequeues == 0 {
-					t.Errorf("Expected key %q to be requeued, got %d requeues", key, numRequeues)
-				}
-			} else {
-				if numRequeues > 0 {
-					t.Errorf("Expected key %q not to be requeued, got %d requeues", key, numRequeues)
-				}
-			}
-
-			// Check if PV annotations were updated as expected.
 			if tc.expectAnnotate {
-				updatedPV, err := f.kubeClient.CoreV1().PersistentVolumes().Get(context.Background(), pvName, metav1.GetOptions{})
+				updatedPV, err := f.kubeClient.CoreV1().PersistentVolumes().Get(context.Background(), tc.key, metav1.GetOptions{})
 				if err != nil {
 					t.Fatalf("Failed to get PV: %v", err)
 				}
@@ -445,6 +526,282 @@ func TestProcessNextWorkItem(t *testing.T) {
 				}
 				if _, exists := updatedPV.Annotations[annotationLastUpdatedTime]; !exists {
 					t.Errorf("Annotation %s not found", annotationLastUpdatedTime)
+				}
+			}
+		})
+	}
+}
+
+// TestSyncPod tests the syncPod function.
+func TestSyncPod(t *testing.T) {
+	// Common resources
+	pvRelevant := createPV(testPVName, testSCName, testBucketName, csiDriverName, nil, nil, nil)
+	pvNotRelevant := createPV("pv-not-relevant", "sc-not-relevant", testBucketName, "other-driver", nil, nil, nil)
+	scValid := createStorageClass(testSCName, validSCParams)
+	scNotRelevant := createStorageClass("sc-not-relevant", nil)
+	pvcBoundRelevant := createPVC(testPVCName, testNamespace, testPVName, testSCName)
+	pvcBoundNotRelevant := createPVC("pvc-not-relevant", testNamespace, "pv-not-relevant", "sc-not-relevant")
+	pvcUnbound := createPVC("pvc-unbound", testNamespace, "", testSCName)
+
+	volRelevant := v1.Volume{Name: "vol1", VolumeSource: v1.VolumeSource{PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{ClaimName: testPVCName}}}
+	volNotRelevant := v1.Volume{Name: "vol2", VolumeSource: v1.VolumeSource{PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{ClaimName: "pvc-not-relevant"}}}
+	volUnbound := v1.Volume{Name: "vol3", VolumeSource: v1.VolumeSource{PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{ClaimName: "pvc-unbound"}}}
+	volMissingPVC := v1.Volume{Name: "vol4", VolumeSource: v1.VolumeSource{PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{ClaimName: "pvc-missing"}}}
+
+	testCases := []struct {
+		name              string
+		pod               *v1.Pod
+		initialObjects    []runtime.Object
+		expectRequeueErr  bool
+		wantErr           bool
+		expectGateRemoved bool
+		expectPVEnqueued  string
+	}{
+		{
+			name:              "Pod with no volumes, gate removed",
+			pod:               createPod(testPodName, testNamespace, nil, podLabels, true),
+			initialObjects:    []runtime.Object{},
+			expectGateRemoved: true,
+		},
+		{
+			name:             "Pod with relevant PV, PV enqueued, Pod requeued",
+			pod:              createPod(testPodName, testNamespace, []v1.Volume{volRelevant}, podLabels, true),
+			initialObjects:   []runtime.Object{pvRelevant, scValid, pvcBoundRelevant},
+			expectRequeueErr: true,
+			expectPVEnqueued: testPVName,
+		},
+		{
+			name:              "Pod with irrelevant PV, gate removed",
+			pod:               createPod(testPodName, testNamespace, []v1.Volume{volNotRelevant}, podLabels, true),
+			initialObjects:    []runtime.Object{pvNotRelevant, scNotRelevant, pvcBoundNotRelevant},
+			expectGateRemoved: true,
+		},
+		{
+			name:             "Pod with mixed PVs (relevant and not), PV enqueued, Pod requeued",
+			pod:              createPod(testPodName, testNamespace, []v1.Volume{volNotRelevant, volRelevant}, podLabels, true),
+			initialObjects:   []runtime.Object{pvRelevant, scValid, pvcBoundRelevant, pvNotRelevant, scNotRelevant, pvcBoundNotRelevant},
+			expectRequeueErr: true,
+			expectPVEnqueued: testPVName,
+		},
+		{
+			name:             "Pod with unbound PVC, Pod requeued",
+			pod:              createPod(testPodName, testNamespace, []v1.Volume{volUnbound}, podLabels, true),
+			initialObjects:   []runtime.Object{pvcUnbound},
+			expectRequeueErr: true,
+		},
+		{
+			name:             "Pod with missing PVC, Pod requeued",
+			pod:              createPod(testPodName, testNamespace, []v1.Volume{volMissingPVC}, podLabels, true),
+			initialObjects:   []runtime.Object{},
+			expectRequeueErr: true,
+		},
+		{
+			name:           "Pod not found, no error",
+			pod:            createPod("other-pod", testNamespace, nil, podLabels, false),
+			initialObjects: []runtime.Object{},
+		},
+		{
+			name:             "PVC found, but PV not found (error)",
+			pod:              createPod(testPodName, testNamespace, []v1.Volume{volRelevant}, podLabels, true),
+			initialObjects:   []runtime.Object{pvcBoundRelevant},
+			wantErr:          true,
+			expectRequeueErr: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			allObjects := tc.initialObjects
+			// Add the pod to initialObjects only if it's the one being tested
+			if tc.pod.Name == testPodName {
+				allObjects = append(allObjects, tc.pod)
+			}
+			f := newTestFixture(t, allObjects...)
+
+			key, _ := cache.MetaNamespaceKeyFunc(tc.pod)
+			err := f.scanner.syncPod(context.Background(), key)
+
+			hasErr := err != nil
+			if hasErr != (tc.wantErr || tc.expectRequeueErr) {
+				t.Errorf("syncPod(%s) returned error: %v, wantErr: %v, wantRequeueErr: %v", key, err, tc.wantErr, tc.expectRequeueErr)
+			}
+
+			if err != nil {
+				isRequeueErr := errors.Is(err, errRequeuePod)
+				if isRequeueErr != tc.expectRequeueErr {
+					t.Errorf("syncPod(%s) error type: got requeue %v, want requeue %v (err: %v)", key, isRequeueErr, tc.expectRequeueErr, err)
+				}
+			}
+
+			if tc.expectPVEnqueued != "" {
+				pvKey := pvPrefix + tc.expectPVEnqueued
+				found := false
+				for i := 0; i < f.scanner.queue.Len(); i++ {
+					item, _ := f.scanner.queue.Get()
+					if item == pvKey {
+						found = true
+					}
+					f.scanner.queue.Done(item)
+				}
+				if !found {
+					t.Errorf("Expected PV %s to be enqueued, but not found in queue", tc.expectPVEnqueued)
+				}
+			}
+
+			if tc.expectGateRemoved {
+				updatedPod, err := f.kubeClient.CoreV1().Pods(testNamespace).Get(context.Background(), testPodName, metav1.GetOptions{})
+				if err != nil {
+					t.Fatalf("Failed to get Pod: %v", err)
+				}
+				gateExists := false
+				for _, gate := range updatedPod.Spec.SchedulingGates {
+					if gate.Name == schedulingGateName {
+						gateExists = true
+						break
+					}
+				}
+				if gateExists {
+					t.Errorf("Scheduling gate %s was not removed from Pod %s", schedulingGateName, key)
+				}
+			}
+		})
+	}
+}
+
+// TestProcessNextWorkItem tests the processNextWorkItem function.
+func TestProcessNextWorkItem(t *testing.T) {
+	pvName := testPVName
+	podName := testPodName
+	namespace := testNamespace
+
+	pvKey, _ := cache.MetaNamespaceKeyFunc(createPV(pvName, "", "", "", nil, nil, nil))
+	podKey, _ := cache.MetaNamespaceKeyFunc(createPod(podName, namespace, nil, nil, false))
+	pvQueueKey := pvPrefix + pvKey
+	podQueueKey := podPrefix + podKey
+
+	// PV related objects
+	pvRelevant := createPV(pvName, testSCName, testBucketName, csiDriverName, nil, nil, nil)
+	scValid := createStorageClass(testSCName, validSCParams)
+
+	// Pod related objects
+	pvcForPod := createPVC(testPVCName, namespace, pvName, testSCName)
+	volForPod := v1.Volume{Name: "vol1", VolumeSource: v1.VolumeSource{PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{ClaimName: testPVCName}}}
+	podRelevant := createPod(podName, namespace, []v1.Volume{volForPod}, podLabels, true)
+
+	testCases := []struct {
+		name              string
+		keyToAdd          string
+		initialObjects    []runtime.Object
+		scanInfo          *bucketInfo // For PV sync
+		scanErr           error       // For PV sync
+		patchErr          error       // For PV or Pod sync
+		expectRequeue     bool
+		expectAnnotate    bool   // For PV sync
+		expectedStatus    string // For PV sync
+		expectGateRemoved bool   // For Pod sync
+	}{
+		// PV Key Tests
+		{
+			name:           "PV Sync Successful",
+			keyToAdd:       pvQueueKey,
+			initialObjects: []runtime.Object{pvRelevant, scValid},
+			scanInfo:       scanResult,
+			expectRequeue:  false,
+			expectAnnotate: true,
+			expectedStatus: scanCompleted,
+		},
+		{
+			name:           "PV Sync Scan Error",
+			keyToAdd:       pvQueueKey,
+			initialObjects: []runtime.Object{pvRelevant, scValid},
+			scanErr:        fmt.Errorf("scan failed"),
+			expectRequeue:  true,
+		},
+		{
+			name:           "PV Sync Patch Error",
+			keyToAdd:       pvQueueKey,
+			initialObjects: []runtime.Object{pvRelevant, scValid},
+			scanInfo:       scanResult,
+			patchErr:       fmt.Errorf("patch failed"),
+			expectRequeue:  true,
+		},
+		// Pod Key Tests
+		{
+			name:              "Pod Sync Successful - Gate Removed",
+			keyToAdd:          podQueueKey,
+			initialObjects:    []runtime.Object{createPod(podName, namespace, nil, podLabels, true)}, // No volumes, gate should be removed
+			expectRequeue:     false,
+			expectGateRemoved: true,
+		},
+		{
+			name:           "Pod Sync Requeue - Relevant PV",
+			keyToAdd:       podQueueKey,
+			initialObjects: []runtime.Object{podRelevant, pvcForPod, pvRelevant, scValid},
+			expectRequeue:  true, // Pod requeued because PV needs scan
+		},
+		{
+			name:          "Unknown Key Prefix",
+			keyToAdd:      "unknown/" + pvKey,
+			expectRequeue: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newTestFixture(t, tc.initialObjects...)
+
+			// Setup for PV sync parts
+			f.scanBucketFn.info = tc.scanInfo
+			f.scanBucketFn.err = tc.scanErr
+
+			if tc.patchErr != nil {
+				f.kubeClient.PrependReactor("patch", "*", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, nil, tc.patchErr
+				})
+			}
+
+			f.scanner.queue.Add(tc.keyToAdd)
+
+			if !f.scanner.processNextWorkItem(context.Background()) {
+				t.Fatalf("processNextWorkItem returned false, expected true")
+			}
+
+			// Check requeue status
+			numRequeues := f.scanner.queue.NumRequeues(tc.keyToAdd)
+			wasRequeued := numRequeues > 0
+			if tc.expectRequeue != wasRequeued {
+				t.Errorf("Key %q requeue status: got %v (requeues: %d), want %v", tc.keyToAdd, wasRequeued, numRequeues, tc.expectRequeue)
+			}
+
+			// Check PV annotations if expected
+			if tc.expectAnnotate {
+				updatedPV, err := f.kubeClient.CoreV1().PersistentVolumes().Get(context.Background(), pvName, metav1.GetOptions{})
+				if err != nil {
+					t.Fatalf("Failed to get PV: %v", err)
+				}
+				if status := updatedPV.Annotations[annotationStatus]; status != tc.expectedStatus {
+					t.Errorf("Annotation %s: got %v, want %v", annotationStatus, status, tc.expectedStatus)
+				}
+			}
+
+			// Check Pod gate removal if expected
+			if tc.expectGateRemoved {
+				updatedPod, err := f.kubeClient.CoreV1().Pods(namespace).Get(context.Background(), podName, metav1.GetOptions{})
+				if err != nil {
+					if apierrors.IsNotFound(err) {
+						t.Fatalf("Pod %s not found, but expected to exist for gate check", podName)
+					}
+					t.Fatalf("Failed to get Pod: %v", err)
+				}
+				gateExists := false
+				for _, gate := range updatedPod.Spec.SchedulingGates {
+					if gate.Name == schedulingGateName {
+						gateExists = true
+						break
+					}
+				}
+				if gateExists {
+					t.Errorf("Scheduling gate %s was not removed from Pod %s", schedulingGateName, podName)
 				}
 			}
 		})
@@ -480,36 +837,59 @@ func TestDeletePV(t *testing.T) {
 	pvName := testPVName
 	key := pvName
 	pv := createPV(pvName, testSCName, testBucketName, csiDriverName, nil, nil, nil)
+	queueKey := pvPrefix + key
 
 	f := newTestFixture(t)
-	f.scanner.queue.Add(key)
+	f.scanner.queue.Add(queueKey)
 	f.scanner.trackedPVs[pvName] = struct{}{}
+	f.scanner.lastSuccessfulScan[pvName] = time.Now()
+
 	f.scanner.deletePV(pv)
 
 	// PV should no longer be in the tracked set.
 	if _, exists := f.scanner.trackedPVs[pvName]; exists {
 		t.Errorf("PV %s still tracked after deletePV() call", pvName)
 	}
+	if _, exists := f.scanner.lastSuccessfulScan[pvName]; exists {
+		t.Errorf("PV %s still in lastSuccessfulScan map after deletePV() call", pvName)
+	}
 
-	// The item is still in the queue, deletePV doesn't remove it from the queue.
+	// Check if the key was forgotten
+	if f.scanner.queue.NumRequeues(queueKey) != 0 {
+		t.Errorf("NumRequeues for %s: got %d, want 0 after deletePV/Forget", key, f.scanner.queue.NumRequeues(queueKey))
+	}
+}
+
+// TestAddPod tests the addPod function.
+func TestAddPod(t *testing.T) {
+	pod := createPod(testPodName, testNamespace, nil, podLabels, false)
+	f := newTestFixture(t, pod)
+
+	f.scanner.addPod(pod)
+
 	if f.scanner.queue.Len() != 1 {
-		t.Errorf("Queue length after deletePV(): got %d, want 1", f.scanner.queue.Len())
+		t.Errorf("Queue length: got %d, want 1", f.scanner.queue.Len())
 	}
+	// We can't easily assert *which* key is in the queue, but length 1 after adding one item is a good sign.
+}
 
-	// Simulate the worker picking up the item.
-	// processNextWorkItem will call syncPV.
-	// Since the PV is not in the fake client, pvLister.Get() will return NotFound.
-	if !f.scanner.processNextWorkItem(context.Background()) {
-		t.Errorf("processNextWorkItem returned false unexpectedly")
-	}
+// TestDeletePod tests the deletePod function.
+func TestDeletePod(t *testing.T) {
+	pod := createPod(testPodName, testNamespace, nil, podLabels, false)
+	key, _ := cache.MetaNamespaceKeyFunc(pod)
+	queueKey := podPrefix + key
 
-	// After processing, the queue should be empty and the item not re-queued
-	// because the PV was not found, simulating a successful handle of the deletion.
-	if f.scanner.queue.Len() != 0 {
-		t.Errorf("Queue length after processNextWorkItem: got %d, want 0", f.scanner.queue.Len())
-	}
-	if f.scanner.queue.NumRequeues(key) > 0 {
-		t.Errorf("Key %s was requeued unexpectedly, NumRequeues: %d", key, f.scanner.queue.NumRequeues(key))
+	f := newTestFixture(t)
+
+	// Add the key to simulate it being in the queue, possibly with a history of failures.
+	f.scanner.queue.AddRateLimited(queueKey)
+	// NumRequeues check can be flaky with fake rate limiters, so we don't assert on it.
+
+	f.scanner.deletePod(pod)
+
+	// After deletePod, the key should be "forgotten", resetting its rate limiting.
+	if f.scanner.queue.NumRequeues(queueKey) != 0 {
+		t.Errorf("NumRequeues for %s: got %d, want 0 after deletePod/Forget", key, f.scanner.queue.NumRequeues(queueKey))
 	}
 }
 
@@ -636,6 +1016,11 @@ func TestUpdatePVScanResult(t *testing.T) {
 		if got != want {
 			t.Errorf("Annotation %s: got %v, want %v", key, got, want)
 		}
+	}
+
+	// Verify in-memory map is updated
+	if lastScan, ok := f.scanner.lastSuccessfulScan[testPVName]; !ok || !lastScan.Equal(now) {
+		t.Errorf("lastSuccessfulScan map not updated correctly: got %v, want %v", lastScan, now)
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind feature

**What this PR does / why we need it**:
This PR enhances the Bucket Scanner controller within the GCSFuse CSI driver by introducing a Pod creation trigger and a scheduling gate mechanism. Instead of only reacting to PV events, the controller now watches for the creation of Pods labeled with `gke-gcsfuse/profile-managed: "true".`

This PRs is part of a chain of previous PRs to implement the bucket scanner controller:
* https://github.com/GoogleCloudPlatform/gcs-fuse-csi-driver/pull/948
* https://github.com/GoogleCloudPlatform/gcs-fuse-csi-driver/pull/953

New Pods with this label are expected to start with a scheduling gate `gke-gcsfuse/bucket-scan-pending`. The controller will:

* **Watch Pods**: Identify new Pods with the label and scheduling gate.
* **Resolve Volumes**: Trace through the Pod's volumes to find PersistentVolumeClaims and their bound PersistentVolumes.
* **Check PV Relevance**: Determine if any of the bound PVs require a bucket scan based on the StorageClass configuration and TTL (Time-To-Live).
* **Enqueue PVs**: Trigger scans for relevant PVs by enqueuing them.
* **Manage Scheduling Gate**: The syncPod function reconciles the Pod. It only removes the `gke-gcsfuse/bucket-scan-pending` gate after confirming that all relevant PVs associated with the Pod have been scanned at least once (i.e., they are no longer considered "relevant" for an initial scan). The Pod remains unschedulable until the gate is removed.
* **Requeue Pods**: Pods are requeued if PVCs are not yet bound or if any PVs still require scanning.

**Key Improvements & Changes**:

* **Pod-Tuned Scans**: Scans are now primarily driven by Pod usage, ensuring metadata is fresh when a workload starts.
* **Scheduling Gate**: Prevents Pods from starting until the bucket scan (if required) is completed, ensuring the GCS Fuse driver has the necessary bucket information.
* **Informer Optimizations**: The Pod informer uses a label selector (`gke-gcsfuse/profile-managed=true`) and a transform function (trimPodObject) to reduce memory consumption.
* **Robust TTL Handling**: Introduced an in-memory map (lastSuccessfulScan) to track the last scan time, mitigating potential race conditions caused by informer cache delays. This supplements the on-PV annotations.
* **Workqueue Prefixes**: Items in the workqueue are now prefixed with pv/ or pod/ to distinguish between resource types.
* **New Event Handlers**: Added handlers for Pod Add and Delete events.
* **Unit Tests**: Expanded scanner_test.go to include tests for syncPod, Pod/PVC/PV interactions, scheduling gate removal, and the new event handlers.

**Manual Verification**:
An example deployment that would interact with this controller:
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: my-deployment
spec:
  replicas: 2
  selector:
    matchLabels:
      app: my-app
  template:
    metadata:
      labels:
        app: my-app
        # Patched by mutating webhook:
        gke-gcsfuse/profile-managed: "true"
      annotations:
        gke-gcsfuse/volumes: "true"
    spec:
      serviceAccountName: my-ksa
      containers:
      - name: my-container
        image: nginx:latest
        volumeMounts:
        - name: my-gcs-volume
          mountPath: "/data/gcs"
        resources:
          limits:
            cpu: 100m
            memory: 100Mi
          requests:
            cpu: 10m
            memory: 80Mi
      volumes:
      - name: my-gcs-volume
        persistentVolumeClaim:
          claimName: my-pvc
      schedulingGates:
        # Patched by mutating webhook:
        - name: "gke-gcsfuse/bucket-scan-pending"
```

The controller will process this Pod, check the PV bound to my-pvc, trigger a scan if needed, and then remove the gate. Here are some test case examples:

1. PV is being scanned:
```
Name:            my-pv
Labels:          <none>
Annotations:     pv.kubernetes.io/bound-by-controller: yes
Finalizers:      [kubernetes.io/pv-protection]
StorageClass:    gcsfusecsi-inference
Status:          Bound
Claim:           default/my-pvc
Reclaim Policy:  Retain
Access Modes:    RWX
VolumeMode:      Filesystem
Capacity:        10Gi
Node Affinity:   <none>
Message:         
Source:
    Type:              CSI (a Container Storage Interface (CSI) volume source)
    Driver:            gcsfuse.csi.storage.gke.io
    FSType:            
    VolumeHandle:      test-bucket
    ReadOnly:          false
    VolumeAttributes:  <none>
Events:
  Type    Reason                       Age   From                 Message
  ----    ------                       ----  ----                 -------
  Normal  ScanOperationStartSucceeded  4s    gke-gcsfuse-scanner  Started bucket scan for PV my-pv, bucket test-bucket, directory '/my-folder/', with timeout 2m0s
```
Pods are schedule gated while they wait:
```
default               my-deployment-68f5ff8675-5zbpr                                   0/2     SchedulingGated  
default               my-deployment-68f5ff8675-7z2qd                                   0/2     SchedulingGated   
```
PV is finished scanning (notice that it was only scanned once, even though there were 2 Pods):
```
Warning  ScanOperationTimedOut        2s    gke-gcsfuse-scanner  Bucket scan timed out after 2m0s for bucket test-bucket, directory '/my-folder/' (2m0.002581084s). Updating with partial results. Consider increasing timeout if bucket size is big
```
Pod scheduling gates are removed:
```
default               my-deployment-68f5ff8675-5zbpr                                   0/2     Init:0/1   
default               my-deployment-68f5ff8675-7z2qd                                   0/2     Init:0/1   
```
A subsequent Pod attempts to use the PV shortly after (this one's gate is immediately removed, since the scan was already peformed):
```
default               my-deployment-68f5ff8675-5zbpr                                   0/2     Init:0/1   
default               my-deployment-68f5ff8675-7z2qd                                   0/2     Init:0/1  
default               my-deployment-68f5ff8675-fqrlz                                   0/2     Init:0/1   
```
A future Pod attempts to use the PV after the scanner's TTL expires and is gated:
```
default               my-deployment-68f5ff8675-5zbpr                                   0/2     Init:0/1  
default               my-deployment-68f5ff8675-7z2qd                                   0/2     Init:0/1  
default               my-deployment-68f5ff8675-fqrlz                                   0/2     Init:0/1   
default               my-deployment-68f5ff8675-98rqw                                    0/2     SchedulingGated  
```
The scanner starts a second operation:
```
  Warning  ScanOperationTimedOut        5m37s                  gke-gcsfuse-scanner  Bucket scan timed out after 10s for bucket test-bucket, directory '/my-folder/' (10.002400573s). Updating with partial results. Consider increasing timeout if bucket size is big
  Normal   ScanOperationStartSucceeded  5m10s (x2 over 5m47s)  gke-gcsfuse-scanner  Started bucket scan for PV my-pv, bucket test-bucket, directory '/my-folder/', with timeout 10s
  Warning  ScanOperationTimedOut        5m                     gke-gcsfuse-scanner  Bucket scan timed out after 10s for bucket test-bucket, directory '/my-folder/' (10.000924826s). Updating with partial results. Consider increasing timeout if bucket size is big
```
The scheduling gate is also removed from the new Pod:
```
default               my-deployment-68f5ff8675-5zbpr                                   0/2     Init:0/1  
default               my-deployment-68f5ff8675-7z2qd                                   0/2     Init:0/1  
default               my-deployment-68f5ff8675-fqrlz                                   0/2     Init:0/1   
default               my-deployment-68f5ff8675-98rqw                                    0/2     Init:0/1
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
* This PR builds upon the Bucket Scanner skeleton. The core PV scanning logic (syncPV and defaultScanBucket) remains largely the same (still simulated bucket scan).
* The actual GCS bucket interaction (e.g., using Dataflux or GCS client) is still not yet implemented in defaultScanBucket.
* Leader election is not yet implemented.
* A mutating webhook will be used to inject the `gke-gcsfuse/profile-managed` label and the schedulingGates into user Pods. That webhook is not part of this PR, but is being developed here: https://github.com/GoogleCloudPlatform/gcs-fuse-csi-driver/pull/955. The TODOs in the example YAML reflect this.
* The new test file scanner_test.go contains detailed unit tests for the Pod reconciliation logic.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```