### PR TITLE
Use version string for rename dir and large file gcsfuse test logic

### DIFF
--- a/test/e2e/testsuites/gcsfuse_integration.go
+++ b/test/e2e/testsuites/gcsfuse_integration.go
@@ -335,6 +335,7 @@ func (t *gcsFuseCSIGCSFuseIntegrationTestSuite) DefineTests(driver storageframew
 		}
 		baseTestCommandWithTestBucket := baseTestCommand + fmt.Sprintf(" --testbucket=%v", bucketName)
 
+		gcsfuseVersion := version.MustParseSemantic(gcsfuseVersionStr)
 		var finalTestCommand string
 		switch testName {
 		case testNameReadonly:
@@ -350,7 +351,7 @@ func (t *gcsFuseCSIGCSFuseIntegrationTestSuite) DefineTests(driver storageframew
 			// https://github.com/GoogleCloudPlatform/gcsfuse/tree/master/tools/integration_tests/concurrent_operations
 			finalTestCommand = baseTestCommandWithTestBucket + " -run TestConcurrentListing/.*"
 		case testNameRenameDirLimit:
-			if gcsfuseTestBranch == masterBranchName || version.MustParseSemantic(gcsfuseTestBranch).AtLeast(version.MustParseSemantic("v2.4.1-gke.0")) {
+			if gcsfuseTestBranch == masterBranchName || gcsfuseVersion.AtLeast(version.MustParseSemantic("v2.4.1-gke.0")) {
 				finalTestCommand = baseTestCommandWithTestBucket
 			} else {
 				finalTestCommand = baseTestCommand
@@ -360,7 +361,7 @@ func (t *gcsFuseCSIGCSFuseIntegrationTestSuite) DefineTests(driver storageframew
 		case testNameListLargeDir, testNameWriteLargeFiles:
 			finalTestCommand = baseTestCommandWithTestBucket + " -timeout 120m"
 		case testNameReadLargeFiles:
-			if gcsfuseTestBranch == masterBranchName || version.MustParseSemantic(gcsfuseTestBranch).AtLeast(version.MustParseSemantic("v2.4.1-gke.0")) {
+			if gcsfuseTestBranch == masterBranchName || gcsfuseVersion.AtLeast(version.MustParseSemantic("v2.4.1-gke.0")) {
 				finalTestCommand = baseTestCommandWithTestBucket + " -timeout 60m"
 			} else {
 				finalTestCommand = baseTestCommand + " -timeout 60m"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation

/kind failing-test

> /kind feature
> /kind flake

**What this PR does / why we need it**:
gcsfuseTestBranch used to be a version string. Now that we are changing it to release branches from gcsfuse 3.3.0 on, these two tests need to be refactored to use the real version strings.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
These two test runs succeeded:
`make e2e-test E2E_TEST_USE_GKE_MANAGED_DRIVER=false E2E_TEST_BUILD_DRIVER=false BUILD_GCSFUSE_FROM_SOURCE=false E2E_TEST_FOCUS="rename_dir" STAGINGVERSION=gcsfusev3 REGISTRY=gcr.io/shensiyan-joonix  `

`make e2e-test E2E_TEST_USE_GKE_MANAGED_DRIVER=false E2E_TEST_BUILD_DRIVER=false BUILD_GCSFUSE_FROM_SOURCE=false E2E_TEST_FOCUS="large_files" STAGINGVERSION=gcsfusev3 REGISTRY=gcr.io/shensiyan-joonix  `

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NA
```