### PR TITLE
fix BUILD_FROM_GCSFUSE_SOURCE that was broken by previous PR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ download-gcsfuse:
 ifeq (${BUILD_GCSFUSE_FROM_SOURCE}, true)
 	rm -f ${BINDIR}/Dockerfile.gcsfuse
 	curl https://raw.githubusercontent.com/GoogleCloudPlatform/gcsfuse/master/tools/package_gcsfuse_docker/Dockerfile -o ${BINDIR}/Dockerfile.gcsfuse
-	$(eval GCSFUSE_VERSION=999.$(shell git ls-remote https://github.com/GoogleCloudPlatform/gcsfuse.git HEAD | cut -c 1-40))
+	$(eval GCSFUSE_VERSION=0.0.1-gcsfuse-git-master-$(shell git ls-remote https://github.com/GoogleCloudPlatform/gcsfuse.git HEAD | cut -c1-7))
 
 	docker buildx build \
 		--load \

--- a/cloudbuild-build-image.yaml
+++ b/cloudbuild-build-image.yaml
@@ -86,7 +86,8 @@ steps:
       fi
 
       curl https://raw.githubusercontent.com/GoogleCloudPlatform/gcsfuse/master/tools/package_gcsfuse_docker/Dockerfile -o Dockerfile.gcsfuse
-      GCSFUSE_VERSION="999.$(git ls-remote https://github.com/GoogleCloudPlatform/gcsfuse.git HEAD | cut -f 1)"
+      GCSFUSE_VERSION="0.0.1-gcsfuse-git-master-$(git ls-remote https://github.com/GoogleCloudPlatform/gcsfuse.git HEAD | cut -c1-7)"
+      echo -n "$${GCSFUSE_VERSION}" > /workspace/gcsfuse_version.txt
 
       # Build for AMD64 and save to a tar file
       docker buildx build \
@@ -127,7 +128,7 @@ steps:
       if [ "${_BUILD_GCSFUSE_FROM_SOURCE}" = "true" ]; then
         # Load the tarball artifact and extract the binary
         docker load < /workspace/gcsfuse-amd.tar
-        GCSFUSE_VERSION="999.$(git ls-remote https://github.com/GoogleCloudPlatform/gcsfuse.git HEAD | cut -f 1)"
+        GCSFUSE_VERSION=$(cat /workspace/gcsfuse_version.txt)
         docker run --rm -v $(pwd)/bin/linux/amd64:/release gcsfuse-release-amd cp /gcsfuse_$${GCSFUSE_VERSION}_amd64/usr/bin/gcsfuse /release
       else
         # Download pre-built binary
@@ -141,7 +142,7 @@ steps:
         then
           # Load the ARM tarball artifact and extract the binary
           docker load < /workspace/gcsfuse-arm.tar
-          GCSFUSE_VERSION="999.$(git ls-remote https://github.com/GoogleCloudPlatform/gcsfuse.git HEAD | cut -f 1)"
+          GCSFUSE_VERSION=$(cat /workspace/gcsfuse_version.txt)
           docker run --rm -v $(pwd)/bin/linux/arm64:/release gcsfuse-release-arm cp /gcsfuse_$${GCSFUSE_VERSION}_arm64/usr/bin/gcsfuse /release
         else
           # Download pre-built ARM binary

--- a/test/e2e/testsuites/gcsfuse_integration.go
+++ b/test/e2e/testsuites/gcsfuse_integration.go
@@ -158,10 +158,9 @@ func (t *gcsFuseCSIGCSFuseIntegrationTestSuite) DefineTests(driver storageframew
 	// qualifies the non-managed driver to run all the tests.
 	skipTestOrProceedWithBranch := func(gcsfuseVersionStr, testName string) string {
 		v, err := version.ParseSemantic(gcsfuseVersionStr)
-		// When the gcsfuse binary is built using the head commit in the test pipeline,
-		// the version format does not obey the syntax and semantics of the "Semantic Versioning".
-		// Always use master branch if the gcsfuse binary is built using the head commit.
-		if err != nil {
+		// When the gcsfuse binary is built using the head commit or has a pre-release tag,
+		// it is a development build. Always use the master branch for these builds.
+		if err != nil || v.PreRelease() != "" {
 			return masterBranchName
 		}
 

--- a/test/e2e/testsuites/gcsfuse_integration_file_cache.go
+++ b/test/e2e/testsuites/gcsfuse_integration_file_cache.go
@@ -92,10 +92,9 @@ func (t *gcsFuseCSIGCSFuseIntegrationFileCacheTestSuite) DefineTests(driver stor
 	// qualifies the non-managed driver to run all the tests.
 	skipTestOrProceedWithBranch := func(gcsfuseVersionStr, testName string) string {
 		v, err := version.ParseSemantic(gcsfuseVersionStr)
-		// When the gcsfuse binary is built using the head commit in the test pipeline,
-		// the version format does not obey the syntax and semantics of the "Semantic Versioning".
-		// Always use master branch if the gcsfuse binary is built using the head commit.
-		if err != nil {
+		// When the gcsfuse binary is built using the head commit or has a pre-release tag,
+		// it is a development build. Always use the master branch for these builds.
+		if err != nil || v.PreRelease() != "" {
 			return masterBranchName
 		}
 

--- a/test/e2e/testsuites/gcsfuse_integration_file_cache_parallel_downloads.go
+++ b/test/e2e/testsuites/gcsfuse_integration_file_cache_parallel_downloads.go
@@ -92,10 +92,9 @@ func (t *gcsFuseCSIGCSFuseIntegrationFileCacheParallelDownloadsTestSuite) Define
 	// qualifies the non-managed driver to run all the tests.
 	skipTestOrProceedWithBranch := func(gcsfuseVersionStr, testName string) string {
 		v, err := version.ParseSemantic(gcsfuseVersionStr)
-		// When the gcsfuse binary is built using the head commit in the test pipeline,
-		// the version format does not obey the syntax and semantics of the "Semantic Versioning".
-		// Always use master branch if the gcsfuse binary is built using the head commit.
-		if err != nil {
+		// When the gcsfuse binary is built using the head commit or has a pre-release tag,
+		// it is a development build. Always use the master branch for these builds.
+		if err != nil || v.PreRelease() != "" {
 			return masterBranchName
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
https://github.com/GoogleCloudPlatform/gcs-fuse-csi-driver/commit/951265546d33fd1081b6f1bbdced35d74fdd6ddd#r166532713 broke running GCSFuse integration tests when driver was built/installed with `BUILD_FROM_GCSFUSE_SOURCE=true`. This is because the change introduced a versioning check that panics when `BUILD_FROM_GCSFUSE_SOURCE=true`. More details in  this comment: https://github.com/GoogleCloudPlatform/gcs-fuse-csi-driver/commit/951265546d33fd1081b6f1bbdced35d74fdd6ddd#r166532713. This PR fixes this case. I tested my change on https://github.com/GoogleCloudPlatform/gcs-fuse-csi-driver/pull/975 as I had to use BUILD_FROM_GCSFUSE_SOURCE=true to test my change there. 

PR 975 will make further improvements to  BUILD_FROM_GCSFUSE_SOURCE=true including allowing you to build from gcsfuse source at a particular tag. It will then use this as the GCSFuse_VERSION, and ensure skipTestOrProceedWithBranch uses this tag so we checkout gcsfuse from that branch ,instead of always using master as done in this PR.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```