### PR TITLE
Release GCSFuse 3.4.0 and disallow profile flag

### DIFF
--- a/cmd/sidecar_mounter/gcsfuse_binary
+++ b/cmd/sidecar_mounter/gcsfuse_binary
@@ -1,1 +1,1 @@
-gs://gke-release-staging/gcsfuse/v3.3.0-gke.1/gcsfuse_bin
+gs://gke-release-staging/gcsfuse/v3.4.0-gke.0/gcsfuse_bin

--- a/pkg/sidecar_mounter/sidecar_mounter_config.go
+++ b/pkg/sidecar_mounter/sidecar_mounter_config.go
@@ -92,6 +92,7 @@ var disallowedFlags = map[string]bool{
 	"cache-dir":                            true,
 	"experimental-local-file-cache":        true,
 	"prometheus-port":                      true,
+	"profile":                              true,
 }
 
 var boolFlags = map[string]bool{

--- a/pkg/sidecar_mounter/sidecar_mounter_config_test.go
+++ b/pkg/sidecar_mounter/sidecar_mounter_config_test.go
@@ -145,6 +145,18 @@ func TestPrepareMountArgs(t *testing.T) {
 			expectedConfigMapArgs: defaultConfigFileFlagMap,
 		},
 		{
+			name: "temporary until we support profile flag - no valid options provided, should return default maps",
+			mc: &MountConfig{
+				BucketName: "test-bucket",
+				BufferDir:  "test-buffer-dir",
+				CacheDir:   "test-cache-dir",
+				ConfigFile: "test-config-file",
+				Options:    []string{"profile=aiml-training", "profile:aiml-training"},
+			},
+			expectedArgs:          defaultFlagMap,
+			expectedConfigMapArgs: defaultConfigFileFlagMap,
+		},
+		{
 			name: "should return valid args with custom app-name",
 			mc: &MountConfig{
 				BucketName: "test-bucket",

--- a/test/e2e/specs/specs.go
+++ b/test/e2e/specs/specs.go
@@ -1242,3 +1242,18 @@ func (t *TestPod) VerifyDefaultingFlagsArePassed(namespace string, expectedMachi
 	gomega.Expect(stdout).To(gomega.ContainSubstring(expectedMachineTypeFlagString),
 		"Should find MachineType flag string %q in stdout", expectedMachineTypeFlagString)
 }
+
+func (t *TestPod) VerifyProfileFlagsAreNotPassed(namespace string) {
+	stdout, stderr, err := e2ekubectl.RunKubectlWithFullOutput(namespace, "logs", t.pod.Name, "-c", "gke-gcsfuse-sidecar")
+	framework.ExpectNoError(err,
+		"Error accessing logs from pod %v, but failed with error message %q\nstdout: %s\nstderr: %s",
+		t.pod.Name, err, stdout, stderr)
+
+	// handles profile=aiml-training case
+	gomega.Expect(stdout).To(gomega.Not(gomega.ContainSubstring("--profile aiml-training")),
+		"Should not find profile flag string in stdout")
+
+	// handles profile:aiml-training case
+	gomega.Expect(stdout).To(gomega.Not(gomega.MatchRegexp(`map\[.*profile:aiml-training.*\]`)),
+		"Should NOT find 'profile:aiml-training' within the gcsfuse config file content map, but it was found.")
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:
Release GCSFuse v3.4.0 and dis-allow unsupported 'profile' flag which is included in 3.4
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
Testing setup
```
gcloud container clusters create gcsfuse-cluster     --workload-pool=fuechr-gke-dev.svc.id.goog --machine-type=n2-standard-8 --zone us-central1-c

make build-image-and-push-multi-arch REGISTRY=gcr.io/fuechr-gke-dev STAGINGVERSION=3.4

make install REGISTRY=gcr.io/fuechr-gke-dev STAGINGVERSION=3.4 PROJECT=fuechr-gke-dev

make e2e-test E2E_TEST_USE_GKE_MANAGED_DRIVER=false E2E_TEST_BUILD_DRIVER=false BUILD_GCSFUSE_FROM_SOURCE=false E2E_TEST_SKIP="should.succeed.in.performance.test" E2E_TEST_FOCUS="mount.*" REGISTRY=gcr.io/fuechr-gke-dev STAGINGVERSION=3.4 

```
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Bumping GCSFuse binary version to v3.4.0
```