### PR TITLE
update gcsfuse branch to use branch if it has gke in the version

### DIFF
--- a/test/e2e/testsuites/gcsfuse_integration_file_cache.go
+++ b/test/e2e/testsuites/gcsfuse_integration_file_cache.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"local/test/e2e/specs"
+	"local/test/e2e/utils"
 
 	"github.com/onsi/ginkgo/v2"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -91,11 +92,9 @@ func (t *gcsFuseCSIGCSFuseIntegrationFileCacheTestSuite) DefineTests(driver stor
 	// we build the non-managed driver, we build gcsfuse from master and assign a tag of 999 to that build. This automatically
 	// qualifies the non-managed driver to run all the tests.
 	skipTestOrProceedWithBranch := func(gcsfuseVersionStr, testName string) string {
-		v, err := version.ParseSemantic(gcsfuseVersionStr)
-		// When the gcsfuse binary is built using the head commit or has a pre-release tag,
-		// it is a development build. Always use the master branch for these builds.
-		if err != nil || v.PreRelease() != "" {
-			return masterBranchName
+		v, branch := utils.GCSFuseBranch(gcsfuseVersionStr)
+		if branch == utils.MasterBranchName {
+			return branch
 		}
 
 		// check if the given gcsfuse version supports the test case
@@ -108,7 +107,7 @@ func (t *gcsFuseCSIGCSFuseIntegrationFileCacheTestSuite) DefineTests(driver stor
 			e2eskipper.Skipf("skip gcsfuse integration HNS tests on gcsfuse version %v", v.String())
 		}
 
-		return fmt.Sprintf(gcsfuseReleaseBranchFormat, v.Major(), v.Minor(), v.Patch())
+		return branch
 	}
 
 	gcsfuseIntegrationFileCacheTest := func(testName string, readOnly bool, fileCacheCapacity, fileCacheForRangeRead, metadataCacheTTLSeconds string, mountOptions ...string) {
@@ -136,7 +135,7 @@ func (t *gcsFuseCSIGCSFuseIntegrationFileCacheTestSuite) DefineTests(driver stor
 		tPod.SetupTmpVolumeMount("/tmp/gcsfuse_read_cache_test_logs")
 		cacheDir := "cache-dir"
 		gcsfuseVersion := version.MustParseSemantic(gcsfuseVersionStr)
-		if gcsfuseTestBranch == masterBranchName || gcsfuseVersion.AtLeast(version.MustParseSemantic("v2.4.1-gke.0")) {
+		if gcsfuseTestBranch == utils.MasterBranchName || gcsfuseVersion.AtLeast(version.MustParseSemantic("v2.4.1-gke.0")) {
 			if hnsEnabled(driver) {
 				cacheDir = "cache-dir-read-cache-hns-true"
 			} else {

--- a/test/e2e/utils/utils_test.go
+++ b/test/e2e/utils/utils_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/version"
+)
+
+// TODO(amacaskill): Add test to presubmit by adding to make unit-test target.
+func TestGCSFuseBranch(t *testing.T) {
+	t.Parallel()
+	t.Run("Testing GCSFuseBranch", func(t *testing.T) {
+		t.Parallel()
+		testCases := []struct {
+			name              string
+			gcsfuseVersionStr string
+			expectedBranch    string
+			expectedVersion   *version.Version
+		}{
+			{
+				name:              "should return master for GCSFuse built from HEAD",
+				gcsfuseVersionStr: "0.0.1-gcsfuse-git-master-abcdef",
+				expectedBranch:    "master",
+				expectedVersion:   nil,
+			},
+			{
+				name:              "should return branch for not valid GCSFuse version v3.3.0-gke.1",
+				gcsfuseVersionStr: "3.3.0-gke.1",
+				expectedBranch:    "v3.3.0_release",
+				expectedVersion:   version.MustParseSemantic("3.3.0-gke.1"),
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Logf("test case: %s", tc.name)
+			v, branch := GCSFuseBranch(tc.gcsfuseVersionStr)
+			if branch != tc.expectedBranch {
+				t.Errorf("For branch, got value %q, but expected %q", branch, tc.expectedBranch)
+			}
+
+			if tc.expectedVersion == nil {
+				if v != nil {
+					t.Errorf("For version, got %v, but expected nil", v)
+				}
+			} else if v == nil {
+				t.Errorf("For version, got %v, but expected %v", v, tc.expectedVersion)
+			} else if v.String() != tc.expectedVersion.String() {
+				t.Errorf("For version, got %q, but expected %q", v.String(), tc.expectedVersion.String())
+			}
+		}
+	})
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Update gcsfuse branch to use branch if it has gke in the version. This was missed in https://github.com/GoogleCloudPlatform/gcs-fuse-csi-driver/pull/980. Added unit test to make sure its working properly, and tested manually

Test both build from source, and build from a particullar gcsfuse tag: 

```
gcloud container clusters create test-gcsfuse-8 \
    --zone=us-central1-a \
    --workload-pool=amacaskill-gke-dev.svc.id.goog --machine-type=n2-standard-8
gcloud container clusters get-credentials  test-gcsfuse-8 --zone us-central1-a

# build and push image to registry
make build-image-and-push-multi-arch REGISTRY=us-central1-docker.pkg.dev/amacaskill-gke-dev/csi-dev STAGINGVERSION=from-source BUILD_GCSFUSE_FROM_SOURCE=true

make build-image-and-push-multi-arch REGISTRY=us-central1-docker.pkg.dev/amacaskill-gke-dev/csi-dev STAGINGVERSION=not-from-source BUILD_GCSFUSE_FROM_SOURCE=false

# install non-managed driver on GKE cluster from source.
make install REGISTRY=us-central1-docker.pkg.dev/amacaskill-gke-dev/csi-dev STAGINGVERSION=from-source PROJECT=amacaskill-gke-dev

# run tests on from source to see its using correct version.
make e2e-test E2E_TEST_USE_GKE_MANAGED_DRIVER=false E2E_TEST_BUILD_DRIVER=false BUILD_GCSFUSE_FROM_SOURCE=false STAGINGVERSION=from-source REGISTRY=us-central1-docker.pkg.dev/amacaskill-gke-dev/csi-dev E2E_TEST_FOCUS="gcsfuseIntegration.should.succeed.in.rename_symlink.test.1" 

make e2e-test E2E_TEST_USE_GKE_MANAGED_DRIVER=false E2E_TEST_BUILD_DRIVER=false BUILD_GCSFUSE_FROM_SOURCE=false STAGINGVERSION=from-source REGISTRY=us-central1-docker.pkg.dev/amacaskill-gke-dev/csi-dev E2E_TEST_FOCUS="gcsfuseIntegration.should.succeed.in.local_file.test.1"

make uninstall

# install non-managed driver on GKE cluster not from source.
make install REGISTRY=us-central1-docker.pkg.dev/amacaskill-gke-dev/csi-dev STAGINGVERSION=not-from-source PROJECT=amacaskill-gke-dev

# run tests on from source to see its using correct version.
make e2e-test E2E_TEST_USE_GKE_MANAGED_DRIVER=false E2E_TEST_BUILD_DRIVER=false BUILD_GCSFUSE_FROM_SOURCE=false STAGINGVERSION=not-from-source REGISTRY=us-central1-docker.pkg.dev/amacaskill-gke-dev/csi-dev E2E_TEST_FOCUS="gcsfuseIntegration.should.succeed.in.rename_symlink.test.1"

make e2e-test E2E_TEST_USE_GKE_MANAGED_DRIVER=false E2E_TEST_BUILD_DRIVER=false BUILD_GCSFUSE_FROM_SOURCE=false STAGINGVERSION=not-from-source REGISTRY=us-central1-docker.pkg.dev/amacaskill-gke-dev/csi-dev E2E_TEST_FOCUS="gcsfuseIntegration.should.succeed.in.local_file.test.1"
```


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```