### PR TITLE
Fix CVE-2025-9230, CVE-2025-9232 and skip profile test for managed

### DIFF
--- a/cmd/csi_driver/Dockerfile
+++ b/cmd/csi_driver/Dockerfile
@@ -24,7 +24,7 @@ ADD . .
 RUN GOARCH=$(echo $TARGETPLATFORM | cut -f2 -d '/') make driver BINDIR=/bin
 
 # Start from Kubernetes Debian base.
-FROM gke.gcr.io/debian-base:bookworm-v1.0.2-gke.2 AS debian
+FROM gke.gcr.io/debian-base:bookworm-v1.0.5-gke.12 AS debian
 # Install necessary dependencies
 RUN clean-install mount bash
 

--- a/cmd/metadata_prefetch/Dockerfile
+++ b/cmd/metadata_prefetch/Dockerfile
@@ -23,7 +23,7 @@ ADD . .
 RUN GOARCH=$(echo $TARGETPLATFORM | cut -f2 -d '/') make metadata-prefetch BINDIR=/bin
 
 # Start from Kubernetes Debian base.
-FROM gke.gcr.io/debian-base:bookworm-v1.0.2-gke.2 AS debian
+FROM gke.gcr.io/debian-base:bookworm-v1.0.5-gke.12 AS debian
 # Install necessary dependencies
 RUN clean-install bash
 

--- a/test/e2e/utils/handler.go
+++ b/test/e2e/utils/handler.go
@@ -265,6 +265,8 @@ func generateTestSkip(testParams *TestParameters) string {
 	if testParams.UseGKEManagedDriver {
 		skipTests = append(skipTests, "metrics") // Skipping as these tests are known to be unstable
 
+		skipTests = append(skipTests, "should.not.pass.profile") // Skipping for managed as changes have not been picked up yet
+
 		supportsKernelReadAhead, _ := ClusterAtLeastMinVersion(testParams.GkeClusterVersion, testParams.GkeNodeVersion, kernelReadAheadMinimumVersion)
 		if !supportsKernelReadAhead {
 			skipTests = append(skipTests, "read.ahead")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

 /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Fixes CVE-2025-9230, CVE-2025-9232 and skip profile test for managed

- Updated debian package to [v1.0.5](https://pantheon.corp.google.com/artifacts/docker/gke-release/us/us.gcr.io/debian-base/sha256:42340af792a01e81a1122a06a248a44884e6669f8db2210da42321a37a7a5bbd?e=13802955&mods=logs_tg_prod) needed to fix vulnerabilities for release 1.19.0
- Needed to fix failing tests on managed test grid that have yet to pick up latest changes from said release
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
TESTED SKIP MECHANISM
make e2e-test E2E_TEST_USE_GKE_MANAGED_DRIVER=true E2E_TEST_BUILD_DRIVER=true BUILD_GCSF
USE_FROM_SOURCE=false E2E_TEST_SKIP="should.succeed.in.performance.test" E2E_TEST_FOCUS="mount.*" REGISTRY=gcr.io/fuechr-gke-dev STAGINGVERSION=prow-go
b-internal-boskos-chris-7

TESTED NON MANAGED FLOW
make e2e-test E2E_TEST_USE_GKE_MANAGED_DRIVER=false E2E_TEST_BUILD_DRIVER=true BUILD_GCSF
USE_FROM_SOURCE=false E2E_TEST_SKIP="should.succeed.in.performance.test" E2E_TEST_FOCUS="mount.*" REGISTRY=gcr.io/fuechr-gke-dev STAGINGVERSION=prow-go
b-internal-boskos-chris-8


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```