### PR TITLE
add host network restriction for SA volume injection

### DIFF
--- a/pkg/webhook/mutatingwebhook.go
+++ b/pkg/webhook/mutatingwebhook.go
@@ -110,7 +110,7 @@ func (si *SidecarInjector) Handle(ctx context.Context, req admission.Request) ad
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 	// Inject service account volume
-	if si.Config.ShouldInjectSAVolume {
+	if pod.Spec.HostNetwork && si.Config.ShouldInjectSAVolume {
 		projectID, err := metadata.ProjectIDWithContext(ctx)
 		if err != nil {
 			return admission.Errored(http.StatusInternalServerError, fmt.Errorf("failed to get project id: %w", err))

--- a/pkg/webhook/sidecar_spec.go
+++ b/pkg/webhook/sidecar_spec.go
@@ -123,7 +123,8 @@ func GetSidecarContainerSpec(c *Config) corev1.Container {
 	limits, requests := prepareResourceList(c)
 
 	volumeMounts := []corev1.VolumeMount{TmpVolumeMount, buffVolumeMount, cacheVolumeMount}
-	if c.ShouldInjectSAVolume {
+	// Inject SA token only for Host Network pods
+	if c.PodHostNetworkSetting && c.ShouldInjectSAVolume {
 		volumeMounts = append(volumeMounts, saTokenVolumeMount)
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup

/kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
https://github.com/GoogleCloudPlatform/gcs-fuse-csi-driver/pull/605 Removed the host network restriction for SA volume injection to support sidecar bucket access check for Workload Identity enabled pods. But we are using default credentials for WI so SA token isn't needed. This PR adds that validation back for SA Volume injection.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```