### PR TITLE
Automated cherry pick of #988: Fix CVE-2025-9230, CVE-2025-9232 and skip profile test for managed

### DIFF
--- a/cmd/csi_driver/Dockerfile
+++ b/cmd/csi_driver/Dockerfile
@@ -24,7 +24,7 @@ ADD . .
 RUN GOARCH=$(echo $TARGETPLATFORM | cut -f2 -d '/') make driver BINDIR=/bin
 
 # Start from Kubernetes Debian base.
-FROM gke.gcr.io/debian-base:bookworm-v1.0.2-gke.2 AS debian
+FROM gke.gcr.io/debian-base:bookworm-v1.0.5-gke.12 AS debian
 # Install necessary dependencies
 RUN clean-install mount bash
 

--- a/cmd/metadata_prefetch/Dockerfile
+++ b/cmd/metadata_prefetch/Dockerfile
@@ -23,7 +23,7 @@ ADD . .
 RUN GOARCH=$(echo $TARGETPLATFORM | cut -f2 -d '/') make metadata-prefetch BINDIR=/bin
 
 # Start from Kubernetes Debian base.
-FROM gke.gcr.io/debian-base:bookworm-v1.0.2-gke.2 AS debian
+FROM gke.gcr.io/debian-base:bookworm-v1.0.5-gke.12 AS debian
 # Install necessary dependencies
 RUN clean-install bash
 

--- a/test/e2e/utils/handler.go
+++ b/test/e2e/utils/handler.go
@@ -265,6 +265,8 @@ func generateTestSkip(testParams *TestParameters) string {
 	if testParams.UseGKEManagedDriver {
 		skipTests = append(skipTests, "metrics") // Skipping as these tests are known to be unstable
 
+		skipTests = append(skipTests, "should.not.pass.profile") // Skipping for managed as changes have not been picked up yet
+
 		supportsKernelReadAhead, _ := ClusterAtLeastMinVersion(testParams.GkeClusterVersion, testParams.GkeNodeVersion, kernelReadAheadMinimumVersion)
 		if !supportsKernelReadAhead {
 			skipTests = append(skipTests, "read.ahead")


### PR DESCRIPTION
Cherry pick of #988 on release-1.19.

#988: Fix CVE-2025-9230, CVE-2025-9232 and skip profile test for managed

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```