### PR TITLE
Automated cherry pick of #989: add host network restriction for SA volume injection

### DIFF
--- a/pkg/webhook/mutatingwebhook.go
+++ b/pkg/webhook/mutatingwebhook.go
@@ -111,7 +111,7 @@ func (si *SidecarInjector) Handle(ctx context.Context, req admission.Request) ad
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 	// Inject service account volume
-	if si.Config.ShouldInjectSAVolume {
+	if pod.Spec.HostNetwork && si.Config.ShouldInjectSAVolume {
 		projectID, err := metadata.ProjectIDWithContext(ctx)
 		if err != nil {
 			return admission.Errored(http.StatusInternalServerError, fmt.Errorf("failed to get project id: %w", err))

--- a/pkg/webhook/sidecar_spec.go
+++ b/pkg/webhook/sidecar_spec.go
@@ -123,7 +123,8 @@ func GetSidecarContainerSpec(c *Config) corev1.Container {
 	limits, requests := prepareResourceList(c)
 
 	volumeMounts := []corev1.VolumeMount{TmpVolumeMount, buffVolumeMount, cacheVolumeMount}
-	if c.ShouldInjectSAVolume {
+	// Inject SA token only for Host Network pods
+	if c.PodHostNetworkSetting && c.ShouldInjectSAVolume {
 		volumeMounts = append(volumeMounts, saTokenVolumeMount)
 	}
 


### PR DESCRIPTION
Cherry pick of #989 on release-1.19.

#989: add host network restriction for SA volume injection

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```