### PR TITLE
Automated cherry pick of #994: safeguard k8s client creation behind feature flag

### DIFF
--- a/cmd/sidecar_mounter/main.go
+++ b/cmd/sidecar_mounter/main.go
@@ -64,11 +64,6 @@ func main() {
 	if err != nil {
 		klog.Fatalf("failed to look up socket paths: %v", err)
 	}
-
-	clientset, err := clientset.New(*kubeconfigPath, *informerResyncDurationSec)
-	if err != nil {
-		klog.Fatalf("Failed to configure k8s client: %v", err)
-	}
 	mounter := sidecarmounter.New(*gcsfusePath)
 	ctx, cancel := context.WithCancel(context.Background())
 	flagsFromDriver := map[string]string{}
@@ -101,6 +96,10 @@ func main() {
 		}
 		if mc != nil {
 			if mc.EnableSidecarBucketAccessCheck {
+					clientset, err := clientset.New(*kubeconfigPath, *informerResyncDurationSec)
+	if err != nil {
+		klog.Fatalf("Failed to configure k8s client: %v", err)
+	}
 				tm, ssm, err := mounter.SetupTokenAndStorageManager(clientset, mc)
 				if err != nil {
 					klog.Errorf("Failed to fetch identity pool and identity provider details required for bucket access check, got error %v", err)


### PR DESCRIPTION
Cherry pick of #994 on release-1.19.

#994: safeguard k8s client creation behind feature flag

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```