### PR TITLE
Disable metrics on GCS Fuse CSI volume counts exceeding threshold of 10

### DIFF
--- a/cmd/csi_driver/main.go
+++ b/cmd/csi_driver/main.go
@@ -222,10 +222,12 @@ func main() {
 
 		clientset.ConfigurePodLister(ctx, *nodeID)
 		clientset.ConfigureNodeLister(ctx, *nodeID)
+		// Both PVs & PVCs are needed to check count of GCSFuseVolumes
+		clientset.ConfigurePVLister(ctx)
+		clientset.ConfigurePVCLister(ctx)
 
 		if featureOptions.FeatureGCSFuseProfiles.Enabled {
 			// Curently, only the gcsfuse profiles feature actually uses these listers.
-			clientset.ConfigurePVLister(ctx)
 			clientset.ConfigureSCLister(ctx)
 		}
 

--- a/deploy/base/node/node_setup.yaml
+++ b/deploy/base/node/node_setup.yaml
@@ -42,6 +42,14 @@ rules:
   - apiGroups: [""]
     resources: ["serviceaccounts"]
     verbs: ["get"]
+# Required to list PV annotations.
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch"]
+# Required to map PVC to PV from Pod.
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/pkg/cloud_provider/clientset/clientset.go
+++ b/pkg/cloud_provider/clientset/clientset.go
@@ -158,6 +158,12 @@ func (c *Clientset) ConfigurePVLister(ctx context.Context) {
 			},
 			Spec: corev1.PersistentVolumeSpec{
 				StorageClassName: pvObj.Spec.StorageClassName, // Required by the gcsfuse profiles feature to map PV to SC.
+				PersistentVolumeSource: corev1.PersistentVolumeSource{
+					CSI: &corev1.CSIPersistentVolumeSource{
+						Driver:       pvObj.Spec.CSI.Driver, // Required by cardinality mitigation to disable metric collectors when gcsfuse volumes exceed threshold
+						VolumeHandle: pvObj.Spec.CSI.VolumeHandle,
+					},
+				},
 			},
 		}, nil
 	}

--- a/pkg/cloud_provider/clientset/clientset.go
+++ b/pkg/cloud_provider/clientset/clientset.go
@@ -44,10 +44,12 @@ type Interface interface {
 	ConfigurePodLister(ctx context.Context, nodeName string)
 	ConfigureNodeLister(ctx context.Context, nodeName string)
 	ConfigurePVLister(ctx context.Context)
+	ConfigurePVCLister(ctx context.Context)
 	ConfigureSCLister(ctx context.Context)
 	GetPod(namespace, name string) (*corev1.Pod, error)
 	GetNode(name string) (*corev1.Node, error)
 	GetPV(name string) (*corev1.PersistentVolume, error)
+	GetPVC(namespace string, name string) (*corev1.PersistentVolumeClaim, error)
 	GetSC(name string) (*storagev1.StorageClass, error)
 	CreateServiceAccountToken(ctx context.Context, namespace, name string, tokenRequest *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error)
 	GetGCPServiceAccountName(ctx context.Context, namespace, name string) (string, error)
@@ -63,6 +65,7 @@ type Clientset struct {
 	podLister                 listersv1.PodLister
 	nodeLister                listersv1.NodeLister
 	pvLister                  listersv1.PersistentVolumeLister
+	pvcLister                 listersv1.PersistentVolumeClaimLister
 	scLister                  storagelisters.StorageClassLister
 	informerResyncDurationSec int
 }
@@ -170,6 +173,37 @@ func (c *Clientset) ConfigurePVLister(ctx context.Context) {
 	informerFactory.WaitForCacheSync(ctx.Done())
 
 	c.pvLister = pvLister
+}
+
+func (c *Clientset) ConfigurePVCLister(ctx context.Context) {
+	trim := func(obj any) (any, error) {
+		pvcObj, ok := obj.(*corev1.PersistentVolumeClaim)
+		if !ok {
+			return obj, nil
+		}
+		return &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      pvcObj.ObjectMeta.Name,
+				Namespace: pvcObj.ObjectMeta.Namespace,
+			},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				VolumeName: pvcObj.Spec.VolumeName,
+			},
+		}, nil
+	}
+
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(
+		c.k8sClients,
+		time.Duration(c.informerResyncDurationSec)*time.Second,
+		informers.WithTransform(trim),
+	)
+
+	pvcLister := informerFactory.Core().V1().PersistentVolumeClaims().Lister()
+
+	informerFactory.Start(ctx.Done())
+	informerFactory.WaitForCacheSync(ctx.Done())
+
+	c.pvcLister = pvcLister
 }
 
 func (c *Clientset) ConfigureSCLister(ctx context.Context) {
@@ -319,6 +353,14 @@ func (c *Clientset) GetPV(name string) (*corev1.PersistentVolume, error) {
 	}
 
 	return c.pvLister.Get(name)
+}
+
+func (c *Clientset) GetPVC(namespace, name string) (*corev1.PersistentVolumeClaim, error) {
+	if c.pvcLister == nil {
+		return nil, errors.New("pvc informer is not ready")
+	}
+
+	return c.pvcLister.PersistentVolumeClaims(namespace).Get(name)
 }
 
 func (c *Clientset) GetSC(name string) (*storagev1.StorageClass, error) {

--- a/pkg/cloud_provider/clientset/clientset.go
+++ b/pkg/cloud_provider/clientset/clientset.go
@@ -148,24 +148,29 @@ func (c *Clientset) ConfigureNodeLister(ctx context.Context, nodeName string) {
 func (c *Clientset) ConfigurePVLister(ctx context.Context) {
 	trim := func(obj any) (any, error) {
 		pvObj, ok := obj.(*corev1.PersistentVolume)
-		if !ok {
+
+		if !ok || pvObj == nil {
 			return obj, nil
 		}
-		return &corev1.PersistentVolume{
+
+		trimmedPV := &corev1.PersistentVolume{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        pvObj.ObjectMeta.Name,
-				Annotations: pvObj.ObjectMeta.Annotations, // Required by the gcsfuse profiles feature to calculate smart cache recommendations.
+				Annotations: pvObj.ObjectMeta.Annotations,
 			},
 			Spec: corev1.PersistentVolumeSpec{
-				StorageClassName: pvObj.Spec.StorageClassName, // Required by the gcsfuse profiles feature to map PV to SC.
-				PersistentVolumeSource: corev1.PersistentVolumeSource{
-					CSI: &corev1.CSIPersistentVolumeSource{
-						Driver:       pvObj.Spec.CSI.Driver, // Required by cardinality mitigation to disable metric collectors when gcsfuse volumes exceed threshold
-						VolumeHandle: pvObj.Spec.CSI.VolumeHandle,
-					},
-				},
+				StorageClassName: pvObj.Spec.StorageClassName,
 			},
-		}, nil
+		}
+
+		if pvObj.Spec.CSI != nil {
+			trimmedPV.Spec.PersistentVolumeSource.CSI = &corev1.CSIPersistentVolumeSource{
+				Driver:       pvObj.Spec.CSI.Driver,
+				VolumeHandle: pvObj.Spec.CSI.VolumeHandle,
+			}
+		}
+
+		return trimmedPV, nil
 	}
 
 	informerFactory := informers.NewSharedInformerFactoryWithOptions(

--- a/pkg/cloud_provider/clientset/fake.go
+++ b/pkg/cloud_provider/clientset/fake.go
@@ -151,8 +151,9 @@ func (c *FakeClientset) CreateNode(nodeConfig FakeNodeConfig) {
 func (c *FakeClientset) CreatePV(pvConfig FakePVConfig) {
 	pv := &corev1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   pvConfig.Name,
-			Labels: map[string]string{},
+			Name:        pvConfig.Name,
+			Labels:      map[string]string{},
+			Annotations: pvConfig.Annotations,
 		},
 		Spec: corev1.PersistentVolumeSpec{
 			StorageClassName: pvConfig.SCName,
@@ -170,7 +171,7 @@ func (c *FakeClientset) CreatePV(pvConfig FakePVConfig) {
 func (c *FakeClientset) CreatePVC(pvcConfig FakePVCConfig) {
 	pvc := &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: pvcConfig.Name,
+			Name:   pvcConfig.Name,
 			Labels: map[string]string{},
 		},
 	}

--- a/pkg/cloud_provider/clientset/fake.go
+++ b/pkg/cloud_provider/clientset/fake.go
@@ -73,6 +73,7 @@ func NewFakeClientset() *FakeClientset {
 	fakeClientSet.CreatePod(FakePodConfig{HostNetworkEnabled: false})
 	fakeClientSet.CreateNode(FakeNodeConfig{IsWorkloadIdentityEnabled: true})
 	fakeClientSet.CreatePV(FakePVConfig{})
+	fakeClientSet.CreatePVC(FakePVCConfig{})
 	fakeClientSet.CreateSC(FakeSCConfig{})
 
 	return fakeClientSet
@@ -208,8 +209,8 @@ func (c *FakeClientset) GetPV(name string) (*corev1.PersistentVolume, error) {
 }
 
 func (c *FakeClientset) GetPVC(namespace, name string) (*corev1.PersistentVolumeClaim, error) {
-	c.fakePV.ObjectMeta.Name = name
-	c.fakePV.ObjectMeta.Namespace = namespace
+	c.fakePVC.ObjectMeta.Name = name
+	c.fakePVC.ObjectMeta.Namespace = namespace
 
 	return c.fakePVC, nil
 }

--- a/pkg/cloud_provider/clientset/fake.go
+++ b/pkg/cloud_provider/clientset/fake.go
@@ -50,6 +50,7 @@ type FakePVConfig struct {
 type FakePVCConfig struct {
 	Name       string
 	VolumeName string
+	Namespace  string
 }
 
 type FakeSCConfig struct {

--- a/pkg/cloud_provider/clientset/fake.go
+++ b/pkg/cloud_provider/clientset/fake.go
@@ -45,6 +45,14 @@ type FakePVConfig struct {
 	SCName      string
 }
 
+type FakePVCSpec struct {
+	VolumeName string
+}
+
+type FakePVCConfig struct {
+	Spec FakePVCSpec
+}
+
 type FakeSCConfig struct {
 	Labels       map[string]string
 	Parameters   map[string]string
@@ -55,6 +63,7 @@ type FakeClientset struct {
 	fakePod  *corev1.Pod
 	fakeNode *corev1.Node
 	fakePV   *corev1.PersistentVolume
+	fakePVC  *corev1.PersistentVolumeClaim
 	fakeSC   *storagev1.StorageClass
 }
 
@@ -78,6 +87,8 @@ func (c *FakeClientset) ConfigurePodLister(_ context.Context, _ string) {}
 func (c *FakeClientset) ConfigureNodeLister(_ context.Context, _ string) {}
 
 func (c *FakeClientset) ConfigurePVLister(_ context.Context) {}
+
+func (c *FakeClientset) ConfigurePVCLister(_ context.Context) {}
 
 func (c *FakeClientset) ConfigureSCLister(_ context.Context) {}
 
@@ -145,6 +156,19 @@ func (c *FakeClientset) CreatePV(pvConfig FakePVConfig) {
 	c.fakePV.Spec.StorageClassName = pvConfig.SCName
 }
 
+func (c *FakeClientset) CreatePVC(pvcConfig FakePVCConfig) {
+	c.fakePVC = &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "",
+			Labels: map[string]string{},
+		},
+	}
+
+	c.fakePVC.Spec = corev1.PersistentVolumeClaimSpec{
+		VolumeName: pvcConfig.Spec.VolumeName,
+	}
+}
+
 func (c *FakeClientset) CreateSC(scConfig FakeSCConfig) {
 	c.fakeSC = &storagev1.StorageClass{
 		ObjectMeta: metav1.ObjectMeta{
@@ -181,6 +205,13 @@ func (c *FakeClientset) GetPV(name string) (*corev1.PersistentVolume, error) {
 	c.fakePV.ObjectMeta.Name = name
 
 	return c.fakePV, nil
+}
+
+func (c *FakeClientset) GetPVC(namespace, name string) (*corev1.PersistentVolumeClaim, error) {
+	c.fakePV.ObjectMeta.Name = name
+	c.fakePV.ObjectMeta.Namespace = namespace
+
+	return c.fakePVC, nil
 }
 
 func (c *FakeClientset) GetSC(name string) (*storagev1.StorageClass, error) {

--- a/pkg/cloud_provider/clientset/fake.go
+++ b/pkg/cloud_provider/clientset/fake.go
@@ -43,14 +43,13 @@ type FakePodConfig struct {
 type FakePVConfig struct {
 	Annotations map[string]string
 	SCName      string
-}
-
-type FakePVCSpec struct {
-	VolumeName string
+	DriverName  string
+	Name        string
 }
 
 type FakePVCConfig struct {
-	Spec FakePVCSpec
+	Name       string
+	VolumeName string
 }
 
 type FakeSCConfig struct {
@@ -62,13 +61,17 @@ type FakeSCConfig struct {
 type FakeClientset struct {
 	fakePod  *corev1.Pod
 	fakeNode *corev1.Node
-	fakePV   *corev1.PersistentVolume
-	fakePVC  *corev1.PersistentVolumeClaim
-	fakeSC   *storagev1.StorageClass
+	fakePVs  map[string]*corev1.PersistentVolume
+	fakePVCs map[string]*corev1.PersistentVolumeClaim
+	fakeSCs  map[string]*storagev1.StorageClass
 }
 
 func NewFakeClientset() *FakeClientset {
-	fakeClientSet := &FakeClientset{}
+	fakeClientSet := &FakeClientset{
+		fakePVs:  make(map[string]*corev1.PersistentVolume),
+		fakePVCs: make(map[string]*corev1.PersistentVolumeClaim),
+		fakeSCs:  make(map[string]*storagev1.StorageClass),
+	}
 	// Default setting for most unit tests is pod doesn't use host network & workload identity is enabled on the node
 	fakeClientSet.CreatePod(FakePodConfig{HostNetworkEnabled: false})
 	fakeClientSet.CreateNode(FakeNodeConfig{IsWorkloadIdentityEnabled: true})
@@ -146,41 +149,50 @@ func (c *FakeClientset) CreateNode(nodeConfig FakeNodeConfig) {
 }
 
 func (c *FakeClientset) CreatePV(pvConfig FakePVConfig) {
-	c.fakePV = &corev1.PersistentVolume{
+	pv := &corev1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   "",
+			Name:   pvConfig.Name,
 			Labels: map[string]string{},
+		},
+		Spec: corev1.PersistentVolumeSpec{
+			StorageClassName: pvConfig.SCName,
+			PersistentVolumeSource: corev1.PersistentVolumeSource{
+				CSI: &corev1.CSIPersistentVolumeSource{
+					Driver: pvConfig.DriverName,
+				},
+			},
 		},
 	}
 
-	c.fakePV.Annotations = pvConfig.Annotations
-	c.fakePV.Spec.StorageClassName = pvConfig.SCName
+	c.fakePVs[pv.Name] = pv
 }
 
 func (c *FakeClientset) CreatePVC(pvcConfig FakePVCConfig) {
-	c.fakePVC = &corev1.PersistentVolumeClaim{
+	pvc := &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   "",
+			Name: pvcConfig.Name,
 			Labels: map[string]string{},
 		},
 	}
 
-	c.fakePVC.Spec = corev1.PersistentVolumeClaimSpec{
-		VolumeName: pvcConfig.Spec.VolumeName,
+	pvc.Spec = corev1.PersistentVolumeClaimSpec{
+		VolumeName: pvcConfig.VolumeName,
 	}
+	c.fakePVCs[pvc.Name] = pvc
 }
 
 func (c *FakeClientset) CreateSC(scConfig FakeSCConfig) {
-	c.fakeSC = &storagev1.StorageClass{
+	sc := &storagev1.StorageClass{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "",
 			Labels: map[string]string{},
 		},
 	}
 
-	c.fakeSC.MountOptions = scConfig.MountOptions
-	c.fakeSC.Parameters = scConfig.Parameters
-	c.fakeSC.Labels = scConfig.Labels
+	sc.MountOptions = scConfig.MountOptions
+	sc.Parameters = scConfig.Parameters
+	sc.Labels = scConfig.Labels
+	c.fakeSCs[sc.Name] = sc
 }
 
 func (c *FakeClientset) AddPodVolumes(volumes []corev1.Volume) {
@@ -203,22 +215,27 @@ func (c *FakeClientset) GetNode(name string) (*corev1.Node, error) {
 }
 
 func (c *FakeClientset) GetPV(name string) (*corev1.PersistentVolume, error) {
-	c.fakePV.ObjectMeta.Name = name
+	if pv, ok := c.fakePVs[name]; ok {
+		return pv, nil
+	}
 
-	return c.fakePV, nil
+	return c.fakePVs[""], nil
 }
 
 func (c *FakeClientset) GetPVC(namespace, name string) (*corev1.PersistentVolumeClaim, error) {
-	c.fakePVC.ObjectMeta.Name = name
-	c.fakePVC.ObjectMeta.Namespace = namespace
+	if pvc, ok := c.fakePVCs[name]; ok {
+		return pvc, nil
+	}
 
-	return c.fakePVC, nil
+	return c.fakePVCs[""], nil
 }
 
 func (c *FakeClientset) GetSC(name string) (*storagev1.StorageClass, error) {
-	c.fakeSC.ObjectMeta.Name = name
+	if sc, ok := c.fakeSCs[name]; ok {
+		return sc, nil
+	}
 
-	return c.fakeSC, nil
+	return c.fakeSCs[""], nil
 }
 
 func (c *FakeClientset) CreateServiceAccountToken(_ context.Context, _, _ string, _ *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error) {

--- a/pkg/cloud_provider/clientset/fake.go
+++ b/pkg/cloud_provider/clientset/fake.go
@@ -158,6 +158,12 @@ func (c *FakeClientset) CreateSC(scConfig FakeSCConfig) {
 	c.fakeSC.Labels = scConfig.Labels
 }
 
+func (c *FakeClientset) AddPodVolumes(volumes []corev1.Volume) {
+	if c.fakePod != nil {
+		c.fakePod.Spec.Volumes = append(c.fakePod.Spec.Volumes, volumes...)
+	}
+}
+
 func (c *FakeClientset) GetPod(namespace, name string) (*corev1.Pod, error) {
 	c.fakePod.ObjectMeta.Name = name
 	c.fakePod.ObjectMeta.Namespace = namespace

--- a/pkg/csi_driver/gcs_fuse_driver_test.go
+++ b/pkg/csi_driver/gcs_fuse_driver_test.go
@@ -42,7 +42,7 @@ func initTestDriver(t *testing.T, fm *mount.FakeMounter) *GCSDriver {
 		Mounter:               fm,
 		NetworkManager:        &fakeNetworkManager{},
 		K8sClients:            clientset.NewFakeClientset(),
-		MetricsManager:        &metrics.FakeMetricsManager{},
+		MetricsManager:        metrics.NewFakeMetricsManager(),
 		FeatureOptions:        &GCSDriverFeatureOptions{FeatureGCSFuseProfiles: &FeatureGCSFuseProfiles{}},
 	}
 	driver, err := NewGCSDriver(config, nil)
@@ -70,7 +70,7 @@ func initTestDriverWithCustomNodeServer(t *testing.T, fm *mount.FakeMounter, cli
 		Mounter:                  fm,
 		NetworkManager:           &fakeNetworkManager{},
 		K8sClients:               clientSet,
-		MetricsManager:           &metrics.FakeMetricsManager{},
+		MetricsManager:           metrics.NewFakeMetricsManager(),
 		WINodeLabelCheck:         wiNodeLabelCheck,
 		FeatureOptions:           &GCSDriverFeatureOptions{FeatureGCSFuseProfiles: &FeatureGCSFuseProfiles{}},
 		AssumeGoodSidecarVersion: true,

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -587,5 +587,7 @@ func (s *nodeServer) countGcsFuseVolumes(pod *corev1.Pod) int {
 		}
 	}
 
+	klog.Warningf("gcsFuseVolumeCount %d", gcsFuseVolumeCount)
+
 	return gcsFuseVolumeCount
 }

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -45,6 +45,7 @@ const (
 	// parameters file is polled and any changes to kernel parameter files are applied.
 	GCSFuseKernelParamsFilePollInterval = time.Second * 5
 	FuseMountType                       = "fuse"
+	maxGcsFuseVolumesForMetrics         = 10
 )
 
 // nodeServer handles mounting and unmounting of GCS FUSE volumes on a node.
@@ -241,7 +242,7 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 	if s.driver.config.MetricsManager != nil && !args.disableMetricsCollection {
 		gcsFuseVolumeCount := s.countGcsFuseVolumes(pod)
 
-		if gcsFuseVolumeCount > 10 {
+		if gcsFuseVolumeCount > maxGcsFuseVolumesForMetrics {
 			klog.Warningf("Metrics collection is disabled for Pod %s/%s as the number of GCS FUSE volumes is %d, which is greater than the limit of 10.", pod.Namespace, pod.Name, gcsFuseVolumeCount)
 		} else {
 			klog.V(6).Infof("NodePublishVolume enabling metrics collector for target path %q", targetPath)
@@ -542,6 +543,11 @@ func gcsFuseSidecarContainerImage(pod *corev1.Pod) string {
 
 func (s *nodeServer) countGcsFuseVolumes(pod *corev1.Pod) int {
 	gcsFuseVolumeCount := 0
+
+	if pod.Spec.Volumes == nil {
+		return gcsFuseVolumeCount
+	}
+
 	for _, v := range pod.Spec.Volumes {
 		if v.CSI != nil && v.CSI.Driver == s.driver.config.Name {
 			gcsFuseVolumeCount++

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -243,7 +243,7 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 		gcsFuseVolumeCount := s.countGcsFuseVolumes(pod)
 
 		if gcsFuseVolumeCount > maxGcsFuseVolumesForMetrics {
-			klog.Warningf("Metrics collection is disabled for Pod %s/%s as the number of GCS FUSE volumes is %d, which is greater than the limit of 10.", pod.Namespace, pod.Name, gcsFuseVolumeCount)
+			klog.Warningf("Metrics collection is disabled for Pod %s/%s as the number of GCS FUSE volumes is %d, which is greater than the limit of %d.", pod.Namespace, pod.Name, gcsFuseVolumeCount, maxGcsFuseVolumesForMetrics)
 		} else {
 			klog.V(6).Infof("NodePublishVolume enabling metrics collector for target path %q", targetPath)
 			s.driver.config.MetricsManager.RegisterMetricsCollector(targetPath, pod.Namespace, pod.Name, args.bucketName)

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -587,7 +587,5 @@ func (s *nodeServer) countGcsFuseVolumes(pod *corev1.Pod) int {
 		}
 	}
 
-	klog.Warningf("gcsFuseVolumeCount %d", gcsFuseVolumeCount)
-
 	return gcsFuseVolumeCount
 }

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -239,8 +239,14 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 	// Register metrics collector.
 	// It is idempotent to register the same collector in node republish calls.
 	if s.driver.config.MetricsManager != nil && !args.disableMetricsCollection {
-		klog.V(6).Infof("NodePublishVolume enabling metrics collector for target path %q", targetPath)
-		s.driver.config.MetricsManager.RegisterMetricsCollector(targetPath, pod.Namespace, pod.Name, args.bucketName)
+		gcsFuseVolumeCount := s.countGcsFuseVolumes(pod)
+
+		if gcsFuseVolumeCount > 10 {
+			klog.Warningf("Metrics collection is disabled for Pod %s/%s as the number of GCS FUSE volumes is %d, which is greater than the limit of 10.", pod.Namespace, pod.Name, gcsFuseVolumeCount)
+		} else {
+			klog.V(6).Infof("NodePublishVolume enabling metrics collector for target path %q", targetPath)
+			s.driver.config.MetricsManager.RegisterMetricsCollector(targetPath, pod.Namespace, pod.Name, args.bucketName)
+		}
 	}
 
 	// Check if the sidecar container is still required,
@@ -532,4 +538,14 @@ func gcsFuseSidecarContainerImage(pod *corev1.Pod) string {
 		}
 	}
 	return ""
+}
+
+func (s *nodeServer) countGcsFuseVolumes(pod *corev1.Pod) int {
+	gcsFuseVolumeCount := 0
+	for _, v := range pod.Spec.Volumes {
+		if v.CSI != nil && v.CSI.Driver == s.driver.config.Name {
+			gcsFuseVolumeCount++
+		}
+	}
+	return gcsFuseVolumeCount
 }

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -35,6 +35,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/klog/v2"
 	mount "k8s.io/mount-utils"
 )
@@ -549,9 +550,37 @@ func (s *nodeServer) countGcsFuseVolumes(pod *corev1.Pod) int {
 	}
 
 	for _, v := range pod.Spec.Volumes {
-		if v.CSI != nil && v.CSI.Driver == s.driver.config.Name {
+		// Count ephemeral gcsfuse volumes
+		if v.PersistentVolumeClaim == nil && v.CSI != nil && v.CSI.Driver == s.driver.config.Name {
+			gcsFuseVolumeCount++
+		}
+
+		// Count persistent gcsfuse volumes
+		pvc, err := s.k8sClients.GetPVC(pod.Namespace, v.PersistentVolumeClaim.ClaimName)
+
+		// If an error occurs in getting information regarding the persistent volume, we ignore it's impact for metrics cardinality volume count restriction
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				klog.Warningf("pvc %q not found: %v", v.Name, err)
+			}
+
+			continue
+		}
+
+		pv, err := s.k8sClients.GetPV(pvc.Spec.VolumeName)
+
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				klog.Warningf("pv %q not found: %v", pvc.Spec.VolumeName, err)
+			}
+
+			continue
+		}
+
+		if pv.Spec.CSI != nil && pv.Spec.CSI.Driver == s.driver.config.Name {
 			gcsFuseVolumeCount++
 		}
 	}
+
 	return gcsFuseVolumeCount
 }

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -572,7 +572,7 @@ func (s *nodeServer) countGcsFuseVolumes(pod *corev1.Pod) (int, error) {
 				continue
 			}
 
-			klog.Errorf("internal error getting PVC %q: %v. GCS Fuse metric count may be inaccurate", v.PersistentVolumeClaim.ClaimName, err)
+			klog.Errorf("internal error getting PVC %q: %v. Setting GCS Fuse metric count to 0", v.PersistentVolumeClaim.ClaimName, err)
 			return 0, err
 		}
 
@@ -584,7 +584,7 @@ func (s *nodeServer) countGcsFuseVolumes(pod *corev1.Pod) (int, error) {
 				continue
 			}
 
-			klog.Errorf("internal error getting PV %q: %v. GCS Fuse metric count may be inaccurate", pvc.Spec.VolumeName, err)
+			klog.Errorf("internal error getting PV %q: %v. Setting GCS Fuse metric count to 0", pvc.Spec.VolumeName, err)
 			return 0, err
 		}
 

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -46,7 +46,7 @@ const (
 	// parameters file is polled and any changes to kernel parameter files are applied.
 	GCSFuseKernelParamsFilePollInterval = time.Second * 5
 	FuseMountType                       = "fuse"
-	maxGcsFuseVolumesForMetrics         = 10
+	maxGCSFuseVolumesForMetrics         = 10
 )
 
 // nodeServer handles mounting and unmounting of GCS FUSE volumes on a node.
@@ -241,10 +241,12 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 	// Register metrics collector.
 	// It is idempotent to register the same collector in node republish calls.
 	if s.driver.config.MetricsManager != nil && !args.disableMetricsCollection {
-		gcsFuseVolumeCount := s.countGcsFuseVolumes(pod)
+		gcsFuseVolumeCount, err := s.countGcsFuseVolumes(pod)
 
-		if gcsFuseVolumeCount > maxGcsFuseVolumesForMetrics {
-			klog.Warningf("Metrics collection is disabled for Pod %s/%s as the number of GCS FUSE volumes is %d, which is greater than the limit of %d.", pod.Namespace, pod.Name, gcsFuseVolumeCount, maxGcsFuseVolumesForMetrics)
+		if err != nil {
+			klog.Errorf("Metrics collection is disabled for Pod %s/%s as counting the number of GCS FUSE volumes failed with error: %v", pod.Namespace, pod.Name, err)
+		} else if gcsFuseVolumeCount > maxGCSFuseVolumesForMetrics {
+			klog.Warningf("Metrics collection is disabled for Pod %s/%s as the number of GCS FUSE volumes is %d, which is greater than the limit of %d.", pod.Namespace, pod.Name, gcsFuseVolumeCount, maxGCSFuseVolumesForMetrics)
 		} else {
 			klog.V(6).Infof("NodePublishVolume enabling metrics collector for target path %q", targetPath)
 			s.driver.config.MetricsManager.RegisterMetricsCollector(targetPath, pod.Namespace, pod.Name, args.bucketName)
@@ -542,11 +544,11 @@ func gcsFuseSidecarContainerImage(pod *corev1.Pod) string {
 	return ""
 }
 
-func (s *nodeServer) countGcsFuseVolumes(pod *corev1.Pod) int {
+func (s *nodeServer) countGcsFuseVolumes(pod *corev1.Pod) (int, error) {
 	gcsFuseVolumeCount := 0
 
 	if pod.Spec.Volumes == nil {
-		return gcsFuseVolumeCount
+		return gcsFuseVolumeCount, nil
 	}
 
 	for _, v := range pod.Spec.Volumes {
@@ -566,10 +568,12 @@ func (s *nodeServer) countGcsFuseVolumes(pod *corev1.Pod) int {
 		// If an error occurs in getting information regarding the persistent volume, we ignore it's impact for metrics cardinality volume count restriction
 		if err != nil {
 			if apierrors.IsNotFound(err) {
-				klog.Warningf("pvc %q not found: %v", v.Name, err)
+				klog.Warningf("pvc %q not found: %v", v.PersistentVolumeClaim.ClaimName, err)
+				continue
 			}
 
-			continue
+			klog.Errorf("internal error getting PVC %q: %v. GCS Fuse metric count may be inaccurate", v.PersistentVolumeClaim.ClaimName, err)
+			return 0, err
 		}
 
 		pv, err := s.k8sClients.GetPV(pvc.Spec.VolumeName)
@@ -577,9 +581,11 @@ func (s *nodeServer) countGcsFuseVolumes(pod *corev1.Pod) int {
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				klog.Warningf("pv %q not found: %v", pvc.Spec.VolumeName, err)
+				continue
 			}
 
-			continue
+			klog.Errorf("internal error getting PV %q: %v. GCS Fuse metric count may be inaccurate", pvc.Spec.VolumeName, err)
+			return 0, err
 		}
 
 		if pv.Spec.CSI != nil && pv.Spec.CSI.Driver == s.driver.config.Name {
@@ -587,5 +593,5 @@ func (s *nodeServer) countGcsFuseVolumes(pod *corev1.Pod) int {
 		}
 	}
 
-	return gcsFuseVolumeCount
+	return gcsFuseVolumeCount, nil
 }

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -553,7 +553,7 @@ func (s *nodeServer) countGcsFuseVolumes(pod *corev1.Pod) (int, error) {
 
 	for _, v := range pod.Spec.Volumes {
 		// Count ephemeral gcsfuse volumes
-		if v.PersistentVolumeClaim == nil && v.CSI != nil && v.CSI.Driver == s.driver.config.Name {
+		if v.CSI != nil && v.CSI.Driver == s.driver.config.Name {
 			gcsFuseVolumeCount++
 			continue
 		}

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -553,6 +553,11 @@ func (s *nodeServer) countGcsFuseVolumes(pod *corev1.Pod) int {
 		// Count ephemeral gcsfuse volumes
 		if v.PersistentVolumeClaim == nil && v.CSI != nil && v.CSI.Driver == s.driver.config.Name {
 			gcsFuseVolumeCount++
+			continue
+		}
+
+		if v.PersistentVolumeClaim == nil {
+			continue
 		}
 
 		// Count persistent gcsfuse volumes

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -565,7 +565,7 @@ func (s *nodeServer) countGcsFuseVolumes(pod *corev1.Pod) (int, error) {
 		// Count persistent gcsfuse volumes
 		pvc, err := s.k8sClients.GetPVC(pod.Namespace, v.PersistentVolumeClaim.ClaimName)
 
-		// If an error occurs in getting information regarding the persistent volume, we ignore it's impact for metrics cardinality volume count restriction
+		// A NotFound error is tolerated, but other errors will abort the count and disable metrics.
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				klog.Warningf("pvc %q not found: %v", v.PersistentVolumeClaim.ClaimName, err)

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -35,6 +35,7 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 	corev1 "k8s.io/api/core/v1"
 	mount "k8s.io/mount-utils"
 )
@@ -880,13 +881,13 @@ func TestNodePublishVolumeAssertMetricsCollectorRegistration(t *testing.T) {
 			}
 
 			// Update request
-			req := *baseReq
+			req := proto.Clone(baseReq).(*csi.NodePublishVolumeRequest)
 			if tc.disableMetricsCollection {
 				req.VolumeContext["disableMetrics"] = "true"
 			}
 
 			// Call NodePublishVolume
-			_, err := ns.NodePublishVolume(context.Background(), &req)
+			_, err := ns.NodePublishVolume(context.Background(), req)
 			if err != nil {
 				// The fake clientset does not have the pod annotations,
 				// which will cause the sidecar check to fail.

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -891,7 +891,6 @@ func TestNodePublishVolumeAssertMetricsCollectorRegistration(t *testing.T) {
 			if err != nil {
 				// The fake clientset does not have the pod annotations,
 				// which will cause the sidecar check to fail.
-				// See if we can find a workaround.
 				if !strings.Contains(err.Error(), "failed to find the sidecar container in Pod spec") {
 					t.Fatalf("NodePublishVolume() failed: %v", err)
 				}

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -800,7 +800,9 @@ func TestNodePublishVolumeAssertMetricsCollectorRegistration(t *testing.T) {
 	testTargetPath, cleanup := setupMountTarget(t)
 	defer cleanup()
 
-	driverName := "gcs-fuse-csi.storage.gke.io"
+	csiDriverName := "gcs-fuse-csi.storage.gke.io"
+	otherDriverName := "other.csi.driver"
+
 	baseReq := &csi.NodePublishVolumeRequest{
 		VolumeId:         testVolumeID,
 		TargetPath:       testTargetPath,
@@ -813,38 +815,88 @@ func TestNodePublishVolumeAssertMetricsCollectorRegistration(t *testing.T) {
 	}
 
 	testCases := []struct {
-		name                      string
-		gcsFuseVolumeCount        int
-		disableMetricsCollection  bool
-		metricsManagerIsNil       bool
-		expectCollectorRegistered bool
+		name                         string
+		totalEphemeralVolumeCount    int
+		totalPersistentVolumeCount   int
+		gcsFuseEphemeralVolumeCount  int
+		gcsFusePersistentVolumeCount int
+		expectCollectorRegistered    bool
 	}{
 		{
-			name:                      "should register collector for 1 volume",
-			gcsFuseVolumeCount:        1,
-			expectCollectorRegistered: true,
+			name:                        "should register collector for 1 gcsfuse ephemeral volume",
+			totalEphemeralVolumeCount:   1,
+			gcsFuseEphemeralVolumeCount: 1,
+			expectCollectorRegistered:   true,
 		},
 		{
-			name:                      "should register collector for 10 volumes",
-			gcsFuseVolumeCount:        10,
-			expectCollectorRegistered: true,
+			name:                         "should register collector for 1 gcsfuse persistent volume",
+			totalPersistentVolumeCount:   1,
+			gcsFusePersistentVolumeCount: 1,
+			expectCollectorRegistered:    true,
 		},
 		{
-			name:                      "should not register collector for 11 volumes",
-			gcsFuseVolumeCount:        11,
-			expectCollectorRegistered: false,
+			name:                         "should register collector for a mix of gcsfuse volumes",
+			totalEphemeralVolumeCount:    2,
+			totalPersistentVolumeCount:   2,
+			gcsFuseEphemeralVolumeCount:  1,
+			gcsFusePersistentVolumeCount: 1,
+			expectCollectorRegistered:    true,
 		},
 		{
-			name:                      "should not register collector when disableMetrics is true",
-			gcsFuseVolumeCount:        1,
-			disableMetricsCollection:  true,
-			expectCollectorRegistered: false,
+			name:                        "should register collector for 10 gcsfuse ephemeral volumes",
+			totalEphemeralVolumeCount:   10,
+			gcsFuseEphemeralVolumeCount: 10,
+			expectCollectorRegistered:   true,
 		},
 		{
-			name:                      "should not register collector when MetricsManager is nil",
-			gcsFuseVolumeCount:        1,
-			metricsManagerIsNil:       true,
-			expectCollectorRegistered: false,
+			name:                         "should register collector for 10 gcsfuse persistent volumes",
+			totalPersistentVolumeCount:   10,
+			gcsFusePersistentVolumeCount: 10,
+			expectCollectorRegistered:    true,
+		},
+		{
+			name:                         "should register collector for a mix of 10 gcsfuse volumes",
+			totalEphemeralVolumeCount:    5,
+			totalPersistentVolumeCount:   5,
+			gcsFuseEphemeralVolumeCount:  5,
+			gcsFusePersistentVolumeCount: 5,
+			expectCollectorRegistered:    true,
+		},
+		{
+			name:                        "should not register collector for 11 gcsfuse ephemeral volumes",
+			totalEphemeralVolumeCount:   11,
+			gcsFuseEphemeralVolumeCount: 11,
+			expectCollectorRegistered:   false,
+		},
+		{
+			name:                         "should not register collector for 11 gcsfuse persistent volumes",
+			totalPersistentVolumeCount:   11,
+			gcsFusePersistentVolumeCount: 11,
+			expectCollectorRegistered:    false,
+		},
+		{
+			name:                         "should not register collector for a mix of 11 gcsfuse volumes",
+			totalEphemeralVolumeCount:    6,
+			totalPersistentVolumeCount:   5,
+			gcsFuseEphemeralVolumeCount:  6,
+			gcsFusePersistentVolumeCount: 5,
+			expectCollectorRegistered:    false,
+		},
+		{
+			name:                         "should register collector with other non gcsfuse volumes",
+			totalEphemeralVolumeCount:    10,
+			totalPersistentVolumeCount:   10,
+			gcsFuseEphemeralVolumeCount:  5,
+			gcsFusePersistentVolumeCount: 5,
+			expectCollectorRegistered:    true,
+		},
+		{
+			name:                         "should not register collector with other non gcsfuse volumes when gcsfuse volumes exceeds limit",
+			totalEphemeralVolumeCount:    15,
+			totalPersistentVolumeCount:   15,
+			gcsFuseEphemeralVolumeCount:  6,
+			gcsFusePersistentVolumeCount: 5,
+			expectCollectorRegistered:    false,
 		},
 	}
 
@@ -853,16 +905,76 @@ func TestNodePublishVolumeAssertMetricsCollectorRegistration(t *testing.T) {
 			// Setup mock clientset
 			fakeClientSet := clientset.NewFakeClientset()
 			volumes := []corev1.Volume{}
-			for i := 0; i < tc.gcsFuseVolumeCount; i++ {
+
+			// Add GCS Fuse ephemeral volumes.
+			for i := 0; i < tc.gcsFuseEphemeralVolumeCount; i++ {
 				volumes = append(volumes, corev1.Volume{
-					Name: "gcs-fuse-csi-volume-" + strconv.Itoa(i),
+					Name: "gcs-fuse-csi-ephemeral-volume-" + strconv.Itoa(i),
 					VolumeSource: corev1.VolumeSource{
 						CSI: &corev1.CSIVolumeSource{
-							Driver: driverName,
+							Driver: csiDriverName,
 						},
 					},
 				})
 			}
+
+			// Add non GCS Fuse ephemeral volumes.
+			for i := 0; i < tc.totalEphemeralVolumeCount-tc.gcsFuseEphemeralVolumeCount; i++ {
+				volumes = append(volumes, corev1.Volume{
+					Name: "other-csi-ephemeral-volume-" + strconv.Itoa(i),
+					VolumeSource: corev1.VolumeSource{
+						CSI: &corev1.CSIVolumeSource{
+							Driver: otherDriverName,
+						},
+					},
+				})
+			}
+
+			// Add GCS Fuse persistent volumes.
+			for i := 0; i < tc.gcsFusePersistentVolumeCount; i++ {
+				pvcName := "gcs-fuse-csi-pvc-" + strconv.Itoa(i)
+				pvName := "gcs-fuse-csi-pv-" + strconv.Itoa(i)
+				volumes = append(volumes, corev1.Volume{
+					Name: pvcName,
+					VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+							ClaimName: pvcName,
+						},
+					},
+				})
+				fakeClientSet.CreatePV(clientset.FakePVConfig{
+					Name:       pvName,
+					DriverName: csiDriverName,
+				})
+				fakeClientSet.CreatePVC(clientset.FakePVCConfig{
+					Name:       pvcName,
+					VolumeName: pvName,
+				})
+			}
+
+			// Add non GCS Fuse persistent volumes.
+			for i := 0; i < tc.totalPersistentVolumeCount-tc.gcsFusePersistentVolumeCount; i++ {
+				pvcName := "other-csi-pvc-" + strconv.Itoa(i)
+				pvName := "other-csi-pv-" + strconv.Itoa(i)
+				volumes = append(volumes, corev1.Volume{
+					Name: pvcName,
+					VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+							ClaimName: pvcName,
+						},
+					},
+				})
+				fakeClientSet.CreatePV(clientset.FakePVConfig{
+					Name:       pvName,
+					DriverName: otherDriverName,
+					SCName:     "test-sc",
+				})
+				fakeClientSet.CreatePVC(clientset.FakePVCConfig{
+					Name:       pvcName,
+					VolumeName: pvName,
+				})
+			}
+
 			fakeClientSet.AddPodVolumes(volumes)
 			// Setup node server
 			testEnv := initTestNodeServerWithCustomClientset(t, fakeClientSet, false)
@@ -870,21 +982,14 @@ func TestNodePublishVolumeAssertMetricsCollectorRegistration(t *testing.T) {
 			if !ok {
 				t.Fatalf("Failed to cast NodeServer to *nodeServer")
 			}
-			ns.driver.config.Name = driverName
+			ns.driver.config.Name = csiDriverName
 
 			// Setup metrics manager
 			mm := metrics.NewFakeMetricsManager()
-			if tc.metricsManagerIsNil {
-				ns.driver.config.MetricsManager = nil
-			} else {
-				ns.driver.config.MetricsManager = mm
-			}
+			ns.driver.config.MetricsManager = mm
 
 			// Update request
 			req := proto.Clone(baseReq).(*csi.NodePublishVolumeRequest)
-			if tc.disableMetricsCollection {
-				req.VolumeContext["disableMetrics"] = "true"
-			}
 
 			// Call NodePublishVolume
 			_, err := ns.NodePublishVolume(context.Background(), req)

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -22,16 +22,20 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
+	"strings"
 	"sync"
 	"testing"
 
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/clientset"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/storage"
+	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/metrics"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	corev1 "k8s.io/api/core/v1"
 	mount "k8s.io/mount-utils"
 )
 
@@ -651,6 +655,256 @@ func TestNodePublishVolumeEnableGCSFuseKernelParams(t *testing.T) {
 				Opts:   tc.expectedOptions,
 			},
 				tc.unexpectedOptions)
+		})
+	}
+}
+
+func TestCountGcsFuseVolumes(t *testing.T) {
+	testEnv := initTestNodeServer(t)
+	ns, ok := testEnv.ns.(*nodeServer)
+	if !ok {
+		t.Fatalf("Failed to cast NodeServer to *nodeServer")
+	}
+
+	testCases := []struct {
+		name          string
+		pod           *corev1.Pod
+		expectedCount int
+	}{
+		{
+			name: "no volumes",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{},
+				},
+			},
+			expectedCount: 0,
+		},
+		{
+			name: "one gcsfuse volume",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{
+						{
+							Name: "gcs-fuse-csi-volume",
+							VolumeSource: corev1.VolumeSource{
+								CSI: &corev1.CSIVolumeSource{
+									Driver: ns.driver.config.Name,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedCount: 1,
+		},
+		{
+			name: "multiple gcsfuse volumes",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{
+						{
+							Name: "gcs-fuse-csi-volume-1",
+							VolumeSource: corev1.VolumeSource{
+								CSI: &corev1.CSIVolumeSource{
+									Driver: ns.driver.config.Name,
+								},
+							},
+						},
+						{
+							Name: "gcs-fuse-csi-volume-2",
+							VolumeSource: corev1.VolumeSource{
+								CSI: &corev1.CSIVolumeSource{
+									Driver: ns.driver.config.Name,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedCount: 2,
+		},
+		{
+			name: "mixed volumes",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{
+						{
+							Name: "gcs-fuse-csi-volume",
+							VolumeSource: corev1.VolumeSource{
+								CSI: &corev1.CSIVolumeSource{
+									Driver: ns.driver.config.Name,
+								},
+							},
+						},
+						{
+							Name: "other-volume",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
+							},
+						},
+					},
+				},
+			},
+			expectedCount: 1,
+		},
+		{
+			name: "other csi driver",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{
+						{
+							Name: "other-csi-volume",
+							VolumeSource: corev1.VolumeSource{
+								CSI: &corev1.CSIVolumeSource{
+									Driver: "other-csi-driver",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedCount: 0,
+		},
+		{
+			name: "volume with no csi source",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{
+						{
+							Name: "other-volume",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
+							},
+						},
+					},
+				},
+			},
+			expectedCount: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			count := ns.countGcsFuseVolumes(tc.pod)
+			if count != tc.expectedCount {
+				t.Errorf("got %d, want %d", count, tc.expectedCount)
+			}
+		})
+	}
+}
+
+func TestNodePublishVolumeAssertMetricsCollectorRegistration(t *testing.T) {
+	t.Parallel()
+	testTargetPath, cleanup := setupMountTarget(t)
+	defer cleanup()
+
+	driverName := "gcs-fuse-csi.storage.gke.io"
+	baseReq := &csi.NodePublishVolumeRequest{
+		VolumeId:         testVolumeID,
+		TargetPath:       testTargetPath,
+		VolumeCapability: testVolumeCapability,
+		VolumeContext: map[string]string{
+			VolumeContextKeyPodName:      "test-pod",
+			VolumeContextKeyPodNamespace: "test-ns",
+			"bucketName":                 testVolumeID,
+		},
+	}
+
+	testCases := []struct {
+		name                      string
+		gcsFuseVolumeCount        int
+		disableMetricsCollection  bool
+		metricsManagerIsNil       bool
+		expectCollectorRegistered bool
+	}{
+		{
+			name:                      "should register collector for 1 volume",
+			gcsFuseVolumeCount:        1,
+			expectCollectorRegistered: true,
+		},
+		{
+			name:                      "should register collector for 10 volumes",
+			gcsFuseVolumeCount:        10,
+			expectCollectorRegistered: true,
+		},
+		{
+			name:                      "should not register collector for 11 volumes",
+			gcsFuseVolumeCount:        11,
+			expectCollectorRegistered: false,
+		},
+		{
+			name:                      "should not register collector when disableMetrics is true",
+			gcsFuseVolumeCount:        1,
+			disableMetricsCollection:  true,
+			expectCollectorRegistered: false,
+		},
+		{
+			name:                      "should not register collector when MetricsManager is nil",
+			gcsFuseVolumeCount:        1,
+			metricsManagerIsNil:       true,
+			expectCollectorRegistered: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup mock clientset
+			fakeClientSet := clientset.NewFakeClientset()
+			volumes := []corev1.Volume{}
+			for i := 0; i < tc.gcsFuseVolumeCount; i++ {
+				volumes = append(volumes, corev1.Volume{
+					Name: "gcs-fuse-csi-volume-" + strconv.Itoa(i),
+					VolumeSource: corev1.VolumeSource{
+						CSI: &corev1.CSIVolumeSource{
+							Driver: driverName,
+						},
+					},
+				})
+			}
+			fakeClientSet.AddPodVolumes(volumes)
+			// Setup node server
+			testEnv := initTestNodeServerWithCustomClientset(t, fakeClientSet, false)
+			ns, ok := testEnv.ns.(*nodeServer)
+			if !ok {
+				t.Fatalf("Failed to cast NodeServer to *nodeServer")
+			}
+			ns.driver.config.Name = driverName
+
+			// Setup metrics manager
+			mm := metrics.NewFakeMetricsManager()
+			if tc.metricsManagerIsNil {
+				ns.driver.config.MetricsManager = nil
+			} else {
+				ns.driver.config.MetricsManager = mm
+			}
+
+			// Update request
+			req := *baseReq
+			if tc.disableMetricsCollection {
+				req.VolumeContext["disableMetrics"] = "true"
+			}
+
+			// Call NodePublishVolume
+			_, err := ns.NodePublishVolume(context.Background(), &req)
+			if err != nil {
+				// The fake clientset does not have the pod annotations,
+				// which will cause the sidecar check to fail.
+				// See if we can find a workaround.
+				if !strings.Contains(err.Error(), "failed to find the sidecar container in Pod spec") {
+					t.Fatalf("NodePublishVolume() failed: %v", err)
+				}
+			}
+
+			// Assertions
+			collectors := mm.GetCollectors()
+			_, collectorRegistered := collectors[testTargetPath]
+			if tc.expectCollectorRegistered && !collectorRegistered {
+				t.Error("expected metrics collector to be registered, but it was not")
+			}
+			if !tc.expectCollectorRegistered && collectorRegistered {
+				t.Error("expected metrics collector not to be registered, but it was")
+			}
 		})
 	}
 }

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -660,126 +660,171 @@ func TestNodePublishVolumeEnableGCSFuseKernelParams(t *testing.T) {
 	}
 }
 
-func TestCountGcsFuseVolumes(t *testing.T) {
-	testEnv := initTestNodeServer(t)
-	ns, ok := testEnv.ns.(*nodeServer)
-	if !ok {
-		t.Fatalf("Failed to cast NodeServer to *nodeServer")
+type volumeTestCase struct {
+	name                         string
+	totalEphemeralVolumeCount    int
+	totalPersistentVolumeCount   int
+	gcsFuseEphemeralVolumeCount  int
+	gcsFusePersistentVolumeCount int
+	expectCollectorRegistered    bool
+}
+
+const csiDriverName string = "gcs-fuse-csi.storage.gke.io"
+const otherDriverName string = "other.csi.driver"
+
+func createVolumesTestCase(fakeClientSet *clientset.FakeClientset, tc volumeTestCase) []corev1.Volume {
+	volumes := []corev1.Volume{}
+
+	// Add GCS Fuse ephemeral volumes.
+	for i := 0; i < tc.gcsFuseEphemeralVolumeCount; i++ {
+		volumes = append(volumes, corev1.Volume{
+			Name: "gcs-fuse-csi-ephemeral-volume-" + strconv.Itoa(i),
+			VolumeSource: corev1.VolumeSource{
+				CSI: &corev1.CSIVolumeSource{
+					Driver: csiDriverName,
+				},
+			},
+		})
 	}
 
+	// Add non GCS Fuse ephemeral volumes.
+	for i := 0; i < tc.totalEphemeralVolumeCount-tc.gcsFuseEphemeralVolumeCount; i++ {
+		volumes = append(volumes, corev1.Volume{
+			Name: "other-csi-ephemeral-volume-" + strconv.Itoa(i),
+			VolumeSource: corev1.VolumeSource{
+				CSI: &corev1.CSIVolumeSource{
+					Driver: otherDriverName,
+				},
+			},
+		})
+	}
+
+	// Add GCS Fuse persistent volumes.
+	for i := 0; i < tc.gcsFusePersistentVolumeCount; i++ {
+		pvcName := "gcs-fuse-csi-pvc-" + strconv.Itoa(i)
+		pvName := "gcs-fuse-csi-pv-" + strconv.Itoa(i)
+		volumes = append(volumes, corev1.Volume{
+			Name: pvcName,
+			VolumeSource: corev1.VolumeSource{
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+					ClaimName: pvcName,
+				},
+			},
+		})
+		fakeClientSet.CreatePV(clientset.FakePVConfig{
+			Name:       pvName,
+			DriverName: csiDriverName,
+		})
+		fakeClientSet.CreatePVC(clientset.FakePVCConfig{
+			Name:       pvcName,
+			VolumeName: pvName,
+		})
+	}
+
+	// Add non GCS Fuse persistent volumes.
+	for i := 0; i < tc.totalPersistentVolumeCount-tc.gcsFusePersistentVolumeCount; i++ {
+		pvcName := "other-csi-pvc-" + strconv.Itoa(i)
+		pvName := "other-csi-pv-" + strconv.Itoa(i)
+		volumes = append(volumes, corev1.Volume{
+			Name: pvcName,
+			VolumeSource: corev1.VolumeSource{
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+					ClaimName: pvcName,
+				},
+			},
+		})
+		fakeClientSet.CreatePV(clientset.FakePVConfig{
+			Name:       pvName,
+			DriverName: otherDriverName,
+			SCName:     "test-sc",
+		})
+		fakeClientSet.CreatePVC(clientset.FakePVCConfig{
+			Name:       pvcName,
+			VolumeName: pvName,
+		})
+	}
+
+	return volumes
+}
+
+func TestCountGcsFuseVolumes(t *testing.T) {
 	testCases := []struct {
 		name          string
-		pod           *corev1.Pod
+		tcVolumes     volumeTestCase
 		expectedCount int
 	}{
 		{
-			name: "no volumes",
-			pod: &corev1.Pod{
-				Spec: corev1.PodSpec{
-					Volumes: []corev1.Volume{},
-				},
-			},
+			name:          "no volumes",
+			tcVolumes:     volumeTestCase{},
 			expectedCount: 0,
 		},
 		{
-			name: "one gcsfuse volume",
-			pod: &corev1.Pod{
-				Spec: corev1.PodSpec{
-					Volumes: []corev1.Volume{
-						{
-							Name: "gcs-fuse-csi-volume",
-							VolumeSource: corev1.VolumeSource{
-								CSI: &corev1.CSIVolumeSource{
-									Driver: ns.driver.config.Name,
-								},
-							},
-						},
-					},
-				},
+			name: "one gcsfuse ephemeral volume",
+			tcVolumes: volumeTestCase{
+				totalEphemeralVolumeCount:   1,
+				gcsFuseEphemeralVolumeCount: 1,
 			},
 			expectedCount: 1,
 		},
 		{
-			name: "multiple gcsfuse volumes",
-			pod: &corev1.Pod{
-				Spec: corev1.PodSpec{
-					Volumes: []corev1.Volume{
-						{
-							Name: "gcs-fuse-csi-volume-1",
-							VolumeSource: corev1.VolumeSource{
-								CSI: &corev1.CSIVolumeSource{
-									Driver: ns.driver.config.Name,
-								},
-							},
-						},
-						{
-							Name: "gcs-fuse-csi-volume-2",
-							VolumeSource: corev1.VolumeSource{
-								CSI: &corev1.CSIVolumeSource{
-									Driver: ns.driver.config.Name,
-								},
-							},
-						},
-					},
-				},
+			name: "one gcsfuse persistent volume",
+			tcVolumes: volumeTestCase{
+				totalPersistentVolumeCount:   1,
+				gcsFusePersistentVolumeCount: 1,
+			},
+			expectedCount: 1,
+		},
+		{
+			name: "multiple gcsfuse ephemeral volumes",
+			tcVolumes: volumeTestCase{
+				totalEphemeralVolumeCount:   2,
+				gcsFuseEphemeralVolumeCount: 2,
 			},
 			expectedCount: 2,
 		},
 		{
-			name: "mixed volumes",
-			pod: &corev1.Pod{
-				Spec: corev1.PodSpec{
-					Volumes: []corev1.Volume{
-						{
-							Name: "gcs-fuse-csi-volume",
-							VolumeSource: corev1.VolumeSource{
-								CSI: &corev1.CSIVolumeSource{
-									Driver: ns.driver.config.Name,
-								},
-							},
-						},
-						{
-							Name: "other-volume",
-							VolumeSource: corev1.VolumeSource{
-								EmptyDir: &corev1.EmptyDirVolumeSource{},
-							},
-						},
-					},
-				},
+			name: "multiple gcsfuse persistent volumes",
+			tcVolumes: volumeTestCase{
+				totalPersistentVolumeCount:   2,
+				gcsFusePersistentVolumeCount: 2,
 			},
-			expectedCount: 1,
+			expectedCount: 2,
 		},
 		{
-			name: "other csi driver",
-			pod: &corev1.Pod{
-				Spec: corev1.PodSpec{
-					Volumes: []corev1.Volume{
-						{
-							Name: "other-csi-volume",
-							VolumeSource: corev1.VolumeSource{
-								CSI: &corev1.CSIVolumeSource{
-									Driver: "other-csi-driver",
-								},
-							},
-						},
-					},
-				},
+			name: "one ephemeral and one persistent gcsfuse volumes",
+			tcVolumes: volumeTestCase{
+				totalEphemeralVolumeCount:    1,
+				totalPersistentVolumeCount:   1,
+				gcsFuseEphemeralVolumeCount:  1,
+				gcsFusePersistentVolumeCount: 1,
 			},
-			expectedCount: 0,
+			expectedCount: 2,
 		},
 		{
-			name: "volume with no csi source",
-			pod: &corev1.Pod{
-				Spec: corev1.PodSpec{
-					Volumes: []corev1.Volume{
-						{
-							Name: "other-volume",
-							VolumeSource: corev1.VolumeSource{
-								EmptyDir: &corev1.EmptyDirVolumeSource{},
-							},
-						},
-					},
-				},
+			name: "multiple ephemeral and multiple persistent gcsfuse volumes",
+			tcVolumes: volumeTestCase{
+				totalEphemeralVolumeCount:    2,
+				totalPersistentVolumeCount:   3,
+				gcsFuseEphemeralVolumeCount:  2,
+				gcsFusePersistentVolumeCount: 3,
+			},
+			expectedCount: 5,
+		},
+		{
+			name: "mixed csi drivers with some gcsfuse volumes",
+			tcVolumes: volumeTestCase{
+				totalEphemeralVolumeCount:    5,
+				totalPersistentVolumeCount:   5,
+				gcsFuseEphemeralVolumeCount:  2,
+				gcsFusePersistentVolumeCount: 3,
+			},
+			expectedCount: 5,
+		},
+		{
+			name: "mixed csi drivers with no gcsfuse volumes",
+			tcVolumes: volumeTestCase{
+				totalEphemeralVolumeCount:  5,
+				totalPersistentVolumeCount: 5,
 			},
 			expectedCount: 0,
 		},
@@ -787,7 +832,20 @@ func TestCountGcsFuseVolumes(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			count := ns.countGcsFuseVolumes(tc.pod)
+			fakeClientSet := clientset.NewFakeClientset()
+			testEnv := initTestNodeServerWithCustomClientset(t, fakeClientSet, false)
+			ns, ok := testEnv.ns.(*nodeServer)
+			if !ok {
+				t.Fatalf("Failed to cast NodeServer to *nodeServer")
+			}
+			ns.driver.config.Name = csiDriverName
+			volumes := createVolumesTestCase(fakeClientSet, tc.tcVolumes)
+			pod := &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Volumes: volumes,
+				},
+			}
+			count, _ := ns.countGcsFuseVolumes(pod)
 			if count != tc.expectedCount {
 				t.Errorf("got %d, want %d", count, tc.expectedCount)
 			}
@@ -800,9 +858,6 @@ func TestNodePublishVolumeAssertMetricsCollectorRegistration(t *testing.T) {
 	testTargetPath, cleanup := setupMountTarget(t)
 	defer cleanup()
 
-	csiDriverName := "gcs-fuse-csi.storage.gke.io"
-	otherDriverName := "other.csi.driver"
-
 	baseReq := &csi.NodePublishVolumeRequest{
 		VolumeId:         testVolumeID,
 		TargetPath:       testTargetPath,
@@ -814,14 +869,7 @@ func TestNodePublishVolumeAssertMetricsCollectorRegistration(t *testing.T) {
 		},
 	}
 
-	testCases := []struct {
-		name                         string
-		totalEphemeralVolumeCount    int
-		totalPersistentVolumeCount   int
-		gcsFuseEphemeralVolumeCount  int
-		gcsFusePersistentVolumeCount int
-		expectCollectorRegistered    bool
-	}{
+	testCases := []volumeTestCase{
 		{
 			name:                        "should register collector for 1 gcsfuse ephemeral volume",
 			totalEphemeralVolumeCount:   1,
@@ -904,76 +952,7 @@ func TestNodePublishVolumeAssertMetricsCollectorRegistration(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Setup mock clientset
 			fakeClientSet := clientset.NewFakeClientset()
-			volumes := []corev1.Volume{}
-
-			// Add GCS Fuse ephemeral volumes.
-			for i := 0; i < tc.gcsFuseEphemeralVolumeCount; i++ {
-				volumes = append(volumes, corev1.Volume{
-					Name: "gcs-fuse-csi-ephemeral-volume-" + strconv.Itoa(i),
-					VolumeSource: corev1.VolumeSource{
-						CSI: &corev1.CSIVolumeSource{
-							Driver: csiDriverName,
-						},
-					},
-				})
-			}
-
-			// Add non GCS Fuse ephemeral volumes.
-			for i := 0; i < tc.totalEphemeralVolumeCount-tc.gcsFuseEphemeralVolumeCount; i++ {
-				volumes = append(volumes, corev1.Volume{
-					Name: "other-csi-ephemeral-volume-" + strconv.Itoa(i),
-					VolumeSource: corev1.VolumeSource{
-						CSI: &corev1.CSIVolumeSource{
-							Driver: otherDriverName,
-						},
-					},
-				})
-			}
-
-			// Add GCS Fuse persistent volumes.
-			for i := 0; i < tc.gcsFusePersistentVolumeCount; i++ {
-				pvcName := "gcs-fuse-csi-pvc-" + strconv.Itoa(i)
-				pvName := "gcs-fuse-csi-pv-" + strconv.Itoa(i)
-				volumes = append(volumes, corev1.Volume{
-					Name: pvcName,
-					VolumeSource: corev1.VolumeSource{
-						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-							ClaimName: pvcName,
-						},
-					},
-				})
-				fakeClientSet.CreatePV(clientset.FakePVConfig{
-					Name:       pvName,
-					DriverName: csiDriverName,
-				})
-				fakeClientSet.CreatePVC(clientset.FakePVCConfig{
-					Name:       pvcName,
-					VolumeName: pvName,
-				})
-			}
-
-			// Add non GCS Fuse persistent volumes.
-			for i := 0; i < tc.totalPersistentVolumeCount-tc.gcsFusePersistentVolumeCount; i++ {
-				pvcName := "other-csi-pvc-" + strconv.Itoa(i)
-				pvName := "other-csi-pv-" + strconv.Itoa(i)
-				volumes = append(volumes, corev1.Volume{
-					Name: pvcName,
-					VolumeSource: corev1.VolumeSource{
-						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-							ClaimName: pvcName,
-						},
-					},
-				})
-				fakeClientSet.CreatePV(clientset.FakePVConfig{
-					Name:       pvName,
-					DriverName: otherDriverName,
-					SCName:     "test-sc",
-				})
-				fakeClientSet.CreatePVC(clientset.FakePVCConfig{
-					Name:       pvcName,
-					VolumeName: pvName,
-				})
-			}
+			volumes := createVolumesTestCase(fakeClientSet, tc)
 
 			fakeClientSet.AddPodVolumes(volumes)
 			// Setup node server

--- a/pkg/metrics/fake.go
+++ b/pkg/metrics/fake.go
@@ -36,17 +36,17 @@ func NewFakeMetricsManager() *FakeMetricsManager {
 func (*FakeMetricsManager) InitializeHTTPHandler() {}
 
 // RegisterMetricsCollector records the registration of a metrics collector.
-func (f *FakeMetricsManager) RegisterMetricsCollector(identifier, _, _, bucketName string) {
+func (f *FakeMetricsManager) RegisterMetricsCollector(targetPath, _, _, bucketName string) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.collectors[identifier] = bucketName
+	f.collectors[targetPath] = bucketName
 }
 
 // UnregisterMetricsCollector records the unregistration of a metrics collector.
-func (f *FakeMetricsManager) UnregisterMetricsCollector(identifier string) {
+func (f *FakeMetricsManager) UnregisterMetricsCollector(targetPath string) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	delete(f.collectors, identifier)
+	delete(f.collectors, targetPath)
 }
 
 // GetCollectors returns the map of registered collectors.

--- a/pkg/metrics/fake.go
+++ b/pkg/metrics/fake.go
@@ -53,7 +53,15 @@ func (f *FakeMetricsManager) UnregisterMetricsCollector(identifier string) {
 func (f *FakeMetricsManager) GetCollectors() map[string]string {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	return f.collectors
+	// Create a new map with the same capacity as the original
+	cp := make(map[string]string, len(f.collectors))
+
+	// Copy all key-value pairs into the new map
+	for k, v := range f.collectors {
+		cp[k] = v
+	}
+
+	return cp
 }
 
 type FakePrometheusMetricManager struct {

--- a/pkg/metrics/fake.go
+++ b/pkg/metrics/fake.go
@@ -56,7 +56,6 @@ func (f *FakeMetricsManager) GetCollectors() map[string]string {
 	return f.collectors
 }
 
-
 type FakePrometheusMetricManager struct {
 	syncPVCounter  map[string]int
 	syncPodCounter map[string]int

--- a/pkg/metrics/fake.go
+++ b/pkg/metrics/fake.go
@@ -17,13 +17,45 @@ limitations under the License.
 
 package metrics
 
-type FakeMetricsManager struct{}
+import "sync"
 
+// FakeMetricsManager is a fake implementation of the MetricsManager interface for testing.
+type FakeMetricsManager struct {
+	collectors map[string]string
+	mu         sync.Mutex
+}
+
+// NewFakeMetricsManager returns a new FakeMetricsManager.
+func NewFakeMetricsManager() *FakeMetricsManager {
+	return &FakeMetricsManager{
+		collectors: make(map[string]string),
+	}
+}
+
+// InitializeHTTPHandler is a no-op.
 func (*FakeMetricsManager) InitializeHTTPHandler() {}
 
-func (*FakeMetricsManager) RegisterMetricsCollector(_, _, _, _ string) {}
+// RegisterMetricsCollector records the registration of a metrics collector.
+func (f *FakeMetricsManager) RegisterMetricsCollector(identifier, _, _, bucketName string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.collectors[identifier] = bucketName
+}
 
-func (*FakeMetricsManager) UnregisterMetricsCollector(_ string) {}
+// UnregisterMetricsCollector records the unregistration of a metrics collector.
+func (f *FakeMetricsManager) UnregisterMetricsCollector(identifier string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.collectors, identifier)
+}
+
+// GetCollectors returns the map of registered collectors.
+func (f *FakeMetricsManager) GetCollectors() map[string]string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.collectors
+}
+
 
 type FakePrometheusMetricManager struct {
 	syncPVCounter  map[string]int

--- a/pkg/profiles/recommender_test.go
+++ b/pkg/profiles/recommender_test.go
@@ -142,6 +142,12 @@ func (b *PVConfigBuilder) WithSCName(scName string) *PVConfigBuilder {
 	return b
 }
 
+// WithName sets the Name field.
+func (b *PVConfigBuilder) WithName(name string) *PVConfigBuilder {
+	b.config.Name = name
+	return b
+}
+
 // Build returns the final FakePVConfig.
 func (b *PVConfigBuilder) Build() clientset.FakePVConfig {
 	return b.config
@@ -248,7 +254,7 @@ func TestBuildProfileConfig(t *testing.T) {
 			name:         "TestBuildProfileConfig - Should build config successfully",
 			targetPath:   testTargetPath,
 			wantErr:      false,
-			pvConfig:     NewPVConfigBuilder().Build(),
+			pvConfig:     NewPVConfigBuilder().WithName("test-pv").Build(),
 			scConfig:     NewSCConfigBuilder().Build(),
 			nodeName:     "test-node",
 			nodeConfig:   NewNodeConfigBuilder().Build(),

--- a/test/e2e/testsuites/metrics.go
+++ b/test/e2e/testsuites/metrics.go
@@ -123,7 +123,7 @@ func (t *gcsFuseCSIMetricsTestSuite) DefineTests(driver storageframework.TestDri
 		framework.ExpectNoError(err, "while cleaning up")
 	}
 
-	verifyMetrics := func(tPod *specs.TestPod, volumeResource *storageframework.VolumeResource, mountPath, volumeName string) {
+	verifyMetrics := func(tPod *specs.TestPod, volumeResource *storageframework.VolumeResource, mountPath, volumeName string, expectMetrics bool) {
 		ginkgo.By("Running file operations on the volume")
 		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("mount | grep %v | grep rw,", mountPath))
 
@@ -255,7 +255,11 @@ func (t *gcsFuseCSIMetricsTestSuite) DefineTests(driver storageframework.TestDri
 			// Skip the gcs_reader_count validation if Zonal Bucket is enabled.
 			// TODO(uriel-guzman): Remove once the GCSFuse bug is fixed.
 			if !gcsfuseDriver.EnableZB || metricName != "gcs_reader_count" {
-				gomega.Expect(len(metricsList)).To(gomega.BeNumerically(">", 0), fmt.Sprintf("Found metric %q count: %v, expected count > 0", metricName, len(metricsList)))
+				if expectMetrics {
+					gomega.Expect(len(metricsList)).To(gomega.BeNumerically(">", 0), fmt.Sprintf("Found metric %q count: %v, expected count > 0", metricName, len(metricsList)))
+				} else {
+					gomega.Expect(len(metricsList)).To(gomega.BeNumerically("==", 0), fmt.Sprintf("Found no metrics for %q count: %v, expected count == 0", metricName, len(metricsList)))
+				}
 			}
 			ginkgo.By(fmt.Sprintf("Found metric %q count: %v", metricName, len(metricsList)))
 		}
@@ -282,7 +286,7 @@ func (t *gcsFuseCSIMetricsTestSuite) DefineTests(driver storageframework.TestDri
 		ginkgo.By("Checking that the pod is running")
 		tPod.WaitForRunning(ctx)
 
-		verifyMetrics(tPod, l.volumeResourceList[0], mountPath, volumeName)
+		verifyMetrics(tPod, l.volumeResourceList[0], mountPath, volumeName, true)
 	})
 
 	// This tests below configuration:
@@ -310,7 +314,53 @@ func (t *gcsFuseCSIMetricsTestSuite) DefineTests(driver storageframework.TestDri
 
 		for i, vr := range l.volumeResourceList {
 			ginkgo.By(fmt.Sprintf("Checking metrics from volume %v", i))
-			verifyMetrics(tPod, vr, fmt.Sprintf("%v/%v", mountPath, i), fmt.Sprintf("%v-%v", volumeName, i))
+			verifyMetrics(tPod, vr, fmt.Sprintf("%v/%v", mountPath, i), fmt.Sprintf("%v-%v", volumeName, i), true)
+		}
+	})
+
+	ginkgo.It("should emit metrics until a threshold of 10 gcsfuse volumes", func() {
+		init(10, specs.EnableFileCacheForceNewBucketAndMetricsPrefix)
+		defer cleanup()
+
+		ginkgo.By("Configuring the pod")
+		tPod := specs.NewTestPod(f.ClientSet, f.Namespace)
+		for i, vr := range l.volumeResourceList {
+			tPod.SetupVolume(vr, fmt.Sprintf("%v-%v", volumeName, i), fmt.Sprintf("%v/%v", mountPath, i), false)
+		}
+
+		ginkgo.By("Deploying the pod")
+		tPod.Create(ctx)
+		defer tPod.Cleanup(ctx)
+
+		ginkgo.By("Checking that the pod is running")
+		tPod.WaitForRunning(ctx)
+
+		for i, vr := range l.volumeResourceList {
+			ginkgo.By(fmt.Sprintf("Checking metrics from volume %v", i))
+			verifyMetrics(tPod, vr, fmt.Sprintf("%v/%v", mountPath, i), fmt.Sprintf("%v-%v", volumeName, i), true)
+		}
+	})
+
+	ginkgo.It("should emit no metrics when more than 10 gcsfuse volumes are mounted", func() {
+		init(11, specs.EnableFileCacheForceNewBucketAndMetricsPrefix)
+		defer cleanup()
+
+		ginkgo.By("Configuring the pod")
+		tPod := specs.NewTestPod(f.ClientSet, f.Namespace)
+		for i, vr := range l.volumeResourceList {
+			tPod.SetupVolume(vr, fmt.Sprintf("%v-%v", volumeName, i), fmt.Sprintf("%v/%v", mountPath, i), false)
+		}
+
+		ginkgo.By("Deploying the pod")
+		tPod.Create(ctx)
+		defer tPod.Cleanup(ctx)
+
+		ginkgo.By("Checking that the pod is running")
+		tPod.WaitForRunning(ctx)
+
+		for i, vr := range l.volumeResourceList {
+			ginkgo.By(fmt.Sprintf("Checking metrics from volume %v", i))
+			verifyMetrics(tPod, vr, fmt.Sprintf("%v/%v", mountPath, i), fmt.Sprintf("%v-%v", volumeName, i), false)
 		}
 	})
 }

--- a/test/sanity/sanity_test.go
+++ b/test/sanity/sanity_test.go
@@ -74,7 +74,7 @@ func TestSanity(t *testing.T) {
 		FeatureOptions:        &driver.GCSDriverFeatureOptions{FeatureGCSFuseProfiles: &driver.FeatureGCSFuseProfiles{}},
 	}
 
-	gcfsDriver, err := driver.NewGCSDriver(driverConfig)
+	gcfsDriver, err := driver.NewGCSDriver(driverConfig, nil)
 	if err != nil {
 		t.Fatalf("Failed to initialize Cloud Storage FUSE CSI Driver: %v", err)
 	}

--- a/test/sanity/sanity_test.go
+++ b/test/sanity/sanity_test.go
@@ -70,11 +70,11 @@ func TestSanity(t *testing.T) {
 		TokenManager:          auth.NewFakeTokenManager(),
 		Mounter:               mount.NewFakeMounter([]mount.MountPoint{}),
 		K8sClients:            clientset.NewFakeClientset(),
-		MetricsManager:        metrics.NewFakeMetricsManager(),
+		MetricsManager:        &metrics.FakeMetricsManager{},
 		FeatureOptions:        &driver.GCSDriverFeatureOptions{FeatureGCSFuseProfiles: &driver.FeatureGCSFuseProfiles{}},
 	}
 
-	gcfsDriver, err := driver.NewGCSDriver(driverConfig, nil)
+	gcfsDriver, err := driver.NewGCSDriver(driverConfig)
 	if err != nil {
 		t.Fatalf("Failed to initialize Cloud Storage FUSE CSI Driver: %v", err)
 	}

--- a/test/sanity/sanity_test.go
+++ b/test/sanity/sanity_test.go
@@ -70,7 +70,7 @@ func TestSanity(t *testing.T) {
 		TokenManager:          auth.NewFakeTokenManager(),
 		Mounter:               mount.NewFakeMounter([]mount.MountPoint{}),
 		K8sClients:            clientset.NewFakeClientset(),
-		MetricsManager:        &metrics.FakeMetricsManager{},
+		MetricsManager:        metrics.NewFakeMetricsManager(),
 		FeatureOptions:        &driver.GCSDriverFeatureOptions{FeatureGCSFuseProfiles: &driver.FeatureGCSFuseProfiles{}},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:
This PR disables the metric collectors when the gcsfuse volumes count in the pod spec is more than a given threshold(10 in this case) as it is considered unbounded without that and contributes to theoretically infinite cardinality and is not accepted for making these metrics live. Hence, disabling metrics collector when the number of gcsfuse volumes exceeds given threshold has been incorporated, accordingly corresponding tests have been added.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
      Metrics from GCSFuse CSI driver wouldn't be exported if the number of GCS CSI volumes are more than the current threshold of 10
```