### PR TITLE
Stream metrics export instead of downloading the entire content

### DIFF
--- a/cmd/csi_driver/main.go
+++ b/cmd/csi_driver/main.go
@@ -80,6 +80,10 @@ var (
 	clusterLocation               = flag.String("cluster-location", "", "The location (region/zone) in which the cluster is deployed")
 	enableGcsfuseProfilesInternal = flag.Bool("enable-gcsfuse-profiles-internal", false, "Allow the temporarily disallowed gcsfuse profiles flag ('profile') to be passed for internal use only")
 	projectNumber                 = flag.String("project-number", "", "The GKE Project Number for which the cluster is deployed")
+
+	// Stream metrics export
+	streamMetricsExport = flag.Bool("stream-metrics-export", false, "Stream metrics export instead of downloading the entire content")
+
 	// Leader election flags.
 	leaderElection                   = flag.Bool("leader-election", false, "Enables leader election for stateful driver.")
 	leaderElectionNamespace          = flag.String("leader-election-namespace", "", "The namespace where the leader election resource exists. Should be set in deployments to use the pod's namespace.")
@@ -237,7 +241,7 @@ func main() {
 		}
 
 		if addr != "" {
-			mm = metrics.NewMetricsManager(addr, *fuseSocketDir, *maximumNumberOfCollectors, clientset)
+			mm = metrics.NewMetricsManager(addr, *fuseSocketDir, *maximumNumberOfCollectors, clientset, *streamMetricsExport)
 			mm.InitializeHTTPHandler()
 		}
 	}

--- a/deploy/base/node/node.yaml
+++ b/deploy/base/node/node.yaml
@@ -60,6 +60,7 @@ spec:
             - --enable-gcsfuse-kernel-params=true
             - --enable-gcsfuse-profiles=true
             - --enable-gcsfuse-profiles-internal=true
+            - --stream-metrics-export=true
           ports:
           - containerPort: 9920
             name: metrics

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"iter"
 	"net"
 	"net/http"
 	"os"
@@ -61,18 +62,20 @@ type manager struct {
 	metricsEndpoint string
 	fuseSocketDir   string
 	clientset       clientset.Interface
+	streamMetrics   bool
 
 	maximumNumberOfCollectors   int
 	volumePublishPathRegistered sets.Set[string]
 	mutex                       sync.Mutex
 }
 
-func NewMetricsManager(metricsEndpoint, fuseSocketDir string, maximumNumberOfCollectors int, clientset clientset.Interface) Manager {
+func NewMetricsManager(metricsEndpoint, fuseSocketDir string, maximumNumberOfCollectors int, clientset clientset.Interface, streamMetrics bool) Manager {
 	mm := &manager{
 		registry:                    prometheus.NewRegistry(),
 		metricsEndpoint:             metricsEndpoint,
 		fuseSocketDir:               fuseSocketDir,
 		clientset:                   clientset,
+		streamMetrics:               streamMetrics,
 		volumePublishPathRegistered: sets.Set[string]{},
 		maximumNumberOfCollectors:   maximumNumberOfCollectors,
 		mutex:                       sync.Mutex{},
@@ -124,7 +127,7 @@ func (mm *manager) RegisterMetricsCollector(targetPath, podNamespace, podName, b
 		"volume_name":    volumeName,
 		"bucket_name":    bucketName,
 		"pod_uid":        "", // podUID is emptied to avoid infinite cardinality in the metric labels
-	}, mm.clientset)
+	}, mm.clientset, mm.streamMetrics)
 
 	// Lock the number of registered collectors while we attempt to register a new collector.
 	mm.mutex.Lock()
@@ -168,7 +171,7 @@ func (mm *manager) UnregisterMetricsCollector(targetPath, nodeName string) {
 	podUID, volumeName, _ := util.ParsePodIDVolumeFromTargetpath(targetPath)
 
 	// metricsCollector uses a hash of pod UID and volume name as an identifier.
-	c := NewMetricsCollector("", "", "", "", podUID, volumeName, nil, nil)
+	c := NewMetricsCollector("", "", "", "", podUID, volumeName, nil, nil, mm.streamMetrics)
 
 	// Lock the number of registered collectors while we attempt to unregister a collector.
 	mm.mutex.Lock()
@@ -191,10 +194,11 @@ type metricsCollector struct {
 	volumeName       string
 	httpClient       *http.Client
 	clientset        clientset.Interface
+	streamMetrics    bool
 }
 
 // NewMetricsCollector returns a new Collector exposing metrics read from the give path.
-func NewMetricsCollector(socketBasePath, emptyDirBasePath, namespace, podName, podUID, volumeName string, labels map[string]string, clientset clientset.Interface) prometheus.Collector {
+func NewMetricsCollector(socketBasePath, emptyDirBasePath, namespace, podName, podUID, volumeName string, labels map[string]string, clientset clientset.Interface, streamMetrics bool) prometheus.Collector {
 	c := &metricsCollector{
 		emptyDirBasePath: emptyDirBasePath,
 		constLabels:      labels,
@@ -203,6 +207,7 @@ func NewMetricsCollector(socketBasePath, emptyDirBasePath, namespace, podName, p
 		podUID:           podUID,
 		volumeName:       volumeName,
 		clientset:        clientset,
+		streamMetrics:    streamMetrics,
 	}
 
 	// Creating a new HTTP client that is configured to make HTTP requests over a unix domain socket.
@@ -258,15 +263,47 @@ func (c *metricsCollector) Collect(ch chan<- prometheus.Metric) {
 		return
 	}
 
-	families, err := ProcessMetricsData(resp.Body)
-	if err != nil {
-		klog.Errorf("failed to process metrics data: %v", err)
+	if c.streamMetrics {
+		for mf, err := range ProcessMetricsDataAsStream(resp.Body) {
+			if err != nil {
+				klog.Errorf("failed to decode metrics data: %v", err)
+				return
+			}
+			c.emitMetricFamily(mf, ch)
+		}
+	} else {
+		families, err := ProcessMetricsData(resp.Body)
+		if err != nil {
+			klog.Errorf("failed to process metrics data: %v", err)
 
-		return
+			return
+		}
+
+		for _, mf := range families {
+			c.emitMetricFamily(mf, ch)
+		}
 	}
+}
 
-	for _, mf := range families {
-		c.emitMetricFamily(mf, ch)
+// ProcessMetricsDataAsStream processes metrics that follow Prometheus text format,
+// returning an iterator of MetricFamily.
+func ProcessMetricsDataAsStream(metricsReader io.Reader) iter.Seq2[*dto.MetricFamily, error] {
+	return func(yield func(*dto.MetricFamily, error) bool) {
+		decoder := expfmt.NewDecoder(metricsReader, expfmt.FmtText)
+		for {
+			var mf dto.MetricFamily
+			err := decoder.Decode(&mf)
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+			if !yield(&mf, nil) {
+				return
+			}
+		}
 	}
 }
 

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -19,6 +19,7 @@ package metrics
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/clientset"
@@ -54,7 +55,7 @@ func TestNewMetricsManager(t *testing.T) {
 			t.Logf("test case: %s", tc.name)
 
 			clientset := clientset.NewFakeClientset()
-			manager := NewMetricsManager(tc.endpoint, tc.socketDir, tc.maxCollectors, clientset).(*manager)
+			manager := NewMetricsManager(tc.endpoint, tc.socketDir, tc.maxCollectors, clientset, false).(*manager)
 
 			if manager.metricsEndpoint != tc.endpoint {
 				t.Errorf("NewMetricsManager did not set metricsEndpoint correctly. Got %q, want %q", manager.metricsEndpoint, tc.endpoint)
@@ -162,5 +163,32 @@ func validatePrometheusMetric(t *testing.T, metric prometheus.Counter, expectedC
 	}
 	if count != expectedCount {
 		t.Fatalf("failed validating metric count, expected %v, got %v", expectedCount, count)
+	}
+}
+
+func TestProcessMetricsDataAsStream(t *testing.T) {
+	metricsData := `
+# HELP fs_ops_count The cumulative number of ops processed by the file system.
+# TYPE fs_ops_count counter
+fs_ops_count{fs_op="GetInodeAttributes"} 26
+fs_ops_count{fs_op="LookUpInode"} 6
+# HELP gcs_request_count The cumulative number of GCS requests processed along with the GCS method.
+# TYPE gcs_request_count counter
+gcs_request_count{gcs_method="ListObjects"} 32
+gcs_request_count{gcs_method="StatObject"} 6
+`
+	reader := strings.NewReader(metricsData)
+	count := 0
+	for mf, err := range ProcessMetricsDataAsStream(reader) {
+		if err != nil {
+			t.Fatalf("unexpected error parsing stream: %v", err)
+		}
+		if *mf.Name != "fs_ops_count" && *mf.Name != "gcs_request_count" {
+			t.Errorf("unexpected metric name: %s", *mf.Name)
+		}
+		count++
+	}
+	if count != 2 {
+		t.Errorf("expected 2 metric families, got %d", count)
 	}
 }

--- a/test/e2e/testsuites/metrics.go
+++ b/test/e2e/testsuites/metrics.go
@@ -244,8 +244,11 @@ func (t *gcsFuseCSIMetricsTestSuite) DefineTests(driver storageframework.TestDri
 		}
 		defer metricsFile.Close()
 
-		families, err := metricspkg.ProcessMetricsData(metricsFile)
-		framework.ExpectNoError(err)
+		families := map[string]*dto.MetricFamily{}
+		for mf, err := range metricspkg.ProcessMetricsDataAsStream(metricsFile) {
+			framework.ExpectNoError(err)
+			families[*mf.Name] = mf
+		}
 
 		volume := volumeName
 		if volumeResource.Pv != nil {

--- a/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/metrics/metrics.go
+++ b/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/metrics/metrics.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"iter"
 	"net"
 	"net/http"
 	"os"
@@ -61,18 +62,20 @@ type manager struct {
 	metricsEndpoint string
 	fuseSocketDir   string
 	clientset       clientset.Interface
+	streamMetrics   bool
 
 	maximumNumberOfCollectors   int
 	volumePublishPathRegistered sets.Set[string]
 	mutex                       sync.Mutex
 }
 
-func NewMetricsManager(metricsEndpoint, fuseSocketDir string, maximumNumberOfCollectors int, clientset clientset.Interface) Manager {
+func NewMetricsManager(metricsEndpoint, fuseSocketDir string, maximumNumberOfCollectors int, clientset clientset.Interface, streamMetrics bool) Manager {
 	mm := &manager{
 		registry:                    prometheus.NewRegistry(),
 		metricsEndpoint:             metricsEndpoint,
 		fuseSocketDir:               fuseSocketDir,
 		clientset:                   clientset,
+		streamMetrics:               streamMetrics,
 		volumePublishPathRegistered: sets.Set[string]{},
 		maximumNumberOfCollectors:   maximumNumberOfCollectors,
 		mutex:                       sync.Mutex{},
@@ -124,7 +127,7 @@ func (mm *manager) RegisterMetricsCollector(targetPath, podNamespace, podName, b
 		"volume_name":    volumeName,
 		"bucket_name":    bucketName,
 		"pod_uid":        "", // podUID is emptied to avoid infinite cardinality in the metric labels
-	}, mm.clientset)
+	}, mm.clientset, mm.streamMetrics)
 
 	// Lock the number of registered collectors while we attempt to register a new collector.
 	mm.mutex.Lock()
@@ -168,7 +171,7 @@ func (mm *manager) UnregisterMetricsCollector(targetPath, nodeName string) {
 	podUID, volumeName, _ := util.ParsePodIDVolumeFromTargetpath(targetPath)
 
 	// metricsCollector uses a hash of pod UID and volume name as an identifier.
-	c := NewMetricsCollector("", "", "", "", podUID, volumeName, nil, nil)
+	c := NewMetricsCollector("", "", "", "", podUID, volumeName, nil, nil, mm.streamMetrics)
 
 	// Lock the number of registered collectors while we attempt to unregister a collector.
 	mm.mutex.Lock()
@@ -191,10 +194,11 @@ type metricsCollector struct {
 	volumeName       string
 	httpClient       *http.Client
 	clientset        clientset.Interface
+	streamMetrics    bool
 }
 
 // NewMetricsCollector returns a new Collector exposing metrics read from the give path.
-func NewMetricsCollector(socketBasePath, emptyDirBasePath, namespace, podName, podUID, volumeName string, labels map[string]string, clientset clientset.Interface) prometheus.Collector {
+func NewMetricsCollector(socketBasePath, emptyDirBasePath, namespace, podName, podUID, volumeName string, labels map[string]string, clientset clientset.Interface, streamMetrics bool) prometheus.Collector {
 	c := &metricsCollector{
 		emptyDirBasePath: emptyDirBasePath,
 		constLabels:      labels,
@@ -203,6 +207,7 @@ func NewMetricsCollector(socketBasePath, emptyDirBasePath, namespace, podName, p
 		podUID:           podUID,
 		volumeName:       volumeName,
 		clientset:        clientset,
+		streamMetrics:    streamMetrics,
 	}
 
 	// Creating a new HTTP client that is configured to make HTTP requests over a unix domain socket.
@@ -258,15 +263,47 @@ func (c *metricsCollector) Collect(ch chan<- prometheus.Metric) {
 		return
 	}
 
-	families, err := ProcessMetricsData(resp.Body)
-	if err != nil {
-		klog.Errorf("failed to process metrics data: %v", err)
+	if c.streamMetrics {
+		for mf, err := range ProcessMetricsDataAsStream(resp.Body) {
+			if err != nil {
+				klog.Errorf("failed to decode metrics data: %v", err)
+				return
+			}
+			c.emitMetricFamily(mf, ch)
+		}
+	} else {
+		families, err := ProcessMetricsData(resp.Body)
+		if err != nil {
+			klog.Errorf("failed to process metrics data: %v", err)
 
-		return
+			return
+		}
+
+		for _, mf := range families {
+			c.emitMetricFamily(mf, ch)
+		}
 	}
+}
 
-	for _, mf := range families {
-		c.emitMetricFamily(mf, ch)
+// ProcessMetricsDataAsStream processes metrics that follow Prometheus text format,
+// returning an iterator of MetricFamily.
+func ProcessMetricsDataAsStream(metricsReader io.Reader) iter.Seq2[*dto.MetricFamily, error] {
+	return func(yield func(*dto.MetricFamily, error) bool) {
+		decoder := expfmt.NewDecoder(metricsReader, expfmt.FmtText)
+		for {
+			var mf dto.MetricFamily
+			err := decoder.Decode(&mf)
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+			if !yield(&mf, nil) {
+				return
+			}
+		}
 	}
 }
 
@@ -450,3 +487,4 @@ func GetErrorCode(err error) string {
 	code := internalErr.Code().String()
 	return code
 }
+


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Stream metrics export instead of downloading the entire content. This will help reduce the memory consumption of the CSI node container.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

Ran the following test that succeeded.

```
make e2e-test E2E_TEST_USE_GKE_MANAGED_DRIVER=false \
        E2E_TEST_BUILD_DRIVER=true \
        BUILD_GCSFUSE_FROM_SOURCE=true \
        REGISTRY=$REGISTRY \
        STAGINGVERSION=$STAGINGVERSION \
        E2E_TEST_FOCUS=metrics.* \
        GCSFUSE_TAG="v3.8.0"
```

**Output**
```
    << Timeline
  ------------------------------
  S
  ------------------------------
  [ReportAfterSuite] PASSED [0.115 seconds]
  [ReportAfterSuite] Autogenerated ReportAfterSuite for --junit-report
  autogenerated by Ginkgo
  ------------------------------

  Ran 8 of 558 Specs in 585.534 seconds
  SUCCESS! -- 8 Passed | 0 Failed | 0 Pending | 550 Skipped
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```