### PR TITLE
Optimize memory: Inline metric closure to prevent heap escapes

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -321,9 +321,6 @@ func ProcessMetricsData(metricsReader io.Reader) (map[string]*dto.MetricFamily, 
 
 // emitMetricFamily iterates MetricFamily, converts metricFamily.Metric to prometheus.Metric, and emits the metric via the given chan.
 func (c *metricsCollector) emitMetricFamily(metricFamily *dto.MetricFamily, ch chan<- prometheus.Metric) {
-	var valType prometheus.ValueType
-	var val float64
-
 	for _, metric := range metricFamily.GetMetric() {
 		var LabelNames []string
 		var LabelValues []string
@@ -337,33 +334,37 @@ func (c *metricsCollector) emitMetricFamily(metricFamily *dto.MetricFamily, ch c
 			LabelValues = append(LabelValues, v)
 		}
 
-		emitNewConstMetric := func() {
+		metricType := metricFamily.GetType()
+		switch metricType {
+		case dto.MetricType_COUNTER:
 			ch <- prometheus.MustNewConstMetric(
 				prometheus.NewDesc(
 					metricFamily.GetName(),
 					metricFamily.GetHelp(),
 					LabelNames, nil,
 				),
-				valType, val, LabelValues...,
+				prometheus.CounterValue, metric.GetCounter().GetValue(), LabelValues...,
 			)
-		}
-
-		metricType := metricFamily.GetType()
-		switch metricType {
-		case dto.MetricType_COUNTER:
-			valType = prometheus.CounterValue
-			val = metric.GetCounter().GetValue()
-			emitNewConstMetric()
 
 		case dto.MetricType_GAUGE:
-			valType = prometheus.GaugeValue
-			val = metric.GetGauge().GetValue()
-			emitNewConstMetric()
+			ch <- prometheus.MustNewConstMetric(
+				prometheus.NewDesc(
+					metricFamily.GetName(),
+					metricFamily.GetHelp(),
+					LabelNames, nil,
+				),
+				prometheus.GaugeValue, metric.GetGauge().GetValue(), LabelValues...,
+			)
 
 		case dto.MetricType_UNTYPED:
-			valType = prometheus.UntypedValue
-			val = metric.GetUntyped().GetValue()
-			emitNewConstMetric()
+			ch <- prometheus.MustNewConstMetric(
+				prometheus.NewDesc(
+					metricFamily.GetName(),
+					metricFamily.GetHelp(),
+					LabelNames, nil,
+				),
+				prometheus.UntypedValue, metric.GetUntyped().GetValue(), LabelValues...,
+			)
 
 		case dto.MetricType_SUMMARY:
 			quantiles := map[float64]float64{}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Optimize memory: Inline metric closure to prevent heap escapes
    
The `emitNewConstMetric` closure in `emitMetricFamily` was capturing
 several variables, causing them to escape to the heap. This resulted
 in unnecessary memory allocations and increased garbage collection
 overhead during metrics processing.
    
 By inlining the `prometheus.MustNewConstMetric` call directly into
 each `switch` case, we avoid the closure and the associated heap
 allocations, improving the performance and memory efficiency of
 metrics collection.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```