### PR TITLE
Memory optimizations - Reduce heap allocations and garbage generation in emitMetricFamily method

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -321,80 +321,86 @@ func ProcessMetricsData(metricsReader io.Reader) (map[string]*dto.MetricFamily, 
 
 // emitMetricFamily iterates MetricFamily, converts metricFamily.Metric to prometheus.Metric, and emits the metric via the given chan.
 func (c *metricsCollector) emitMetricFamily(metricFamily *dto.MetricFamily, ch chan<- prometheus.Metric) {
-	var valType prometheus.ValueType
-	var val float64
+	name := metricFamily.GetName()
+	help := metricFamily.GetHelp()
+	metricType := metricFamily.GetType()
+
+	var cachedDesc *prometheus.Desc
+
+	var cachedLabelNames []string
 
 	for _, metric := range metricFamily.GetMetric() {
-		var LabelNames []string
-		var LabelValues []string
-		for _, label := range metric.GetLabel() {
-			LabelNames = append(LabelNames, label.GetName())
-			LabelValues = append(LabelValues, label.GetValue())
+		labels := metric.GetLabel()
+
+		var desc *prometheus.Desc
+		// Reuse cached prometheus.Desc assuming identical label ordering.
+		if cachedDesc != nil && len(cachedLabelNames) == len(labels) {
+			desc = cachedDesc
+			for i, label := range labels {
+				if cachedLabelNames[i] != label.GetName() {
+					// Cache new prometheus.Desc to reduce garbage collection overhead and expensive string formatting.
+					desc = nil
+					break
+				}
+			}
 		}
 
-		for n, v := range c.constLabels {
-			LabelNames = append(LabelNames, n)
-			LabelValues = append(LabelValues, v)
+		if desc == nil {
+			labelNames := make([]string, len(labels))
+			for i, label := range labels {
+				labelNames[i] = label.GetName()
+			}
+			desc = prometheus.NewDesc(name, help, labelNames, prometheus.Labels(c.constLabels))
+			cachedDesc = desc
+			cachedLabelNames = labelNames
 		}
 
-		emitNewConstMetric := func() {
-			ch <- prometheus.MustNewConstMetric(
-				prometheus.NewDesc(
-					metricFamily.GetName(),
-					metricFamily.GetHelp(),
-					LabelNames, nil,
-				),
-				valType, val, LabelValues...,
-			)
+		labelValues := make([]string, len(labels))
+		for i, label := range labels {
+			labelValues[i] = label.GetValue()
 		}
 
-		metricType := metricFamily.GetType()
 		switch metricType {
 		case dto.MetricType_COUNTER:
-			valType = prometheus.CounterValue
-			val = metric.GetCounter().GetValue()
-			emitNewConstMetric()
+			ch <- prometheus.MustNewConstMetric(
+				desc,
+				prometheus.CounterValue, metric.GetCounter().GetValue(), labelValues...,
+			)
 
 		case dto.MetricType_GAUGE:
-			valType = prometheus.GaugeValue
-			val = metric.GetGauge().GetValue()
-			emitNewConstMetric()
+			ch <- prometheus.MustNewConstMetric(
+				desc,
+				prometheus.GaugeValue, metric.GetGauge().GetValue(), labelValues...,
+			)
 
 		case dto.MetricType_UNTYPED:
-			valType = prometheus.UntypedValue
-			val = metric.GetUntyped().GetValue()
-			emitNewConstMetric()
+			ch <- prometheus.MustNewConstMetric(
+				desc,
+				prometheus.UntypedValue, metric.GetUntyped().GetValue(), labelValues...,
+			)
 
 		case dto.MetricType_SUMMARY:
-			quantiles := map[float64]float64{}
+			quantiles := make(map[float64]float64, len(metric.GetSummary().GetQuantile()))
 			for _, q := range metric.GetSummary().GetQuantile() {
 				quantiles[q.GetQuantile()] = q.GetValue()
 			}
 			ch <- prometheus.MustNewConstSummary(
-				prometheus.NewDesc(
-					metricFamily.GetName(),
-					metricFamily.GetHelp(),
-					LabelNames, nil,
-				),
+				desc,
 				metric.GetSummary().GetSampleCount(),
 				metric.GetSummary().GetSampleSum(),
-				quantiles, LabelValues...,
+				quantiles, labelValues...,
 			)
 
 		case dto.MetricType_HISTOGRAM, dto.MetricType_GAUGE_HISTOGRAM:
-			buckets := map[float64]uint64{}
+			buckets := make(map[float64]uint64, len(metric.GetHistogram().GetBucket()))
 			for _, b := range metric.GetHistogram().GetBucket() {
 				buckets[b.GetUpperBound()] = b.GetCumulativeCount()
 			}
 			ch <- prometheus.MustNewConstHistogram(
-				prometheus.NewDesc(
-					metricFamily.GetName(),
-					metricFamily.GetHelp(),
-					LabelNames, nil,
-				),
+				desc,
 				metric.GetHistogram().GetSampleCount(),
 				metric.GetHistogram().GetSampleSum(),
-				buckets, LabelValues...,
+				buckets, labelValues...,
 			)
 
 		default:

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/clientset"
 	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -191,4 +192,56 @@ gcs_request_count{gcs_method="StatObject"} 6
 	if count != 2 {
 		t.Errorf("expected 2 metric families, got %d", count)
 	}
+}
+
+func BenchmarkEmitMetricFamily(b *testing.B) {
+	name := "test_metric"
+	help := "test help"
+	metricType := dto.MetricType_COUNTER
+	val := float64(42.0)
+
+	var metrics []*dto.Metric
+	for i := 0; i < 100; i++ {
+		labelName := "foo"
+		labelVal := fmt.Sprintf("bar_%d", i)
+		metrics = append(metrics, &dto.Metric{
+			Label: []*dto.LabelPair{
+				{Name: &labelName, Value: &labelVal},
+			},
+			Counter: &dto.Counter{Value: &val},
+		})
+	}
+
+	mf := &dto.MetricFamily{
+		Name:   &name,
+		Help:   &help,
+		Type:   &metricType,
+		Metric: metrics,
+	}
+
+	c := &metricsCollector{
+		constLabels: map[string]string{
+			"const_foo": "const_bar",
+		},
+	}
+
+	ch := make(chan prometheus.Metric, 1000)
+	done := make(chan struct{})
+
+	go func() {
+		for range ch {
+		}
+		close(done)
+	}()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		c.emitMetricFamily(mf, ch)
+	}
+
+	b.StopTimer()
+	close(ch)
+	<-done
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Memory optimizations:
* Inline metric closure to prevent heap escapes
* Avoid iterations by passing constLabels directly to NewDesc
* Pre-allocate slices and maps based on known capacities
* Cache Prometheus.Desc per metric family

Added a benchmark test to validate the performance improvements.



### Performance before changes
```
 % go test -v -bench=. --run=^$ -benchmem  ./pkg/metrics/...
goos: linux
goarch: amd64
pkg: github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/metrics
cpu: Intel(R) Xeon(R) CPU @ 2.20GHz
BenchmarkEmitMetricFamily
BenchmarkEmitMetricFamily-16    	    5414	    248757 ns/op	   77602 B/op	    2400 allocs/op
PASS
ok  	github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/metrics	1.568s
```

### Performance after changes
```
 % go test -v -bench=. --run=^$ -benchmem  ./pkg/metrics/...
goos: linux
goarch: amd64
pkg: github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/metrics
cpu: Intel(R) Xeon(R) CPU @ 2.20GHz
BenchmarkEmitMetricFamily
BenchmarkEmitMetricFamily-16    	   12562	     96032 ns/op	   35568 B/op	    1012 allocs/op
PASS
ok  	github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/metrics	2.377s

```


### E2E Test results
```
    << Timeline
  ------------------------------
  S
  ------------------------------
  [ReportAfterSuite] PASSED [0.125 seconds]
  [ReportAfterSuite] Autogenerated ReportAfterSuite for --junit-report
  autogenerated by Ginkgo
  ------------------------------

  Ran 8 of 558 Specs in 585.621 seconds
  SUCCESS! -- 8 Passed | 0 Failed | 0 Pending | 550 Skipped


  Ginkgo ran 1 suite in 9m52.772847778s
  Test Suite Passed
Completed running e2e tests for testing the PR

```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```