### PR TITLE
Add support for X.509 Pod Certificates in GCS Fuse CSI driver

### DIFF
--- a/deploy/base/node/node_setup.yaml
+++ b/deploy/base/node/node_setup.yaml
@@ -50,6 +50,10 @@ rules:
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
     verbs: ["get", "list", "watch"]
+# Required to read pod certificate secret.
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/pkg/cloud_provider/auth/fake.go
+++ b/pkg/cloud_provider/auth/fake.go
@@ -31,6 +31,10 @@ func (tm *fakeTokenManager) GetTokenSourceFromK8sServiceAccount(saNamespace, saN
 	return &FakeGCPTokenSource{k8sSAName: saName, k8sSANamespace: saNamespace}
 }
 
+func (tm *fakeTokenManager) GetTokenSourceFromCertificate(certData, keyData []byte, audience string, tokenURL string) oauth2.TokenSource {
+	return &FakeGCPTokenSource{}
+}
+
 func (tm *fakeTokenManager) GetIdentityProvider() string {
 	return "fake.identity.provider"
 }

--- a/pkg/cloud_provider/auth/token_manager.go
+++ b/pkg/cloud_provider/auth/token_manager.go
@@ -31,6 +31,7 @@ const (
 
 type TokenManager interface {
 	GetTokenSourceFromK8sServiceAccount(saNamespace, saName, saToken, audience string, fetchFromFile bool) oauth2.TokenSource
+	GetTokenSourceFromCertificate(certData, keyData []byte, audience string, tokenURL string) oauth2.TokenSource
 	GetIdentityProvider() string
 	GetIdentityPool() string
 }
@@ -66,5 +67,16 @@ func (tm *tokenManager) GetTokenSourceFromK8sServiceAccount(saNamespace, saName,
 		k8sClients:         tm.k8sClients,
 		audience:           audience,
 		fetchTokenfromFile: fetchFromFile,
+	}
+}
+
+func (tm *tokenManager) GetTokenSourceFromCertificate(certData, keyData []byte, audience string, tokenURL string) oauth2.TokenSource {
+	return &GCPTokenSource{
+		meta:       tm.meta,
+		k8sClients: tm.k8sClients,
+		certData:   certData,
+		keyData:    keyData,
+		audience:   audience,
+		tokenURL:   tokenURL,
 	}
 }

--- a/pkg/cloud_provider/auth/token_sources.go
+++ b/pkg/cloud_provider/auth/token_sources.go
@@ -19,9 +19,13 @@ package auth
 
 import (
 	"context"
+	"crypto/tls"
+	"encoding/base64"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -58,12 +62,20 @@ type GCPTokenSource struct {
 	k8sClients         clientset.Interface
 	audience           string
 	fetchTokenfromFile bool // This is set for sidecar where pod doesn't have access to get service account details
+	certData           []byte
+	keyData            []byte
+	tokenURL           string
 }
 
 // Token exchanges a GCP IAM SA Token with a Kubernetes Service Account token.
 func (ts *GCPTokenSource) Token() (*oauth2.Token, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
+
+	if len(ts.certData) > 0 && len(ts.keyData) > 0 {
+		return ts.fetchTokenViaCertificate(ctx)
+	}
+
 	var k8sSAToken string
 	var err error
 	// If fetchTokenfromFile is set we assume the request is coming from sidecar, as the sidecar (user pod) doesn't have access to get service account details we fetch the service account from file.
@@ -96,6 +108,73 @@ func (ts *GCPTokenSource) Token() (*oauth2.Token, error) {
 		return nil, fmt.Errorf("GCP service account token fetch error: %w", err)
 	}
 	return token, nil
+}
+
+func (ts *GCPTokenSource) fetchTokenViaCertificate(ctx context.Context) (*oauth2.Token, error) {
+	klog.Infof("fetchTokenViaCertificate called with audience: %s", ts.audience)
+	cert, err := tls.X509KeyPair(ts.certData, ts.keyData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load X509 key pair: %w", err)
+	}
+	klog.Infof("Successfully loaded X509 key pair")
+
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+	}
+
+	tr := &http.Transport{TLSClientConfig: tlsConfig}
+	client := &http.Client{Transport: tr}
+
+	u, err := url.Parse(ts.tokenURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse token URL %q: %w", ts.tokenURL, err)
+	}
+	baseURL := fmt.Sprintf("%s://%s/", u.Scheme, u.Host)
+
+	// Use the custom client with the STS service
+	stsService, err := sts.NewService(ctx, option.WithHTTPClient(client), option.WithEndpoint(baseURL))
+	if err != nil {
+		return nil, fmt.Errorf("new STS service error: %w", err)
+	}
+
+	var convertedChain []string
+	rest := ts.certData
+	for {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		derBase64 := base64.StdEncoding.EncodeToString(block.Bytes)
+		convertedChain = append(convertedChain, derBase64)
+	}
+
+	convertedChainBytes, err := json.Marshal(convertedChain)
+	if err != nil {
+		return nil, fmt.Errorf("while marshaling converted chain: %w", err)
+	}
+
+	stsRequest := &sts.GoogleIdentityStsV1ExchangeTokenRequest{
+		Audience:           ts.audience,
+		GrantType:          "urn:ietf:params:oauth:grant-type:token-exchange",
+		Scope:              credentials.DefaultAuthScopes()[0],
+		RequestedTokenType: "urn:ietf:params:oauth:token-type:access_token",
+		SubjectTokenType:   "urn:ietf:params:oauth:token-type:mtls",
+		SubjectToken:       string(convertedChainBytes),
+	}
+
+	stsResponse, err := stsService.V1.Token(stsRequest).Do()
+	if err != nil {
+		return nil, fmt.Errorf("STS exchange failed: %w", err)
+	}
+
+	klog.Infof("Successfully obtained token from STS")
+
+	return &oauth2.Token{
+		AccessToken: stsResponse.AccessToken,
+		TokenType:   stsResponse.TokenType,
+		Expiry:      time.Now().Add(time.Second * time.Duration(stsResponse.ExpiresIn)),
+	}, nil
 }
 
 // fetch Kubernetes Service Account token by calling Kubernetes API.

--- a/pkg/cloud_provider/auth/token_sources_test.go
+++ b/pkg/cloud_provider/auth/token_sources_test.go
@@ -1,0 +1,113 @@
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestFetchTokenViaCertificate(t *testing.T) {
+	// 1. Generate a self-signed certificate for testing
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization: []string{"Test Org"},
+		},
+		NotBefore: time.Now(),
+		NotAfter:  time.Now().Add(time.Hour),
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:         []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	certPem := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+	keyPem := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(priv)})
+
+	// 2. Setup mock STS server
+	expectedAccessToken := "mock-access-token"
+	expectedExpiresIn := 3600
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("Expected POST request, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/token" {
+			t.Errorf("Expected path /v1/token, got %s", r.URL.Path)
+		}
+
+		var reqBody struct {
+			Audience           string `json:"audience"`
+			GrantType          string `json:"grantType"`
+			Scope              string `json:"scope"`
+			RequestedTokenType string `json:"requestedTokenType"`
+			SubjectTokenType   string `json:"subjectTokenType"`
+			SubjectToken       string `json:"subjectToken"`
+		}
+
+		if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+			t.Fatal(err)
+		}
+
+		// Verify SubjectToken contains the base64 encoded DER
+		var subjectTokenList []string
+		if err := json.Unmarshal([]byte(reqBody.SubjectToken), &subjectTokenList); err != nil {
+			t.Fatal(err)
+		}
+
+		if len(subjectTokenList) != 1 {
+			t.Errorf("Expected 1 cert in SubjectToken, got %d", len(subjectTokenList))
+		}
+
+		expectedDerBase64 := base64.StdEncoding.EncodeToString(derBytes)
+		if subjectTokenList[0] != expectedDerBase64 {
+			t.Errorf("Expected SubjectToken to contain %s, got %s", expectedDerBase64, subjectTokenList[0])
+		}
+
+		// Return mock response
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": expectedAccessToken,
+			"token_type":   "Bearer",
+			"expires_in":   expectedExpiresIn,
+		})
+	}))
+	defer server.Close()
+
+	// 3. Run the test
+	ts := &GCPTokenSource{
+		certData: certPem,
+		keyData:  keyPem,
+		audience: "fake-audience",
+		tokenURL: server.URL + "/v1/token", // Pass full URL, code should extract base URL
+	}
+
+	token, err := ts.fetchTokenViaCertificate(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if token.AccessToken != expectedAccessToken {
+		t.Errorf("Expected access token %s, got %s", expectedAccessToken, token.AccessToken)
+	}
+}

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -31,11 +31,13 @@ import (
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/webhook"
 	"golang.org/x/net/context"
+	"golang.org/x/oauth2"
 	"golang.org/x/time/rate"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 	mount "k8s.io/mount-utils"
 )
@@ -489,7 +491,24 @@ func (s *nodeServer) setupMultiNIC(args *requestArgs, pod *corev1.Pod, sidecarSu
 
 // prepareStorageService prepares the GCS Storage Service using the Kubernetes Service Account from VolumeContext.
 func (s *nodeServer) prepareStorageService(ctx context.Context, vc map[string]string) (storage.Service, error) {
-	ts := s.driver.config.TokenManager.GetTokenSourceFromK8sServiceAccount(vc[VolumeContextKeyPodNamespace], vc[VolumeContextKeyServiceAccountName], vc[VolumeContextKeyServiceAccountToken], "" /*audience*/, false)
+	klog.Infof("prepareStorageService called, VolumeContext: %+v", vc)
+	var ts oauth2.TokenSource
+	if secretName, ok := vc["podCertificateSecret"]; ok && secretName != "" {
+		klog.V(4).Infof("prepareStorageService using podCertificateSecret %s", secretName)
+		secret, err := s.k8sClients.K8sClient().CoreV1().Secrets(vc[VolumeContextKeyPodNamespace]).Get(ctx, secretName, metav1.GetOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("failed to get secret %s: %w", secretName, err)
+		}
+		certData := secret.Data["tls.crt"]
+		keyData := secret.Data["tls.key"]
+		audience := vc["podCertificateAudience"]
+		tokenURL := vc["podCertificateTokenURL"]
+
+		ts = s.driver.config.TokenManager.GetTokenSourceFromCertificate(certData, keyData, audience, tokenURL)
+	} else {
+		ts = s.driver.config.TokenManager.GetTokenSourceFromK8sServiceAccount(vc[VolumeContextKeyPodNamespace], vc[VolumeContextKeyServiceAccountName], vc[VolumeContextKeyServiceAccountToken], "" /*audience*/, false)
+	}
+
 	storageService, err := s.storageServiceManager.SetupService(ctx, ts)
 	if err != nil {
 		return nil, fmt.Errorf("storage service manager failed to setup service: %w", err)

--- a/pkg/webhook/mutatingwebhook.go
+++ b/pkg/webhook/mutatingwebhook.go
@@ -56,6 +56,8 @@ const (
 	metadataPrefetchMemoryRequestAnnotation          = "gke-gcsfuse/metadata-prefetch-memory-request"
 	GCPWorkloadIdentityCredentialConfigMapAnnotation = "gke-gcsfuse/workload-identity-credential-configmap"
 	NumaPinningAnnotation                            = "gke-gcsfuse/enable-numa-pinning"
+	GcsFuseUsePodCertificateAnnotation               = "gke-gcsfuse/use-pod-certificate"
+	GcsFusePodCertificateSecretAnnotation            = "gke-gcsfuse/pod-certificate-secret"
 )
 
 var (
@@ -134,7 +136,12 @@ func (si *SidecarInjector) Handle(ctx context.Context, req admission.Request) ad
 	}
 
 	var sidecarCredentialConfig *SidecarContainerCredentialConfiguration
-	// Inject GCP workload identity credential config configmap and token.
+	// Inject GCP workload identity credential config configmap and token/certificate.
+	usePodCertificate := false
+	if usePodCertStr, ok := pod.Annotations[GcsFuseUsePodCertificateAnnotation]; ok {
+		usePodCertificate, _ = ParseBool(usePodCertStr)
+	}
+
 	if configMapName, ok := pod.Annotations[GCPWorkloadIdentityCredentialConfigMapAnnotation]; ok && configMapName != "" && si.K8SClient != nil {
 		// Validate that OIDC authentication is not used with hostNetwork pods
 		if pod.Spec.HostNetwork {
@@ -145,16 +152,34 @@ func (si *SidecarInjector) Handle(ctx context.Context, req admission.Request) ad
 					GCPWorkloadIdentityCredentialConfigMapAnnotation))
 		}
 
-		filename, credentialConfig, err := appendWorkloadCredentialConfigurationVolumes(si.K8SClient, pod, configMapName)
+		var filename string
+		var credentialConfig *CredentialConfig
+		var err error
+
+		if usePodCertificate {
+			signerName := "kubernetes.io/kube-apiserver-client" // Default signer
+			filename, credentialConfig, err = appendPodCertificateVolumes(si.K8SClient, pod, configMapName, signerName)
+		} else {
+			filename, credentialConfig, err = appendWorkloadCredentialConfigurationVolumes(si.K8SClient, pod, configMapName)
+		}
+
 		if err != nil {
 			return admission.Errored(http.StatusBadRequest, err)
 		}
+		mountPath := "/var/run/secrets/pod-certs"
+		if !usePodCertificate {
+			mountPath = filepath.Dir(credentialConfig.CredentialSource.File)
+		}
+
 		sidecarCredentialConfig = &SidecarContainerCredentialConfiguration{
 			GacEnv: &corev1.EnvVar{Name: "GOOGLE_APPLICATION_CREDENTIALS", Value: fmt.Sprintf("%s/%s", SidecarContainerWICredentialConfigMapVolumeMountPath, filename)},
 			CredentialVolumeMounts: []corev1.VolumeMount{
-				{Name: SidecarContainerWITokenVolumeName, MountPath: filepath.Dir(credentialConfig.CredentialSource.File)},
+				{Name: SidecarContainerWITokenVolumeName, MountPath: mountPath},
 				{Name: SidecarContainerWICredentialConfigMapVolumeName, MountPath: SidecarContainerWICredentialConfigMapVolumeMountPath},
 			},
+		}
+		if usePodCertificate {
+			sidecarCredentialConfig.GaccEnv = &corev1.EnvVar{Name: "GOOGLE_API_CERTIFICATE_CONFIG", Value: fmt.Sprintf("%s/%s", SidecarContainerWICredentialConfigMapVolumeMountPath, "certificate_config.json")}
 		}
 		klog.Infof("Injected GCP workload identity credential configuration configMap %s in namespace %s", configMapName, pod.Namespace)
 	}
@@ -452,6 +477,60 @@ func appendWorkloadCredentialConfigurationVolumes(client kubernetes.Interface, p
 	return filename, credConfig, nil
 }
 
+func appendPodCertificateVolumes(client kubernetes.Interface, pod *corev1.Pod, configMapName string, signerName string) (string, *CredentialConfig, error) {
+	klog.Infof("appendPodCertificateVolumes called, pod volumes: %+v", pod.Spec.Volumes)
+	filename, credConfig, err := parseCredentialConfigurationConfigMap(client, pod, configMapName)
+	if err != nil {
+		klog.Errorf("failed to parse the workload identity credential configuration configMap %s in namespace %s: %v", configMapName, pod.Namespace, err)
+		return "", nil, err
+	}
+	klog.Infof("Parsed the workload identity credential configuration configMap %s in namespace %s %+v", configMapName, pod.Namespace, credConfig)
+
+	secretName := "pod-certs" // Default
+	if val, ok := pod.Annotations[GcsFusePodCertificateSecretAnnotation]; ok && val != "" {
+		secretName = val
+	}
+
+	pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
+		Name: SidecarContainerWITokenVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: secretName,
+			},
+		},
+	})
+
+	// Inject secret name, audience and token URL into VolumeAttributes of the CSI volume
+	for i, v := range pod.Spec.Volumes {
+		klog.Infof("Checking volume %s for CSI driver, CSI: %+v", v.Name, v.CSI)
+		if v.CSI != nil && (v.CSI.Driver == "gcsfuse.csi.storage.gke.io" || v.CSI.Driver == util.GCSFuseCsiDriverName) {
+			if v.CSI.VolumeAttributes == nil {
+				pod.Spec.Volumes[i].CSI.VolumeAttributes = make(map[string]string)
+			}
+			pod.Spec.Volumes[i].CSI.VolumeAttributes["podCertificateSecret"] = secretName
+			pod.Spec.Volumes[i].CSI.VolumeAttributes["podCertificateAudience"] = credConfig.Audience
+			pod.Spec.Volumes[i].CSI.VolumeAttributes["podCertificateTokenURL"] = credConfig.TokenURL
+			klog.Infof("Injected podCertificateSecret=%s, podCertificateAudience=%s, podCertificateTokenURL=%s into VolumeAttributes for volume %s", secretName, credConfig.Audience, credConfig.TokenURL, v.Name)
+			break
+		}
+	}
+
+	if !checkConfigMapVolumeExists(pod) {
+		pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
+			Name: SidecarContainerWICredentialConfigMapVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: configMapName,
+					},
+					DefaultMode: &defaultMode,
+				},
+			},
+		})
+	}
+	return filename, credConfig, nil
+}
+
 // checkConfigMapVolumeExists checks if the configMap volume already exists in the pod volumes.
 // pod: the pod to log information for.
 func checkConfigMapVolumeExists(pod *corev1.Pod) bool {
@@ -466,6 +545,7 @@ func checkConfigMapVolumeExists(pod *corev1.Pod) bool {
 
 type CredentialConfig struct {
 	Audience         string `json:"audience"`
+	TokenURL         string `json:"token_url"`
 	CredentialSource struct {
 		File string `json:"file"`
 	} `json:"credential_source"`
@@ -480,18 +560,19 @@ func parseCredentialConfigurationConfigMap(client kubernetes.Interface, pod *cor
 		return "", nil, fmt.Errorf("failed to get configMap %s in namespace %s: %v", configMapName, pod.Namespace, err)
 	}
 
-	if len(configMap.Data) != 1 {
-		return "", nil, fmt.Errorf("ConfigMap %s in namespace %s must contain exactly one data entry, but found %d", configMapName, pod.Namespace, len(configMap.Data))
-	}
-
-	// Find the file name for the credential configuration. Typically it is credential-configuration.json
 	var filename string
-	for key := range configMap.Data {
-		filename = key
-	}
-
-	if len(filename) == 0 {
-		return "", nil, fmt.Errorf("ill-formatted workload identity credential configuration configMap %s in namespace %s", configMapName, pod.Namespace)
+	if len(configMap.Data) == 1 {
+		for key := range configMap.Data {
+			filename = key
+		}
+	} else if len(configMap.Data) > 1 {
+		if _, ok := configMap.Data["credential-configuration.json"]; ok {
+			filename = "credential-configuration.json"
+		} else {
+			return "", nil, fmt.Errorf("ConfigMap %s in namespace %s contains multiple entries but not 'credential-configuration.json'", configMapName, pod.Namespace)
+		}
+	} else {
+		return "", nil, fmt.Errorf("ConfigMap %s in namespace %s contains no data", configMapName, pod.Namespace)
 	}
 
 	// Parse the JSON content

--- a/pkg/webhook/mutatingwebhook_test.go
+++ b/pkg/webhook/mutatingwebhook_test.go
@@ -595,6 +595,13 @@ func TestValidateMutatingWebhookResponse(t *testing.T) {
 			wantResponse: wantResponse(t, false, false, true),
 			nodes:        nativeSupportNodes(),
 		},
+		{
+			name:         "pod certificate injection successful test.",
+			operation:    admissionv1.Create,
+			inputPod:     validInputPodWithPodCertificate("test-credentials", true),
+			wantResponse: wantPodCertificateResponse(t, "test-credentials"),
+			nodes:        nativeSupportNodes(),
+		},
 	}
 
 	for _, tc := range testCases {
@@ -1624,6 +1631,66 @@ func modifySpecWithWorkloadIdentity(newPod corev1.Pod, configMapName string) *co
 	}
 
 	// Add native sidecar container
+	newPod.Spec.InitContainers = append([]corev1.Container{GetNativeSidecarContainerSpec(config, sidecarCredentialConfig)}, newPod.Spec.InitContainers...)
+	newPod.Spec.Volumes = append(GetSidecarContainerVolumeSpec(newPod.Spec.Volumes...), newPod.Spec.Volumes...)
+
+	return &newPod
+}
+
+func validInputPodWithPodCertificate(configMapName string, usePodCert bool) *corev1.Pod {
+	pod := validInputPod()
+	pod.ObjectMeta.Namespace = testNamespace
+	if configMapName != "" {
+		pod.ObjectMeta.Annotations[GCPWorkloadIdentityCredentialConfigMapAnnotation] = configMapName
+	}
+	if usePodCert {
+		pod.ObjectMeta.Annotations[GcsFuseUsePodCertificateAnnotation] = "true"
+	}
+	return pod
+}
+
+func wantPodCertificateResponse(t *testing.T, configMapName string) admission.Response {
+	t.Helper()
+	originalPod := validInputPodWithPodCertificate(configMapName, true)
+	newPod := *modifySpecWithPodCertificate(*originalPod, configMapName)
+	return generatePatch(t, originalPod, &newPod)
+}
+
+func modifySpecWithPodCertificate(newPod corev1.Pod, configMapName string) *corev1.Pod {
+	config := FakeConfig()
+	sidecarCredentialConfig := &SidecarContainerCredentialConfiguration{
+		GacEnv: &corev1.EnvVar{
+			Name:  "GOOGLE_APPLICATION_CREDENTIALS",
+			Value: fmt.Sprintf("%s/%s", SidecarContainerWICredentialConfigMapVolumeMountPath, "credential-configuration.json"),
+		},
+		CredentialVolumeMounts: []corev1.VolumeMount{
+			{Name: SidecarContainerWITokenVolumeName, MountPath: "/var/run/service-account"},
+			{Name: SidecarContainerWICredentialConfigMapVolumeName, MountPath: SidecarContainerWICredentialConfigMapVolumeMountPath},
+		},
+	}
+
+	newPod.Spec.Volumes = append(newPod.Spec.Volumes,
+		corev1.Volume{
+			Name: SidecarContainerWITokenVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: "pod-certs",
+				},
+			},
+		},
+		corev1.Volume{
+			Name: SidecarContainerWICredentialConfigMapVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: configMapName,
+					},
+					DefaultMode: &defaultMode,
+				},
+			},
+		},
+	)
+
 	newPod.Spec.InitContainers = append([]corev1.Container{GetNativeSidecarContainerSpec(config, sidecarCredentialConfig)}, newPod.Spec.InitContainers...)
 	newPod.Spec.Volumes = append(GetSidecarContainerVolumeSpec(newPod.Spec.Volumes...), newPod.Spec.Volumes...)
 

--- a/pkg/webhook/sidecar_spec.go
+++ b/pkg/webhook/sidecar_spec.go
@@ -117,6 +117,7 @@ var (
 
 type SidecarContainerCredentialConfiguration struct {
 	GacEnv                 *corev1.EnvVar       // This is the environment variable for GOOGLE_APPLICATION_CREDENTIALS that will be injected into the sidecar container.
+	GaccEnv                *corev1.EnvVar       // This is the environment variable for GOOGLE_API_CERTIFICATE_CONFIG that will be injected into the sidecar container.
 	CredentialVolumeMounts []corev1.VolumeMount // These are the volume mounts for the credential files that will be injected into the sidecar container.
 }
 
@@ -157,6 +158,11 @@ func GetSidecarContainerSpec(c *Config, credentialConfig *SidecarContainerCreden
 		// Inject the environment variable for GOOGLE_APPLICATION_CREDENTIALS.
 		if credentialConfig.GacEnv != nil {
 			container.Env = append(container.Env, *credentialConfig.GacEnv)
+		}
+
+		// Inject the environment variable for GOOGLE_API_CERTIFICATE_CONFIG.
+		if credentialConfig.GaccEnv != nil {
+			container.Env = append(container.Env, *credentialConfig.GaccEnv)
 		}
 
 		// Inject the volume mounts for the credential files.

--- a/poc/option1/README.md
+++ b/poc/option1/README.md
@@ -1,0 +1,27 @@
+# Option 1 POC: Meta CLI in Sidecar
+
+This directory contains the resources to run a Proof of Concept for integrating a custom token-fetching CLI into the GCS Fuse sidecar using Google Cloud Workload Identity Federation's executable-sourced credentials.
+
+## Files
+
+- `mock_cli.go`: Source code for the dummy CLI that returns a mock token.
+- `option1_poc.yaml`: Kubernetes manifest containing ConfigMaps for the code and credential config, and a Pod that builds and runs it.
+
+## How to Run
+
+1. Apply the manifest to your cluster:
+   ```bash
+   kubectl apply -f option1_poc.yaml
+   ```
+
+2. Verify the pod is running:
+   ```bash
+   kubectl get pod gcsfuse-poc-option1
+   ```
+
+3. Check the logs of the `gcsfuse-sidecar` container to see the authentication attempt:
+   ```bash
+   kubectl logs gcsfuse-poc-option1 -c gcsfuse-sidecar
+   ```
+
+Note: The authentication will fail with `invalid_target` because it uses dummy values for the project and workload identity pool. This is expected and proves the mechanism works.

--- a/poc/option1/README.md
+++ b/poc/option1/README.md
@@ -1,4 +1,4 @@
-# Option 1 POC: Meta CLI in Sidecar
+# Option 1 POC: CLI in Sidecar
 
 This directory contains the resources to run a Proof of Concept for integrating a custom token-fetching CLI into the GCS Fuse sidecar using Google Cloud Workload Identity Federation's executable-sourced credentials.
 

--- a/poc/option1/mock_cli.go
+++ b/poc/option1/mock_cli.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"fmt"
+)
+
+func main() {
+	fmt.Println(`{
+  "version": 1,
+  "success": true,
+  "token_type": "urn:ietf:params:oauth:token-type:id_token",
+  "id_token": "DUMMY_TOKEN_FROM_MOCK_CLI"
+}`)
+}

--- a/poc/option1/option1_poc.yaml
+++ b/poc/option1/option1_poc.yaml
@@ -1,0 +1,85 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mock-cli-source
+data:
+  mock_cli.go: |
+    package main
+    import "fmt"
+    func main() {
+      fmt.Println(`{
+        "version": 1,
+        "success": true,
+        "token_type": "urn:ietf:params:oauth:token-type:id_token",
+        "id_token": "DUMMY_TOKEN_FROM_MOCK_CLI"
+      }`)
+    }
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mock-cred-config
+data:
+  cred_config.json: |
+    {
+      "type": "external_account",
+      "audience": "//iam.googleapis.com/projects/123456789/locations/global/workloadIdentityPools/mock-pool/providers/mock-provider",
+      "subject_token_type": "urn:ietf:params:oauth:token-type:id_token",
+      "token_url": "https://sts.googleapis.com/v1/token",
+      "credential_source": {
+        "executable": {
+          "command": "/scripts/mock_cli.sh",
+          "timeout_millis": 5000,
+          "output_files": []
+        }
+      }
+    }
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: gcsfuse-poc-option1
+spec:
+  initContainers:
+  - name: build-cli
+    image: golang:1.24-alpine
+    command: ["sh", "-c", "CGO_ENABLED=0 go build -o /out/mock_cli.sh /src/mock_cli.go"]
+    volumeMounts:
+    - name: source-volume
+      mountPath: /src
+    - name: binary-volume
+      mountPath: /out
+  containers:
+  - name: main-app
+    image: busybox
+    command: ["sleep", "3600"]
+  - name: gcsfuse-sidecar
+    image: us-docker.pkg.dev/yangspirit-joonix/main/gcs-fuse-csi-driver-sidecar-mounter:test-x509_linux_amd64
+    command: ["/gcsfuse"]
+    args: ["--foreground", "--debug_fuse", "--debug_gcs", "--custom-endpoint", "https://storage.mtls.googleapis.com:443", "yangspirit-gcsfuse-profiles-bug-bash-bucket", "/mnt/gcs"]
+    securityContext:
+      privileged: true
+    env:
+    - name: GOOGLE_APPLICATION_CREDENTIALS
+      value: /config/cred_config.json
+    - name: GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES
+      value: "1"
+    volumeMounts:
+    - name: config-volume
+      mountPath: /config
+    - name: binary-volume
+      mountPath: /scripts
+    - name: gcs-volume
+      mountPath: /mnt/gcs
+      mountPropagation: Bidirectional
+  volumes:
+  - name: config-volume
+    configMap:
+      name: mock-cred-config
+  - name: source-volume
+    configMap:
+      name: mock-cli-source
+  - name: binary-volume
+    emptyDir: {}
+  - name: gcs-volume
+    emptyDir: {}

--- a/poc/option2/README.md
+++ b/poc/option2/README.md
@@ -1,0 +1,30 @@
+# Option 2 POC: Token Server Sidecar
+
+This directory contains the resources to run a Proof of Concept for using a customer-managed token server sidecar with GCS Fuse, communicating over a Unix Domain Socket.
+
+## Files
+
+- `token_server.py`: Python script for the mock token server.
+- `option2_poc.yaml`: Kubernetes manifest containing a ConfigMap for the script and a Pod that runs both the token server and the GCS Fuse sidecar.
+
+## How to Run
+
+1. Apply the manifest to your cluster:
+   ```bash
+   kubectl apply -f option2_poc.yaml
+   ```
+
+2. Verify the pod is running:
+   ```bash
+   kubectl get pod gcsfuse-poc-option2
+   ```
+
+3. Check the logs of the `gcsfuse-sidecar` container to see if it connects to the socket and fetches the token:
+   ```bash
+   kubectl logs gcsfuse-poc-option2 -c gcsfuse-sidecar
+   ```
+
+4. Check the logs of the `token-server` container to see if it receives requests:
+   ```bash
+   kubectl logs gcsfuse-poc-option2 -c token-server
+   ```

--- a/poc/option2/option2_poc.yaml
+++ b/poc/option2/option2_poc.yaml
@@ -1,0 +1,74 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mock-token-server-script
+data:
+  token_server.py: |
+    import socket
+    import os
+    import json
+    import time
+    
+    socket_path = "/tmp/token.sock"
+    
+    if os.path.exists(socket_path):
+        os.remove(socket_path)
+    
+    server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    server.bind(socket_path)
+    server.listen(1)
+    
+    while True:
+        conn, addr = server.accept()
+        try:
+            data = conn.recv(1024)
+            if data:
+                print(f"[{time.strftime('%Y-%m-%d %H:%M:%S')}] Received request from GCS Fuse")
+                token_data = {
+                    "access_token": "DUMMY_TOKEN_FROM_SERVER",
+                    "expires_in": 10,
+                    "token_type": "Bearer"
+                }
+                response_body = json.dumps(token_data)
+                response = f"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n{response_body}".encode('utf-8')
+                conn.sendall(response)
+        finally:
+            conn.close()
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: gcsfuse-poc-option2
+spec:
+  containers:
+  - name: main-app
+    image: busybox
+    command: ["sleep", "3600"]
+  - name: token-server
+    image: python:3.9-slim
+    command: ["python", "-u", "/scripts/token_server.py"] # Added -u for unbuffered output
+    volumeMounts:
+    - name: shared-socket
+      mountPath: /tmp
+    - name: script-volume
+      mountPath: /scripts
+  - name: gcsfuse-sidecar
+    image: us-docker.pkg.dev/yangspirit-joonix/main/gcs-fuse-csi-driver-sidecar-mounter:test-x509_linux_amd64
+    command: ["/gcsfuse"]
+    args: ["--foreground", "--debug_fuse", "--debug_gcs", "--custom-endpoint", "https://storage.mtls.googleapis.com:443", "--token-url=unix:///tmp/token.sock", "yangspirit-gcsfuse-profiles-bug-bash-bucket", "/mnt/gcs"]
+    securityContext:
+      privileged: true
+    volumeMounts:
+    - name: shared-socket
+      mountPath: /tmp
+    - name: gcs-volume
+      mountPath: /mnt/gcs
+      mountPropagation: Bidirectional
+  volumes:
+  - name: shared-socket
+    emptyDir: {}
+  - name: script-volume
+    configMap:
+      name: mock-token-server-script
+  - name: gcs-volume
+    emptyDir: {}

--- a/poc/option2/token_server.py
+++ b/poc/option2/token_server.py
@@ -1,0 +1,39 @@
+import socket
+import os
+import sys
+import json
+import time
+
+socket_path = "/tmp/token.sock"
+
+if os.path.exists(socket_path):
+    os.remove(socket_path)
+
+server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+server.bind(socket_path)
+server.listen(1)
+
+print(f"Listening on {socket_path}...")
+
+try:
+    while True:
+        conn, addr = server.accept()
+        try:
+            data = conn.recv(1024)
+            if data:
+                print(f"[{time.strftime('%Y-%m-%d %H:%M:%S')}] Received request from GCS Fuse")
+                # Respond with a short-lived token (10 seconds) to force refresh
+                token_data = {
+                    "access_token": "DUMMY_TOKEN_FROM_SERVER",
+                    "expires_in": 10,
+                    "token_type": "Bearer"
+                }
+                response_body = json.dumps(token_data)
+                response = f"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n{response_body}".encode('utf-8')
+                conn.sendall(response)
+        finally:
+            conn.close()
+except KeyboardInterrupt:
+    print("Shutting down.")
+finally:
+    os.remove(socket_path)


### PR DESCRIPTION
What type of PR is this? /kind feature

What this PR does / why we need it: This PR adds support for X.509 Pod Certificates for authentication in the GCS Fuse CSI driver.

Native support for Pod Certificates in OSS Kubernetes (via CSI TokenRequest) is a long-term effort requiring KEPs and substantial development time (6-12 months). This PR implements a workaround to unblock an important customer by leveraging the mutating webhook and refactoring the driver's token exchange logic to use the official STS library.

Which issue(s) this PR fixes:

Fixes b/495760030

Special notes for your reviewer: This PR contains changes in two main areas:

Webhook (pkg/webhook): Added support for annotations gke-gcsfuse/use-pod-certificate and gke-gcsfuse/workload-identity-credential-configmap to inject the necessary environment variables and volume mounts. It also automatically injects volume attributes needed by the driver.
CSI Driver (pkg/cloud_provider/auth): Refactored fetchTokenViaCertificate to use the official Google STS library and resolved issues with 404 (base URL) and 400 (missing certificate chain in payload) errors.
All unit tests for the modified pkg/webhook package passed successfully.

Does this PR introduce a user-facing change?:

release-note
Added support for X.509 Pod Certificates in GCS Fuse CSI driver via new pod annotations `gke-gcsfuse/use-pod-certificate` and `gke-gcsfuse/workload-identity-credential-configmap`.