### PR TITLE
Automated cherry pick of #1316: Support custom-endpoint in sidecar mounter & CSI driver

### DIFF
--- a/pkg/cloud_provider/storage/fake.go
+++ b/pkg/cloud_provider/storage/fake.go
@@ -42,7 +42,7 @@ type fakeServiceManager struct {
 	createdBuckets map[string]*ServiceBucket
 }
 
-func (manager *fakeServiceManager) SetupService(_ context.Context, _ oauth2.TokenSource) (Service, error) {
+func (manager *fakeServiceManager) SetupService(_ context.Context, _ oauth2.TokenSource, _ string) (Service, error) {
 	return &fakeService{sm: *manager}, nil
 }
 
@@ -50,7 +50,7 @@ func (manager *fakeServiceManager) SetupServiceWithDefaultCredential(_ context.C
 	return &fakeService{sm: *manager}, nil
 }
 
-func (manager *fakeServiceManager) SetupStorageServiceForSidecar(_ context.Context, _ oauth2.TokenSource) (Service, error) {
+func (manager *fakeServiceManager) SetupStorageServiceForSidecar(_ context.Context, _ oauth2.TokenSource, _ string) (Service, error) {
 	return &fakeService{sm: *manager}, nil
 }
 

--- a/pkg/cloud_provider/storage/storage.go
+++ b/pkg/cloud_provider/storage/storage.go
@@ -66,9 +66,9 @@ type Service interface {
 }
 
 type ServiceManager interface {
-	SetupService(ctx context.Context, ts oauth2.TokenSource) (Service, error)
+	SetupService(ctx context.Context, ts oauth2.TokenSource, customEndpoint string) (Service, error)
 	SetupServiceWithDefaultCredential(ctx context.Context, enableZB bool) (Service, error)
-	SetupStorageServiceForSidecar(ctx context.Context, ts oauth2.TokenSource) (Service, error)
+	SetupStorageServiceForSidecar(ctx context.Context, ts oauth2.TokenSource, customEndpoint string) (Service, error)
 }
 
 type gcsService struct {
@@ -83,7 +83,7 @@ func NewGCSServiceManager() (ServiceManager, error) {
 	return &gcsServiceManager{}, nil
 }
 
-func (manager *gcsServiceManager) SetupService(ctx context.Context, ts oauth2.TokenSource) (Service, error) {
+func (manager *gcsServiceManager) SetupService(ctx context.Context, ts oauth2.TokenSource, customEndpoint string) (Service, error) {
 	if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 30*time.Second, true, func(context.Context) (bool, error) {
 		if _, err := ts.Token(); err != nil {
 			klog.Errorf("error fetching initial token: %v", err)
@@ -97,12 +97,12 @@ func (manager *gcsServiceManager) SetupService(ctx context.Context, ts oauth2.To
 	}
 
 	client := oauth2.NewClient(ctx, ts)
-	storageClient, err := storage.NewClient(ctx, option.WithHTTPClient(client))
+	storageClient, err := storage.NewClient(ctx, withCustomEndpoint([]option.ClientOption{option.WithHTTPClient(client)}, customEndpoint)...)
 	if err != nil {
 		return nil, err
 	}
 
-	controlClient, err := control.NewStorageControlClient(ctx, option.WithTokenSource(ts))
+	controlClient, err := control.NewStorageControlClient(ctx, withCustomEndpoint([]option.ClientOption{option.WithTokenSource(ts)}, customEndpoint)...)
 	if err != nil {
 		storageClient.Close()
 		return nil, err
@@ -432,7 +432,16 @@ func isBucketAZonalBucket(ctx context.Context, client *storage.Client, bucketNam
 	return attrs.StorageClass == "RAPID", nil
 }
 
-func (manager *gcsServiceManager) SetupStorageServiceForSidecar(ctx context.Context, ts oauth2.TokenSource) (Service, error) {
+func withCustomEndpoint(opts []option.ClientOption, customEndpoint string) []option.ClientOption {
+	// Use a custom endpoint, if provided.
+	// TODO(urielguzman): Dynamically fetch the Google Universe if custom endpoint isn't provided.
+	if customEndpoint != "" {
+		return append(opts, option.WithEndpoint(customEndpoint))
+	}
+	return opts
+}
+
+func (manager *gcsServiceManager) SetupStorageServiceForSidecar(ctx context.Context, ts oauth2.TokenSource, customEndpoint string) (Service, error) {
 	var storageOpts []option.ClientOption
 	var controlOpts []option.ClientOption
 
@@ -445,12 +454,12 @@ func (manager *gcsServiceManager) SetupStorageServiceForSidecar(ctx context.Cont
 		controlOpts = append(controlOpts, option.WithTokenSource(ts))
 	}
 
-	storageClient, err := storage.NewClient(ctx, storageOpts...)
+	storageClient, err := storage.NewClient(ctx, withCustomEndpoint(storageOpts, customEndpoint)...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create storage client: %w", err)
 	}
 
-	controlClient, err := control.NewStorageControlClient(ctx, controlOpts...)
+	controlClient, err := control.NewStorageControlClient(ctx, withCustomEndpoint(controlOpts, customEndpoint)...)
 	if err != nil {
 		storageClient.Close()
 		return nil, fmt.Errorf("failed to create control client: %w", err)

--- a/pkg/csi_driver/controller.go
+++ b/pkg/csi_driver/controller.go
@@ -238,7 +238,8 @@ func (s *controllerServer) prepareStorageService(ctx context.Context, secrets ma
 	}
 
 	ts := s.driver.config.TokenManager.GetTokenSourceFromK8sServiceAccount(serviceAccountNamespace, serviceAccountName, "", "" /*audience*/, false)
-	storageService, err := s.storageServiceManager.SetupService(ctx, ts)
+	// TODO(urielguzman): Dynamically fetch the Google Universe if custom endpoint isn't provided.
+	storageService, err := s.storageServiceManager.SetupService(ctx, ts, "")
 	if err != nil {
 		return nil, fmt.Errorf("storage service manager failed to setup service: %w", err)
 	}

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -166,7 +166,7 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 	// skip check if it has ever succeeded
 	if vs != nil && !args.skipCSIBucketAccessCheck {
 		if !vs.BucketAccessCheckPassed {
-			storageService, err := s.prepareStorageService(ctx, vc)
+			storageService, err := s.prepareStorageService(ctx, vc, args.customEndpoint)
 			if err != nil {
 				return nil, status.Errorf(codes.Unauthenticated, "failed to prepare storage service: %v", err)
 			}
@@ -489,9 +489,9 @@ func (s *nodeServer) setupMultiNIC(args *requestArgs, pod *corev1.Pod, sidecarSu
 }
 
 // prepareStorageService prepares the GCS Storage Service using the Kubernetes Service Account from VolumeContext.
-func (s *nodeServer) prepareStorageService(ctx context.Context, vc map[string]string) (storage.Service, error) {
+func (s *nodeServer) prepareStorageService(ctx context.Context, vc map[string]string, customEndpoint string) (storage.Service, error) {
 	ts := s.driver.config.TokenManager.GetTokenSourceFromK8sServiceAccount(vc[VolumeContextKeyPodNamespace], vc[VolumeContextKeyServiceAccountName], vc[VolumeContextKeyServiceAccountToken], "" /*audience*/, false)
-	storageService, err := s.storageServiceManager.SetupService(ctx, ts)
+	storageService, err := s.storageServiceManager.SetupService(ctx, ts, customEndpoint)
 	if err != nil {
 		return nil, fmt.Errorf("storage service manager failed to setup service: %w", err)
 	}

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -59,7 +59,7 @@ func initTestNodeServer(t *testing.T) *nodeServerTestEnv {
 	t.Helper()
 	mounter := mount.NewFakeMounter([]mount.MountPoint{})
 	driver := initTestDriver(t, mounter)
-	s, _ := driver.config.StorageServiceManager.SetupService(context.TODO(), nil)
+	s, _ := driver.config.StorageServiceManager.SetupService(context.TODO(), nil, "")
 	if _, err := s.CreateBucket(context.Background(), &storage.ServiceBucket{Name: testVolumeID}); err != nil {
 		t.Fatalf("failed to create the fake bucket: %v", err)
 	}
@@ -75,7 +75,7 @@ func initTestNodeServerWithCustomClientset(t *testing.T, clientSet *clientset.Fa
 	t.Helper()
 	mounter := mount.NewFakeMounter([]mount.MountPoint{})
 	driver := initTestDriverWithCustomNodeServer(t, mounter, clientSet, wiNodeLabelCheck)
-	s, _ := driver.config.StorageServiceManager.SetupService(context.TODO(), nil)
+	s, _ := driver.config.StorageServiceManager.SetupService(context.TODO(), nil, "")
 	if _, err := s.CreateBucket(context.Background(), &storage.ServiceBucket{Name: testVolumeID}); err != nil {
 		t.Fatalf("failed to create the fake bucket: %v", err)
 	}
@@ -636,7 +636,7 @@ func TestNodePublishVolumeEnableGCSFuseKernelParams(t *testing.T) {
 			fakeMounter := mount.NewFakeMounter([]mount.MountPoint{})
 
 			driver := initTestDriver(t, fakeMounter)
-			s, _ := driver.config.StorageServiceManager.SetupService(context.TODO(), nil)
+			s, _ := driver.config.StorageServiceManager.SetupService(context.TODO(), nil, "")
 			if _, err := s.CreateBucket(context.Background(), &storage.ServiceBucket{Name: testVolumeID}); err != nil {
 				t.Fatalf("failed to create the fake bucket: %v", err)
 			}

--- a/pkg/csi_driver/utils.go
+++ b/pkg/csi_driver/utils.go
@@ -114,6 +114,7 @@ type requestArgs struct {
 	optInHostnetworkKSA           bool
 	enableCloudProfilerForSidecar bool
 	multiNICIndex                 int
+	customEndpoint                string
 }
 
 func NewControllerServiceCapability(c csi.ControllerServiceCapability_RPC_Type) *csi.ControllerServiceCapability {
@@ -369,6 +370,9 @@ func parseRequestArguments(req *csi.NodePublishVolumeRequest, vc map[string]stri
 
 	args, err := parseVolumeAttributes(fuseMountOptions, vc)
 	args.bucketName = bucketName
+	if customEndpointVal := util.CustomEndpointFromOpts(args.fuseMountOptions); customEndpointVal != "" {
+		args.customEndpoint = customEndpointVal
+	}
 	return args, err
 }
 

--- a/pkg/sidecar_mounter/sidecar_mounter.go
+++ b/pkg/sidecar_mounter/sidecar_mounter.go
@@ -460,7 +460,7 @@ func (m *Mounter) checkBucketAccessWithRetry(ctx context.Context, tokenSource oa
 	var ss storage.Service
 	ssCreateAndBucketCheckFunc := func(ctx context.Context) (bool, error) {
 		if ss == nil {
-			ss, err = m.StorageServiceManager.SetupStorageServiceForSidecar(ctx, tokenSource)
+			ss, err = m.StorageServiceManager.SetupStorageServiceForSidecar(ctx, tokenSource, mc.CustomEndpoint)
 			if err != nil {
 				mc.ErrWriter.WriteMsg(retryableError(fmt.Sprintf("%q: %v %v, retrying...", util.StorageServiceErrorStr, storage.ParseErrCode(err), err)))
 				return false, nil

--- a/pkg/sidecar_mounter/sidecar_mounter_config.go
+++ b/pkg/sidecar_mounter/sidecar_mounter_config.go
@@ -67,6 +67,7 @@ type MountConfig struct {
 	SidecarRetryConfig             sidecarRetryConfig    `json:"-"`
 	FileCacheMedium                string                `json:"-"`
 	GcsFuseNumaNode                int                   `json:"-"`
+	CustomEndpoint                 string                `json:"-"`
 }
 
 // sidecarRetryConfig controls the retry configurations for sidecarRetry behivior for storage service creation and bucket access check.
@@ -198,6 +199,10 @@ func (mc *MountConfig) prepareMountArgs() {
 	}
 
 	invalidArgs := []string{}
+
+	if customEndpointVal := util.CustomEndpointFromOpts(mc.Options); customEndpointVal != "" {
+		mc.CustomEndpoint = customEndpointVal
+	}
 
 	mc.GcsFuseNumaNode = -1
 	for _, arg := range mc.Options {

--- a/pkg/sidecar_mounter/sidecar_mounter_config_test.go
+++ b/pkg/sidecar_mounter/sidecar_mounter_config_test.go
@@ -64,12 +64,13 @@ func TestPrepareMountArgs(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
-		name                  string
-		mc                    *MountConfig
-		expectedArgs          map[string]string
-		expectedConfigMapArgs map[string]string
-		expectNumaNode        bool
-		expectedNumaNode      int
+		name                   string
+		mc                     *MountConfig
+		expectedArgs           map[string]string
+		expectedConfigMapArgs  map[string]string
+		expectNumaNode         bool
+		expectedNumaNode       int
+		expectedCustomEndpoint string
 	}{
 		{
 			name: "should return valid args correctly",
@@ -317,6 +318,7 @@ func TestPrepareMountArgs(t *testing.T) {
 				"cache-dir":                      "",
 				"gcs-connection:custom-endpoint": "custom-service.my-system.svc.cluster.local:8080",
 			},
+			expectedCustomEndpoint: "custom-service.my-system.svc.cluster.local:8080",
 		},
 		{
 			name: "should correctly parse custom-endpoint with a port in CLI format",
@@ -336,7 +338,35 @@ func TestPrepareMountArgs(t *testing.T) {
 				"gid":             "0",
 				"custom-endpoint": "custom-service.my-system.svc.cluster.local:8080",
 			},
-			expectedConfigMapArgs: defaultConfigFileFlagMap,
+			expectedConfigMapArgs:  defaultConfigFileFlagMap,
+			expectedCustomEndpoint: "custom-service.my-system.svc.cluster.local:8080",
+		},
+		{
+			name: "should correctly prioritize custom-endpoint with a port in CLI format over config-file format when both exist",
+			mc: &MountConfig{
+				BucketName: "test-bucket",
+				BufferDir:  "test-buffer-dir",
+				CacheDir:   "test-cache-dir",
+				ConfigFile: "test-config-file",
+				Options:    []string{"custom-endpoint=custom-service.my-system.svc.cluster.local:8080", "gcs-connection:custom-endpoint:custom-service.my-system.svc.cluster.local:1234"},
+			},
+			expectedArgs: map[string]string{
+				"app-name":        GCSFuseAppName,
+				"temp-dir":        "test-buffer-dir/temp-dir",
+				"config-file":     "test-config-file",
+				"foreground":      "",
+				"uid":             "0",
+				"gid":             "0",
+				"custom-endpoint": "custom-service.my-system.svc.cluster.local:8080",
+			},
+			expectedConfigMapArgs: map[string]string{
+				"logging:file-path": "/dev/fd/1",
+				"logging:format":    "json",
+				"cache-dir":         "",
+				// Config-file option is also passed to GCSFuse, but GCSFuse will prioritze the CLI flag format
+				"gcs-connection:custom-endpoint": "custom-service.my-system.svc.cluster.local:1234",
+			},
+			expectedCustomEndpoint: "custom-service.my-system.svc.cluster.local:8080", // CLI flag format prioritzed by sidecar mounter
 		},
 		{
 			name: "should return valid args with newly allowed flags",
@@ -494,6 +524,9 @@ func TestPrepareMountArgs(t *testing.T) {
 				if tc.mc.GcsFuseNumaNode != -1 {
 					t.Errorf("Got numa node %d, but expected none (-1)", tc.mc.GcsFuseNumaNode)
 				}
+			}
+			if tc.expectedCustomEndpoint != "" && tc.expectedCustomEndpoint != tc.mc.CustomEndpoint {
+				t.Errorf("Got custom endpoint %s, but expected %s", tc.mc.CustomEndpoint, tc.expectedCustomEndpoint)
 			}
 		})
 	}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -61,6 +61,8 @@ const (
 	GCSFuseCsiDriverName                = "gcsfuse.csi.storage.gke.io"
 	GCSFuseNumaNodeArg                  = "gcs-fuse-numa-node"
 	GCSFuseAppNameArg                   = "app-name"
+	CustomEndpointConfigFileFlag        = "gcs-connection:custom-endpoint"
+	CustomEndpointCLIFlag               = "custom-endpoint"
 )
 
 var (
@@ -299,4 +301,33 @@ func ParseBool(str string) (bool, error) {
 	default:
 		return false, fmt.Errorf("could not parse string to bool: the acceptable values for %q are 'True', 'true', 'false' or 'False'", str)
 	}
+}
+
+// CustomEndpointFromOpts parses a list of mount options to extract the custom endpoint value.
+// It looks for options in two formats:
+// 1. Config file format (e.g., "gcs-connection:custom-endpoint:storage.example.com:443")
+// 2. CLI flag format (e.g., "custom-endpoint=storage.example.com:443")
+// If both formats are present, the CLI flag value is prioritized, and a warning is logged.
+func CustomEndpointFromOpts(opts []string) string {
+	var configFileVal string
+	var cliFlagVal string
+	for _, arg := range opts {
+		if strings.HasPrefix(arg, CustomEndpointConfigFileFlag+":") {
+			if parts := strings.SplitN(arg, ":", 3); len(parts) == 3 {
+				configFileVal = parts[2]
+			}
+		} else if strings.HasPrefix(arg, CustomEndpointCLIFlag+"=") {
+			if parts := strings.SplitN(arg, "=", 2); len(parts) == 2 {
+				cliFlagVal = parts[1]
+			}
+		}
+	}
+	if configFileVal != "" && cliFlagVal != "" {
+		klog.Warningf("found conflicting mountOptions: config-file: %s:%s, CLI flag: %s=%s, prioritizing CLI flag value", CustomEndpointConfigFileFlag, configFileVal, CustomEndpointCLIFlag, cliFlagVal)
+		return cliFlagVal
+	}
+	if cliFlagVal != "" {
+		return cliFlagVal
+	}
+	return configFileVal
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -549,3 +549,61 @@ func TestIsGKEIdentityProvider(t *testing.T) {
 		}
 	}
 }
+
+func TestCustomEndpointFromOpts(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		opts     []string
+		expected string
+	}{
+		{
+			name:     "should return empty string when no relevant options are present",
+			opts:     []string{"other-option=foo", "read-only"},
+			expected: "",
+		},
+		{
+			name:     "should parse config file format correctly",
+			opts:     []string{"gcs-connection:custom-endpoint:storage.example.com:443"},
+			expected: "storage.example.com:443",
+		},
+		{
+			name:     "should parse CLI flag format correctly",
+			opts:     []string{"custom-endpoint=storage.googleapis.com"},
+			expected: "storage.googleapis.com",
+		},
+		{
+			name: "should prioritize CLI flag over config file format",
+			opts: []string{
+				"gcs-connection:custom-endpoint:old.endpoint.com",
+				"custom-endpoint=new.endpoint.com",
+			},
+			expected: "new.endpoint.com",
+		},
+		{
+			name: "should work when relevant flag is among other flags",
+			opts: []string{
+				"uid=1000",
+				"gid=1000",
+				"custom-endpoint=storage.example.com",
+				"debug_gcs",
+			},
+			expected: "storage.example.com",
+		},
+		{
+			name:     "should handle empty opts slice",
+			opts:     []string{},
+			expected: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := CustomEndpointFromOpts(tc.opts)
+			if actual != tc.expected {
+				t.Errorf("CustomEndpointFromOpts(%v) = %q, want %q", tc.opts, actual, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Cherry pick of #1316 on release-1.23.

#1316: Support custom-endpoint in sidecar mounter & CSI driver

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Support custom-endpoint for sidecar mounter & CSI driver for TPC support
```