### PR TITLE
Add e2e tests for OIDC authentication failures with misconfigured and non-existent WIF providers

### DIFF
--- a/test/e2e/testsuites/gcsfuse_oidc_auth.go
+++ b/test/e2e/testsuites/gcsfuse_oidc_auth.go
@@ -43,14 +43,20 @@ import (
 )
 
 const (
-	oidcTestPrefix                 = "gcsfuse-csi-oidc"
-	oidcWorkloadIdentityPoolID     = "gcs-fuse-oidc-pool"
-	oidcWorkloadIdentityProviderID = "gcs-fuse-oidc-provider"
-	oidcConfigMapName              = "workload-identity-credentials"
-	oidcCredentialConfigFileName   = "credential-configuration.json"
-	oidcServiceAccountName         = "gcs-fuse-oidc-ksa"
-	oidcVolumeName                 = "gcs-volume"
-	oidcMountPath                  = "/mnt/gcs"
+	oidcTestPrefix                             = "gcsfuse-csi-oidc"
+	oidcWorkloadIdentityPoolID                 = "gcs-fuse-oidc-pool"
+	oidcWorkloadIdentityProviderID             = "gcs-fuse-oidc-provider"
+	oidcWorkloadIdentityProviderIDMisconfigured = "gcs-fuse-oidc-provider-bad"
+	oidcConfigMapName                          = "workload-identity-credentials"
+	oidcMisconfiguredConfigMapName             = "workload-identity-credentials-bad"
+	oidcNonExistentPoolConfigMapName           = "workload-identity-credentials-nonexistent-pool"
+	oidcCredentialConfigFileName               = "credential-configuration.json"
+	oidcServiceAccountName                     = "gcs-fuse-oidc-ksa"
+	oidcVolumeName                             = "gcs-volume"
+	oidcMountPath                              = "/mnt/gcs"
+	wrongIssuerURI                             = "https://wrong-issuer.example.com"
+	nonExistentPoolID                          = "gcs-fuse-nonexistent-pool"
+	nonExistentProviderID                      = "gcs-fuse-nonexistent-provider"
 )
 
 type gcsFuseCSIOIDCTestSuite struct {
@@ -366,6 +372,138 @@ func (t *gcsFuseCSIOIDCTestSuite) DefineTests(driver storageframework.TestDriver
 		tPod.WaitForFailedMountError(ctx, "PermissionDenied")
 	}
 
+	testCaseOIDCMisconfiguredProvider := func() {
+		// Uses SkipCSIBucketAccessCheckPrefix so the CSI node driver skips its own
+		// prepareStorageService call. The authentication failure happens entirely
+		// inside the sidecar container when it tries to exchange the KSA token
+		// with Google STS using a provider registered with a wrong issuer URI.
+		init(specs.SkipCSIBucketAccessCheckPrefix)
+		defer cleanup()
+
+		bucketName := l.volumeResource.VolSource.CSI.VolumeAttributes["bucketName"]
+		gomega.Expect(bucketName).NotTo(gomega.BeEmpty(), "bucketName must be set in volume attributes")
+
+		projectID := os.Getenv(utils.ProjectEnvVar)
+		gomega.Expect(projectID).NotTo(gomega.BeEmpty(), fmt.Sprintf("%s environment variable must be set", utils.ProjectEnvVar))
+
+		ginkgo.By("Getting GCP project number")
+		projectNumber := getProjectNumber(projectID)
+		gomega.Expect(projectNumber).NotTo(gomega.BeEmpty(), "Failed to get project number")
+
+		// Reuse the existing WI pool — creation is idempotent.
+		ginkgo.By(fmt.Sprintf("Creating workload identity pool: %s", oidcWorkloadIdentityPoolID))
+		createWorkloadIdentityPool(projectID, oidcWorkloadIdentityPoolID)
+
+		// Create a separate provider with a deliberately wrong issuer URI.
+		// Google STS will fail to verify the KSA token because the token's
+		// "iss" claim will not match this issuer.
+		ginkgo.By(fmt.Sprintf("Creating misconfigured workload identity provider %q with wrong issuer %q",
+			oidcWorkloadIdentityProviderIDMisconfigured, wrongIssuerURI))
+		createWorkloadIdentityProvider(projectID, oidcWorkloadIdentityPoolID,
+			oidcWorkloadIdentityProviderIDMisconfigured, wrongIssuerURI)
+
+		// Generate a credential config whose audience points to the bad provider.
+		ginkgo.By("Generating credential config pointing to the misconfigured provider")
+		credentialConfig := generateCredentialConfig(projectNumber, oidcWorkloadIdentityPoolID,
+			oidcWorkloadIdentityProviderIDMisconfigured)
+
+		ginkgo.By(fmt.Sprintf("Creating Kubernetes service account: %s", oidcServiceAccountName))
+		createServiceAccount(ctx, f, oidcServiceAccountName)
+		defer deleteServiceAccount(ctx, f, oidcServiceAccountName)
+
+		ginkgo.By(fmt.Sprintf("Creating ConfigMap with misconfigured credentials: %s", oidcMisconfiguredConfigMapName))
+		createCredentialConfigMap(ctx, f, oidcMisconfiguredConfigMapName, credentialConfig)
+		defer deleteConfigMap(ctx, f, oidcMisconfiguredConfigMapName)
+
+		// Grant bucket access so that the only failure is authentication,
+		// not a missing IAM binding masking the real error.
+		ginkgo.By("Granting bucket access to workload identity principal")
+		principal := fmt.Sprintf(
+			"principal://iam.googleapis.com/projects/%s/locations/global/workloadIdentityPools/%s/subject/system:serviceaccount:%s:%s",
+			projectNumber, oidcWorkloadIdentityPoolID, f.Namespace.Name, oidcServiceAccountName)
+		grantBucketAccess(bucketName, principal, "roles/storage.objectUser")
+		defer revokeBucketAccess(bucketName, principal, "roles/storage.objectUser")
+
+		ginkgo.By("Waiting for IAM policy propagation")
+		time.Sleep(5 * time.Second)
+
+		ginkgo.By("Configuring test pod with misconfigured OIDC provider")
+		tPod := specs.NewTestPodModifiedSpec(f.ClientSet, f.Namespace, true)
+		tPod.SetServiceAccount(oidcServiceAccountName)
+		tPod.SetupVolume(l.volumeResource, oidcVolumeName, oidcMountPath, false)
+		tPod.SetAnnotations(map[string]string{
+			webhook.GCPWorkloadIdentityCredentialConfigMapAnnotation: oidcMisconfiguredConfigMapName,
+		})
+
+		ginkgo.By("Deploying test pod and expecting STS authentication failure in sidecar")
+		tPod.Create(ctx)
+		defer tPod.Cleanup(ctx)
+
+		// The sidecar reads the credential config, fetches the KSA token, and
+		// calls Google STS to exchange it. Because the provider was registered
+		// with a wrong issuer URI, STS cannot verify the token and returns an
+		// error. The sidecar logs "IdentityBindingToken exchange error" and
+		// retries with exponential backoff until the context deadline.
+		ginkgo.By("Checking that gcsfuse logs an STS authentication error due to misconfigured provider")
+		tPod.WaitForLog(ctx, webhook.GcsFuseSidecarName, "Error connecting to the given credential's issuer.")
+	}
+
+	testCaseOIDCNonExistentPool := func() {
+		// Uses SkipCSIBucketAccessCheckPrefix so the CSI node driver skips its own
+		// prepareStorageService call. The authentication failure happens entirely
+		// inside the sidecar container when it tries to exchange the KSA token
+		// with Google STS using a credential config that points to a pool and
+		// provider that do not exist in GCP at all.
+		init(specs.SkipCSIBucketAccessCheckPrefix)
+		defer cleanup()
+
+		bucketName := l.volumeResource.VolSource.CSI.VolumeAttributes["bucketName"]
+		gomega.Expect(bucketName).NotTo(gomega.BeEmpty(), "bucketName must be set in volume attributes")
+
+		projectID := os.Getenv(utils.ProjectEnvVar)
+		gomega.Expect(projectID).NotTo(gomega.BeEmpty(), fmt.Sprintf("%s environment variable must be set", utils.ProjectEnvVar))
+
+		ginkgo.By("Getting GCP project number")
+		projectNumber := getProjectNumber(projectID)
+		gomega.Expect(projectNumber).NotTo(gomega.BeEmpty(), "Failed to get project number")
+
+		// Generate a credential config that points to a pool and provider that
+		// do not exist in GCP. Google STS will return an error because it cannot
+		// find any configuration to validate the token against.
+		ginkgo.By(fmt.Sprintf("Generating credential config pointing to non-existent pool %q and provider %q",
+			nonExistentPoolID, nonExistentProviderID))
+		credentialConfig := generateCredentialConfig(projectNumber, nonExistentPoolID, nonExistentProviderID)
+
+		ginkgo.By(fmt.Sprintf("Creating Kubernetes service account: %s", oidcServiceAccountName))
+		createServiceAccount(ctx, f, oidcServiceAccountName)
+		defer deleteServiceAccount(ctx, f, oidcServiceAccountName)
+
+		ginkgo.By(fmt.Sprintf("Creating ConfigMap with non-existent pool credentials: %s", oidcNonExistentPoolConfigMapName))
+		createCredentialConfigMap(ctx, f, oidcNonExistentPoolConfigMapName, credentialConfig)
+		defer deleteConfigMap(ctx, f, oidcNonExistentPoolConfigMapName)
+
+		ginkgo.By("Configuring test pod with non-existent pool credential config")
+		tPod := specs.NewTestPodModifiedSpec(f.ClientSet, f.Namespace, true)
+		tPod.SetServiceAccount(oidcServiceAccountName)
+		tPod.SetupVolume(l.volumeResource, oidcVolumeName, oidcMountPath, false)
+		tPod.SetAnnotations(map[string]string{
+			webhook.GCPWorkloadIdentityCredentialConfigMapAnnotation: oidcNonExistentPoolConfigMapName,
+		})
+
+		ginkgo.By("Deploying test pod and expecting STS authentication failure in sidecar")
+		tPod.Create(ctx)
+		defer tPod.Cleanup(ctx)
+
+		// The sidecar reads the credential config, fetches the KSA token, and
+		// calls Google STS to exchange it. Because the pool and provider in the
+		// audience do not exist in GCP, STS cannot find any configuration to
+		// validate the token against and returns an error. The sidecar logs
+		// "IdentityBindingToken exchange error" and retries with exponential
+		// backoff until the context deadline.
+		ginkgo.By("Checking that gcsfuse logs an STS authentication error due to non-existent pool or provider")
+		tPod.WaitForLog(ctx, webhook.GcsFuseSidecarName, "invalid_target")
+	}
+
 	ginkgo.It("should successfully mount with OIDC authentication", func() {
 		testCaseOIDCMount()
 	})
@@ -384,6 +522,14 @@ func (t *gcsFuseCSIOIDCTestSuite) DefineTests(driver storageframework.TestDriver
 
 	ginkgo.It("should fail when CSI bucket access check is enabled with OIDC authentication", func() {
 		testCaseOIDCWithCSIBucketAccessCheck()
+	})
+
+	ginkgo.It("should fail authentication when workload identity provider is misconfigured", func() {
+		testCaseOIDCMisconfiguredProvider()
+	})
+
+	ginkgo.It("should fail authentication when workload identity pool or provider does not exist", func() {
+		testCaseOIDCNonExistentPool()
 	})
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds two negative e2e test cases to the existing `oidc` test suite to validate STS-level authentication failures for Workload Identity Federation:

- **Misconfigured provider**: a WIF provider is created with a deliberately wrong issuer URI. Google STS cannot verify the KSA token's `iss` claim and the gcsfuse sidecar logs `"Error connecting to the given credential's issuer."`
- **Non-existent pool/provider**: credential config points to a pool and provider that do not exist in GCP. STS returns `invalid_target` and the sidecar logs it accordingly.

Both tests use `SkipCSIBucketAccessCheckPrefix` so the failure surface is entirely inside the gcsfuse sidecar, not the CSI node driver pre-flight check.

**Which issue(s) this PR fixes**:

N/A


**Does this PR introduce a user-facing change?**:

```release-note
NONE