### PR TITLE
Add e2e tests for OIDC authentication failures with misconfigured and non-existent WIF providers

### DIFF
--- a/test/e2e/specs/testdriver.go
+++ b/test/e2e/specs/testdriver.go
@@ -503,8 +503,12 @@ func (n *GCSFuseCSITestDriver) prepareStorageService(ctx context.Context) (stora
 }
 
 // bucketIAMMember returns the IAM member string for the given KSA.
-// When OSS_WIF_POOL_ID is set, uses the WIF principal format for self-managed clusters.
-// Otherwise falls back to the GKE Workload Identity format.
+// For GKE with GCP SA tests (!skipGcpSaTest), uses the per-test GCP SA email.
+// For OSS clusters (IS_OSS=true): if OSS_WIF_POOL_ID is set, uses the WIF principal
+// format; otherwise (ADC flow) all pods share the node compute SA identity, so
+// NODE_SERVICE_ACCOUNT is used if set, falling back to the default compute SA derived
+// from PROJECT_NUMBER.
+// For GKE without GCP SA tests, uses the GKE Workload Identity format.
 func (n *GCSFuseCSITestDriver) bucketIAMMember(serviceAccountNamespace, serviceAccountName string) string {
 	if !n.skipGcpSaTest {
 		return fmt.Sprintf("serviceAccount:%v@%v.iam.gserviceaccount.com", prepareGcpSAName(serviceAccountNamespace), n.meta.GetProjectID())
@@ -513,6 +517,13 @@ func (n *GCSFuseCSITestDriver) bucketIAMMember(serviceAccountNamespace, serviceA
 		projectNumber := os.Getenv(utils.ProjectNumberEnvVar)
 		return fmt.Sprintf("principal://iam.googleapis.com/projects/%s/locations/global/workloadIdentityPools/%s/subject/system:serviceaccount:%s:%s",
 			projectNumber, wifPoolID, serviceAccountNamespace, serviceAccountName)
+	}
+	if os.Getenv(utils.IsOSSEnvVar) == "true" {
+		if nodeSA := os.Getenv(utils.NodeServiceAccountEnvVar); nodeSA != "" {
+			return nodeSA
+		}
+		projectNumber := os.Getenv(utils.ProjectNumberEnvVar)
+		return fmt.Sprintf("serviceAccount:%s-compute@developer.gserviceaccount.com", projectNumber)
 	}
 	return fmt.Sprintf("serviceAccount:%v.svc.id.goog[%v/%v]", n.meta.GetProjectID(), serviceAccountNamespace, serviceAccountName)
 }

--- a/test/e2e/specs/testdriver.go
+++ b/test/e2e/specs/testdriver.go
@@ -504,16 +504,21 @@ func (n *GCSFuseCSITestDriver) prepareStorageService(ctx context.Context) (stora
 
 // bucketIAMMember returns the IAM member string for the given KSA.
 // For GKE with GCP SA tests (!skipGcpSaTest), uses the per-test GCP SA email.
-// For OSS clusters (IS_OSS=true): if OSS_WIF_POOL_ID is set, uses the WIF principal
-// format; otherwise (ADC flow) all pods share the node compute SA identity, so
-// NODE_SERVICE_ACCOUNT is used if set, falling back to the default compute SA derived
-// from PROJECT_NUMBER.
+// For OSS clusters where WIF is configured in the node DaemonSet, uses the WIF
+// principal format — auto-detected from the gcsfusecsi-node DaemonSet, with
+// OSS_WIF_POOL_ID env var as an explicit override.
+// For OSS clusters without WIF (pure ADC), falls back to the node compute SA.
 // For GKE without GCP SA tests, uses the GKE Workload Identity format.
-func (n *GCSFuseCSITestDriver) bucketIAMMember(serviceAccountNamespace, serviceAccountName string) string {
+func (n *GCSFuseCSITestDriver) bucketIAMMember(ctx context.Context, serviceAccountNamespace, serviceAccountName string) string {
 	if !n.skipGcpSaTest {
 		return fmt.Sprintf("serviceAccount:%v@%v.iam.gserviceaccount.com", prepareGcpSAName(serviceAccountNamespace), n.meta.GetProjectID())
 	}
-	if wifPoolID := os.Getenv("OSS_WIF_POOL_ID"); wifPoolID != "" {
+	// OSS_WIF_POOL_ID takes precedence; otherwise auto-detect from the node DaemonSet.
+	wifPoolID := os.Getenv("OSS_WIF_POOL_ID")
+	if wifPoolID == "" {
+		wifPoolID = n.detectOSSIdentityPool(ctx)
+	}
+	if wifPoolID != "" {
 		projectNumber := os.Getenv(utils.ProjectNumberEnvVar)
 		return fmt.Sprintf("principal://iam.googleapis.com/projects/%s/locations/global/workloadIdentityPools/%s/subject/system:serviceaccount:%s:%s",
 			projectNumber, wifPoolID, serviceAccountNamespace, serviceAccountName)
@@ -528,6 +533,25 @@ func (n *GCSFuseCSITestDriver) bucketIAMMember(serviceAccountNamespace, serviceA
 	return fmt.Sprintf("serviceAccount:%v.svc.id.goog[%v/%v]", n.meta.GetProjectID(), serviceAccountNamespace, serviceAccountName)
 }
 
+// detectOSSIdentityPool reads the IDENTITY_POOL env var baked into the gcsfusecsi-node
+// DaemonSet. On an OSS cluster configured with WIF, this pool is what every sidecar
+// authenticates against — so bucket IAM grants must use the corresponding WIF principal.
+// Returns "" on GKE clusters or OSS clusters without a configured identity pool.
+func (n *GCSFuseCSITestDriver) detectOSSIdentityPool(ctx context.Context) string {
+	ds, err := n.clientset.K8sClient().AppsV1().DaemonSets(driverNamespaceOSS).Get(ctx, "gcsfusecsi-node", metav1.GetOptions{})
+	if err != nil {
+		return ""
+	}
+	for _, c := range ds.Spec.Template.Spec.Containers {
+		for _, env := range c.Env {
+			if env.Name == "IDENTITY_POOL" {
+				return env.Value
+			}
+		}
+	}
+	return ""
+}
+
 // SetIAMPolicy sets IAM policy for the GCS bucket.
 func (n *GCSFuseCSITestDriver) SetIAMPolicy(ctx context.Context, bucket *storage.ServiceBucket, serviceAccountNamespace, serviceAccountName string) {
 	storageService, err := n.prepareStorageService(ctx)
@@ -535,7 +559,7 @@ func (n *GCSFuseCSITestDriver) SetIAMPolicy(ctx context.Context, bucket *storage
 		e2eframework.Failf("Failed to prepare storage service: %v", err)
 	}
 
-	member := n.bucketIAMMember(serviceAccountNamespace, serviceAccountName)
+	member := n.bucketIAMMember(ctx, serviceAccountNamespace, serviceAccountName)
 	if err := storageService.SetIAMPolicy(ctx, bucket, member, "roles/storage.admin"); err != nil {
 		e2eframework.Failf("Failed to set the IAM policy for the new GCS bucket: %v", err)
 	}
@@ -548,7 +572,7 @@ func (n *GCSFuseCSITestDriver) RemoveIAMPolicy(ctx context.Context, bucket *stor
 		e2eframework.Failf("Failed to prepare storage service: %v", err)
 	}
 
-	member := n.bucketIAMMember(serviceAccountNamespace, serviceAccountName)
+	member := n.bucketIAMMember(ctx, serviceAccountNamespace, serviceAccountName)
 	if err := storageService.RemoveIAMPolicy(ctx, bucket, member, "roles/storage.admin"); err != nil {
 		e2eframework.Failf("Failed to remove the IAM policy from the GCS bucket: %v", err)
 	}

--- a/test/e2e/testsuites/gcsfuse_oidc_auth.go
+++ b/test/e2e/testsuites/gcsfuse_oidc_auth.go
@@ -35,6 +35,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
@@ -431,6 +432,7 @@ func (t *gcsFuseCSIOIDCTestSuite) DefineTests(driver storageframework.TestDriver
 		// error. The sidecar logs "IdentityBindingToken exchange error" and
 		// retries with exponential backoff until the context deadline.
 		ginkgo.By("Checking that gcsfuse logs an STS authentication error due to misconfigured provider")
+		waitForSidecarContainerStarted(ctx, f, f.Namespace.Name, tPod.GetPodName(), webhook.GcsFuseSidecarName)
 		tPod.WaitForLog(ctx, webhook.GcsFuseSidecarName, "Error connecting to the given credential's issuer.")
 	}
 
@@ -484,6 +486,7 @@ func (t *gcsFuseCSIOIDCTestSuite) DefineTests(driver storageframework.TestDriver
 		// "IdentityBindingToken exchange error" and retries with exponential
 		// backoff until the context deadline.
 		ginkgo.By("Checking that gcsfuse logs an STS authentication error due to non-existent pool or provider")
+		waitForSidecarContainerStarted(ctx, f, f.Namespace.Name, tPod.GetPodName(), webhook.GcsFuseSidecarName)
 		tPod.WaitForLog(ctx, webhook.GcsFuseSidecarName, "invalid_target")
 	}
 
@@ -564,6 +567,24 @@ func (t *gcsFuseCSIOIDCTestSuite) DefineTests(driver storageframework.TestDriver
 }
 
 // Helper functions for GCP operations
+
+// waitForSidecarContainerStarted polls until the named sidecar container has been
+// started by the kubelet. This must be called before WaitForLog to avoid a 400
+// from the log API when the container is still in ContainerCreating state.
+func waitForSidecarContainerStarted(ctx context.Context, f *framework.Framework, namespace, podName, containerName string) {
+	_ = wait.PollUntilContextTimeout(ctx, 2*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+		pod, err := f.ClientSet.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
+		if err != nil {
+			return false, nil
+		}
+		for _, cs := range pod.Status.ContainerStatuses {
+			if cs.Name == containerName {
+				return cs.Started != nil && *cs.Started, nil
+			}
+		}
+		return false, nil
+	})
+}
 
 func getProjectNumber(projectID string) string {
 	cmd := exec.Command("gcloud", "projects", "describe", projectID, "--format=value(projectNumber)")

--- a/test/e2e/testsuites/gcsfuse_oidc_auth.go
+++ b/test/e2e/testsuites/gcsfuse_oidc_auth.go
@@ -381,9 +381,6 @@ func (t *gcsFuseCSIOIDCTestSuite) DefineTests(driver storageframework.TestDriver
 		init(specs.SkipCSIBucketAccessCheckPrefix)
 		defer cleanup()
 
-		bucketName := l.volumeResource.VolSource.CSI.VolumeAttributes["bucketName"]
-		gomega.Expect(bucketName).NotTo(gomega.BeEmpty(), "bucketName must be set in volume attributes")
-
 		projectID := os.Getenv(utils.ProjectEnvVar)
 		gomega.Expect(projectID).NotTo(gomega.BeEmpty(), fmt.Sprintf("%s environment variable must be set", utils.ProjectEnvVar))
 
@@ -416,18 +413,6 @@ func (t *gcsFuseCSIOIDCTestSuite) DefineTests(driver storageframework.TestDriver
 		createCredentialConfigMap(ctx, f, oidcMisconfiguredConfigMapName, credentialConfig)
 		defer deleteConfigMap(ctx, f, oidcMisconfiguredConfigMapName)
 
-		// Grant bucket access so that the only failure is authentication,
-		// not a missing IAM binding masking the real error.
-		ginkgo.By("Granting bucket access to workload identity principal")
-		principal := fmt.Sprintf(
-			"principal://iam.googleapis.com/projects/%s/locations/global/workloadIdentityPools/%s/subject/system:serviceaccount:%s:%s",
-			projectNumber, oidcWorkloadIdentityPoolID, f.Namespace.Name, oidcServiceAccountName)
-		grantBucketAccess(bucketName, principal, "roles/storage.objectUser")
-		defer revokeBucketAccess(bucketName, principal, "roles/storage.objectUser")
-
-		ginkgo.By("Waiting for IAM policy propagation")
-		time.Sleep(5 * time.Second)
-
 		ginkgo.By("Configuring test pod with misconfigured OIDC provider")
 		tPod := specs.NewTestPodModifiedSpec(f.ClientSet, f.Namespace, true)
 		tPod.SetServiceAccount(oidcServiceAccountName)
@@ -457,9 +442,6 @@ func (t *gcsFuseCSIOIDCTestSuite) DefineTests(driver storageframework.TestDriver
 		// provider that do not exist in GCP at all.
 		init(specs.SkipCSIBucketAccessCheckPrefix)
 		defer cleanup()
-
-		bucketName := l.volumeResource.VolSource.CSI.VolumeAttributes["bucketName"]
-		gomega.Expect(bucketName).NotTo(gomega.BeEmpty(), "bucketName must be set in volume attributes")
 
 		projectID := os.Getenv(utils.ProjectEnvVar)
 		gomega.Expect(projectID).NotTo(gomega.BeEmpty(), fmt.Sprintf("%s environment variable must be set", utils.ProjectEnvVar))

--- a/test/e2e/testsuites/gcsfuse_oidc_auth.go
+++ b/test/e2e/testsuites/gcsfuse_oidc_auth.go
@@ -44,14 +44,20 @@ import (
 )
 
 const (
-	oidcTestPrefix                 = "gcsfuse-csi-oidc"
-	oidcWorkloadIdentityPoolID     = "gcs-fuse-oidc-pool"
-	oidcWorkloadIdentityProviderID = "gcs-fuse-oidc-provider"
-	oidcConfigMapName              = "workload-identity-credentials"
-	oidcCredentialConfigFileName   = "credential-configuration.json"
-	oidcServiceAccountName         = "gcs-fuse-oidc-ksa"
-	oidcVolumeName                 = "gcs-volume"
-	oidcMountPath                  = "/mnt/gcs"
+	oidcTestPrefix                             = "gcsfuse-csi-oidc"
+	oidcWorkloadIdentityPoolID                 = "gcs-fuse-oidc-pool"
+	oidcWorkloadIdentityProviderID             = "gcs-fuse-oidc-provider"
+	oidcWorkloadIdentityProviderIDMisconfigured = "gcs-fuse-oidc-provider-bad"
+	oidcConfigMapName                          = "workload-identity-credentials"
+	oidcMisconfiguredConfigMapName             = "workload-identity-credentials-bad"
+	oidcNonExistentPoolConfigMapName           = "workload-identity-credentials-nonexistent-pool"
+	oidcCredentialConfigFileName               = "credential-configuration.json"
+	oidcServiceAccountName                     = "gcs-fuse-oidc-ksa"
+	oidcVolumeName                             = "gcs-volume"
+	oidcMountPath                              = "/mnt/gcs"
+	wrongIssuerURI                             = "https://wrong-issuer.example.com"
+	nonExistentPoolID                          = "gcs-fuse-nonexistent-pool"
+	nonExistentProviderID                      = "gcs-fuse-nonexistent-provider"
 )
 
 type gcsFuseCSIOIDCTestSuite struct {
@@ -367,6 +373,138 @@ func (t *gcsFuseCSIOIDCTestSuite) DefineTests(driver storageframework.TestDriver
 		tPod.WaitForFailedMountError(ctx, "PermissionDenied")
 	}
 
+	testCaseOIDCMisconfiguredProvider := func() {
+		// Uses SkipCSIBucketAccessCheckPrefix so the CSI node driver skips its own
+		// prepareStorageService call. The authentication failure happens entirely
+		// inside the sidecar container when it tries to exchange the KSA token
+		// with Google STS using a provider registered with a wrong issuer URI.
+		init(specs.SkipCSIBucketAccessCheckPrefix)
+		defer cleanup()
+
+		bucketName := l.volumeResource.VolSource.CSI.VolumeAttributes["bucketName"]
+		gomega.Expect(bucketName).NotTo(gomega.BeEmpty(), "bucketName must be set in volume attributes")
+
+		projectID := os.Getenv(utils.ProjectEnvVar)
+		gomega.Expect(projectID).NotTo(gomega.BeEmpty(), fmt.Sprintf("%s environment variable must be set", utils.ProjectEnvVar))
+
+		ginkgo.By("Getting GCP project number")
+		projectNumber := getProjectNumber(projectID)
+		gomega.Expect(projectNumber).NotTo(gomega.BeEmpty(), "Failed to get project number")
+
+		// Reuse the existing WI pool — creation is idempotent.
+		ginkgo.By(fmt.Sprintf("Creating workload identity pool: %s", oidcWorkloadIdentityPoolID))
+		createWorkloadIdentityPool(projectID, oidcWorkloadIdentityPoolID)
+
+		// Create a separate provider with a deliberately wrong issuer URI.
+		// Google STS will fail to verify the KSA token because the token's
+		// "iss" claim will not match this issuer.
+		ginkgo.By(fmt.Sprintf("Creating misconfigured workload identity provider %q with wrong issuer %q",
+			oidcWorkloadIdentityProviderIDMisconfigured, wrongIssuerURI))
+		createWorkloadIdentityProvider(projectID, oidcWorkloadIdentityPoolID,
+			oidcWorkloadIdentityProviderIDMisconfigured, wrongIssuerURI)
+
+		// Generate a credential config whose audience points to the bad provider.
+		ginkgo.By("Generating credential config pointing to the misconfigured provider")
+		credentialConfig := generateCredentialConfig(projectNumber, oidcWorkloadIdentityPoolID,
+			oidcWorkloadIdentityProviderIDMisconfigured)
+
+		ginkgo.By(fmt.Sprintf("Creating Kubernetes service account: %s", oidcServiceAccountName))
+		createServiceAccount(ctx, f, oidcServiceAccountName)
+		defer deleteServiceAccount(ctx, f, oidcServiceAccountName)
+
+		ginkgo.By(fmt.Sprintf("Creating ConfigMap with misconfigured credentials: %s", oidcMisconfiguredConfigMapName))
+		createCredentialConfigMap(ctx, f, oidcMisconfiguredConfigMapName, credentialConfig)
+		defer deleteConfigMap(ctx, f, oidcMisconfiguredConfigMapName)
+
+		// Grant bucket access so that the only failure is authentication,
+		// not a missing IAM binding masking the real error.
+		ginkgo.By("Granting bucket access to workload identity principal")
+		principal := fmt.Sprintf(
+			"principal://iam.googleapis.com/projects/%s/locations/global/workloadIdentityPools/%s/subject/system:serviceaccount:%s:%s",
+			projectNumber, oidcWorkloadIdentityPoolID, f.Namespace.Name, oidcServiceAccountName)
+		grantBucketAccess(bucketName, principal, "roles/storage.objectUser")
+		defer revokeBucketAccess(bucketName, principal, "roles/storage.objectUser")
+
+		ginkgo.By("Waiting for IAM policy propagation")
+		time.Sleep(5 * time.Second)
+
+		ginkgo.By("Configuring test pod with misconfigured OIDC provider")
+		tPod := specs.NewTestPodModifiedSpec(f.ClientSet, f.Namespace, true)
+		tPod.SetServiceAccount(oidcServiceAccountName)
+		tPod.SetupVolume(l.volumeResource, oidcVolumeName, oidcMountPath, false)
+		tPod.SetAnnotations(map[string]string{
+			webhook.GCPWorkloadIdentityCredentialConfigMapAnnotation: oidcMisconfiguredConfigMapName,
+		})
+
+		ginkgo.By("Deploying test pod and expecting STS authentication failure in sidecar")
+		tPod.Create(ctx)
+		defer tPod.Cleanup(ctx)
+
+		// The sidecar reads the credential config, fetches the KSA token, and
+		// calls Google STS to exchange it. Because the provider was registered
+		// with a wrong issuer URI, STS cannot verify the token and returns an
+		// error. The sidecar logs "IdentityBindingToken exchange error" and
+		// retries with exponential backoff until the context deadline.
+		ginkgo.By("Checking that gcsfuse logs an STS authentication error due to misconfigured provider")
+		tPod.WaitForLog(ctx, webhook.GcsFuseSidecarName, "Error connecting to the given credential's issuer.")
+	}
+
+	testCaseOIDCNonExistentPool := func() {
+		// Uses SkipCSIBucketAccessCheckPrefix so the CSI node driver skips its own
+		// prepareStorageService call. The authentication failure happens entirely
+		// inside the sidecar container when it tries to exchange the KSA token
+		// with Google STS using a credential config that points to a pool and
+		// provider that do not exist in GCP at all.
+		init(specs.SkipCSIBucketAccessCheckPrefix)
+		defer cleanup()
+
+		bucketName := l.volumeResource.VolSource.CSI.VolumeAttributes["bucketName"]
+		gomega.Expect(bucketName).NotTo(gomega.BeEmpty(), "bucketName must be set in volume attributes")
+
+		projectID := os.Getenv(utils.ProjectEnvVar)
+		gomega.Expect(projectID).NotTo(gomega.BeEmpty(), fmt.Sprintf("%s environment variable must be set", utils.ProjectEnvVar))
+
+		ginkgo.By("Getting GCP project number")
+		projectNumber := getProjectNumber(projectID)
+		gomega.Expect(projectNumber).NotTo(gomega.BeEmpty(), "Failed to get project number")
+
+		// Generate a credential config that points to a pool and provider that
+		// do not exist in GCP. Google STS will return an error because it cannot
+		// find any configuration to validate the token against.
+		ginkgo.By(fmt.Sprintf("Generating credential config pointing to non-existent pool %q and provider %q",
+			nonExistentPoolID, nonExistentProviderID))
+		credentialConfig := generateCredentialConfig(projectNumber, nonExistentPoolID, nonExistentProviderID)
+
+		ginkgo.By(fmt.Sprintf("Creating Kubernetes service account: %s", oidcServiceAccountName))
+		createServiceAccount(ctx, f, oidcServiceAccountName)
+		defer deleteServiceAccount(ctx, f, oidcServiceAccountName)
+
+		ginkgo.By(fmt.Sprintf("Creating ConfigMap with non-existent pool credentials: %s", oidcNonExistentPoolConfigMapName))
+		createCredentialConfigMap(ctx, f, oidcNonExistentPoolConfigMapName, credentialConfig)
+		defer deleteConfigMap(ctx, f, oidcNonExistentPoolConfigMapName)
+
+		ginkgo.By("Configuring test pod with non-existent pool credential config")
+		tPod := specs.NewTestPodModifiedSpec(f.ClientSet, f.Namespace, true)
+		tPod.SetServiceAccount(oidcServiceAccountName)
+		tPod.SetupVolume(l.volumeResource, oidcVolumeName, oidcMountPath, false)
+		tPod.SetAnnotations(map[string]string{
+			webhook.GCPWorkloadIdentityCredentialConfigMapAnnotation: oidcNonExistentPoolConfigMapName,
+		})
+
+		ginkgo.By("Deploying test pod and expecting STS authentication failure in sidecar")
+		tPod.Create(ctx)
+		defer tPod.Cleanup(ctx)
+
+		// The sidecar reads the credential config, fetches the KSA token, and
+		// calls Google STS to exchange it. Because the pool and provider in the
+		// audience do not exist in GCP, STS cannot find any configuration to
+		// validate the token against and returns an error. The sidecar logs
+		// "IdentityBindingToken exchange error" and retries with exponential
+		// backoff until the context deadline.
+		ginkgo.By("Checking that gcsfuse logs an STS authentication error due to non-existent pool or provider")
+		tPod.WaitForLog(ctx, webhook.GcsFuseSidecarName, "invalid_target")
+	}
+
 	ginkgo.It("should successfully mount with OIDC authentication", func() {
 		testCaseOIDCMount()
 	})
@@ -432,6 +570,14 @@ func (t *gcsFuseCSIOIDCTestSuite) DefineTests(driver storageframework.TestDriver
 			webhook.GCPWorkloadIdentityCredentialConfigMapAnnotation: "",
 		})
 		tPod.CreateExpectError(ctx)
+	})
+
+	ginkgo.It("should fail authentication when workload identity provider is misconfigured", func() {
+		testCaseOIDCMisconfiguredProvider()
+	})
+
+	ginkgo.It("should fail authentication when workload identity pool or provider does not exist", func() {
+		testCaseOIDCNonExistentPool()
 	})
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds two negative e2e test cases to the existing `oidc` test suite to validate STS-level authentication failures for Workload Identity Federation:

- **Misconfigured provider**: a WIF provider is created with a deliberately wrong issuer URI. Google STS cannot verify the KSA token's `iss` claim and the gcsfuse sidecar logs `"Error connecting to the given credential's issuer."`
- **Non-existent pool/provider**: credential config points to a pool and provider that do not exist in GCP. STS returns `invalid_target` and the sidecar logs it accordingly.

Both tests use `SkipCSIBucketAccessCheckPrefix` so the failure surface is entirely inside the gcsfuse sidecar, not the CSI node driver pre-flight check.

**Which issue(s) this PR fixes**:

N/A

**Does this PR introduce a user-facing change?**:

```release-note
NONE