### PR TITLE
Add GCSFUSE_PR_NUMBER to support testing against a specific gcsfuse PR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,17 @@ export STAGINGVERSION ?= $(shell git describe --long --tags --match='v*' --dirty
 export OVERLAY ?= stable
 export BUILD_GCSFUSE_FROM_SOURCE ?= false
 export GCSFUSE_TAG ?= master
+export GCSFUSE_REPO ?=
 export BUILD_ARM ?= false
 export SELF_MANAGED_K8S ?= false
+export GCSFUSE_PR_NUMBER ?=
+export E2E_TEST_BUILD_DRIVER ?= false
+
+# When GCSFUSE_PR_NUMBER is set, force building gcsfuse from source and building the driver image.
+ifneq ($(GCSFUSE_PR_NUMBER),)
+  BUILD_GCSFUSE_FROM_SOURCE := true
+  E2E_TEST_BUILD_DRIVER := true
+endif
 
 # Self-Managed / OSS K8s Logic. These match the defaults in cloudbuild-install.yaml for self-managed k8s.
 ifeq ($(SELF_MANAGED_K8S), true)
@@ -113,9 +122,26 @@ webhook:
 download-gcsfuse:
 	mkdir -p ${BINDIR}/linux/amd64 ${BINDIR}/linux/arm64
 ifeq (${BUILD_GCSFUSE_FROM_SOURCE}, true)
+# When building from a PR, resolve GCSFUSE_REPO and GCSFUSE_TAG from the
+# GitHub API.  $(eval) defers execution to recipe time so that `make e2e-test`
+# (which triggers a nested `make build-image-and-push-multi-arch` via
+# test/e2e/utils/image.go) does not pay for these curl calls at parse time.
+ifneq ($(GCSFUSE_PR_NUMBER),)
+ifeq ($(GCSFUSE_REPO),)
+	$(eval GCSFUSE_REPO := $(shell curl -sf -H "User-Agent: gcs-fuse-csi-driver" \
+	  "https://api.github.com/repos/GoogleCloudPlatform/gcsfuse/pulls/$(GCSFUSE_PR_NUMBER)" \
+	  | jq -r '.head.repo.clone_url'))
+	$(eval GCSFUSE_TAG := $(shell curl -sf -H "User-Agent: gcs-fuse-csi-driver" \
+	  "https://api.github.com/repos/GoogleCloudPlatform/gcsfuse/pulls/$(GCSFUSE_PR_NUMBER)" \
+	  | jq -r '.head.ref'))
+	$(info Resolved from PR $(GCSFUSE_PR_NUMBER): GCSFUSE_REPO=$(GCSFUSE_REPO) GCSFUSE_TAG=$(GCSFUSE_TAG))
+endif
+endif
 	rm -f ${BINDIR}/Dockerfile.gcsfuse
 	curl https://raw.githubusercontent.com/GoogleCloudPlatform/gcsfuse/${GCSFUSE_TAG}/tools/package_gcsfuse_docker/Dockerfile -o ${BINDIR}/Dockerfile.gcsfuse
-ifeq ($(GCSFUSE_TAG), master)
+ifneq ($(GCSFUSE_PR_NUMBER),)
+	$(eval GCSFUSE_VERSION = 0.0.1-gcsfuse-pr-$(GCSFUSE_PR_NUMBER))
+else ifeq ($(GCSFUSE_TAG), master)
 	$(eval GCSFUSE_VERSION = 0.0.1-gcsfuse-git-master-$(shell git ls-remote https://github.com/GoogleCloudPlatform/gcsfuse.git HEAD | cut -c1-7))
 else
 	$(eval GCSFUSE_VERSION=$(shell echo ${GCSFUSE_TAG} | sed 's/^v//'))
@@ -126,6 +152,7 @@ endif
 		--tag gcsfuse-release:${GCSFUSE_VERSION}-amd \
 		--build-arg GCSFUSE_VERSION=${GCSFUSE_VERSION} \
 		--build-arg BRANCH_NAME=${GCSFUSE_TAG} \
+		$(if $(GCSFUSE_REPO),--build-arg GCSFUSE_REPO=${GCSFUSE_REPO}) \
 		--build-arg ARCHITECTURE=amd64 \
 		--platform=linux/amd64 .
 
@@ -140,6 +167,7 @@ ifeq (${BUILD_ARM}, true)
 		--tag gcsfuse-release:${GCSFUSE_VERSION}-arm \
 		--build-arg GCSFUSE_VERSION=${GCSFUSE_VERSION} \
 		--build-arg BRANCH_NAME=${GCSFUSE_TAG} \
+		$(if $(GCSFUSE_REPO),--build-arg GCSFUSE_REPO=${GCSFUSE_REPO}) \
 		--build-arg ARCHITECTURE=arm64 \
 		--platform=linux/arm64 .
 	docker run \

--- a/docs/development.md
+++ b/docs/development.md
@@ -100,9 +100,37 @@ echo "latest GCSFuse CSI driver release is $LATEST_TAG, which uses GCSFuse versi
 ```bash
 # REGISTRY=<your-container-registry>: Required. Define your container registry. Make sure you have logged in your registry so that you have image pull/push permissions.
 # STAGINGVERSION=<staging-version>: Optional. Define a build version. If not defined, a staging version will be generated based on the commit hash.
-# BUILD_GCSFUSE_FROM_SOURCE=<true|false>: Optional, default: false. Indicate if you want to build the gcsfuse binary from source. This is required for building images from non-google internal projects OR if you want to test any CSI change depend on an unreleased GCSFuse enhancement. If BUILD_GCSFUSE_FROM_SOURCE is true, by default it builts GCSFuse from head of the master branch. If you want to build GCSFuse from a particular tag, then set GCSFUSE_TAG as explained in cloudbuild sections above.
+# BUILD_GCSFUSE_FROM_SOURCE=<true|false>: Optional, default: false. Indicate if you want to build the gcsfuse binary from source. This is required for building images from non-google internal projects OR if you want to test any CSI change depend on an unreleased GCSFuse enhancement. If BUILD_GCSFUSE_FROM_SOURCE is true, by default it builds GCSFuse from head of the master branch. If you want to build GCSFuse from a particular tag, then set GCSFUSE_TAG as explained in cloudbuild sections above. This flag is also automatically set by GCSFUSE_PR_NUMBER.
 # GCSFUSE_TAG=<gcsfuse-tag>: Optional. The GCSFuse tag you would like to build GCSFuse from. This is only used if BUILD_GCSFUSE_FROM_SOURCE is set to true.
 make build-image-and-push-multi-arch REGISTRY=$REGISTRY STAGINGVERSION=v999.999.999
+```
+
+#### Building GCSFuse from a specific GCSFuse PR (Optional)
+
+To test the CSI driver against a specific [GCSFuse PR](https://github.com/GoogleCloudPlatform/gcsfuse/pulls), pass `GCSFUSE_PR_NUMBER`. This automatically implies `BUILD_GCSFUSE_FROM_SOURCE=true` and resolves the PR's fork repo URL and branch name from the GitHub API. Works for both main-repo and fork PRs.
+
+```bash
+make build-image-and-push-multi-arch \
+  REGISTRY=$REGISTRY STAGINGVERSION=v999.999.999 \
+  GCSFUSE_PR_NUMBER=4651
+```
+
+> **Note**: `BUILD_GCSFUSE_FROM_SOURCE` and `GCSFUSE_PR_NUMBER` serve related but distinct purposes:
+> - `BUILD_GCSFUSE_FROM_SOURCE=true` alone builds GCSFuse from `master` (or the branch/tag specified by `GCSFUSE_TAG`).
+> - `GCSFUSE_PR_NUMBER=<N>` implies `BUILD_GCSFUSE_FROM_SOURCE=true` and also fetches the test configuration from that PR.
+
+#### Running E2E Tests from a Customized GCSFuse Release Branch
+
+When `BUILD_GCSFUSE_FROM_SOURCE=true` is set along with `GCSFUSE_TAG` (e.g., `GCSFUSE_TAG=v3.7.0`), the testing framework performs two key actions:
+1. **Driver Image Build**: It builds the driver image using the GCSFuse binary from the specified tag.
+2. **E2E Test Execution**: During E2E testing, the framework dynamically fetches the `gcsfuse` version from the running pod and automatically checks out the corresponding release branch (e.g., `v3.7.0_release`) from the GCSFuse repository. This ensures that the integration tests executed exactly match the GCSFuse version running inside the driver.
+
+To run the E2E tests using a customized release branch, execute:
+
+```bash
+make e2e-test E2E_TEST_USE_GKE_MANAGED_DRIVER=false E2E_TEST_BUILD_DRIVER=true \
+  BUILD_GCSFUSE_FROM_SOURCE=true GCSFUSE_TAG=v3.7.0 \
+  STAGINGVERSION=v999.999.999 REGISTRY=$REGISTRY
 ```
 
 ## Manual installation

--- a/test/README.md
+++ b/test/README.md
@@ -88,8 +88,11 @@ You can control the test through the following make parameters, eg `make e2e-tes
 - `E2E_TEST_USE_GKE_AUTOPILOT`: default value is `false`. Change it to `true` if you will test the CSI driver on an Autopilot cluster.
 - `CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER`: default value is `https://container.googleapis.com/`. **Only works for Google GKE developers.** Valid values are `https://staging-container.sandbox.googleapis.com/`, `https://staging2-container.sandbox.googleapis.com/`, and `https://test-container.sandbox.googleapis.com/`.
 - `E2E_TEST_USE_GKE_MANAGED_DRIVER`: default value is `true`. Change it to `false` if you want to manually install the CSI driver.
-- `E2E_TEST_BUILD_DRIVER`: default value is `false`. Change it to `true` if you want to build the CSI images from source code.
-- `BUILD_GCSFUSE_FROM_SOURCE`: default value is `false`. Change it to `true` if you want to build the GCS FUSE binary from source code.
+- `E2E_TEST_BUILD_DRIVER`: default value is `false`. Change it to `true` if you want to build the CSI images from source code. This will automatically set to `true` when `GCSFUSE_PR_NUMBER` is set.
+- `BUILD_GCSFUSE_FROM_SOURCE`: default value is `false`. Change it to `true` if you want to build the GCS FUSE binary from source code. This will automatically set to `true` when `GCSFUSE_PR_NUMBER` is set.
+- `GCSFUSE_PR_NUMBER`: default value is empty. Pass the Pull Request Number of `gcsfuse` (e.g., `4651` from `https://github.com/GoogleCloudPlatform/gcsfuse/pull/4651`) to enable two behaviors simultaneously:
+  1. **Test config**: Fetches `test_config.yaml` from the PR's head commit, so integration tests use the test definitions from that PR.
+  2. **Build from source**: Automatically sets `BUILD_GCSFUSE_FROM_SOURCE=true` and resolves the PR's fork repo URL and branch name, so the GCSFuse binary (and sidecar image) is built from that PR's code. Works for both main-repo and fork PRs.
 - `E2E_TEST_FOCUS`: default value is an empty string. The value will be passed to `ginkgo run --focus` flag.
 - `E2E_TEST_SKIP`: default value is `should.succeed.in.performance.test`. The value will be passed to `ginkgo run --skip` flag.
 - `E2E_TEST_GINKGO_PROCS`: default value is `5`. The value will be passed to `ginkgo run --procs` flag.
@@ -104,6 +107,10 @@ make e2e-test E2E_TEST_USE_GKE_MANAGED_DRIVER=true E2E_TEST_USE_GKE_AUTOPILOT=tr
 # Build the CSI driver and install it before the test. The GCS FUSE binary will be built from source code. The images will be using the version "v999.999.999", and will be pushed to your own container registry.
 make e2e-test E2E_TEST_USE_GKE_MANAGED_DRIVER=false E2E_TEST_BUILD_DRIVER=true BUILD_GCSFUSE_FROM_SOURCE=true STAGINGVERSION=v999.999.999 REGISTRY=my-registry
 
+
+# Build and test against a specific GCSFuse PR.
+make e2e-test E2E_TEST_USE_GKE_MANAGED_DRIVER=false E2E_TEST_BUILD_DRIVER=true \
+  GCSFUSE_PR_NUMBER=4651 STAGINGVERSION=v999.999.999 REGISTRY=my-registry
 # Run the test with customized Ginkgo flags.
 make e2e-test E2E_TEST_FOCUS=gcsfuseIntegration E2E_TEST_SKIP=failedMount E2E_TEST_GINKGO_PROCS=3 E2E_TEST_GINKGO_TIMEOUT=20m E2E_TEST_GINKGO_FLAKE_ATTEMPTS=1
 ```

--- a/test/e2e/main.go
+++ b/test/e2e/main.go
@@ -48,6 +48,7 @@ var (
 	enableGcsFuseProfiles          = flag.Bool("enable-gcsfuse-profiles", false, "enables gcsfuse profiles for e2e tests")
 	enableGCSFuseKernelParams      = flag.Bool("enable-gcsfuse-kernel-params", false, "enables kernel params for e2e tests")
 	skipCSIDriverInstall           = flag.Bool("skip-csi-driver-install", false, "skips the install of the driver. You must have manually deployed the driver and webhook.")
+	gcsFusePrNumber                = flag.String("gcsfuse-pr-number", "", "PR number for gcsfuse to test against")
 
 	// Test infrastructure flags.
 	inProw             = flag.Bool("run-in-prow", false, "whether or not to run the test in PROW")
@@ -123,6 +124,7 @@ func main() {
 		EnableGcsFuseProfiles:          *enableGcsFuseProfiles,
 		EnableGCSFuseKernelParams:      *enableGCSFuseKernelParams,
 		SkipCSIDriverInstall:           *skipCSIDriverInstall,
+		GCSFusePRNumber:                *gcsFusePrNumber,
 	}
 
 	if strings.Contains(testParams.GinkgoFocus, "performance") {

--- a/test/e2e/run-e2e-ci.sh
+++ b/test/e2e/run-e2e-ci.sh
@@ -46,6 +46,7 @@ readonly enable_sidecar_bucket_access_check=${ENABLE_SIDECAR_BUCKET_ACCESS_CHECK
 readonly enable_gcsfuse_profiles=${ENABLE_GCSFUSE_PROFILES:-true}
 readonly enable_gcsfuse_kernel_params=${ENABLE_GCSFUSE_KERNEL_PARAMS:-true}
 readonly overlay="${OVERLAY:-stable}"
+readonly gcsfuse_pr_number=${GCSFUSE_PR_NUMBER:-}
 
 # Install golang
 version=1.22.7
@@ -92,5 +93,6 @@ base_cmd="${PKGDIR}/bin/e2e-test-ci \
             --enable-gcsfuse-kernel-params=${enable_gcsfuse_kernel_params} \
             --gke-gcloud-command='${gke_gcloud_command}' \
             --gke-gcloud-args='${gke_gcloud_args}'\
-            --deploy-overlay-name=${overlay}"
+            --deploy-overlay-name=${overlay} \
+            --gcsfuse-pr-number=${gcsfuse_pr_number}"
 eval "$base_cmd"

--- a/test/e2e/run-e2e-local.sh
+++ b/test/e2e/run-e2e-local.sh
@@ -36,7 +36,7 @@ readonly overlay="${OVERLAY:-dev}"
 readonly ginkgo_focus="${E2E_TEST_FOCUS:-}"
 # TODO(amacaskill): Remove oidc from default skip when the test can be run without additional configuration.
 readonly ginkgo_skip="${E2E_TEST_SKIP:-'should.succeed.in.performance.test|oidc'}"
-readonly ginkgo_procs="${E2E_TEST_GINKGO_PROCS:-10}"
+readonly ginkgo_procs="${E2E_TEST_GINKGO_PROCS:-20}"
 readonly ginkgo_timeout="${E2E_TEST_GINKGO_TIMEOUT:-4h}"
 readonly ginkgo_flake_attempts="${E2E_TEST_GINKGO_FLAKE_ATTEMPTS:-2}"
 readonly gcsfuse_client_protocol=${GCSFUSE_CLIENT_PROTOCOL:-http1}
@@ -44,6 +44,7 @@ readonly enable_zb=${ENABLE_ZB:-false}
 readonly enable_sidecar_bucket_access_check=${ENABLE_SIDECAR_BUCKET_ACCESS_CHECK:-true}
 readonly enable_gcsfuse_profiles=${ENABLE_GCSFUSE_PROFILES:-true}
 readonly enable_gcsfuse_kernel_params=${ENABLE_GCSFUSE_KERNEL_PARAMS:-true}
+readonly gcsfuse_pr_number=${GCSFUSE_PR_NUMBER:-}
 
 if [ "${skip_csi_driver_install}" = true ]; then
   use_gke_managed_driver=false
@@ -89,5 +90,6 @@ base_cmd="${PKGDIR}/bin/e2e-test-ci \
             --gcsfuse-enable-zb=${enable_zb} \
             --enable-sidecar-bucket-access-check=${enable_sidecar_bucket_access_check} \
             --enable-gcsfuse-profiles=${enable_gcsfuse_profiles} \
-            --enable-gcsfuse-kernel-params=${enable_gcsfuse_kernel_params}"
+            --enable-gcsfuse-kernel-params=${enable_gcsfuse_kernel_params} \
+            --gcsfuse-pr-number=${gcsfuse_pr_number}"
 eval "$base_cmd"

--- a/test/e2e/testsuites/gcsfuse_integration.go
+++ b/test/e2e/testsuites/gcsfuse_integration.go
@@ -1227,7 +1227,13 @@ func (t *gcsFuseCSIGCSFuseIntegrationTestSuite) DefineTests(driver storageframew
 
 func installGcsfuseDependencies(tPod *specs.TestPod, f *framework.Framework, gcsfuseTestBranch string, installGcloud bool) {
 	ginkgo.By("Installing dependencies")
-	tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("git clone --branch %v https://github.com/GoogleCloudPlatform/gcsfuse.git", gcsfuseTestBranch))
+	if utils.GCSFusePRNumber != "" {
+		framework.Logf("Running tests against GCSFuse PR %s", utils.GCSFusePRNumber)
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("git clone https://github.com/GoogleCloudPlatform/gcsfuse.git && cd gcsfuse && git fetch origin pull/%s/head:pr-branch && git checkout pr-branch", utils.GCSFusePRNumber))
+	} else {
+		framework.Logf("Running tests against GCSFuse branch %s", gcsfuseTestBranch)
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("git clone --branch %v https://github.com/GoogleCloudPlatform/gcsfuse.git", gcsfuseTestBranch))
+	}
 	tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, "ln -s /usr/bin/python3 /usr/bin/python")
 
 	if installGcloud {

--- a/test/e2e/utils/handler.go
+++ b/test/e2e/utils/handler.go
@@ -86,6 +86,7 @@ type TestParameters struct {
 
 	GkeGcloudCommand string
 	GkeGcloudArgs    string
+	GCSFusePRNumber  string
 }
 
 const (
@@ -99,6 +100,7 @@ const (
 	TestEnvEnvVar                          = "TEST_ENV"
 	IsOSSEnvVar                            = "IS_OSS"
 	IsZBEnabledEnvVar                      = "IS_ZB_ENABLED"
+	GCSFusePRNumberEnvVar                  = "GCSFUSE_PR_NUMBER"
 )
 
 var skipDynamicPVTests = []string{"stable", "sidecar_bucket_access_check", "profiles"}
@@ -201,7 +203,10 @@ func Handle(testParams *TestParameters) error {
 		os.Setenv(IsOSSEnvVar, "true")
 		if testParams.BuildGcsFuseCsiDriver {
 			klog.Infof("Building GCS FUSE CSI Driver")
-			if err := buildAndPushImage(testParams.PkgDir, testParams.ImageRegistry, testParams.BuildGcsFuseFromSource, testParams.BuildArm); err != nil {
+			if testParams.GCSFusePRNumber != "" {
+				klog.Infof("GCSFUSE_PR_NUMBER=%s is provided, building GCSFuse from this PR source", testParams.GCSFusePRNumber)
+			}
+			if err := buildAndPushImage(testParams.PkgDir, testParams.ImageRegistry, testParams.BuildGcsFuseFromSource, testParams.BuildArm, testParams.GCSFusePRNumber); err != nil {
 				return fmt.Errorf("failed pushing GCS FUSE CSI Driver images: %w", err)
 			}
 
@@ -344,6 +349,11 @@ func Handle(testParams *TestParameters) error {
 func setTestEnvVars(testParams *TestParameters) {
 	if err := os.Setenv(IsZBEnabledEnvVar, strconv.FormatBool(testParams.EnableZB)); err != nil {
 		klog.Errorf(`env variable "%s" could not be set: %v`, IsZBEnabledEnvVar, err)
+	}
+	if testParams.GCSFusePRNumber != "" {
+		if err := os.Setenv(GCSFusePRNumberEnvVar, testParams.GCSFusePRNumber); err != nil {
+			klog.Errorf(`env variable "%s" could not be set: %v`, GCSFusePRNumberEnvVar, err)
+		}
 	}
 }
 

--- a/test/e2e/utils/image.go
+++ b/test/e2e/utils/image.go
@@ -23,17 +23,26 @@ import (
 	"strconv"
 )
 
-func buildAndPushImage(pkgDir, registry string, buildGcsFuseFromSource, buildArm bool) error {
-	//nolint:gosec
-	cmd := exec.Command("make", "-C", pkgDir,
+func buildAndPushImage(pkgDir, registry string, buildGcsFuseFromSource, buildArm bool, gcsFusePRNumber string) error {
+	args := []string{
+		"-C", pkgDir,
 		"build-image-and-push-multi-arch",
-		"REGISTRY="+registry,
-		"BUILD_GCSFUSE_FROM_SOURCE="+strconv.FormatBool(buildGcsFuseFromSource),
-		"BUILD_ARM="+strconv.FormatBool(buildArm))
+		"REGISTRY=" + registry,
+		"BUILD_GCSFUSE_FROM_SOURCE=" + strconv.FormatBool(buildGcsFuseFromSource),
+		"BUILD_ARM=" + strconv.FormatBool(buildArm),
+	}
+
+	if gcsFusePRNumber != "" {
+		args = append(args,
+			"GCSFUSE_PR_NUMBER="+gcsFusePRNumber,
+		)
+	}
+
+	//nolint:gosec
+	cmd := exec.Command("make", args...)
 	if err := runCommand("Pushing image to REGISTRY "+registry, cmd); err != nil {
 		return fmt.Errorf("failed to run push image: %w", err)
 	}
-
 	return nil
 }
 

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -19,6 +19,7 @@ package utils
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -62,6 +63,7 @@ const (
 
 var (
 	MasterBranchName = "master"
+	GCSFusePRNumber  = os.Getenv("GCSFUSE_PR_NUMBER")
 
 	// Use release branch for corresponding gcsfuse version. This ensures we
 	// can pick up test fixes without requiring a new gcsfuse release.
@@ -157,11 +159,89 @@ type TestBucketType struct {
 
 type TestPackages map[string][]TestPackage
 
+// LoadTestConfig loads the test_config.yaml from the gcsfuse repository.
+// If GCSFUSE_PR_NUMBER is set, it fetches the config from the PR's head commit.
+// Otherwise, it resolves the release branch from the gcsfuse version string.
 func LoadTestConfig(gcsfuseVersion string) error {
+	if GCSFusePRNumber != "" {
+		return loadTestConfigFromPR(GCSFusePRNumber)
+	}
 	_, branch := GCSFuseBranch(gcsfuseVersion)
 	klog.Infof("LoadTestConfig: Loading test config for GCSFuse branch %v", branch)
 	url := fmt.Sprintf(testConfigUrlFormat, branch)
-	klog.Infof("LoadTestConfig: Fetching test config from %v", url)
+	return fetchAndParseTestConfig(url)
+}
+
+// loadTestConfigFromPR queries the GitHub API to resolve the head commit SHA for the given PR Number.
+// It then fetches the raw test_config.yaml from that specific commit via raw.githubusercontent.com.
+// Finally, it parses the YAML content to populate LoadedTestPackages for dynamic test generation.
+func loadTestConfigFromPR(prNumber string) error {
+	klog.Infof("loadTestConfigFromPR: Fetching PR info for PR %v", prNumber)
+	apiURL := fmt.Sprintf("https://api.github.com/repos/GoogleCloudPlatform/gcsfuse/pulls/%s", prNumber)
+
+	req, err := http.NewRequest("GET", apiURL, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create HTTP request: %w", err)
+	}
+	// GitHub API requires a User-Agent header.
+	req.Header.Set("User-Agent", "gcs-fuse-csi-driver-e2e")
+
+	// Fetch PR info from GitHub API with exponential backoff.
+	httpClient := &http.Client{
+		Timeout: 30 * time.Second,
+	}
+	var resp *http.Response
+	err = wait.ExponentialBackoff(httpRetryBackoff, func() (bool, error) {
+		var httpErr error
+		resp, httpErr = httpClient.Do(req)
+		if httpErr != nil {
+			klog.Warningf("Failed to fetch PR info, retrying: %v", httpErr)
+			return false, nil
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			resp.Body.Close()
+			klog.Warningf("Failed to fetch PR info (status %d), retrying", resp.StatusCode)
+			return false, nil
+		}
+
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to fetch PR info after %d retries: %w", httpRetryBackoff.Steps, err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read PR info body: %w", err)
+	}
+
+	// Define a minimal struct to extract only the head commit SHA from the PR response.
+	var pr struct {
+		Head struct {
+			SHA string `json:"sha"`
+		} `json:"head"`
+	}
+	if err := json.Unmarshal(body, &pr); err != nil {
+		return fmt.Errorf("failed to unmarshal PR info: %w", err)
+	}
+
+	// Extract the resolved SHA.
+	sha := pr.Head.SHA
+	if sha == "" {
+		return fmt.Errorf("failed to resolve head SHA for PR %s", prNumber)
+	}
+	klog.Infof("loadTestConfigFromPR: Found PR head SHA %v", sha)
+
+	configURL := fmt.Sprintf(testConfigUrlFormat, sha)
+	return fetchAndParseTestConfig(configURL)
+}
+
+// fetchAndParseTestConfig fetches the test_config.yaml from the given URL,
+// parses it, and stores the result in LoadedTestPackages.
+func fetchAndParseTestConfig(url string) error {
+	klog.Infof("fetchAndParseTestConfig: Fetching test config from %v", url)
 	var resp *http.Response
 	err := wait.ExponentialBackoff(httpRetryBackoff, func() (bool, error) {
 		var httpErr error
@@ -191,11 +271,10 @@ func LoadTestConfig(gcsfuseVersion string) error {
 
 	config, err := ParseTestConfig(body)
 	if err != nil {
-		klog.Errorf("LoadTestConfig: failed to parse test config: %v", err)
 		return fmt.Errorf("failed to parse test config: %w", err)
 	}
 
-	klog.Infof("LoadTestConfig: Successfully loaded and parsed %d test packages", len(config))
+	klog.Infof("fetchAndParseTestConfig: Successfully loaded and parsed %d test packages", len(config))
 	LoadedTestPackages = config
 	return nil
 }
@@ -329,8 +408,13 @@ func ParseConfigFlags(flagStr string) ParsedConfig {
 	return parsed
 }
 
-// Checks if the gcsfuse version supports test_config.yaml for integration tests.
+// IsReadFromTestConfig checks if the gcsfuse version supports test_config.yaml for integration tests.
+// It also returns true when GCSFUSE_PR_NUMBER is set, since the PR is assumed to have a test_config.yaml.
 func IsReadFromTestConfig(gcsfuseVersionStr string) bool {
+	if GCSFusePRNumber != "" {
+		return true
+	}
+
 	if gcsfuseVersionStr == "" {
 		return false
 	}
@@ -383,9 +467,10 @@ func FetchGCSFuseVersion(ctx context.Context, cl clientset.Interface) (string, e
 			TerminationGracePeriodSeconds: ptr.To(int64(0)),
 			Containers: []corev1.Container{
 				{
-					Name:    webhook.GcsFuseSidecarName,
-					Image:   image,
-					Command: []string{"/gcsfuse", "--version"},
+					Name:            webhook.GcsFuseSidecarName,
+					Image:           image,
+					ImagePullPolicy: corev1.PullAlways,
+					Command:         []string{"/gcsfuse", "--version"},
 				},
 				{
 					Name:    "sleeper",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR enables running E2E integration tests against specific unmerged GCSFuse PRs, so the GCSFuse team no longer needs to merge their changes or manually modify the CSI driver code before testing.

**How it works**:
- The Makefile now accepts a `GCSFUSE_PR_NUMBER` variable. When set, `download-gcsfuse` resolves the PR's fork repo URL and branch name from the GitHub API, then builds the gcsfuse binary from that PR's source via `docker buildx build`.
- On the test side, when `GCSFUSE_PR_NUMBER` is set, the test harness fetches `test_config.yaml` directly from the PR's head commit SHA and bypasses version-based branching logic, ensuring all integration tests run against the PR's code.

When user execute `make e2e-test GCSFUSE_PR_NUMBER=xxx` it will triggers the following automated workflow:
1. `make e2e-test` sets `BUILD_GCSFUSE_FROM_SOURCE=true` and exports `GCSFUSE_PR_NUMBER` to the environment.
2. `run-e2e-local.sh` builds the Go test binary (`e2e-test-ci`) and passes `--gcsfuse-pr-number` to it.
3. The Go harness (`test/e2e/utils/image.go`) calls `make build-image-and-push-multi-arch GCSFUSE_PR_NUMBER=...`.
4. The `download-gcsfuse` step resolves the PR's fork repository URL and branch from the GitHub API, passes them as `GCSFUSE_REPO` and `BRANCH_NAME` for [GCSFuse's Dockerfile](https://github.com/GoogleCloudPlatform/gcsfuse/blob/b97b8cc2a0ff46db7dc59d5f6d7d2dd92c4de064/tools/package_gcsfuse_docker/Dockerfile#L55-L61) to clone the corresponding repository and checkout the specified branch, builds `gcsfuse` from that source via `docker buildx build`, and extracts the binary.
5. The built gcsfuse binary is packaged into the sidecar-mounter image and pushed to the registry.
6. The CSI driver is installed on the cluster with the new image.
7. The test framework fetches `test_config.yaml` from the PR's head commit and runs Ginkgo integration tests against the PR's code.

**Other changes**:
- Increased default Ginkgo processes from 10 to 20 to match CI and avoid timeouts as the GCSFuse test suite grows.
- Set `BUILD_GCSFUSE_FROM_SOURCE` and `E2E_TEST_BUILD_DRIVER` as `true` when `GCSFUSE_PR_NUMBER` is provided

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
I have tested on the unmanaged driver on GCSFuse v3.9 against GCSFuse [PR #4651](https://github.com/GoogleCloudPlatform/gcsfuse/pull/4651/changes) which fix the test failure issues in GCSFuse v3.9
```
make e2e-test \  REGISTRY=$REGISTRY \                                                     
  STAGINGVERSION=prow-gob-internal-boskos-3.9 \
  GCSFUSE_PR_NUMBER=4651 \
  E2E_TEST_FOCUS=gcsfuseIntegration \
  E2E_TEST_USE_MANAGED_DRIVER=false 

Ran 272 of 585 Specs in 10380.587 seconds
SUCCESS! -- 272 Passed | 0 Failed | 4 Flaked | 0 Pending | 313 Skipped


Ginkgo ran 1 suite in 2h53m10.193675691s
Test Suite Passed
```
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
