### PR TITLE
Add e2e tests for WIF IAM authorization failures on OSS and GKE clusters

### DIFF
--- a/test/e2e/specs/testdriver.go
+++ b/test/e2e/specs/testdriver.go
@@ -503,16 +503,7 @@ func (n *GCSFuseCSITestDriver) prepareStorageService(ctx context.Context) (stora
 }
 
 // bucketIAMMember returns the IAM member string for the given KSA.
-<<<<<<< HEAD
-<<<<<<< HEAD
 // When OSS_WIF_POOL_ID is set, uses the WIF principal format for self-managed clusters.
-=======
-// On OSS clusters (IS_OSS=true), uses the external WIF principal format with ossWIFOIDCPoolID
-// since the GKE Workload Identity pool (<project>.svc.id.goog) does not exist on non-GKE projects.
->>>>>>> d2e87503 (e2e/wif: replace gcloud CLI with GCS Go client, add sanitizeProjectID helper, and deduplicate pool ID constant)
-=======
-// When OSS_WIF_POOL_ID is set, uses the WIF principal format for self-managed clusters.
->>>>>>> fa4a1622 (remove ossWIFOIDCPoolID constant, use OSS_WIF_POOL_ID env var in bucketIAMMember)
 // Otherwise falls back to the GKE Workload Identity format.
 func (n *GCSFuseCSITestDriver) bucketIAMMember(serviceAccountNamespace, serviceAccountName string) string {
 	if !n.skipGcpSaTest {
@@ -521,15 +512,7 @@ func (n *GCSFuseCSITestDriver) bucketIAMMember(serviceAccountNamespace, serviceA
 	if wifPoolID := os.Getenv("OSS_WIF_POOL_ID"); wifPoolID != "" {
 		projectNumber := os.Getenv(utils.ProjectNumberEnvVar)
 		return fmt.Sprintf("principal://iam.googleapis.com/projects/%s/locations/global/workloadIdentityPools/%s/subject/system:serviceaccount:%s:%s",
-<<<<<<< HEAD
-<<<<<<< HEAD
 			projectNumber, wifPoolID, serviceAccountNamespace, serviceAccountName)
-=======
-			projectNumber, ossWIFOIDCPoolID, serviceAccountNamespace, serviceAccountName)
->>>>>>> d2e87503 (e2e/wif: replace gcloud CLI with GCS Go client, add sanitizeProjectID helper, and deduplicate pool ID constant)
-=======
-			projectNumber, wifPoolID, serviceAccountNamespace, serviceAccountName)
->>>>>>> fa4a1622 (remove ossWIFOIDCPoolID constant, use OSS_WIF_POOL_ID env var in bucketIAMMember)
 	}
 	return fmt.Sprintf("serviceAccount:%v.svc.id.goog[%v/%v]", n.meta.GetProjectID(), serviceAccountNamespace, serviceAccountName)
 }

--- a/test/e2e/specs/testdriver.go
+++ b/test/e2e/specs/testdriver.go
@@ -109,9 +109,6 @@ const (
 	gcsfuseCSIProfilesStaticBucketRegion = "us-central1"
 	gkeScalabilityImagesProjectID        = "gke-scalability-images"
 	iamPropagationWaitTime               = 10 * time.Minute
-	// ossWIFOIDCPoolID is the WIF pool ID used for OSS cluster bucket IAM in e2e tests.
-	// Must stay in sync with wifWorkloadIdentityPoolID in workload_identity_federation.go.
-	ossWIFOIDCPoolID = "gcs-fuse-oidc-pool"
 )
 
 var (
@@ -507,11 +504,15 @@ func (n *GCSFuseCSITestDriver) prepareStorageService(ctx context.Context) (stora
 
 // bucketIAMMember returns the IAM member string for the given KSA.
 <<<<<<< HEAD
+<<<<<<< HEAD
 // When OSS_WIF_POOL_ID is set, uses the WIF principal format for self-managed clusters.
 =======
 // On OSS clusters (IS_OSS=true), uses the external WIF principal format with ossWIFOIDCPoolID
 // since the GKE Workload Identity pool (<project>.svc.id.goog) does not exist on non-GKE projects.
 >>>>>>> d2e87503 (e2e/wif: replace gcloud CLI with GCS Go client, add sanitizeProjectID helper, and deduplicate pool ID constant)
+=======
+// When OSS_WIF_POOL_ID is set, uses the WIF principal format for self-managed clusters.
+>>>>>>> fa4a1622 (remove ossWIFOIDCPoolID constant, use OSS_WIF_POOL_ID env var in bucketIAMMember)
 // Otherwise falls back to the GKE Workload Identity format.
 func (n *GCSFuseCSITestDriver) bucketIAMMember(serviceAccountNamespace, serviceAccountName string) string {
 	if !n.skipGcpSaTest {
@@ -521,10 +522,14 @@ func (n *GCSFuseCSITestDriver) bucketIAMMember(serviceAccountNamespace, serviceA
 		projectNumber := os.Getenv(utils.ProjectNumberEnvVar)
 		return fmt.Sprintf("principal://iam.googleapis.com/projects/%s/locations/global/workloadIdentityPools/%s/subject/system:serviceaccount:%s:%s",
 <<<<<<< HEAD
+<<<<<<< HEAD
 			projectNumber, wifPoolID, serviceAccountNamespace, serviceAccountName)
 =======
 			projectNumber, ossWIFOIDCPoolID, serviceAccountNamespace, serviceAccountName)
 >>>>>>> d2e87503 (e2e/wif: replace gcloud CLI with GCS Go client, add sanitizeProjectID helper, and deduplicate pool ID constant)
+=======
+			projectNumber, wifPoolID, serviceAccountNamespace, serviceAccountName)
+>>>>>>> fa4a1622 (remove ossWIFOIDCPoolID constant, use OSS_WIF_POOL_ID env var in bucketIAMMember)
 	}
 	return fmt.Sprintf("serviceAccount:%v.svc.id.goog[%v/%v]", n.meta.GetProjectID(), serviceAccountNamespace, serviceAccountName)
 }

--- a/test/e2e/specs/testdriver.go
+++ b/test/e2e/specs/testdriver.go
@@ -109,6 +109,9 @@ const (
 	gcsfuseCSIProfilesStaticBucketRegion = "us-central1"
 	gkeScalabilityImagesProjectID        = "gke-scalability-images"
 	iamPropagationWaitTime               = 10 * time.Minute
+	// ossWIFOIDCPoolID is the WIF pool ID used for OSS cluster bucket IAM in e2e tests.
+	// Must stay in sync with wifWorkloadIdentityPoolID in workload_identity_federation.go.
+	ossWIFOIDCPoolID = "gcs-fuse-oidc-pool"
 )
 
 var (
@@ -503,7 +506,12 @@ func (n *GCSFuseCSITestDriver) prepareStorageService(ctx context.Context) (stora
 }
 
 // bucketIAMMember returns the IAM member string for the given KSA.
+<<<<<<< HEAD
 // When OSS_WIF_POOL_ID is set, uses the WIF principal format for self-managed clusters.
+=======
+// On OSS clusters (IS_OSS=true), uses the external WIF principal format with ossWIFOIDCPoolID
+// since the GKE Workload Identity pool (<project>.svc.id.goog) does not exist on non-GKE projects.
+>>>>>>> d2e87503 (e2e/wif: replace gcloud CLI with GCS Go client, add sanitizeProjectID helper, and deduplicate pool ID constant)
 // Otherwise falls back to the GKE Workload Identity format.
 func (n *GCSFuseCSITestDriver) bucketIAMMember(serviceAccountNamespace, serviceAccountName string) string {
 	if !n.skipGcpSaTest {
@@ -512,7 +520,11 @@ func (n *GCSFuseCSITestDriver) bucketIAMMember(serviceAccountNamespace, serviceA
 	if wifPoolID := os.Getenv("OSS_WIF_POOL_ID"); wifPoolID != "" {
 		projectNumber := os.Getenv(utils.ProjectNumberEnvVar)
 		return fmt.Sprintf("principal://iam.googleapis.com/projects/%s/locations/global/workloadIdentityPools/%s/subject/system:serviceaccount:%s:%s",
+<<<<<<< HEAD
 			projectNumber, wifPoolID, serviceAccountNamespace, serviceAccountName)
+=======
+			projectNumber, ossWIFOIDCPoolID, serviceAccountNamespace, serviceAccountName)
+>>>>>>> d2e87503 (e2e/wif: replace gcloud CLI with GCS Go client, add sanitizeProjectID helper, and deduplicate pool ID constant)
 	}
 	return fmt.Sprintf("serviceAccount:%v.svc.id.goog[%v/%v]", n.meta.GetProjectID(), serviceAccountNamespace, serviceAccountName)
 }

--- a/test/e2e/testsuites/workload_identity_federation.go
+++ b/test/e2e/testsuites/workload_identity_federation.go
@@ -836,7 +836,12 @@ func (t *gcsFuseCSIWorkloadIdentityFederationTestSuite) DefineTests(driver stora
 	})
 
 	ginkgo.It("should fail GCS access when WI principal has no storage role", func() {
-		init(specs.SkipCSIBucketAccessCheckPrefix)
+		isOSS := os.Getenv(utils.IsOSSEnvVar) == "true"
+		if isOSS {
+			init(specs.SkipCSIBucketAccessCheckPrefix)
+		} else {
+			init()
+		}		
 		defer cleanup()
 
 		const (
@@ -846,7 +851,6 @@ func (t *gcsFuseCSIWorkloadIdentityFederationTestSuite) DefineTests(driver stora
 			mountPath     = "/mnt/gcs"
 		)
 
-		isOSS := os.Getenv(utils.IsOSSEnvVar) == "true"
 		var principal string
 		if isOSS {
 			principal, _ = setupOSSWIFPrincipal(wifKSA, wifWorkloadIdentityPoolID, wifWorkloadIdentityProviderID, configMapName)
@@ -873,7 +877,12 @@ func (t *gcsFuseCSIWorkloadIdentityFederationTestSuite) DefineTests(driver stora
 	})
 
 	ginkgo.It("should fail write operations when WI principal has read-only storage role", func() {
-		init(specs.SkipCSIBucketAccessCheckPrefix)
+		isOSS := os.Getenv(utils.IsOSSEnvVar) == "true"
+		if isOSS {
+			init(specs.SkipCSIBucketAccessCheckPrefix)
+		} else {
+			init()
+		}
 		defer cleanup()
 
 		bucketName := l.volumeResource.VolSource.CSI.VolumeAttributes["bucketName"]
@@ -886,7 +895,6 @@ func (t *gcsFuseCSIWorkloadIdentityFederationTestSuite) DefineTests(driver stora
 			mountPath     = "/mnt/gcs"
 		)
 
-		isOSS := os.Getenv(utils.IsOSSEnvVar) == "true"
 		var principal string
 		if isOSS {
 			principal, _ = setupOSSWIFPrincipal(wifKSA, wifWorkloadIdentityPoolID, wifWorkloadIdentityProviderID, configMapName)
@@ -920,7 +928,12 @@ func (t *gcsFuseCSIWorkloadIdentityFederationTestSuite) DefineTests(driver stora
 	})
 
 	ginkgo.It("should fail GCS access when WI principal role is on a different bucket", func() {
-		init(specs.SkipCSIBucketAccessCheckPrefix)
+		isOSS := os.Getenv(utils.IsOSSEnvVar) == "true"
+		if isOSS {
+			init(specs.SkipCSIBucketAccessCheckPrefix)
+		} else {
+			init()
+		}		
 		defer cleanup()
 
 		bucketName := l.volumeResource.VolSource.CSI.VolumeAttributes["bucketName"]
@@ -933,7 +946,6 @@ func (t *gcsFuseCSIWorkloadIdentityFederationTestSuite) DefineTests(driver stora
 			mountPath     = "/mnt/gcs"
 		)
 
-		isOSS := os.Getenv(utils.IsOSSEnvVar) == "true"
 		rawProjectID := os.Getenv(utils.ProjectEnvVar)
 		lines := strings.Split(strings.TrimSpace(rawProjectID), "\n")
 		projectID := lines[len(lines)-1]

--- a/test/e2e/testsuites/workload_identity_federation.go
+++ b/test/e2e/testsuites/workload_identity_federation.go
@@ -23,13 +23,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 	"time"
 
 	"local/test/e2e/specs"
 	"local/test/e2e/utils"
 
+	gostorage "cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/webhook"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -150,6 +150,7 @@ func (t *gcsFuseCSIWorkloadIdentityFederationTestSuite) DefineTests(driver stora
 	// roles/iam.workloadIdentityUser, and creates the annotated KSA. Returns the
 	// GSA principal string. Cleanup is registered via ginkgo.DeferCleanup.
 	setupGKEWIPrincipal := func(ksaName string) string {
+<<<<<<< HEAD
 		projectID := os.Getenv(utils.ProjectEnvVar)
 		gomega.Expect(projectID).NotTo(gomega.BeEmpty(), fmt.Sprintf("%s environment variable must be set", utils.ProjectEnvVar))
 		// Use ksaName as base + namespace numeric suffix to keep names unique per
@@ -157,6 +158,15 @@ func (t *gcsFuseCSIWorkloadIdentityFederationTestSuite) DefineTests(driver stora
 		nsIdx := strings.LastIndex(f.Namespace.Name, "-")
 		nsSuffix := f.Namespace.Name[nsIdx+1:]
 		saName := fmt.Sprintf("%s-%s", ksaName, nsSuffix)
+=======
+		rawProjectID := os.Getenv(utils.ProjectEnvVar)
+		gomega.Expect(rawProjectID).NotTo(gomega.BeEmpty(), "PROJECT must be set")
+		projectID := sanitizeProjectID(rawProjectID)
+		gomega.Expect(strings.Contains(projectID, "Your active configuration")).To(gomega.BeFalse(),
+			fmt.Sprintf("invalid projectID detected: %q", projectID))
+
+		saName := f.Namespace.Name
+>>>>>>> d2e87503 (e2e/wif: replace gcloud CLI with GCS Go client, add sanitizeProjectID helper, and deduplicate pool ID constant)
 		if len(saName) > 30 {
 			saName = strings.TrimRight(saName[:30], "-")
 		}
@@ -173,7 +183,7 @@ func (t *gcsFuseCSIWorkloadIdentityFederationTestSuite) DefineTests(driver stora
 		testK8sSA.Create(ctx)
 		ginkgo.DeferCleanup(func() { testK8sSA.Cleanup(ctx) })
 
-		ginkgo.By("Waiting for Workload Identity binding to propagate globally (~60s)")
+		ginkgo.By("Waiting for Workload Identity binding to propagate globally (~2 minutes)")
 		time.Sleep(2 * time.Minute)
 
 		return "serviceAccount:" + testGcpSA.GetEmail()
@@ -946,9 +956,7 @@ func (t *gcsFuseCSIWorkloadIdentityFederationTestSuite) DefineTests(driver stora
 			mountPath     = "/mnt/gcs"
 		)
 
-		rawProjectID := os.Getenv(utils.ProjectEnvVar)
-		lines := strings.Split(strings.TrimSpace(rawProjectID), "\n")
-		projectID := lines[len(lines)-1]
+		projectID := sanitizeProjectID(os.Getenv(utils.ProjectEnvVar))
 
 		var principal string
 		if isOSS {
@@ -959,12 +967,15 @@ func (t *gcsFuseCSIWorkloadIdentityFederationTestSuite) DefineTests(driver stora
 
 		altBucket := fmt.Sprintf("gcs-fuse-wif-alt-%s", f.Namespace.Name)
 		ginkgo.By(fmt.Sprintf("Creating alternate bucket: %s", altBucket))
-		if out, err := exec.Command("gcloud", "storage", "buckets", "create", "gs://"+altBucket, "--project="+projectID).CombinedOutput(); err != nil {
-			klog.Warningf("Failed to create alternate bucket %s: %v, output: %s", altBucket, err, string(out))
+		storageClient, err := gostorage.NewClient(ctx)
+		framework.ExpectNoError(err, "creating GCS storage client for alternate bucket")
+		defer storageClient.Close()
+		if err := storageClient.Bucket(altBucket).Create(ctx, projectID, nil); err != nil {
+			framework.Failf("Failed to create alternate bucket %s: %v", altBucket, err)
 		}
 		defer func() {
-			if out, err := exec.Command("gcloud", "storage", "buckets", "delete", "gs://"+altBucket, "--project="+projectID, "--quiet").CombinedOutput(); err != nil {
-				klog.Warningf("Failed to delete alternate bucket %s: %v, output: %s", altBucket, err, string(out))
+			if err := storageClient.Bucket(altBucket).Delete(ctx); err != nil {
+				klog.Warningf("Failed to delete alternate bucket %s: %v", altBucket, err)
 			}
 		}()
 
@@ -1068,3 +1079,13 @@ func getOSSClusterOIDCIssuer(ctx context.Context, f *framework.Framework) string
 	gomega.Expect(claims.Issuer).NotTo(gomega.BeEmpty(), "cluster OIDC issuer must not be empty")
 	return claims.Issuer
 }
+<<<<<<< HEAD
+=======
+
+// sanitizeProjectID strips any Cloud Shell "Your active configuration is: [...]"
+// warning that gcloud can prepend to stdout, returning only the actual project ID.
+func sanitizeProjectID(raw string) string {
+	lines := strings.Split(strings.TrimSpace(raw), "\n")
+	return lines[len(lines)-1]
+}
+>>>>>>> d2e87503 (e2e/wif: replace gcloud CLI with GCS Go client, add sanitizeProjectID helper, and deduplicate pool ID constant)

--- a/test/e2e/testsuites/workload_identity_federation.go
+++ b/test/e2e/testsuites/workload_identity_federation.go
@@ -19,8 +19,11 @@ package testsuites
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"strings"
 	"time"
 
@@ -31,6 +34,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	iam "google.golang.org/api/iam/v1"
+	authv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -830,6 +834,151 @@ func (t *gcsFuseCSIWorkloadIdentityFederationTestSuite) DefineTests(driver stora
 		tPod2.VerifyExecInPodSucceed(f, specs.TesterContainerName,
 			fmt.Sprintf("ls %v", mountPath))
 	})
+
+	ginkgo.It("should fail GCS access when WI principal has no storage role", func() {
+		init(specs.SkipCSIBucketAccessCheckPrefix)
+		defer cleanup()
+
+		const (
+			wifKSA        = "wif-no-role-ksa"
+			configMapName = "wif-credentials-no-role"
+			volumeName    = "gcs-wif-volume"
+			mountPath     = "/mnt/gcs"
+		)
+
+		isOSS := os.Getenv(utils.IsOSSEnvVar) == "true"
+		var principal string
+		if isOSS {
+			principal, _ = setupOSSWIFPrincipal(wifKSA, wifWorkloadIdentityPoolID, wifWorkloadIdentityProviderID, configMapName)
+		} else {
+			principal = setupGKEWIPrincipal(wifKSA)
+		}
+		_ = principal // intentionally no bucket IAM role granted
+
+		credMap := ""
+		if isOSS {
+			credMap = configMapName
+		}
+		tPod := deployWIFPod(wifKSA, credMap, volumeName, mountPath)
+		defer tPod.Cleanup(ctx)
+
+		if os.Getenv(utils.TestWithSidecarBucketAccessCheckEnvVar) == "true" || os.Getenv(utils.IsOSSEnvVar) == "true" {
+			ginkgo.By("Checking that the sidecar bucket access check returns PermissionDenied")
+			tPod.WaitForFailedMountError(ctx, "PermissionDenied")
+		} else {
+			tPod.WaitForRunning(ctx)
+			ginkgo.By("Checking that gcsfuse logs a permission denied error from GCS")
+			tPod.WaitForLog(ctx, webhook.GcsFuseSidecarName, "PermissionDenied")
+		}
+	})
+
+	ginkgo.It("should fail write operations when WI principal has read-only storage role", func() {
+		init(specs.SkipCSIBucketAccessCheckPrefix)
+		defer cleanup()
+
+		bucketName := l.volumeResource.VolSource.CSI.VolumeAttributes["bucketName"]
+		gomega.Expect(bucketName).NotTo(gomega.BeEmpty(), "bucketName must be set in volume attributes")
+
+		const (
+			wifKSA        = "wif-readonly-ksa"
+			configMapName = "wif-credentials-readonly"
+			volumeName    = "gcs-wif-volume"
+			mountPath     = "/mnt/gcs"
+		)
+
+		isOSS := os.Getenv(utils.IsOSSEnvVar) == "true"
+		var principal string
+		if isOSS {
+			principal, _ = setupOSSWIFPrincipal(wifKSA, wifWorkloadIdentityPoolID, wifWorkloadIdentityProviderID, configMapName)
+		} else {
+			principal = setupGKEWIPrincipal(wifKSA)
+		}
+
+		ginkgo.By("Granting read-only (objectViewer) access to bucket")
+		grantBucketAccess(bucketName, principal, "roles/storage.objectViewer")
+		defer revokeBucketAccess(bucketName, principal, "roles/storage.objectViewer")
+
+		ginkgo.By("Waiting for IAM policy propagation")
+		time.Sleep(2 * time.Minute)
+
+		credMap := ""
+		if isOSS {
+			credMap = configMapName
+		}
+		tPod := deployWIFPod(wifKSA, credMap, volumeName, mountPath)
+		defer tPod.Cleanup(ctx)
+
+		tPod.WaitForRunning(ctx)
+
+		ginkgo.By("Verifying read operations succeed with objectViewer role")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("ls %v", mountPath))
+
+		ginkgo.By("Verifying write operations fail with objectViewer role")
+		tPod.VerifyExecInPodFail(f, specs.TesterContainerName,
+			fmt.Sprintf("echo 'write-test' > %v/wif-write-test.txt", mountPath), 1)
+	})
+
+	ginkgo.It("should fail GCS access when WI principal role is on a different bucket", func() {
+		init(specs.SkipCSIBucketAccessCheckPrefix)
+		defer cleanup()
+
+		bucketName := l.volumeResource.VolSource.CSI.VolumeAttributes["bucketName"]
+		gomega.Expect(bucketName).NotTo(gomega.BeEmpty(), "bucketName must be set in volume attributes")
+
+		const (
+			wifKSA        = "wif-wrong-bucket-ksa"
+			configMapName = "wif-credentials-wrong-bucket"
+			volumeName    = "gcs-wif-volume"
+			mountPath     = "/mnt/gcs"
+		)
+
+		isOSS := os.Getenv(utils.IsOSSEnvVar) == "true"
+		rawProjectID := os.Getenv(utils.ProjectEnvVar)
+		lines := strings.Split(strings.TrimSpace(rawProjectID), "\n")
+		projectID := lines[len(lines)-1]
+
+		var principal string
+		if isOSS {
+			principal, _ = setupOSSWIFPrincipal(wifKSA, wifWorkloadIdentityPoolID, wifWorkloadIdentityProviderID, configMapName)
+		} else {
+			principal = setupGKEWIPrincipal(wifKSA)
+		}
+
+		altBucket := fmt.Sprintf("gcs-fuse-wif-alt-%s", f.Namespace.Name)
+		ginkgo.By(fmt.Sprintf("Creating alternate bucket: %s", altBucket))
+		if out, err := exec.Command("gcloud", "storage", "buckets", "create", "gs://"+altBucket, "--project="+projectID).CombinedOutput(); err != nil {
+			klog.Warningf("Failed to create alternate bucket %s: %v, output: %s", altBucket, err, string(out))
+		}
+		defer func() {
+			if out, err := exec.Command("gcloud", "storage", "buckets", "delete", "gs://"+altBucket, "--project="+projectID, "--quiet").CombinedOutput(); err != nil {
+				klog.Warningf("Failed to delete alternate bucket %s: %v, output: %s", altBucket, err, string(out))
+			}
+		}()
+
+		ginkgo.By(fmt.Sprintf("Granting objectUser on alternate bucket %s (not on test bucket %s)", altBucket, bucketName))
+		grantBucketAccess(altBucket, principal, "roles/storage.objectUser")
+		defer revokeBucketAccess(altBucket, principal, "roles/storage.objectUser")
+
+		ginkgo.By("Waiting for IAM policy propagation")
+		time.Sleep(5 * time.Second)
+
+		credMap := ""
+		if isOSS {
+			credMap = configMapName
+		}
+		tPod := deployWIFPod(wifKSA, credMap, volumeName, mountPath)
+		defer tPod.Cleanup(ctx)
+
+		if os.Getenv(utils.TestWithSidecarBucketAccessCheckEnvVar) == "true" || os.Getenv(utils.IsOSSEnvVar) == "true" {
+			ginkgo.By("Checking that the sidecar bucket access check returns PermissionDenied")
+			tPod.WaitForFailedMountError(ctx, "PermissionDenied")
+		} else {
+			tPod.WaitForRunning(ctx)
+			ginkgo.By("Checking that gcsfuse logs a permission denied error for the test bucket")
+			tPod.WaitForLog(ctx, webhook.GcsFuseSidecarName, "PermissionDenied")
+		}
+	})
 }
 
 // addWorkloadIdentityBinding grants roles/iam.workloadIdentityUser on the given GCP service
@@ -875,4 +1024,35 @@ func addWorkloadIdentityBinding(ctx context.Context, gcpSAEmail, projectID, name
 		return true, nil
 	})
 	framework.ExpectNoError(err, "setting workload identity binding for %s", gcpSAEmail)
+}
+
+// getOSSClusterOIDCIssuer discovers the cluster OIDC issuer URL by decoding a live
+// ServiceAccount token issued by the cluster. Unlike getClusterOIDCIssuer, this works
+// on any Kubernetes cluster (GKE or self-managed) without requiring cluster-name or
+// location environment variables.
+func getOSSClusterOIDCIssuer(ctx context.Context, f *framework.Framework) string {
+	expirationSecs := int64(600)
+	tok, err := f.ClientSet.CoreV1().ServiceAccounts(f.Namespace.Name).CreateToken(
+		ctx,
+		"default",
+		&authv1.TokenRequest{
+			Spec: authv1.TokenRequestSpec{ExpirationSeconds: &expirationSecs},
+		},
+		metav1.CreateOptions{},
+	)
+	framework.ExpectNoError(err, "creating service account token to discover cluster OIDC issuer")
+
+	parts := strings.Split(tok.Status.Token, ".")
+	if len(parts) != 3 {
+		framework.Failf("unexpected JWT format: want 3 parts, got %d", len(parts))
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	framework.ExpectNoError(err, "base64-decoding JWT payload")
+
+	var claims struct {
+		Issuer string `json:"iss"`
+	}
+	framework.ExpectNoError(json.Unmarshal(payload, &claims), "unmarshalling JWT claims")
+	gomega.Expect(claims.Issuer).NotTo(gomega.BeEmpty(), "cluster OIDC issuer must not be empty")
+	return claims.Issuer
 }

--- a/test/e2e/testsuites/workload_identity_federation.go
+++ b/test/e2e/testsuites/workload_identity_federation.go
@@ -47,11 +47,6 @@ import (
 	admissionapi "k8s.io/pod-security-admission/api"
 )
 
-const (
-	wifWorkloadIdentityPoolID     = "gcs-fuse-oidc-pool"
-	wifWorkloadIdentityProviderID = "gcs-fuse-oidc-provider"
-)
-
 type gcsFuseCSIWorkloadIdentityFederationTestSuite struct {
 	tsInfo storageframework.TestSuiteInfo
 }
@@ -854,7 +849,7 @@ func (t *gcsFuseCSIWorkloadIdentityFederationTestSuite) DefineTests(driver stora
 
 		var principal string
 		if isOSS {
-			principal, _ = setupOSSWIFPrincipal(wifKSA, wifWorkloadIdentityPoolID, wifWorkloadIdentityProviderID, configMapName)
+			principal, _ = setupOSSWIFPrincipal(wifKSA, oidcWorkloadIdentityPoolID, oidcWorkloadIdentityProviderID, configMapName)
 		} else {
 			principal = setupGKEWIPrincipal(wifKSA)
 		}
@@ -898,7 +893,7 @@ func (t *gcsFuseCSIWorkloadIdentityFederationTestSuite) DefineTests(driver stora
 
 		var principal string
 		if isOSS {
-			principal, _ = setupOSSWIFPrincipal(wifKSA, wifWorkloadIdentityPoolID, wifWorkloadIdentityProviderID, configMapName)
+			principal, _ = setupOSSWIFPrincipal(wifKSA, oidcWorkloadIdentityPoolID, oidcWorkloadIdentityProviderID, configMapName)
 		} else {
 			principal = setupGKEWIPrincipal(wifKSA)
 		}
@@ -953,7 +948,7 @@ func (t *gcsFuseCSIWorkloadIdentityFederationTestSuite) DefineTests(driver stora
 
 		var principal string
 		if isOSS {
-			principal, _ = setupOSSWIFPrincipal(wifKSA, wifWorkloadIdentityPoolID, wifWorkloadIdentityProviderID, configMapName)
+			principal, _ = setupOSSWIFPrincipal(wifKSA, oidcWorkloadIdentityPoolID, oidcWorkloadIdentityProviderID, configMapName)
 		} else {
 			principal = setupGKEWIPrincipal(wifKSA)
 		}

--- a/test/e2e/testsuites/workload_identity_federation.go
+++ b/test/e2e/testsuites/workload_identity_federation.go
@@ -150,7 +150,6 @@ func (t *gcsFuseCSIWorkloadIdentityFederationTestSuite) DefineTests(driver stora
 	// roles/iam.workloadIdentityUser, and creates the annotated KSA. Returns the
 	// GSA principal string. Cleanup is registered via ginkgo.DeferCleanup.
 	setupGKEWIPrincipal := func(ksaName string) string {
-<<<<<<< HEAD
 		projectID := os.Getenv(utils.ProjectEnvVar)
 		gomega.Expect(projectID).NotTo(gomega.BeEmpty(), fmt.Sprintf("%s environment variable must be set", utils.ProjectEnvVar))
 		// Use ksaName as base + namespace numeric suffix to keep names unique per
@@ -158,15 +157,6 @@ func (t *gcsFuseCSIWorkloadIdentityFederationTestSuite) DefineTests(driver stora
 		nsIdx := strings.LastIndex(f.Namespace.Name, "-")
 		nsSuffix := f.Namespace.Name[nsIdx+1:]
 		saName := fmt.Sprintf("%s-%s", ksaName, nsSuffix)
-=======
-		rawProjectID := os.Getenv(utils.ProjectEnvVar)
-		gomega.Expect(rawProjectID).NotTo(gomega.BeEmpty(), "PROJECT must be set")
-		projectID := sanitizeProjectID(rawProjectID)
-		gomega.Expect(strings.Contains(projectID, "Your active configuration")).To(gomega.BeFalse(),
-			fmt.Sprintf("invalid projectID detected: %q", projectID))
-
-		saName := f.Namespace.Name
->>>>>>> d2e87503 (e2e/wif: replace gcloud CLI with GCS Go client, add sanitizeProjectID helper, and deduplicate pool ID constant)
 		if len(saName) > 30 {
 			saName = strings.TrimRight(saName[:30], "-")
 		}
@@ -1079,13 +1069,3 @@ func getOSSClusterOIDCIssuer(ctx context.Context, f *framework.Framework) string
 	gomega.Expect(claims.Issuer).NotTo(gomega.BeEmpty(), "cluster OIDC issuer must not be empty")
 	return claims.Issuer
 }
-<<<<<<< HEAD
-=======
-
-// sanitizeProjectID strips any Cloud Shell "Your active configuration is: [...]"
-// warning that gcloud can prepend to stdout, returning only the actual project ID.
-func sanitizeProjectID(raw string) string {
-	lines := strings.Split(strings.TrimSpace(raw), "\n")
-	return lines[len(lines)-1]
-}
->>>>>>> d2e87503 (e2e/wif: replace gcloud CLI with GCS Go client, add sanitizeProjectID helper, and deduplicate pool ID constant)

--- a/test/e2e/testsuites/workload_identity_federation.go
+++ b/test/e2e/testsuites/workload_identity_federation.go
@@ -19,6 +19,8 @@ package testsuites
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -32,12 +34,9 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	iam "google.golang.org/api/iam/v1"
-<<<<<<< HEAD
 	authv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-=======
->>>>>>> 3727096f (replace getOSSClusterOIDCIssuer with getClusterOIDCIssuer, inline sanitizeProjectID, return credentialConfig from setupOSSWIFPrincipal)
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
 	klog "k8s.io/klog/v2"
@@ -45,6 +44,11 @@ import (
 	e2evolume "k8s.io/kubernetes/test/e2e/framework/volume"
 	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
 	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+const (
+	wifWorkloadIdentityPoolID     = "gcs-fuse-oidc-pool"
+	wifWorkloadIdentityProviderID = "gcs-fuse-oidc-provider"
 )
 
 type gcsFuseCSIWorkloadIdentityFederationTestSuite struct {
@@ -837,7 +841,7 @@ func (t *gcsFuseCSIWorkloadIdentityFederationTestSuite) DefineTests(driver stora
 			init(specs.SkipCSIBucketAccessCheckPrefix)
 		} else {
 			init()
-		}		
+		}
 		defer cleanup()
 
 		const (
@@ -929,7 +933,7 @@ func (t *gcsFuseCSIWorkloadIdentityFederationTestSuite) DefineTests(driver stora
 			init(specs.SkipCSIBucketAccessCheckPrefix)
 		} else {
 			init()
-		}		
+		}
 		defer cleanup()
 
 		bucketName := l.volumeResource.VolSource.CSI.VolumeAttributes["bucketName"]

--- a/test/e2e/testsuites/workload_identity_federation.go
+++ b/test/e2e/testsuites/workload_identity_federation.go
@@ -19,8 +19,6 @@ package testsuites
 
 import (
 	"context"
-	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -34,9 +32,12 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	iam "google.golang.org/api/iam/v1"
+<<<<<<< HEAD
 	authv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+=======
+>>>>>>> 3727096f (replace getOSSClusterOIDCIssuer with getClusterOIDCIssuer, inline sanitizeProjectID, return credentialConfig from setupOSSWIFPrincipal)
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
 	klog "k8s.io/klog/v2"
@@ -946,7 +947,9 @@ func (t *gcsFuseCSIWorkloadIdentityFederationTestSuite) DefineTests(driver stora
 			mountPath     = "/mnt/gcs"
 		)
 
-		projectID := sanitizeProjectID(os.Getenv(utils.ProjectEnvVar))
+		rawProjectID := os.Getenv(utils.ProjectEnvVar)
+		lines := strings.Split(strings.TrimSpace(rawProjectID), "\n")
+		projectID := lines[len(lines)-1]
 
 		var principal string
 		if isOSS {


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds three negative e2e test cases to the `workload-identity-federation`
test suite to validate IAM-level authorization failures for Workload
Identity Federation on both OSS (self-managed) and GKE clusters:

- **No storage role**: A WIF principal with no IAM role on the bucket.
  When the sidecar bucket access check is enabled, the mount is denied
  at setup time with a `PermissionDenied` error. Without the check, the
  pod runs but gcsfuse logs a permission denied error on first GCS access.

- **Read-only role, write fails**: A WIF principal granted
  `roles/storage.objectViewer` on the bucket. Read operations (e.g. `ls`)
  succeed; write operations are rejected by GCS with a permission error.

- **Role on a different bucket**: A WIF principal granted
  `roles/storage.objectUser` on an alternate bucket, not the one being
  mounted. GCS denies access to the mounted bucket.

All three tests run on both OSS clusters (via external WIF pool/provider
and credential ConfigMap) and GKE clusters (via native Workload Identity
with GSA impersonation), selected at runtime via the `IS_OSS` environment
variable.

**Which issue(s) this PR fixes**:

N/A

**Does this PR introduce a user-facing change?**:
```release-note
NONE