### PR TITLE
Add skipped WIF node-identity fallback security test

### DIFF
--- a/test/e2e/specs/testdriver.go
+++ b/test/e2e/specs/testdriver.go
@@ -109,6 +109,9 @@ const (
 	gcsfuseCSIProfilesStaticBucketRegion = "us-central1"
 	gkeScalabilityImagesProjectID        = "gke-scalability-images"
 	iamPropagationWaitTime               = 10 * time.Minute
+	// ossWIFOIDCPoolID is the WIF pool ID used for OSS cluster bucket IAM in e2e tests.
+	// Must stay in sync with wifWorkloadIdentityPoolID in gcsfuse_oidc_auth.go.
+	ossWIFOIDCPoolID = "gcs-fuse-oidc-pool"
 )
 
 var (
@@ -502,6 +505,22 @@ func (n *GCSFuseCSITestDriver) prepareStorageService(ctx context.Context) (stora
 	return storageService, nil
 }
 
+// bucketIAMMember returns the IAM member string for the given KSA.
+// On OSS clusters (IS_OSS=true), uses the external WIF principal format with ossWIFOIDCPoolID
+// since the GKE Workload Identity pool (<project>.svc.id.goog) does not exist on non-GKE projects.
+// Otherwise falls back to the GKE Workload Identity format.
+func (n *GCSFuseCSITestDriver) bucketIAMMember(serviceAccountNamespace, serviceAccountName string) string {
+	if !n.skipGcpSaTest {
+		return fmt.Sprintf("serviceAccount:%v@%v.iam.gserviceaccount.com", prepareGcpSAName(serviceAccountNamespace), n.meta.GetProjectID())
+	}
+	if os.Getenv(utils.IsOSSEnvVar) == "true" {
+		projectNumber := os.Getenv(utils.ProjectNumberEnvVar)
+		return fmt.Sprintf("principal://iam.googleapis.com/projects/%s/locations/global/workloadIdentityPools/%s/subject/system:serviceaccount:%s:%s",
+			projectNumber, ossWIFOIDCPoolID, serviceAccountNamespace, serviceAccountName)
+	}
+	return fmt.Sprintf("serviceAccount:%v.svc.id.goog[%v/%v]", n.meta.GetProjectID(), serviceAccountNamespace, serviceAccountName)
+}
+
 // SetIAMPolicy sets IAM policy for the GCS bucket.
 func (n *GCSFuseCSITestDriver) SetIAMPolicy(ctx context.Context, bucket *storage.ServiceBucket, serviceAccountNamespace, serviceAccountName string) {
 	storageService, err := n.prepareStorageService(ctx)
@@ -509,10 +528,7 @@ func (n *GCSFuseCSITestDriver) SetIAMPolicy(ctx context.Context, bucket *storage
 		e2eframework.Failf("Failed to prepare storage service: %v", err)
 	}
 
-	member := fmt.Sprintf("serviceAccount:%v.svc.id.goog[%v/%v]", n.meta.GetProjectID(), serviceAccountNamespace, serviceAccountName)
-	if !n.skipGcpSaTest {
-		member = fmt.Sprintf("serviceAccount:%v@%v.iam.gserviceaccount.com", prepareGcpSAName(serviceAccountNamespace), n.meta.GetProjectID())
-	}
+	member := n.bucketIAMMember(serviceAccountNamespace, serviceAccountName)
 	if err := storageService.SetIAMPolicy(ctx, bucket, member, "roles/storage.admin"); err != nil {
 		e2eframework.Failf("Failed to set the IAM policy for the new GCS bucket: %v", err)
 	}
@@ -525,10 +541,7 @@ func (n *GCSFuseCSITestDriver) RemoveIAMPolicy(ctx context.Context, bucket *stor
 		e2eframework.Failf("Failed to prepare storage service: %v", err)
 	}
 
-	member := fmt.Sprintf("serviceAccount:%v.svc.id.goog[%v/%v]", n.meta.GetProjectID(), serviceAccountNamespace, serviceAccountName)
-	if !n.skipGcpSaTest {
-		member = fmt.Sprintf("serviceAccount:%v@%v.iam.gserviceaccount.com", prepareGcpSAName(serviceAccountNamespace), n.meta.GetProjectID())
-	}
+	member := n.bucketIAMMember(serviceAccountNamespace, serviceAccountName)
 	if err := storageService.RemoveIAMPolicy(ctx, bucket, member, "roles/storage.admin"); err != nil {
 		e2eframework.Failf("Failed to remove the IAM policy from the GCS bucket: %v", err)
 	}

--- a/test/e2e/specs/testdriver.go
+++ b/test/e2e/specs/testdriver.go
@@ -109,9 +109,6 @@ const (
 	gcsfuseCSIProfilesStaticBucketRegion = "us-central1"
 	gkeScalabilityImagesProjectID        = "gke-scalability-images"
 	iamPropagationWaitTime               = 10 * time.Minute
-	// ossWIFOIDCPoolID is the WIF pool ID used for OSS cluster bucket IAM in e2e tests.
-	// Must stay in sync with wifWorkloadIdentityPoolID in gcsfuse_oidc_auth.go.
-	ossWIFOIDCPoolID = "gcs-fuse-oidc-pool"
 )
 
 var (
@@ -506,17 +503,16 @@ func (n *GCSFuseCSITestDriver) prepareStorageService(ctx context.Context) (stora
 }
 
 // bucketIAMMember returns the IAM member string for the given KSA.
-// On OSS clusters (IS_OSS=true), uses the external WIF principal format with ossWIFOIDCPoolID
-// since the GKE Workload Identity pool (<project>.svc.id.goog) does not exist on non-GKE projects.
+// When OSS_WIF_POOL_ID is set, uses the WIF principal format for self-managed clusters.
 // Otherwise falls back to the GKE Workload Identity format.
 func (n *GCSFuseCSITestDriver) bucketIAMMember(serviceAccountNamespace, serviceAccountName string) string {
 	if !n.skipGcpSaTest {
 		return fmt.Sprintf("serviceAccount:%v@%v.iam.gserviceaccount.com", prepareGcpSAName(serviceAccountNamespace), n.meta.GetProjectID())
 	}
-	if os.Getenv(utils.IsOSSEnvVar) == "true" {
+	if wifPoolID := os.Getenv("OSS_WIF_POOL_ID"); wifPoolID != "" {
 		projectNumber := os.Getenv(utils.ProjectNumberEnvVar)
 		return fmt.Sprintf("principal://iam.googleapis.com/projects/%s/locations/global/workloadIdentityPools/%s/subject/system:serviceaccount:%s:%s",
-			projectNumber, ossWIFOIDCPoolID, serviceAccountNamespace, serviceAccountName)
+			projectNumber, wifPoolID, serviceAccountNamespace, serviceAccountName)
 	}
 	return fmt.Sprintf("serviceAccount:%v.svc.id.goog[%v/%v]", n.meta.GetProjectID(), serviceAccountNamespace, serviceAccountName)
 }

--- a/test/e2e/testsuites/gcsfuse_oidc_auth.go
+++ b/test/e2e/testsuites/gcsfuse_oidc_auth.go
@@ -37,6 +37,7 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	e2evolume "k8s.io/kubernetes/test/e2e/framework/volume"
 	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
 	admissionapi "k8s.io/pod-security-admission/api"
@@ -384,6 +385,53 @@ func (t *gcsFuseCSIOIDCTestSuite) DefineTests(driver storageframework.TestDriver
 
 	ginkgo.It("should fail when CSI bucket access check is enabled with OIDC authentication", func() {
 		testCaseOIDCWithCSIBucketAccessCheck()
+	})
+
+	// Security scenario: node SA has bucket access but the pod has no WIF credentials.
+	// The admission webhook must reject pod creation when the WIF credential ConfigMap
+	// annotation is empty, preventing any fallback to the node's identity.
+	//
+	// TODO: Remove the skip below once the node-identity-fallback security bug is fixed.
+	ginkgo.It("should fail GCS mount when WIF credential config is absent and node SA has bucket access", func() {
+		e2eskipper.Skipf("skipping until node-identity-fallback security bug is fixed")
+
+		init(specs.SkipCSIBucketAccessCheckPrefix)
+		defer cleanup()
+
+		bucketName := l.volumeResource.VolSource.CSI.VolumeAttributes["bucketName"]
+		gomega.Expect(bucketName).NotTo(gomega.BeEmpty(), "bucketName must be set in volume attributes")
+
+		projectNumber := os.Getenv(utils.ProjectNumberEnvVar)
+		gomega.Expect(projectNumber).NotTo(gomega.BeEmpty(),
+			fmt.Sprintf("%s environment variable must be set", utils.ProjectNumberEnvVar))
+
+		nodeComputeSA := fmt.Sprintf("%s-compute@developer.gserviceaccount.com", projectNumber)
+		nodeComputePrincipal := "serviceAccount:" + nodeComputeSA
+
+		ginkgo.By(fmt.Sprintf("Granting objectUser on bucket %s to node compute SA %s", bucketName, nodeComputeSA))
+		grantBucketAccess(bucketName, nodeComputePrincipal, "roles/storage.objectUser")
+		defer revokeBucketAccess(bucketName, nodeComputePrincipal, "roles/storage.objectUser")
+
+		ginkgo.By("Waiting for IAM policy propagation")
+		time.Sleep(5 * time.Second)
+
+		const wifKSA = "wif-no-creds-ksa"
+
+		ginkgo.By(fmt.Sprintf("Creating Kubernetes service account: %s", wifKSA))
+		createServiceAccount(ctx, f, wifKSA)
+		defer deleteServiceAccount(ctx, f, wifKSA)
+
+		// Deploy pod with the credential ConfigMap annotation explicitly set to empty.
+		// The admission webhook must reject the pod when the annotation is empty,
+		// preventing any fallback to the node's identity.
+		ginkgo.By("Verifying pod creation is rejected by the admission webhook when WIF credential annotation is empty")
+		tPod := specs.NewTestPodModifiedSpec(f.ClientSet, f.Namespace, true)
+		tPod.SetServiceAccount(wifKSA)
+		tPod.SetupVolume(l.volumeResource, oidcVolumeName, oidcMountPath, false)
+		tPod.SetAnnotations(map[string]string{
+			webhook.GCPWorkloadIdentityCredentialConfigMapAnnotation: "",
+		})
+		tPod.CreateExpectError(ctx)
 	})
 }
 

--- a/test/e2e/testsuites/gcsfuse_oidc_auth.go
+++ b/test/e2e/testsuites/gcsfuse_oidc_auth.go
@@ -392,7 +392,7 @@ func (t *gcsFuseCSIOIDCTestSuite) DefineTests(driver storageframework.TestDriver
 	// annotation is empty, preventing any fallback to the node's identity.
 	//
 	// TODO: Remove the skip below once the node-identity-fallback security bug is fixed.
-	ginkgo.It("should fail GCS mount when WIF credential config is absent and node SA has bucket access", func() {
+	ginkgo.It("should fail to start pod when WIF credential config is absent and node SA has bucket access", func() {
 		e2eskipper.Skipf("skipping until node-identity-fallback security bug is fixed")
 
 		init(specs.SkipCSIBucketAccessCheckPrefix)


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it:**

Adds a skipped e2e test case to the `workload-identity-federation` test suite to validate a security vulnerability where gcsfuse silently falls back to the node's compute service account when WIF credentials are absent at pod creation time:

- **Node SA has access, pod has no WIF credentials**: When the node compute SA has bucket access but the pod has no WIF credential ConfigMap annotation, gcsfuse should deny the mount instead of silently inheriting the node's GCS permissions. The test is skipped until the node-identity fallback security bug is fixed.

**Which issue(s) this PR fixes:**

N/A

**Does this PR introduce a user-facing change?:**

```release-note
NONE
