### PR TITLE
Add TestCase - should successfully mount when pod KSA has WIF bucket access but node SA does not (well-configured wif)

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -124,7 +124,6 @@ var _ = ginkgo.Describe("E2E Test Suite", func() {
 			testsuites.InitGcsFuseCSIMetricsTestSuite,
 			testsuites.InitGcsFuseCSIMetadataPrefetchTestSuite,
 			testsuites.InitGcsFuseMountTestSuite,
-			testsuites.InitGcsFuseCSIWorkloadIdentityFederationTestSuite,
 			testsuites.InitGcsFuseCSIOIDCTestSuite,
 			testsuites.InitGcsFuseCSICloudProfilerTestSuite,
 			testsuites.InitGcsFuseCSIWorkloadIdentityFederationTestSuite,

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -127,6 +127,7 @@ var _ = ginkgo.Describe("E2E Test Suite", func() {
 			testsuites.InitGcsFuseCSIWorkloadIdentityFederationTestSuite,
 			testsuites.InitGcsFuseCSIOIDCTestSuite,
 			testsuites.InitGcsFuseCSICloudProfilerTestSuite,
+			testsuites.InitGcsFuseCSIWorkloadIdentityFederationTestSuite,
 		}
 
 		if *profilesFlag {

--- a/test/e2e/specs/testdriver.go
+++ b/test/e2e/specs/testdriver.go
@@ -543,6 +543,7 @@ func (n *GCSFuseCSITestDriver) RemoveIAMPolicy(ctx context.Context, bucket *stor
 	}
 }
 
+
 // createBucket creates a GCS bucket.
 func (n *GCSFuseCSITestDriver) createBucket(ctx context.Context, serviceAccountNamespace string) string {
 	storageService, err := n.prepareStorageService(ctx)

--- a/test/e2e/testsuites/workload_identity_federation.go
+++ b/test/e2e/testsuites/workload_identity_federation.go
@@ -19,8 +19,6 @@ package testsuites
 
 import (
 	"context"
-	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -33,7 +31,6 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	iam "google.golang.org/api/iam/v1"
-	authv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -193,6 +190,7 @@ func (t *gcsFuseCSIWorkloadIdentityFederationTestSuite) DefineTests(driver stora
 		return tPod
 	}
 
+	// Test 1: Verify that GCS access fails after WIF principal permissions are revoked mid-run.
 	ginkgo.It("should fail GCS access after workload identity federation principal permissions are removed while pod is running", func() {
 		isOSS := os.Getenv(utils.IsOSSEnvVar) == "true"
 
@@ -244,35 +242,6 @@ func (t *gcsFuseCSIWorkloadIdentityFederationTestSuite) DefineTests(driver stora
 		// triggers a GCS upload which is IAM-checked. When permission is revoked the next
 		// upload returns 403 and dd exits non-zero, stopping the loop.
 		ginkgo.By("Creating and deploying test pod with continuous write loop")
-	ginkgo.It("should successfully mount when pod KSA has WIF bucket access but node SA does not", func() {
-		isOSS := os.Getenv(utils.IsOSSEnvVar) == "true"
-		init(specs.SkipCSIBucketAccessCheckPrefix)
-		ginkgo.DeferCleanup(cleanup)
-		bucketName := l.volumeResource.VolSource.CSI.VolumeAttributes["bucketName"]
-		gomega.Expect(bucketName).NotTo(gomega.BeEmpty(), "bucketName must be set in volume attributes")
-		const (
-			wifKSA     = "wif-pod-access-node-no-access-ksa"
-			volumeName = "gcs-volume"
-			mountPath  = "/mnt/gcs"
-		)
-		var (
-			principal               string
-			credentialConfigMapName string
-		)
-		if isOSS {
-			credentialConfigMapName = "wif-pod-access-credentials"
-			principal = setupOSSWIFPrincipal(wifKSA, wifWorkloadIdentityPoolID, wifWorkloadIdentityProviderID, credentialConfigMapName)
-		} else {
-			principal = setupGKEWIPrincipal(wifKSA)
-		}
-		ginkgo.By("Granting bucket access to pod WIF principal only (node SA gets no access)")
-		grantBucketAccess(bucketName, principal, "roles/storage.objectAdmin")
-		ginkgo.DeferCleanup(func() { revokeBucketAccess(bucketName, principal, "roles/storage.objectAdmin") })
-
-		ginkgo.By("Waiting for IAM policy propagation")
-		time.Sleep(2 * time.Minute)
-
-		ginkgo.By(fmt.Sprintf("Configuring test pod with KSA %q (node SA has no bucket access)", wifKSA))
 		tPod := specs.NewTestPodModifiedSpec(f.ClientSet, f.Namespace, true)
 		tPod.SetServiceAccount(wifKSA)
 		tPod.SetupVolume(l.volumeResource, volumeName, mountPath, false)
@@ -324,9 +293,7 @@ func (t *gcsFuseCSIWorkloadIdentityFederationTestSuite) DefineTests(driver stora
 		time.Sleep(20 * time.Second)
 
 		ginkgo.By("Waiting until writes stop progressing")
-
 		var countStable bool
-
 		err = wait.PollUntilContextTimeout(ctx, 10*time.Second, 2*time.Minute, true,
 			func(ctx context.Context) (bool, error) {
 				out1 := tPod.VerifyExecInPodSucceedWithOutput(
@@ -349,7 +316,6 @@ func (t *gcsFuseCSIWorkloadIdentityFederationTestSuite) DefineTests(driver stora
 			},
 		)
 		framework.ExpectNoError(err, "polling for writes to stop after permission revocation")
-
 		gomega.Expect(countStable).To(gomega.BeTrue(),
 			"expected writes to stop after permission revocation")
 
@@ -362,9 +328,71 @@ func (t *gcsFuseCSIWorkloadIdentityFederationTestSuite) DefineTests(driver stora
 		framework.ExpectNoError(err, "fetching GCS FUSE sidecar logs")
 		sidecarLogs := strings.ToLower(string(sidecarLogBytes))
 		gomega.Expect(
-			strings.Contains(sidecarLogs, "403") || strings.Contains(sidecarLogs, "PermissionDenied"),
+			strings.Contains(sidecarLogs, "403") || strings.Contains(sidecarLogs, "permissiondenied"),
 		).To(gomega.BeTrue(),
-			"expected GCS FUSE sidecar logs to contain '403' or 'forbidden' after permission revocation;\nsidecar logs: %s", string(sidecarLogBytes))
+			"expected GCS FUSE sidecar logs to contain '403' or 'permissiondenied' after permission revocation;\nsidecar logs: %s", string(sidecarLogBytes))
+	})
+
+	// Test 2: Verify that a pod whose KSA has WIF bucket access can mount and write,
+	// even when the node SA has no bucket access.
+	ginkgo.It("should successfully mount when pod KSA has WIF bucket access but node SA does not", func() {
+		isOSS := os.Getenv(utils.IsOSSEnvVar) == "true"
+
+		// Skip the CSI pre-mount bucket access check for both OSS and GKE in this test,
+		// since we want to confirm that pod-level WIF credentials (not node SA) are used.
+		init(specs.SkipCSIBucketAccessCheckPrefix)
+		defer cleanup()
+
+		bucketName := l.volumeResource.VolSource.CSI.VolumeAttributes["bucketName"]
+		gomega.Expect(bucketName).NotTo(gomega.BeEmpty(), "bucketName must be set in volume attributes")
+
+		const (
+			wifKSA     = "wif-pod-access-node-no-access-ksa"
+			volumeName = "gcs-volume"
+			mountPath  = "/mnt/gcs"
+		)
+
+		var (
+			principal               string
+			credentialConfigMapName string
+		)
+
+		if isOSS {
+			credentialConfigMapName = "wif-pod-access-credentials"
+			principal, _ = setupOSSWIFPrincipal(wifKSA, wifWorkloadIdentityPoolID, wifWorkloadIdentityProviderID, credentialConfigMapName)
+		} else {
+			principal = setupGKEWIPrincipal(wifKSA)
+		}
+
+		ginkgo.By("Granting bucket access to pod WIF principal only (node SA gets no access)")
+		grantBucketAccess(bucketName, principal, "roles/storage.objectAdmin")
+		defer revokeBucketAccess(bucketName, principal, "roles/storage.objectAdmin")
+
+		ginkgo.By("Waiting for IAM policy propagation")
+		time.Sleep(2 * time.Minute)
+
+		ginkgo.By(fmt.Sprintf("Configuring test pod with KSA %q (node SA has no bucket access)", wifKSA))
+		tPod := specs.NewTestPodModifiedSpec(f.ClientSet, f.Namespace, true)
+		tPod.SetServiceAccount(wifKSA)
+		tPod.SetupVolume(l.volumeResource, volumeName, mountPath, false)
+		if credentialConfigMapName != "" {
+			tPod.SetAnnotations(map[string]string{
+				webhook.GCPWorkloadIdentityCredentialConfigMapAnnotation: credentialConfigMapName,
+			})
+		}
+		tPod.Create(ctx)
+		defer tPod.Cleanup(ctx)
+
+		ginkgo.By("Waiting for pod to reach Running state — confirms WIF mount succeeded using pod KSA credentials")
+		tPod.WaitForRunning(ctx)
+
+		ginkgo.By("Verifying the GCS volume is mounted read-write")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("mount | grep %s | grep rw,", mountPath))
+
+		ginkgo.By("Verifying pod KSA can write to the GCS bucket")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("dd if=/dev/urandom bs=1M count=1 of=%s/wif-node-test.bin 2>&1", mountPath))
 	})
 
 	ginkgo.It("should isolate workload identity federation access for Kubernetes service accounts with the same name across different namespaces", func() {
@@ -477,7 +505,6 @@ func (t *gcsFuseCSIWorkloadIdentityFederationTestSuite) DefineTests(driver stora
 				webhook.GCPWorkloadIdentityCredentialConfigMapAnnotation: credentialConfigMapName,
 			})
 		}
-
 		tPodNs1.Create(ctx)
 		defer tPodNs1.Cleanup(ctx)
 
@@ -701,35 +728,4 @@ func addWorkloadIdentityBinding(ctx context.Context, gcpSAEmail, projectID, name
 		return true, nil
 	})
 	framework.ExpectNoError(err, "setting workload identity binding for %s", gcpSAEmail)
-}
-
-// getOSSClusterOIDCIssuer discovers the cluster OIDC issuer URL by decoding a live
-// ServiceAccount token issued by the cluster. Unlike getClusterOIDCIssuer, this works
-// on any Kubernetes cluster (GKE or self-managed) without requiring cluster-name or
-// location environment variables.
-func getOSSClusterOIDCIssuer(ctx context.Context, f *framework.Framework) string {
-	expirationSecs := int64(600)
-	tok, err := f.ClientSet.CoreV1().ServiceAccounts(f.Namespace.Name).CreateToken(
-		ctx,
-		"default",
-		&authv1.TokenRequest{
-			Spec: authv1.TokenRequestSpec{ExpirationSeconds: &expirationSecs},
-		},
-		metav1.CreateOptions{},
-	)
-	framework.ExpectNoError(err, "creating service account token to discover cluster OIDC issuer")
-
-	parts := strings.Split(tok.Status.Token, ".")
-	if len(parts) != 3 {
-		framework.Failf("unexpected JWT format: want 3 parts, got %d", len(parts))
-	}
-	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
-	framework.ExpectNoError(err, "base64-decoding JWT payload")
-
-	var claims struct {
-		Issuer string `json:"iss"`
-	}
-	framework.ExpectNoError(json.Unmarshal(payload, &claims), "unmarshalling JWT claims")
-	gomega.Expect(claims.Issuer).NotTo(gomega.BeEmpty(), "cluster OIDC issuer must not be empty")
-	return claims.Issuer
 }

--- a/test/e2e/testsuites/workload_identity_federation.go
+++ b/test/e2e/testsuites/workload_identity_federation.go
@@ -19,6 +19,8 @@ package testsuites
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -31,6 +33,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	iam "google.golang.org/api/iam/v1"
+	authv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -241,6 +244,35 @@ func (t *gcsFuseCSIWorkloadIdentityFederationTestSuite) DefineTests(driver stora
 		// triggers a GCS upload which is IAM-checked. When permission is revoked the next
 		// upload returns 403 and dd exits non-zero, stopping the loop.
 		ginkgo.By("Creating and deploying test pod with continuous write loop")
+	ginkgo.It("should successfully mount when pod KSA has WIF bucket access but node SA does not", func() {
+		isOSS := os.Getenv(utils.IsOSSEnvVar) == "true"
+		init(specs.SkipCSIBucketAccessCheckPrefix)
+		ginkgo.DeferCleanup(cleanup)
+		bucketName := l.volumeResource.VolSource.CSI.VolumeAttributes["bucketName"]
+		gomega.Expect(bucketName).NotTo(gomega.BeEmpty(), "bucketName must be set in volume attributes")
+		const (
+			wifKSA     = "wif-pod-access-node-no-access-ksa"
+			volumeName = "gcs-volume"
+			mountPath  = "/mnt/gcs"
+		)
+		var (
+			principal               string
+			credentialConfigMapName string
+		)
+		if isOSS {
+			credentialConfigMapName = "wif-pod-access-credentials"
+			principal = setupOSSWIFPrincipal(wifKSA, wifWorkloadIdentityPoolID, wifWorkloadIdentityProviderID, credentialConfigMapName)
+		} else {
+			principal = setupGKEWIPrincipal(wifKSA)
+		}
+		ginkgo.By("Granting bucket access to pod WIF principal only (node SA gets no access)")
+		grantBucketAccess(bucketName, principal, "roles/storage.objectAdmin")
+		ginkgo.DeferCleanup(func() { revokeBucketAccess(bucketName, principal, "roles/storage.objectAdmin") })
+
+		ginkgo.By("Waiting for IAM policy propagation")
+		time.Sleep(2 * time.Minute)
+
+		ginkgo.By(fmt.Sprintf("Configuring test pod with KSA %q (node SA has no bucket access)", wifKSA))
 		tPod := specs.NewTestPodModifiedSpec(f.ClientSet, f.Namespace, true)
 		tPod.SetServiceAccount(wifKSA)
 		tPod.SetupVolume(l.volumeResource, volumeName, mountPath, false)
@@ -669,4 +701,35 @@ func addWorkloadIdentityBinding(ctx context.Context, gcpSAEmail, projectID, name
 		return true, nil
 	})
 	framework.ExpectNoError(err, "setting workload identity binding for %s", gcpSAEmail)
+}
+
+// getOSSClusterOIDCIssuer discovers the cluster OIDC issuer URL by decoding a live
+// ServiceAccount token issued by the cluster. Unlike getClusterOIDCIssuer, this works
+// on any Kubernetes cluster (GKE or self-managed) without requiring cluster-name or
+// location environment variables.
+func getOSSClusterOIDCIssuer(ctx context.Context, f *framework.Framework) string {
+	expirationSecs := int64(600)
+	tok, err := f.ClientSet.CoreV1().ServiceAccounts(f.Namespace.Name).CreateToken(
+		ctx,
+		"default",
+		&authv1.TokenRequest{
+			Spec: authv1.TokenRequestSpec{ExpirationSeconds: &expirationSecs},
+		},
+		metav1.CreateOptions{},
+	)
+	framework.ExpectNoError(err, "creating service account token to discover cluster OIDC issuer")
+
+	parts := strings.Split(tok.Status.Token, ".")
+	if len(parts) != 3 {
+		framework.Failf("unexpected JWT format: want 3 parts, got %d", len(parts))
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	framework.ExpectNoError(err, "base64-decoding JWT payload")
+
+	var claims struct {
+		Issuer string `json:"iss"`
+	}
+	framework.ExpectNoError(json.Unmarshal(payload, &claims), "unmarshalling JWT claims")
+	gomega.Expect(claims.Issuer).NotTo(gomega.BeEmpty(), "cluster OIDC issuer must not be empty")
+	return claims.Issuer
 }

--- a/test/e2e/testsuites/workload_identity_federation.go
+++ b/test/e2e/testsuites/workload_identity_federation.go
@@ -154,7 +154,7 @@ func (t *gcsFuseCSIWorkloadIdentityFederationTestSuite) DefineTests(driver stora
 		nsSuffix := f.Namespace.Name[nsIdx+1:]
 		saName := fmt.Sprintf("%s-%s", ksaName, nsSuffix)
 		if len(saName) > 30 {
-			saName = saName[:30]
+			saName = strings.TrimRight(saName[:30], "-")
 		}
 		testGcpSA := utils.NewTestGCPServiceAccount(saName, projectID)
 		ginkgo.By(fmt.Sprintf("Creating GCP service account: %s", saName))

--- a/test/e2e/testsuites/workload_identity_federation.go
+++ b/test/e2e/testsuites/workload_identity_federation.go
@@ -685,6 +685,7 @@ func (t *gcsFuseCSIWorkloadIdentityFederationTestSuite) DefineTests(driver stora
 	})
 }
 
+
 // addWorkloadIdentityBinding grants roles/iam.workloadIdentityUser on the given GCP service
 // account to the Workload Identity principal for ksaName, enabling GKE token exchange.
 // Retries with backoff to handle IAM eventual consistency after SA creation.


### PR DESCRIPTION
## testcase for wif-pod-has-access-node-does-not

### What type of PR is this?
/kind feature

### What this PR does / why we need it

Adds an E2E test that validates WIF pod-level access isolation: a pod whose KSA has WIF bucket access can successfully mount and read/write a GCS bucket even when the node SA has no bucket access. The test confirms the CSI driver correctly uses the pod's WIF identity rather than falling back to the node SA.

This test covers both:
- OSS clusters (OIDC pool/provider-based Workload Identity Federation)
- GKE clusters (native Workload Identity)

### Which issue(s) this PR fixes

```release-note
NONE