### PR TITLE
test(e2e): support GCSFuse v3.10+ cloud profiler service name optimization and skip on older versions

### DIFF
--- a/test/e2e/testsuites/gcsfuse_integration.go
+++ b/test/e2e/testsuites/gcsfuse_integration.go
@@ -243,10 +243,10 @@ func runIntegrationTest(ctx context.Context, f *framework.Framework, driver stor
 	if opts.TestPkg == testNameCloudProfiler || opts.TestName == testNameCloudProfiler {
 		prefix := getDecreasingString()
 		profileLabel = fmt.Sprintf("%s-cloud-profiler-test", prefix)
-		// serviceName and profileLabel can be identical or different. They must follow 
-		// a decreasing lexicographical order per run to avoid excessive pagination 
+		// serviceName and profileLabel can be identical or different. They must follow
+		// a decreasing lexicographical order per run to avoid excessive pagination
 		// and potential timeouts when retrieving profiles from the GCP project.
-		serviceName = profileLabel 
+		serviceName = profileLabel
 
 		vars["PROFILE_LABEL"] = profileLabel
 		vars["PROFILE_SERVICE_NAME"] = serviceName

--- a/test/e2e/testsuites/gcsfuse_integration.go
+++ b/test/e2e/testsuites/gcsfuse_integration.go
@@ -243,7 +243,10 @@ func runIntegrationTest(ctx context.Context, f *framework.Framework, driver stor
 	if opts.TestPkg == testNameCloudProfiler || opts.TestName == testNameCloudProfiler {
 		prefix := getDecreasingString()
 		profileLabel = fmt.Sprintf("%s-cloud-profiler-test", prefix)
-		serviceName = profileLabel
+		// serviceName and profileLabel can be identical or different. They must follow 
+		// a decreasing lexicographical order per run to avoid excessive pagination 
+		// and potential timeouts when retrieving profiles from the GCP project.
+		serviceName = profileLabel 
 
 		vars["PROFILE_LABEL"] = profileLabel
 		vars["PROFILE_SERVICE_NAME"] = serviceName

--- a/test/e2e/testsuites/gcsfuse_integration.go
+++ b/test/e2e/testsuites/gcsfuse_integration.go
@@ -20,12 +20,13 @@ package testsuites
 import (
 	"context"
 	"fmt"
+	"math"
 	"strings"
+	"time"
 
 	"local/test/e2e/specs"
 	"local/test/e2e/utils"
 
-	"github.com/google/uuid"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -164,6 +165,7 @@ type TestCommandConfig struct {
 	BucketName         string
 	OnlyDir            string
 	ProfileLabel       string
+	ProfileServiceName string
 	ReadOnly           bool
 	BillingProject     string
 }
@@ -180,6 +182,25 @@ type IntegrationTestOptions struct {
 	TestPodCPU          string
 	TestPodMemoryLimit  string
 	TestPodStorageLimit string
+}
+
+// The alphabet defines the sort order: 0 is smallest, z is largest.
+const alphabet = "0123456789abcdefghijklmnopqrstuvwxyz"
+const fixedLength = 13 // math.MaxInt64 in base 36 fits in 13 characters.
+
+// getDecreasingString generates a string that decreases lexicographically as time increases, making newer items appear earlier in sorted results.
+func getDecreasingString() string {
+	// Calculate the decreasing value
+	val := uint64(math.MaxInt64 - time.Now().UnixNano()) 
+
+	// Map the value to our 36-character alphabet
+	res := make([]byte, fixedLength)
+	for i := fixedLength - 1; i >= 0; i-- {
+		res[i] = alphabet[val%36]
+		val /= 36
+	}
+
+	return string(res)
 }
 
 // runIntegrationTest sets up necessary resources for the test pod and volumes,
@@ -218,10 +239,14 @@ func runIntegrationTest(ctx context.Context, f *framework.Framework, driver stor
 
 	vars := map[string]string{"BUCKET_NAME": bucketName}
 
-	var profileLabel string
+	var profileLabel, serviceName string
 	if opts.TestPkg == testNameCloudProfiler || opts.TestName == testNameCloudProfiler {
-		profileLabel = fmt.Sprintf("ve2e0.0.0-%s", strings.ReplaceAll(uuid.New().String(), "-", "")[:8])
+		prefix := getDecreasingString()
+		profileLabel = fmt.Sprintf("%s-cloud-profiler-test", prefix)
+		serviceName = profileLabel // kept identical
+
 		vars["PROFILE_LABEL"] = profileLabel
+		vars["PROFILE_SERVICE_NAME"] = serviceName
 	}
 
 	if opts.TestPkg == testNameReadonly && !opts.Config.ReadOnly {
@@ -291,15 +316,16 @@ func runIntegrationTest(ctx context.Context, f *framework.Framework, driver stor
 	gcsfuseGoVersionCommand := getGoParsingCommand(*gcsfuseVersion, gcsfuseTestBranch)
 
 	cmdOpts := TestCommandConfig{
-		TestPkg:        opts.TestPkg,
-		TestName:       opts.TestName,
-		GoEnvSetupCmd:  gcsfuseGoVersionCommand,
-		MountPath:      mountPath,
-		BucketName:     bucketName,
-		OnlyDir:        onlyDir,
-		ProfileLabel:   profileLabel,
-		ReadOnly:       opts.Config.ReadOnly,
-		BillingProject: opts.Config.BillingProject,
+		TestPkg:            opts.TestPkg,
+		TestName:           opts.TestName,
+		GoEnvSetupCmd:      gcsfuseGoVersionCommand,
+		MountPath:          mountPath,
+		BucketName:         bucketName,
+		OnlyDir:            onlyDir,
+		ProfileLabel:       profileLabel,
+		ProfileServiceName: serviceName,
+		ReadOnly:           opts.Config.ReadOnly,
+		BillingProject:     opts.Config.BillingProject,
 	}
 	if opts.SecondaryConfig != nil {
 		cmdOpts.SecondaryMountPath = mountPath2
@@ -341,6 +367,10 @@ func generateTestCommand(opts TestCommandConfig) string {
 
 	if opts.ProfileLabel != "" {
 		commandArgs = append(commandArgs, fmt.Sprintf("export PROFILE_LABEL=%s", opts.ProfileLabel))
+	}
+
+	if opts.ProfileServiceName != "" {
+		commandArgs = append(commandArgs, fmt.Sprintf("export PROFILE_SERVICE_NAME=%s", opts.ProfileServiceName))
 	}
 
 	if opts.SecondaryMountPath != "" {
@@ -514,6 +544,11 @@ func (t *gcsFuseCSIGCSFuseIntegrationTestSuite) DefineTests(driver storageframew
 		// GCSFuse requester_pays_bucket tests are supported after v3.9.0.
 		if !v.AtLeast(version.MustParseSemantic("v3.9.0-gke.0")) && testName == testNameRequesterPaysBucket {
 			e2eskipper.Skipf("skip gcsfuse integration test %v on gcsfuse version %v", testNameRequesterPaysBucket, v.String())
+		}
+
+		// GCSFuse cloud_profiler tests are supported after v3.9.0.
+		if !v.AtLeast(version.MustParseSemantic("v3.9.0-gke.0")) && testName == testNameCloudProfiler {
+			e2eskipper.Skipf("skip gcsfuse integration test %v on gcsfuse version %v", testNameCloudProfiler, v.String())
 		}
 
 		return branch

--- a/test/e2e/testsuites/gcsfuse_integration.go
+++ b/test/e2e/testsuites/gcsfuse_integration.go
@@ -243,7 +243,7 @@ func runIntegrationTest(ctx context.Context, f *framework.Framework, driver stor
 	if opts.TestPkg == testNameCloudProfiler || opts.TestName == testNameCloudProfiler {
 		prefix := getDecreasingString()
 		profileLabel = fmt.Sprintf("%s-cloud-profiler-test", prefix)
-		serviceName = profileLabel // kept identical
+		serviceName = profileLabel
 
 		vars["PROFILE_LABEL"] = profileLabel
 		vars["PROFILE_SERVICE_NAME"] = serviceName
@@ -546,8 +546,8 @@ func (t *gcsFuseCSIGCSFuseIntegrationTestSuite) DefineTests(driver storageframew
 			e2eskipper.Skipf("skip gcsfuse integration test %v on gcsfuse version %v", testNameRequesterPaysBucket, v.String())
 		}
 
-		// GCSFuse cloud_profiler tests are supported after v3.9.0.
-		if !v.AtLeast(version.MustParseSemantic("v3.9.0-gke.0")) && testName == testNameCloudProfiler {
+		// GCSFuse cloud_profiler tests are supported after v3.10.0.
+		if !v.AtLeast(version.MustParseSemantic("v3.10.0-gke.0")) && testName == testNameCloudProfiler {
 			e2eskipper.Skipf("skip gcsfuse integration test %v on gcsfuse version %v", testNameCloudProfiler, v.String())
 		}
 

--- a/test/e2e/testsuites/gcsfuse_integration.go
+++ b/test/e2e/testsuites/gcsfuse_integration.go
@@ -191,7 +191,7 @@ const fixedLength = 13 // math.MaxInt64 in base 36 fits in 13 characters.
 // getDecreasingString generates a string that decreases lexicographically as time increases, making newer items appear earlier in sorted results.
 func getDecreasingString() string {
 	// Calculate the decreasing value
-	val := uint64(math.MaxInt64 - time.Now().UnixNano()) 
+	val := uint64(math.MaxInt64 - time.Now().UnixNano())
 
 	// Map the value to our 36-character alphabet
 	res := make([]byte, fixedLength)


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
The `cloud_profiler` test running on GKE currently experiences intermittent `context deadline exceeded` errors. This happens because the test project accumulates a massive amount of profile data under the default `gcsfuse` service name, causing the profile lookup pagination to time out while iterating through unrelated profiles.

An optimization was introduced in GCSFuse v3.9.0 to use a unique, lexicographically decreasing custom service name for each test run. This allows the API pagination to break early since the results are sorted alphabetically. 

This PR updates the GKE integration test framework to support this optimization by:
1. Generating a lexicographically decreasing string using base36 encoding.
2. Exporting `PROFILE_SERVICE_NAME` and `PROFILE_LABEL` variables into the test pod environment, which are picked up by `test_config.yaml` to dynamically set `--cloud-profiler-service-name` and `--cloud-profiler-label`.
3. Skipping the `cloud_profiler` test for GCSFuse versions older than `v3.9.0-gke.0` (such as `v3.8`), as this optimization involves core code changes not backported to older versions and the v3.9 test grid is already stable.

**Which issue(s) this PR fixes**:
Fixes b/512210213

**Special notes for your reviewer**:
This brings the GKE integration tests in sync with the GCSFuse integration tests changes made in GoogleCloudPlatform/gcsfuse#4538.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
Test gPaste output: https://paste.googleplex.com/6206146571534336