### PR TITLE
ci: declare contents: read on the CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - '*'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
The four jobs in `ci.yml` (build / unit-test / sanity-test / verify) all do `actions/checkout` + `setup-go` + `make`. No git pushes, comments, or release actions — `contents: read` is the right floor. `codeql.yml` already declares its own permissions per the default template; this PR just brings `ci.yml` in line.