### PR TITLE
Replace os.Chown with os.Lchown to prevent following symbolic links during ownership changes.

### DIFF
--- a/pkg/csi_driver/utils.go
+++ b/pkg/csi_driver/utils.go
@@ -430,7 +430,10 @@ func putExitFile(pod *corev1.Pod, targetPath string) error {
 		}
 		f.Close()
 
-		err = os.Chown(exitFilePath, webhook.NobodyUID, webhook.NobodyGID)
+		if err := util.CheckNotSymlink(exitFilePath); err != nil {
+			return fmt.Errorf("failed to verify exit file before changing ownership: %w", err)
+		}
+		err = os.Lchown(exitFilePath, webhook.NobodyUID, webhook.NobodyGID)
 		if err != nil {
 			return fmt.Errorf("failed to change ownership on the exit file: %w", err)
 		}

--- a/pkg/csi_mounter/csi_mounter.go
+++ b/pkg/csi_mounter/csi_mounter.go
@@ -274,17 +274,23 @@ func (m *Mounter) createSocket(target string, logPrefix string) (net.Listener, e
 	// 3. Change ownership of the mount socket itself.
 
 	targetSocketPath := filepath.Join(emptyDirBasePath, socketName)
+	baseDir := filepath.Dir(emptyDirBasePath)
+	if err := util.CheckNotSymlink(baseDir); err != nil {
+		return nil, fmt.Errorf("failed to verify base directory before changing ownership: %w", err)
+	}
 	// First changing ownership of parent directory where socket resides.
 	// Full path: /var/lib/kubelet/pods/<pod-uid>/volumes/kubernetes.io~empty-dir/gke-gcsfuse-tmp/.volumes/
-	baseDir := filepath.Dir(emptyDirBasePath)
-	if err = os.Chown(baseDir, webhook.NobodyUID, webhook.NobodyGID); err != nil {
+	if err = os.Lchown(baseDir, webhook.NobodyUID, webhook.NobodyGID); err != nil {
 		return nil, fmt.Errorf("failed to change ownership on base of emptyDirBasePath: %w", err)
 	}
 	klog.V(4).Infof("Chown on basedir %s done", baseDir)
 
+	if err := util.CheckNotSymlink(emptyDirBasePath); err != nil {
+		return nil, fmt.Errorf("failed to verify volume directory before changing ownership: %w", err)
+	}
 	// Changing ownership of base path directory.
 	// Full path: /var/lib/kubelet/pods/<pod-uid>/volumes/kubernetes.io~empty-dir/gke-gcsfuse-tmp/.volumes/my-vol
-	if err = os.Chown(emptyDirBasePath, webhook.NobodyUID, webhook.NobodyGID); err != nil {
+	if err = os.Lchown(emptyDirBasePath, webhook.NobodyUID, webhook.NobodyGID); err != nil {
 		return nil, fmt.Errorf("failed to change ownership on emptyDirBasePath: %w", err)
 	}
 	_, err = os.Stat(emptyDirBasePath)
@@ -294,9 +300,12 @@ func (m *Mounter) createSocket(target string, logPrefix string) (net.Listener, e
 
 	klog.V(4).Infof("Chown on emptyDirBasePath %s success", emptyDirBasePath)
 
+	if err := util.CheckNotSymlink(targetSocketPath); err != nil {
+		return nil, fmt.Errorf("failed to verify socket path before changing ownership: %w", err)
+	}
 	// Changing ownership of socket itself.
 	// Full path: /var/lib/kubelet/pods/<pod-uid>/volumes/kubernetes.io~empty-dir/gke-gcsfuse-tmp/.volumes/my-vol/socket
-	if err = os.Chown(targetSocketPath, webhook.NobodyUID, webhook.NobodyGID); err != nil {
+	if err = os.Lchown(targetSocketPath, webhook.NobodyUID, webhook.NobodyGID); err != nil {
 		return nil, fmt.Errorf("failed to change ownership on targetSocketPath: %w", err)
 	}
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -343,3 +343,16 @@ func GetCloudProfilerServiceVersion(podName, podUID string) string {
 	}
 	return fmt.Sprintf("%s_%s", podName, podUID)
 }
+
+// CheckNotSymlink verifies that the given path is not a symbolic link.
+// This is used to prevent TOCTOU symlink takeover attacks.
+func CheckNotSymlink(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return fmt.Errorf("failed to stat path %q: %w", path, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("security error: path %q is a symlink", path)
+	}
+	return nil
+}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -607,3 +607,75 @@ func TestCustomEndpointFromOpts(t *testing.T) {
 		})
 	}
 }
+
+func TestCheckNotSymlink(t *testing.T) {
+	t.Parallel()
+
+	// Set up a temporary directory for the test files
+	base, err := os.MkdirTemp("", "symlink-test")
+	if err != nil {
+		t.Fatalf("failed to setup testdir: %v", err)
+	}
+	defer os.RemoveAll(base)
+
+	// Create test files, directories, and symlinks
+	normalFile := filepath.Join(base, "normal.txt")
+	os.WriteFile(normalFile, []byte("test data"), 0644)
+
+	normalDir := filepath.Join(base, "normal_dir")
+	os.MkdirAll(normalDir, 0755)
+
+	symlinkToFile := filepath.Join(base, "symlink_file")
+	os.Symlink(normalFile, symlinkToFile)
+
+	symlinkToDir := filepath.Join(base, "symlink_dir")
+	os.Symlink(normalDir, symlinkToDir)
+
+	nonExistentPath := filepath.Join(base, "does_not_exist")
+
+	testCases := []struct {
+		name          string
+		path          string
+		expectedError bool
+	}{
+		{
+			name:          "regular file should pass",
+			path:          normalFile,
+			expectedError: false,
+		},
+		{
+			name:          "regular directory should pass",
+			path:          normalDir,
+			expectedError: false,
+		},
+		{
+			name:          "symlink to file should fail",
+			path:          symlinkToFile,
+			expectedError: true,
+		},
+		{
+			name:          "symlink to directory should fail",
+			path:          symlinkToDir,
+			expectedError: true,
+		},
+		{
+			name:          "non-existent path should fail",
+			path:          nonExistentPath,
+			expectedError: true, // os.Lstat returns an error for non-existent files
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := CheckNotSymlink(tc.path)
+
+			if tc.expectedError && err == nil {
+				t.Errorf("Expected error but got none")
+			}
+
+			if !tc.expectedError && err != nil {
+				t.Errorf("Did not expect error but got: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Replace os.Chown with os.Lchown to prevent following symbolic links during ownership changes.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

Tested on cluster with gcsfusecsi managed driver disabled. Used n2-standard-16 to make it run faster. 

```
gcloud container clusters get-credentials test-gcsfuse --zone=us-central1-a
export REGION=us-central1
export REGISTRY="$REGION-docker.pkg.dev/$USER-joonix/csi-dev"
export STAGINGVERSION=prow-gob-internal-boskos-equil-1
make build-image-and-push-multi-arch REGISTRY=$REGISTRY STAGINGVERSION=$STAGINGVERSION && make install  REGISTRY=$REGISTRY STAGINGVERSION=$STAGINGVERSION && make e2e-test E2E_TEST_USE_GKE_MANAGED_DRIVER=false E2E_TEST_BUILD_DRIVER=false BUILD_GCSFUSE_FROM_SOURCE=false STAGINGVERSION=$STAGINGVERSION REGISTRY=$REGISTRY
```


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Replace os.Chown with os.Lchown to prevent following symbolic links during ownership changes.
```