### PR TITLE
Redact Overly generous logs

### DIFF
--- a/pkg/profiles/scanner.go
+++ b/pkg/profiles/scanner.go
@@ -347,7 +347,7 @@ func generateTokenSource(ctx context.Context, configFile *ConfigFile) (oauth2.To
 	// If configFile.Global.TokenURL is defined use AltTokenSource
 	if configFile != nil && configFile.Global.TokenURL != "" && configFile.Global.TokenURL != "nil" {
 		tokenSource := auth.NewAltTokenSource(ctx, configFile.Global.TokenURL, configFile.Global.TokenBody)
-		klog.Infof("Using AltTokenSource %#v", tokenSource)
+		klog.Infof("Using AltTokenSource with token url %q", configFile.Global.TokenURL)
 		return tokenSource, nil
 	}
 
@@ -382,8 +382,7 @@ func buildCloudConfig(configPath string) (*ConfigFile, error) {
 	if err := gcfg.FatalOnly(gcfg.ReadInto(cfg, reader)); err != nil {
 		return nil, fmt.Errorf("couldn't read cloud provider configuration at %s: %w", configPath, err)
 	}
-	klog.Infof("Config file read %#v", cfg)
-
+	klog.Infof("Config file read with token url %q", cfg.Global.TokenURL)
 	return cfg, nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Removes logging which has been identified to create a vulnerability. There are 2 vulnerabilities identified and targeted with this pr. 

Scanner.go - Line 385 - "klog.Infof("Config file read %#v", cfg)"
Mitigation - log modified to only log safe identifiers - the configFile.Global.TokenURL

Scanner.go - Line 350 - "klog.Infof("Using AltTokenSource %#v", tokenSource)"
Mitigation - log modified to only log safe identifiers - the configFile.Global.TokenURL
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```