### PR TITLE
Migrate remaining gsutil references to gcloud storage cp

### DIFF
--- a/cloudbuild-build-image.yaml
+++ b/cloudbuild-build-image.yaml
@@ -143,7 +143,11 @@ steps:
         docker run --rm -v $(pwd)/bin/linux/amd64:/release gcsfuse-release-amd cp /gcsfuse_$${GCSFUSE_VERSION}_amd64/usr/bin/gcsfuse /release
       else
         # Download pre-built binary
-        gsutil cp "${_GCSFUSE_BINARY_GCS_PATH}/linux/amd64/gcsfuse" ./bin/linux/amd64/gcsfuse
+        if [ ! -d "/tmp/google-cloud-sdk" ]; then
+          curl -sSL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-linux-x86_64.tar.gz -o /tmp/gcloud.tar.gz
+          tar -xf /tmp/gcloud.tar.gz -C /tmp
+        fi
+        /tmp/google-cloud-sdk/bin/gcloud storage cp "${_GCSFUSE_BINARY_GCS_PATH}/linux/amd64/gcsfuse" ./bin/linux/amd64/gcsfuse
       fi
       chmod 0555 ./bin/linux/amd64/gcsfuse
 
@@ -157,7 +161,11 @@ steps:
           docker run --rm -v $(pwd)/bin/linux/arm64:/release gcsfuse-release-arm cp /gcsfuse_$${GCSFUSE_VERSION}_arm64/usr/bin/gcsfuse /release
         else
           # Download pre-built ARM binary
-          gsutil cp "${_GCSFUSE_BINARY_GCS_PATH}/linux/arm64/gcsfuse" ./bin/linux/arm64/gcsfuse
+          if [ ! -d "/tmp/google-cloud-sdk" ]; then
+            curl -sSL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-linux-x86_64.tar.gz -o /tmp/gcloud.tar.gz
+            tar -xf /tmp/gcloud.tar.gz -C /tmp
+          fi
+          /tmp/google-cloud-sdk/bin/gcloud storage cp "${_GCSFUSE_BINARY_GCS_PATH}/linux/arm64/gcsfuse" ./bin/linux/arm64/gcsfuse
         fi
         chmod 0555 ./bin/linux/arm64/gcsfuse
       fi

--- a/examples/dlio/data-loader/templates/dlio-data-loader.yaml
+++ b/examples/dlio/data-loader/templates/dlio-data-loader.yaml
@@ -40,7 +40,7 @@ spec:
       - "/bin/sh"
       - "-c"
       - |
-        echo "Installing gsutil..."
+        echo "Installing gcloud..."
         apt-get update && apt-get install -y apt-transport-https ca-certificates gnupg curl
         curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
         echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
@@ -57,7 +57,7 @@ spec:
         ++workload.dataset.record_length_stdev=0 \
         ++workload.dataset.record_length_resize=0
 
-        gsutil -m cp -R /data/train gs://{{ .Values.bucketName }}
+        gcloud storage cp --recursive /data/train gs://{{ .Values.bucketName }}
         mkdir -p /bucket/valid
     volumeMounts:
     - name: local-dir

--- a/examples/dlio/parse_logs.py
+++ b/examples/dlio/parse_logs.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     
     for bucketName in bucketNames:
         print(f"Download DLIO logs from the bucket {bucketName}...")
-        result = subprocess.run(["gsutil", "-m", "cp", "-r", f"gs://{bucketName}/logs", LOCAL_LOGS_LOCATION], capture_output=False, text=True)
+        result = subprocess.run(["gcloud", "storage", "cp", "--recursive", f"gs://{bucketName}/logs", LOCAL_LOGS_LOCATION], capture_output=False, text=True)
         if result.returncode < 0:
             print(f"failed to fetch DLIO logs, error: {result.stderr}")
     

--- a/examples/dlio/unet3d-loading-test/templates/dlio-tester.yaml
+++ b/examples/dlio/unet3d-loading-test/templates/dlio-tester.yaml
@@ -50,7 +50,7 @@ spec:
         x=$((x + 1))
         sed -i "${x} i \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ os.system(\"sudo sh -c 'echo 3 > /proc/sys/vm/drop_caches'\")" $main_file
 
-        echo "Installing gsutil..."
+        echo "Installing gcloud..."
         apt-get update && apt-get install -y apt-transport-https ca-certificates gnupg curl
         curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
         echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
@@ -86,7 +86,7 @@ spec:
         ++workload.reader.read_threads={{ .Values.dlio.readThreads }} \
         ++workload.output.folder=/logs/{{ .Values.dlio.numFilesTrain }}-{{ .Values.dlio.recordLength }}-{{ .Values.dlio.batchSize }}/{{ .Values.scenario }}
 
-        gsutil -m cp -R /logs gs://{{ .Values.bucketName }}/logs/$(date +"%Y-%m-%d-%H-%M")
+        gcloud storage cp --recursive /logs gs://{{ .Values.bucketName }}/logs/$(date +"%Y-%m-%d-%H-%M")
     volumeMounts:
     - name: dshm
       mountPath: /dev/shm

--- a/examples/fio/data-loader/templates/fio-data-loader.yaml
+++ b/examples/fio/data-loader/templates/fio-data-loader.yaml
@@ -39,7 +39,7 @@ spec:
         apt-get update
         apt-get install -y libaio-dev gcc make git wget
         
-        echo "Installing gsutil..."
+        echo "Installing gcloud..."
         apt-get update && apt-get install -y apt-transport-https ca-certificates gnupg curl
         curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
         echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
@@ -86,7 +86,7 @@ spec:
         NUMJOBS=50 NRFILES={{ .Values.fio.filesPerThread }} FILE_SIZE={{ .Values.fio.fileSize }} BLOCK_SIZE={{ .Values.fio.blockSize }} READ_TYPE=read DIR=/data fio ${filename} --alloc-size=1048576
 
         echo "Uploading data to bucket {{ .Values.bucketName }}..."
-        gsutil -m cp -R /data/* gs://{{ .Values.bucketName }}
+        gcloud storage cp --recursive /data/* gs://{{ .Values.bucketName }}
     volumeMounts:
     - name: local-dir
       mountPath: /data

--- a/examples/fio/loading-test/templates/fio-tester.yaml
+++ b/examples/fio/loading-test/templates/fio-tester.yaml
@@ -47,13 +47,13 @@ spec:
         apt-get install -y libaio-dev gcc make git time wget
         
         {{ if eq .Values.scenario "local-ssd" }}
-        echo "Installing gsutil..."
+        echo "Installing gcloud..."
         apt-get update && apt-get install -y apt-transport-https ca-certificates gnupg curl
         curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
         echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
         apt-get update && apt-get install -y google-cloud-cli
 
-        gsutil -m cp -R gs://{{ .Values.bucketName }}/* /data 
+        gcloud storage cp --recursive gs://{{ .Values.bucketName }}/* /data 
 
         echo "Sleeping 5 minutes to wait for Local SSD RAID to populate data."
         sleep 300
@@ -148,7 +148,7 @@ spec:
         done
         
         {{ if eq .Values.scenario "local-ssd" }}
-        gsutil -m cp -R /data/fio-output/local-ssd gs://{{ .Values.bucketName }}/fio-output
+        gcloud storage cp --recursive /data/fio-output/local-ssd gs://{{ .Values.bucketName }}/fio-output
         {{ end }}
         
         echo "fio job completed!"

--- a/examples/fio/parse_logs.py
+++ b/examples/fio/parse_logs.py
@@ -53,7 +53,7 @@ if __name__ == "__main__":
         except FileExistsError:
             pass
         print(f"Download FIO output from the folder {folder}...")
-        result = subprocess.run(["gsutil", "-m", "cp", "-r", f"gs://{folder}/fio-output", LOCAL_LOGS_LOCATION+"/"+fileSize], capture_output=False, text=True)
+        result = subprocess.run(["gcloud", "storage", "cp", "--recursive", f"gs://{folder}/fio-output", LOCAL_LOGS_LOCATION+"/"+fileSize], capture_output=False, text=True)
         if result.returncode < 0:
             print(f"failed to fetch FIO output, error: {result.stderr}")
     

--- a/examples/pytorch/data-loader-job.yaml
+++ b/examples/pytorch/data-loader-job.yaml
@@ -61,7 +61,7 @@ spec:
             kaggle competitions download -c imagenet-object-localization-challenge -p /local_disk;
             mkdir /local_disk/imagenet -p;
             unzip /local_disk/imagenet-object-localization-challenge.zip -x "ILSVRC/Annotations/*" "ILSVRC/ImageSets/*" "ILSVRC/*.csv" -d /local_disk/imagenet;
-            gsutil -m cp -R /local_disk/imagenet gs://${BUCKET_NAME}/imagenet;
+            gcloud storage cp --recursive /local_disk/imagenet gs://${BUCKET_NAME}/imagenet;
         resources:
           limits:
             cpu: "1"

--- a/hack/utils/delete-generated-buckets.sh
+++ b/hack/utils/delete-generated-buckets.sh
@@ -20,7 +20,7 @@
 BUCKET_PREFIX="gcsfusecsi-testsuite-gen-"
 
 # List all buckets
-BUCKETS=$(gsutil ls)
+BUCKETS=$(gcloud storage ls)
 
 # Array to store buckets to be deleted
 DELETE_BUCKETS=()
@@ -51,7 +51,7 @@ read -p "Are you sure you want to delete ALL the listed buckets? (y/n): " CONFIR
 if [[ "$CONFIRM" == "y" || "$CONFIRM" == "Y" ]]; then
   echo "Deleting buckets..."
   for BUCKET_NAME in "${DELETE_BUCKETS[@]}"; do
-    gsutil -m rm -r "gs://$BUCKET_NAME"
+    gcloud storage rm --recursive "gs://$BUCKET_NAME"
     echo "Deleted: $BUCKET_NAME"
   done
   echo "All specified buckets have been deleted."

--- a/test/e2e/testsuites/performance.go
+++ b/test/e2e/testsuites/performance.go
@@ -25,13 +25,14 @@ import (
 	"os"
 	"os/exec"
 
+	"local/test/e2e/specs"
+
 	"github.com/onsi/ginkgo/v2"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2evolume "k8s.io/kubernetes/test/e2e/framework/volume"
 	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
 	admissionapi "k8s.io/pod-security-admission/api"
-	"local/test/e2e/specs"
 )
 
 type metrics struct {
@@ -229,7 +230,7 @@ func (t *gcsFuseCSIPerformanceTestSuite) DefineTests(driver storageframework.Tes
 			bucketName := l.volumeResource.VolSource.CSI.VolumeAttributes["bucketName"]
 
 			//nolint:gosec
-			if output, err := exec.Command("gsutil", "cp", fmt.Sprintf("gs://%v/fio-logs/output.json", bucketName), l.artifactsDir+"/output.json").CombinedOutput(); err != nil {
+			if output, err := exec.Command("gcloud", "storage", "cp", fmt.Sprintf("gs://%v/fio-logs/output.json", bucketName), l.artifactsDir+"/output.json").CombinedOutput(); err != nil {
 				framework.Failf("Failed to download the FIO metrics from GCS bucket %q: %v, output: %s", bucketName, err, output)
 			}
 		})


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup

> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

gsutil is deprecated. This PR removes the remaining gsutil references in our code base.  

Per https://github.com/GoogleCloudPlatform/gcs-fuse-csi-driver/pull/1142/changes#r3067015443, gcloud doesn't exist in image `gcr.io/cloud-builders/docker`, so I had to change the cloudbuild prepare-gcsfuse-binary stage to install gcloud directly by downloading and extracting the standalone Google Cloud CLI archive. This avoids having to change the base image of that stage (I don't know of a base image that contains both gcloud and other things needed in that stage). 


Manually tested with 

```
export REGION='us-central1'
export PROJECT_ID=$(gcloud config get project)
export REGISTRY="$REGION-docker.pkg.dev/$PROJECT_ID/csi-dev"
export STAGINGVERSION=v999.999.999
export GCSFUSE_BINARY_GCS_PATH=$(cat cmd/sidecar_mounter/gcsfuse_binary)
gcloud builds submit . --config=cloudbuild-build-image.yaml --substitutions=_REGISTRY=$REGISTRY,_BUILD_GCSFUSE_FROM_SOURCE=true,_GCSFUSE_TAG=$GCSFUSE_TAG,_STAGINGVERSION=$STAGINGVERSION

DONE
---------------------------------------------------------------------------------------------------------------------------------------------------------
ID                                    CREATE_TIME                DURATION  SOURCE                                                                                           IMAGES  STATUS
3e39ca35-8853-4171-ba1a-4f3f75c765f8  2026-05-18T20:08:02+00:00  19M18S    gs://amacaskill-joonix_cloudbuild/source/1779134852.095433-c7b3031f4ffe4e2a8a783368c81693ea.tgz  -       SUCCESS
```




**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Swap gsutil to gcloud storage in examples/ and in cloudbuild-build-image.yaml
```