### PR TITLE
Automated cherry pick of #1367: Redact Overly generous logs

### DIFF
--- a/pkg/cloud_provider/auth/token_sources.go
+++ b/pkg/cloud_provider/auth/token_sources.go
@@ -177,7 +177,9 @@ func (ts *GCPTokenSource) FetchIdentityBindingToken(ctx context.Context, k8sSATo
 
 	stsResponse, err := stsService.V1.Token(stsRequest).Do()
 	if err != nil {
-		return nil, fmt.Errorf("IdentityBindingToken exchange error with audience %q: and request %v: error %w", audience, stsRequest, err)
+		// Redact the SubjectToken (k8s service account token) from logs to prevent leakage.
+		stsRequest.SubjectToken = "<REDACTED>"
+		return nil, fmt.Errorf("IdentityBindingToken exchange error with audience %q: request=%v: error %w", audience, stsRequest, err)
 	}
 
 	return &oauth2.Token{


### PR DESCRIPTION
Cherry pick of #1367 on release-1.22.

#1367: Redact Overly generous logs

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```