### PR TITLE
Override storage endpoint with options.go endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ endif
 GCSFUSE_PATH ?= $(shell cat cmd/sidecar_mounter/gcsfuse_binary)
 LDFLAGS ?= -s -w -X main.version=${STAGINGVERSION} -extldflags '-static'
 PROJECT_NUMBER ?= $(shell gcloud projects describe $(PROJECT) --format="value(projectNumber)")
+UNIVERSE_DOMAIN ?= $(shell gcloud config get universe_domain)
 
 DRIVER_BINARY = gcs-fuse-csi-driver
 SIDECAR_BINARY = gcs-fuse-csi-driver-sidecar-mounter
@@ -93,6 +94,7 @@ DOCKER_BUILDX_ARGS += --quiet
 $(info PROJECT is ${PROJECT})
 $(info CLUSTER_LOCATION is ${CLUSTER_LOCATION})
 $(info CLUSTER_NAME is ${CLUSTER_NAME})
+$(info UNIVERSE_DOMAIN is ${UNIVERSE_DOMAIN})
 $(info OVERLAY is ${OVERLAY})
 $(info STAGINGVERSION is ${STAGINGVERSION})
 $(info DRIVER_IMAGE is ${DRIVER_IMAGE})
@@ -309,6 +311,7 @@ generate-spec-yaml:
 	cd ./deploy/overlays/${OVERLAY}; ${BINDIR}/kustomize edit add configmap gcsfusecsi-image-config --behavior=merge --disableNameSuffixHash --from-literal=metadata-sidecar-image=${PREFETCH_IMAGE}:${STAGINGVERSION};
 	cd ./deploy/overlays/${OVERLAY}; ${BINDIR}/kustomize edit add configmap gcsfusecsi-profiles-config --behavior=merge --disableNameSuffixHash --from-literal=cluster-location=${CLUSTER_LOCATION};
 	cd ./deploy/overlays/${OVERLAY}; ${BINDIR}/kustomize edit add configmap gcsfusecsi-profiles-config --behavior=merge --disableNameSuffixHash --from-literal=project-number=${PROJECT_NUMBER};
+	cd ./deploy/overlays/${OVERLAY}; ${BINDIR}/kustomize edit add configmap gcsfusecsi-node-config --behavior=merge --disableNameSuffixHash --from-literal=universe-domain=${UNIVERSE_DOMAIN};
 # Must be unindented. When Make sees indented text, it attempts to pass it to the shell (/bin/sh) to execute. The shell doesn't know what ifeq is, so it crashes.
 ifeq ($(SELF_MANAGED_K8S), true)
 	echo "[{\"op\": \"replace\",\"path\": \"/spec/tokenRequests/0/audience\",\"value\": \"${IDENTITY_PROVIDER}\"}]" > ./deploy/overlays/${OVERLAY}/project_patch_csi_driver.json

--- a/cmd/csi_driver/main.go
+++ b/cmd/csi_driver/main.go
@@ -73,6 +73,7 @@ var (
 	assumeGoodSidecarVersion       = flag.Bool("assume-good-sidecar-version", false, "Assume the sidecar version is compatible with all features in the running version of the driver.")
 	enableAutoGoMemLimit           = flag.Bool("enable-auto-gomemlimit", false, "Automatically set GOMEMLIMIT to a percentage of the container's cgroup memory limit.")
 	autoGoMemLimitRatio            = flag.Float64("auto-gomemlimit-ratio", util.GoMemLimitCgroupPercentage, "The ratio of the container's cgroup memory limit to set as GOMEMLIMIT when enable-auto-gomemlimit is enabled.")
+	universeDomain                 = flag.String("universe-domain", "googleapis.com", "The universe domain. The default value is googleapis.com.")
 
 	// GCSFuse kernel params feature.
 	enableGCSFuseKernelParams = flag.Bool("enable-gcsfuse-kernel-params", false, "Enable gcsfuse kernel params feature.")
@@ -290,6 +291,7 @@ func main() {
 		EnableSidecarBucketAccessCheck: *enableSidecarBucketAccessCheck,
 		FeatureOptions:                 featureOptions,
 		AssumeGoodSidecarVersion:       *assumeGoodSidecarVersion,
+		UniverseDomain:                 *universeDomain,
 	}
 
 	gcfsDriver, err := driver.NewGCSDriver(config, recorder)

--- a/deploy/base/controller/controller.yaml
+++ b/deploy/base/controller/controller.yaml
@@ -47,6 +47,7 @@ spec:
             - "--http-endpoint=:29633"
             - "--enable-auto-gomemlimit=true"
             - "--auto-gomemlimit-ratio=0.95"
+            # TODO(urielguzman): Add universe-domain to support profiles.
           ports:
             - containerPort: 29633
               name: http-endpoint

--- a/deploy/base/node/node.yaml
+++ b/deploy/base/node/node.yaml
@@ -64,6 +64,7 @@ spec:
             - --enable-cloud-profiler-for-driver=true
             - --enable-auto-gomemlimit=true
             - --auto-gomemlimit-ratio=0.95
+            - --universe-domain=$(UNIVERSE_DOMAIN)
           ports:
             - containerPort: 9920
               name: metrics
@@ -91,6 +92,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.uid
+            - name: UNIVERSE_DOMAIN
+              valueFrom:
+                configMapKeyRef:
+                  name: gcsfusecsi-node-config
+                  key: universe-domain
           volumeMounts:
             - name: kubelet-dir
               mountPath: /var/lib/kubelet/pods
@@ -172,3 +178,10 @@ metadata:
 data:
   sidecar-image: gke.gcr.io/gcs-fuse-csi-driver-sidecar-mounter
   metadata-sidecar-image: gke.gcr.io/gcs-fuse-csi-driver-metadata-prefetch
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gcsfusecsi-node-config
+data:
+  universe-domain: googleapis.com

--- a/pkg/csi_driver/gcs_fuse_driver.go
+++ b/pkg/csi_driver/gcs_fuse_driver.go
@@ -74,6 +74,7 @@ type GCSDriverConfig struct {
 	EnableCloudProfilerForSidecar  bool
 	FeatureOptions                 *GCSDriverFeatureOptions
 	AssumeGoodSidecarVersion       bool
+	UniverseDomain                 string
 }
 
 type GCSDriver struct {

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -164,9 +164,10 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 
 	// Check if the given Service Account has the access to the GCS bucket, and the bucket exists.
 	// skip check if it has ever succeeded
+	storageEndpoint := storageEndpointFromUniverseDomain(s.driver.config.UniverseDomain)
 	if vs != nil && !args.skipCSIBucketAccessCheck {
 		if !vs.BucketAccessCheckPassed {
-			storageService, err := s.prepareStorageService(ctx, vc, args.customEndpoint)
+			storageService, err := s.prepareStorageService(ctx, vc, storageEndpoint)
 			if err != nil {
 				return nil, status.Errorf(codes.Unauthenticated, "failed to prepare storage service: %v", err)
 			}
@@ -383,6 +384,12 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 
 	disallowedFlags := s.driver.generateDisallowedFlagsMap(gcsFuseSidecarImage)
 	args.fuseMountOptions = removeDisallowedMountOptions(args.fuseMountOptions, disallowedFlags)
+
+	// Pass the universe-aware storage endpoint if the sidecar version supports it.
+	if s.driver.isSidecarVersionSupportedForGivenFeature(gcsFuseSidecarImage, StorageEndpointInternalMinVersion) {
+		args.fuseMountOptions = overrideStorageEndpointInternal(args.fuseMountOptions, storageEndpoint)
+	}
+
 	// Start to mount
 	if err = s.mounter.Mount(args.bucketName, targetPath, FuseMountType, args.fuseMountOptions); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to mount volume %q to target path %q: %v", args.bucketName, targetPath, err)

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -549,9 +549,21 @@ func TestNodePublishVolumeEnableAutoGoMemLimit(t *testing.T) {
 			// 2. Exact match check: ensure no extra options were injected
 			if len(fakeMounter.MountPoints) == 1 {
 				actualOpts := fakeMounter.MountPoints[0].Opts
-				if len(actualOpts) != len(tc.expectedOptions) {
-					t.Errorf("expected exactly %d options %v, but got %d options %v",
-						len(tc.expectedOptions), tc.expectedOptions, len(actualOpts), actualOpts)
+				actualSet := make(map[string]bool)
+				for _, opt := range actualOpts {
+					actualSet[opt] = true
+				}
+
+				var missingOpts []string
+				for _, expectedOpt := range tc.expectedOptions {
+					if !actualSet[expectedOpt] {
+						missingOpts = append(missingOpts, expectedOpt)
+					}
+				}
+
+				if len(missingOpts) > 0 {
+					t.Errorf("Expected options %v to be present, but options %v are missing from actual options %v",
+						tc.expectedOptions, missingOpts, actualOpts)
 				}
 			}
 		})
@@ -1149,6 +1161,86 @@ func TestNodePublishVolumeAssertMetricsCollectorRegistration(t *testing.T) {
 			}
 			if !tc.expectCollectorRegistered && collectorRegistered {
 				t.Error("expected metrics collector not to be registered, but it was")
+			}
+		})
+	}
+}
+
+func TestNodePublishVolumeStorageEndpointInternal(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name                     string
+		universeDomain           string
+		assumeGoodSidecarVersion bool
+		expectedOptions          []string
+		unexpectedOptions        []string
+	}{
+		{
+			name:                     "sidecar version supported, universe domain set, injects internal storage endpoint override",
+			universeDomain:           "my-custom-universe",
+			assumeGoodSidecarVersion: true,
+			expectedOptions:          []string{"storage-endpoint-internal=storage.my-custom-universe:443"},
+		},
+		{
+			name:                     "sidecar version supported, empty universe domain, injects default internal storage endpoint override",
+			universeDomain:           "",
+			assumeGoodSidecarVersion: true,
+			expectedOptions:          []string{"storage-endpoint-internal=storage.googleapis.com:443"},
+		},
+		{
+			name:                     "sidecar version not supported, universe domain set, should not inject flag",
+			universeDomain:           "my-custom-universe.com",
+			assumeGoodSidecarVersion: false,
+			unexpectedOptions:        []string{"storage-endpoint-internal="},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			testTargetPath, cleanup := setupMountTarget(t)
+			defer cleanup()
+
+			req := &csi.NodePublishVolumeRequest{
+				VolumeId:         testVolumeID,
+				TargetPath:       testTargetPath,
+				VolumeCapability: testVolumeCapability,
+				VolumeContext: map[string]string{
+					VolumeContextKeyPodName:      "test-pod",
+					VolumeContextKeyPodNamespace: "test-ns",
+				},
+			}
+			fakeMounter := mount.NewFakeMounter([]mount.MountPoint{})
+
+			driver := initTestDriver(t, fakeMounter)
+			s, _ := driver.config.StorageServiceManager.SetupService(context.TODO(), nil, "")
+			if _, err := s.CreateBucket(context.Background(), &storage.ServiceBucket{Name: testVolumeID}); err != nil {
+				t.Fatalf("failed to create the fake bucket: %v", err)
+			}
+
+			driver.config.UniverseDomain = tc.universeDomain
+			driver.config.AssumeGoodSidecarVersion = tc.assumeGoodSidecarVersion
+			ns := newNodeServer(driver, fakeMounter)
+
+			_, err := ns.NodePublishVolume(context.Background(), req)
+			if err != nil {
+				t.Fatalf("failed to publish volume: %v", err)
+			}
+
+			validateMountPoint(t, fakeMounter, &mount.MountPoint{
+				Device: testVolumeID,
+				Path:   testTargetPath,
+				Type:   "fuse",
+				Opts:   tc.expectedOptions,
+			}, tc.unexpectedOptions)
+
+			// Double check if unexpected options were completely avoided from the list prefix
+			if !tc.assumeGoodSidecarVersion && len(fakeMounter.MountPoints) == 1 {
+				for _, opt := range fakeMounter.MountPoints[0].Opts {
+					if strings.HasPrefix(opt, "storage-endpoint-internal=") {
+						t.Errorf("found unexpected storage-endpoint-internal flag option: %s", opt)
+					}
+				}
 			}
 		})
 	}

--- a/pkg/csi_driver/utils.go
+++ b/pkg/csi_driver/utils.go
@@ -90,6 +90,8 @@ const (
 	FlagFileForDefaultingPath              = "flags-for-defaulting"
 	GCSFuseProfileFlag                     = "profile"
 	LocalSocketAddressArg                  = "experimental-local-socket-address"
+	// TODO(urielguzman): Change this to the actual version where it's supported.
+	StorageEndpointInternalMinVersion = "v1.999.0-gke.0"
 )
 
 var (
@@ -118,7 +120,6 @@ type requestArgs struct {
 	optInHostnetworkKSA           bool
 	enableCloudProfilerForSidecar bool
 	multiNICIndex                 int
-	customEndpoint                string
 }
 
 func NewControllerServiceCapability(c csi.ControllerServiceCapability_RPC_Type) *csi.ControllerServiceCapability {
@@ -374,10 +375,40 @@ func parseRequestArguments(req *csi.NodePublishVolumeRequest, vc map[string]stri
 
 	args, err := parseVolumeAttributes(fuseMountOptions, vc)
 	args.bucketName = bucketName
-	if customEndpointVal := util.CustomEndpointFromOpts(args.fuseMountOptions); customEndpointVal != "" {
-		args.customEndpoint = customEndpointVal
-	}
 	return args, err
+}
+
+// storageEndpointFromUniverseDomain returns the storage endpoint for the universe domain,
+// in the format storage.UNIVERSE_DOMAIN:443. If no universe domain is provided, googleapis.com
+// will be used as default.
+func storageEndpointFromUniverseDomain(universeDomain string) string {
+	if universeDomain == "" {
+		universeDomain = "googleapis.com"
+	}
+	return fmt.Sprintf("storage.%s:443", universeDomain)
+}
+
+// overrideStorageEndpointInternal adds the storage-endpoint-internal flag to the mountOptions.
+// If it already exists, it will be overridden.
+func overrideStorageEndpointInternal(opts []string, storageEndpoint string) []string {
+	prefix := fmt.Sprintf("%s=", util.StorageEndpointInternal)
+	replacement := fmt.Sprintf("%s%s", prefix, storageEndpoint)
+	newMountOptions := make([]string, 0, len(opts)+1)
+
+	for _, opt := range opts {
+		if strings.HasPrefix(opt, prefix) {
+			if opt != replacement {
+				// Log a warning if we are actively changing an existing value.
+				klog.Warningf("Found flag %q, replaced with %q", opt, replacement)
+			}
+			// Skip adding the old/incorrect flag to the new slice.
+			continue
+		}
+		newMountOptions = append(newMountOptions, opt)
+	}
+
+	// Always append the correct/updated flag at the end.
+	return append(newMountOptions, replacement)
 }
 
 func putExitFile(pod *corev1.Pod, targetPath string) error {

--- a/pkg/csi_driver/utils_test.go
+++ b/pkg/csi_driver/utils_test.go
@@ -380,6 +380,48 @@ func TestIsSidecarVersionSupportedForGivenFeature(t *testing.T) {
 				expectedSupported:          false,
 				minFeatureVersionSupported: GCSFuseKernelParamsMinVersion,
 			},
+			{
+				name:                       "storage-endpoint-internal - should return true for supported sidecar version",
+				imageName:                  "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gcs-fuse-csi-driver-sidecar-mounter:v1.999.0-gke.2@sha256:abcd",
+				expectedSupported:          true,
+				minFeatureVersionSupported: StorageEndpointInternalMinVersion,
+			},
+			{
+				name:                       "storage-endpoint-internal - should return true for supported sidecar version with container registry gke.gcr.io",
+				imageName:                  "gke.gcr.io/gcs-fuse-csi-driver-sidecar-mounter:v1.999.0-gke.0@sha256:abcd",
+				expectedSupported:          true,
+				minFeatureVersionSupported: StorageEndpointInternalMinVersion,
+			},
+			{
+				name:                       "storage-endpoint-internal - false for unsupported registry host suffix gke.gcr.io",
+				imageName:                  "random-gke.gcr.io/gcs-fuse-csi-driver-sidecar-mounter:v1.999.0-gke.0@sha256:abcd",
+				expectedSupported:          false,
+				minFeatureVersionSupported: StorageEndpointInternalMinVersion,
+			},
+			{
+				name:                       "storage-endpoint-internal - false for gke.gcr.io in image path",
+				imageName:                  "randomhost.gcr.io/gke.gcr.io/gcs-fuse-csi-driver-sidecar-mounter:v1.999.0-gke.0@sha256:abcd",
+				expectedSupported:          false,
+				minFeatureVersionSupported: StorageEndpointInternalMinVersion,
+			},
+			{
+				name:                       "storage-endpoint-internal - should return true for supported sidecar version in staging gcr",
+				imageName:                  "gcr.io/gke-release-staging/gcs-fuse-csi-driver-sidecar-mounter:v1.999.0-gke.0@sha256:abcd",
+				expectedSupported:          true,
+				minFeatureVersionSupported: StorageEndpointInternalMinVersion,
+			},
+			{
+				name:                       "storage-endpoint-internal - should return false for unsupported sidecar version",
+				imageName:                  "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gcs-fuse-csi-driver-sidecar-mounter:v1.22.14-gke.0@sha256:abcd",
+				expectedSupported:          false,
+				minFeatureVersionSupported: StorageEndpointInternalMinVersion,
+			},
+			{
+				name:                       "storage-endpoint-internal - should return false for private sidecar",
+				imageName:                  "customer.gcr.io/dir/gcs-fuse-csi-driver-sidecar-mounter:v1.999.0-gke.0@sha256:abcd",
+				expectedSupported:          false,
+				minFeatureVersionSupported: StorageEndpointInternalMinVersion,
+			},
 		}
 		for _, tc := range testCases {
 			t.Logf("test case: %s", tc.name)
@@ -1009,6 +1051,94 @@ func TestTransformKeysToSet(t *testing.T) {
 
 			if !reflect.DeepEqual(gotSet, tt.wantSet) {
 				t.Errorf("transformKeysToSet() = %v, want %v", gotSet, tt.wantSet)
+			}
+		})
+	}
+}
+
+func TestStorageEndpointFromUniverseDomain(t *testing.T) {
+	testCases := []struct {
+		name           string
+		universeDomain string
+		want           string
+	}{
+		{
+			name:           "Fake domain",
+			universeDomain: "fakeapis.goog",
+			want:           "storage.fakeapis.goog:443",
+		},
+		{
+			name:           "Empty domain",
+			universeDomain: "",
+			want:           "storage.googleapis.com:443", // Default
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := storageEndpointFromUniverseDomain(tc.universeDomain)
+			if got != tc.want {
+				t.Errorf("storageEndpointFromUniverseDomain(%q) = %q, want %q", tc.universeDomain, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestOverrideStorageEndpointInternal(t *testing.T) {
+	t.Parallel()
+
+	storageEndpoint := storageEndpointFromUniverseDomain("googleapis.com")
+
+	testCases := []struct {
+		name            string
+		opts            []string
+		expectedOptions []string
+	}{
+		{
+			name: "should replace existing flag",
+			opts: []string{
+				"o=noexec",
+				"storage-endpoint-internal=storage.faceapis:443",
+				"rw",
+			},
+			expectedOptions: []string{
+				"o=noexec",
+				"rw",
+				fmt.Sprintf("storage-endpoint-internal=%s", storageEndpoint),
+			},
+		},
+		{
+			name: "should append flag if no pre-existing flags exist",
+			opts: []string{
+				"o=noexec",
+				"rw",
+			},
+			expectedOptions: []string{
+				"o=noexec",
+				"rw",
+				fmt.Sprintf("storage-endpoint-internal=%s", storageEndpoint),
+			},
+		},
+		{
+			name: "should replace multiple flags if they co-exist",
+			opts: []string{
+				"storage-endpoint-internal=https://config-endpoint.com",
+				"storage-endpoint-internal=https://old-config-endpoint.com",
+			},
+			expectedOptions: []string{
+				fmt.Sprintf("storage-endpoint-internal=%s", storageEndpoint),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			output := overrideStorageEndpointInternal(tc.opts, storageEndpoint)
+
+			if diff := cmp.Diff(output, tc.expectedOptions); diff != "" {
+				t.Errorf("unexpected options slice (-got, +want)\n%s", diff)
 			}
 		})
 	}

--- a/pkg/sidecar_mounter/sidecar_mounter.go
+++ b/pkg/sidecar_mounter/sidecar_mounter.go
@@ -479,7 +479,7 @@ func (m *Mounter) checkBucketAccessWithRetry(ctx context.Context, tokenSource oa
 	var ss storage.Service
 	ssCreateAndBucketCheckFunc := func(ctx context.Context) (bool, error) {
 		if ss == nil {
-			ss, err = m.StorageServiceManager.SetupStorageServiceForSidecar(ctx, tokenSource, mc.CustomEndpoint)
+			ss, err = m.StorageServiceManager.SetupStorageServiceForSidecar(ctx, tokenSource, mc.StorageEndpoint)
 			if err != nil {
 				mc.ErrWriter.WriteMsg(retryableError(fmt.Sprintf("%q: %v %v, retrying...", util.StorageServiceErrorStr, storage.ParseErrCode(err), err)))
 				return false, nil

--- a/pkg/sidecar_mounter/sidecar_mounter_config.go
+++ b/pkg/sidecar_mounter/sidecar_mounter_config.go
@@ -72,6 +72,7 @@ type MountConfig struct {
 	CustomEndpoint                 string                `json:"-"`
 	EnableAutoGoMemLimit           bool                  `json:"-"`
 	AutoGoMemLimitRatio            float64               `json:"-"`
+	StorageEndpoint                string                `json:"-"`
 }
 
 // sidecarRetryConfig controls the retry configurations for sidecarRetry behivior for storage service creation and bucket access check.
@@ -205,10 +206,6 @@ func (mc *MountConfig) prepareMountArgs() {
 
 	invalidArgs := []string{}
 
-	if customEndpointVal := util.CustomEndpointFromOpts(mc.Options); customEndpointVal != "" {
-		mc.CustomEndpoint = customEndpointVal
-	}
-
 	mc.GcsFuseNumaNode = -1
 	for _, arg := range mc.Options {
 		klog.Infof("processing mount arg %v", arg)
@@ -330,6 +327,10 @@ func (mc *MountConfig) prepareMountArgs() {
 			} else {
 				mc.AutoGoMemLimitRatio = ratio
 			}
+			continue
+
+		case util.StorageEndpointInternal:
+			mc.StorageEndpoint = value
 			continue
 		}
 

--- a/pkg/sidecar_mounter/sidecar_mounter_config_test.go
+++ b/pkg/sidecar_mounter/sidecar_mounter_config_test.go
@@ -64,13 +64,13 @@ func TestPrepareMountArgs(t *testing.T) {
 	// Do not parallelize [e.g t.Parallel()] because all testcases share testPrometheusPort.
 
 	testCases := []struct {
-		name                   string
-		mc                     *MountConfig
-		expectedArgs           map[string]string
-		expectedConfigMapArgs  map[string]string
-		expectNumaNode         bool
-		expectedNumaNode       int
-		expectedCustomEndpoint string
+		name                    string
+		mc                      *MountConfig
+		expectedArgs            map[string]string
+		expectedConfigMapArgs   map[string]string
+		expectNumaNode          bool
+		expectedNumaNode        int
+		expectedStorageEndpoint string
 	}{
 		{
 			name: "should return valid args correctly",
@@ -303,31 +303,33 @@ func TestPrepareMountArgs(t *testing.T) {
 			},
 		},
 		{
-			name: "should correctly parse custom-endpoint with a port",
+			name: "should correctly parse storage-endpoint-internal with a port",
 			mc: &MountConfig{
 				BucketName: "test-bucket",
 				BufferDir:  "test-buffer-dir",
 				CacheDir:   "test-cache-dir",
 				ConfigFile: "test-config-file",
-				Options:    []string{"gcs-connection:custom-endpoint:custom-service.my-system.svc.cluster.local:8080"},
+				Options:    []string{"storage-endpoint-internal=custom-service.my-system.svc.cluster.local:8080"},
 			},
-			expectedArgs: defaultFlagMap,
-			expectedConfigMapArgs: map[string]string{
-				"logging:file-path":              "/dev/fd/1",
-				"logging:format":                 "json",
-				"cache-dir":                      "",
-				"gcs-connection:custom-endpoint": "custom-service.my-system.svc.cluster.local:8080",
+			expectedArgs: map[string]string{
+				"app-name":    GCSFuseAppName,
+				"temp-dir":    "test-buffer-dir/temp-dir",
+				"config-file": "test-config-file",
+				"foreground":  "",
+				"uid":         "0",
+				"gid":         "0",
 			},
-			expectedCustomEndpoint: "custom-service.my-system.svc.cluster.local:8080",
+			expectedConfigMapArgs:   defaultConfigFileFlagMap,
+			expectedStorageEndpoint: "custom-service.my-system.svc.cluster.local:8080",
 		},
 		{
-			name: "should correctly parse custom-endpoint with a port in CLI format",
+			name: "should correctly parse storage-endpoint-internal with a port, even if custom-endpoint is also specified",
 			mc: &MountConfig{
 				BucketName: "test-bucket",
 				BufferDir:  "test-buffer-dir",
 				CacheDir:   "test-cache-dir",
 				ConfigFile: "test-config-file",
-				Options:    []string{"custom-endpoint=custom-service.my-system.svc.cluster.local:8080"},
+				Options:    []string{"storage-endpoint-internal=custom-service.my-system.svc.cluster.local:8080", "custom-endpoint=storage.fakeapis.goog:443"},
 			},
 			expectedArgs: map[string]string{
 				"app-name":        GCSFuseAppName,
@@ -336,37 +338,11 @@ func TestPrepareMountArgs(t *testing.T) {
 				"foreground":      "",
 				"uid":             "0",
 				"gid":             "0",
-				"custom-endpoint": "custom-service.my-system.svc.cluster.local:8080",
+				"custom-endpoint": "storage.fakeapis.goog:443",
 			},
-			expectedConfigMapArgs:  defaultConfigFileFlagMap,
-			expectedCustomEndpoint: "custom-service.my-system.svc.cluster.local:8080",
-		},
-		{
-			name: "should correctly prioritize custom-endpoint with a port in CLI format over config-file format when both exist",
-			mc: &MountConfig{
-				BucketName: "test-bucket",
-				BufferDir:  "test-buffer-dir",
-				CacheDir:   "test-cache-dir",
-				ConfigFile: "test-config-file",
-				Options:    []string{"custom-endpoint=custom-service.my-system.svc.cluster.local:8080", "gcs-connection:custom-endpoint:custom-service.my-system.svc.cluster.local:1234"},
-			},
-			expectedArgs: map[string]string{
-				"app-name":        GCSFuseAppName,
-				"temp-dir":        "test-buffer-dir/temp-dir",
-				"config-file":     "test-config-file",
-				"foreground":      "",
-				"uid":             "0",
-				"gid":             "0",
-				"custom-endpoint": "custom-service.my-system.svc.cluster.local:8080",
-			},
-			expectedConfigMapArgs: map[string]string{
-				"logging:file-path": "/dev/fd/1",
-				"logging:format":    "json",
-				"cache-dir":         "",
-				// Config-file option is also passed to GCSFuse, but GCSFuse will prioritze the CLI flag format
-				"gcs-connection:custom-endpoint": "custom-service.my-system.svc.cluster.local:1234",
-			},
-			expectedCustomEndpoint: "custom-service.my-system.svc.cluster.local:8080", // CLI flag format prioritzed by sidecar mounter
+			expectedConfigMapArgs: defaultConfigFileFlagMap,
+			// The storage endpoint should ignore custom-endpoint.
+			expectedStorageEndpoint: "custom-service.my-system.svc.cluster.local:8080",
 		},
 		{
 			name: "should return valid args with newly allowed flags",
@@ -575,8 +551,8 @@ func TestPrepareMountArgs(t *testing.T) {
 					t.Errorf("Got numa node %d, but expected none (-1)", tc.mc.GcsFuseNumaNode)
 				}
 			}
-			if tc.expectedCustomEndpoint != "" && tc.expectedCustomEndpoint != tc.mc.CustomEndpoint {
-				t.Errorf("Got custom endpoint %s, but expected %s", tc.mc.CustomEndpoint, tc.expectedCustomEndpoint)
+			if tc.expectedStorageEndpoint != "" && tc.expectedStorageEndpoint != tc.mc.StorageEndpoint {
+				t.Errorf("Got storage endpoint %s, but expected %s", tc.mc.StorageEndpoint, tc.expectedStorageEndpoint)
 			}
 		})
 	}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -69,6 +69,7 @@ const (
 	EnableAutoGoMemLimitConst           = "enable-auto-gomemlimit"
 	AutoGoMemLimitRatioConst            = "auto-gomemlimit-ratio"
 	GoMemLimitCgroupPercentage          = 0.95
+	StorageEndpointInternal             = "storage-endpoint-internal"
 )
 
 var (
@@ -307,35 +308,6 @@ func ParseBool(str string) (bool, error) {
 	default:
 		return false, fmt.Errorf("could not parse string to bool: the acceptable values for %q are 'True', 'true', 'false' or 'False'", str)
 	}
-}
-
-// CustomEndpointFromOpts parses a list of mount options to extract the custom endpoint value.
-// It looks for options in two formats:
-// 1. Config file format (e.g., "gcs-connection:custom-endpoint:storage.example.com:443")
-// 2. CLI flag format (e.g., "custom-endpoint=storage.example.com:443")
-// If both formats are present, the CLI flag value is prioritized, and a warning is logged.
-func CustomEndpointFromOpts(opts []string) string {
-	var configFileVal string
-	var cliFlagVal string
-	for _, arg := range opts {
-		if strings.HasPrefix(arg, CustomEndpointConfigFileFlag+":") {
-			if parts := strings.SplitN(arg, ":", 3); len(parts) == 3 {
-				configFileVal = parts[2]
-			}
-		} else if strings.HasPrefix(arg, CustomEndpointCLIFlag+"=") {
-			if parts := strings.SplitN(arg, "=", 2); len(parts) == 2 {
-				cliFlagVal = parts[1]
-			}
-		}
-	}
-	if configFileVal != "" && cliFlagVal != "" {
-		klog.Warningf("found conflicting mountOptions: config-file: %s:%s, CLI flag: %s=%s, prioritizing CLI flag value", CustomEndpointConfigFileFlag, configFileVal, CustomEndpointCLIFlag, cliFlagVal)
-		return cliFlagVal
-	}
-	if cliFlagVal != "" {
-		return cliFlagVal
-	}
-	return configFileVal
 }
 
 // GetCloudProfilerServiceVersion returns the service version for Cloud Profiler.

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -550,64 +550,6 @@ func TestIsGKEIdentityProvider(t *testing.T) {
 	}
 }
 
-func TestCustomEndpointFromOpts(t *testing.T) {
-	t.Parallel()
-
-	testCases := []struct {
-		name     string
-		opts     []string
-		expected string
-	}{
-		{
-			name:     "should return empty string when no relevant options are present",
-			opts:     []string{"other-option=foo", "read-only"},
-			expected: "",
-		},
-		{
-			name:     "should parse config file format correctly",
-			opts:     []string{"gcs-connection:custom-endpoint:storage.example.com:443"},
-			expected: "storage.example.com:443",
-		},
-		{
-			name:     "should parse CLI flag format correctly",
-			opts:     []string{"custom-endpoint=storage.googleapis.com"},
-			expected: "storage.googleapis.com",
-		},
-		{
-			name: "should prioritize CLI flag over config file format",
-			opts: []string{
-				"gcs-connection:custom-endpoint:old.endpoint.com",
-				"custom-endpoint=new.endpoint.com",
-			},
-			expected: "new.endpoint.com",
-		},
-		{
-			name: "should work when relevant flag is among other flags",
-			opts: []string{
-				"uid=1000",
-				"gid=1000",
-				"custom-endpoint=storage.example.com",
-				"debug_gcs",
-			},
-			expected: "storage.example.com",
-		},
-		{
-			name:     "should handle empty opts slice",
-			opts:     []string{},
-			expected: "",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			actual := CustomEndpointFromOpts(tc.opts)
-			if actual != tc.expected {
-				t.Errorf("CustomEndpointFromOpts(%v) = %q, want %q", tc.opts, actual, tc.expected)
-			}
-		})
-	}
-}
-
 func TestCheckNotSymlink(t *testing.T) {
 	t.Parallel()
 

--- a/test/e2e/specs/testdriver.go
+++ b/test/e2e/specs/testdriver.go
@@ -543,7 +543,6 @@ func (n *GCSFuseCSITestDriver) RemoveIAMPolicy(ctx context.Context, bucket *stor
 	}
 }
 
-
 // createBucket creates a GCS bucket.
 func (n *GCSFuseCSITestDriver) createBucket(ctx context.Context, serviceAccountNamespace string) string {
 	storageService, err := n.prepareStorageService(ctx)

--- a/test/e2e/testsuites/workload_identity_federation.go
+++ b/test/e2e/testsuites/workload_identity_federation.go
@@ -778,7 +778,6 @@ func (t *gcsFuseCSIWorkloadIdentityFederationTestSuite) DefineTests(driver stora
 	})
 }
 
-
 // addWorkloadIdentityBinding grants roles/iam.workloadIdentityUser on the given GCP service
 // account to the Workload Identity principal for ksaName, enabling GKE token exchange.
 // Retries with backoff to handle IAM eventual consistency after SA creation.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
kind feature

**What this PR does / why we need it**:
Currently, customers need to specify `custom-endpoint` to use the GCSFuse CSI Driver in non-GDU universes. This PR makes the detection of the storage endpoint automatic, by passing an internal flag 'storage-endpoint-internal' to the sidecar, so that it also creates the clients in the correct universe.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Automatically determine storage endpoint.
```