### PR TITLE
update GCSFuse binary to 3.8.2

### DIFF
--- a/cmd/sidecar_mounter/gcsfuse_binary
+++ b/cmd/sidecar_mounter/gcsfuse_binary
@@ -1,1 +1,1 @@
-gs://gke-release-staging/gcsfuse/v3.8.1-gke.0/gcsfuse_bin
+gs://gke-release-staging/gcsfuse/v3.8.2-gke.0/gcsfuse_bin


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Bump GCSFuse binary to 3.8.2 to pick up grpc direct path bug fixes  (memory leak and gRPC strategy improvement) in PR 4659: https://github.com/GoogleCloudPlatform/gcsfuse/pull/4659

Context: We saw timeout issues in large tesselation runs due to the directpath enforcement strategy. In some instances, the token fetching was taking beyond 10 seconds resulting in the context getting cancelled resulting in no storage client in Rapid (we had fallback client in non rapid) resulting in crashes. This patch release fixes this issue. Also, one of the customer had reported a rare memory leak in buffered reader wherein a very edge case scenario, we were not decrementing the ref count for memory block. This change fixes that issue as well.



**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Bump GCSFuse binary to 3.8.2 to fix memory leak and gRPC strategy improvement
```