### PR TITLE
Automated cherry pick of #1364: Set GOMEMLIMIT  to be 95% of whatever the c group memory limit is

### DIFF
--- a/cmd/csi_driver/main.go
+++ b/cmd/csi_driver/main.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/profiler"
+	"github.com/KimMachineGun/automemlimit/memlimit"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/auth"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/clientset"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/metadata"
@@ -70,6 +71,8 @@ var (
 	enableSidecarBucketAccessCheck = flag.Bool("enable-sidecar-bucket-access-check", false, "Enable bucket access check on sidecar, this does not disable bucket access check in node driver.")
 	enableCloudProfilerForDriver   = flag.Bool("enable-cloud-profiler-for-driver", false, "Enable cloud profiler to collect analysis data.")
 	assumeGoodSidecarVersion       = flag.Bool("assume-good-sidecar-version", false, "Assume the sidecar version is compatible with all features in the running version of the driver.")
+	enableAutoGoMemLimit           = flag.Bool("enable-auto-gomemlimit", false, "Automatically set GOMEMLIMIT to a percentage of the container's cgroup memory limit.")
+	autoGoMemLimitRatio            = flag.Float64("auto-gomemlimit-ratio", util.GoMemLimitCgroupPercentage, "The ratio of the container's cgroup memory limit to set as GOMEMLIMIT when enable-auto-gomemlimit is enabled.")
 
 	// GCSFuse kernel params feature.
 	enableGCSFuseKernelParams = flag.Bool("enable-gcsfuse-kernel-params", false, "Enable gcsfuse kernel params feature.")
@@ -100,6 +103,20 @@ var (
 func main() {
 	klog.InitFlags(nil)
 	flag.Parse()
+
+	if *enableAutoGoMemLimit {
+		// Sets GOMEMLIMIT to a percentage of the cgroup limit.
+		// If cgroup limits are unavailable, it falls back to doing nothing
+		// (no limit).
+		if _, err := memlimit.SetGoMemLimitWithOpts(
+			memlimit.WithRatio(*autoGoMemLimitRatio),
+			memlimit.WithProvider(memlimit.FromCgroup),
+		); err != nil {
+			// This can happen if the gcs-fuse-csi-driver container memory
+			// limit is not set.
+			klog.Warningf("Failed to automatically set GOMEMLIMIT: %v", err)
+		}
+	}
 
 	// All CSI sidecars use http-endpoint for metrics and health checks.
 	// Example: https://gke-internal.googlesource.com/third_party/kubernetes-csi/livenessprobe/+/refs/heads/master/cmd/livenessprobe/main.go#113
@@ -221,6 +238,10 @@ func main() {
 			EnableGcsfuseProfilesInternal: *enableGcsfuseProfilesInternal,
 		},
 		EnableGCSFuseKernelParams: *enableGCSFuseKernelParams,
+		GoMemLimitOptions: &driver.GoMemLimitOptions{
+			EnableAutoGoMemLimit: *enableAutoGoMemLimit,
+			AutoGoMemLimitRatio:  *autoGoMemLimitRatio,
+		},
 	}
 
 	var mounter mount.Interface

--- a/cmd/sidecar_mounter/gcsfuse_binary
+++ b/cmd/sidecar_mounter/gcsfuse_binary
@@ -1,1 +1,1 @@
-gs://gke-release-staging/gcsfuse/v3.9.0-gke.0/gcsfuse_bin
+gs://gke-release-staging/gcsfuse/v3.9.1-gke.0/gcsfuse_bin

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -22,7 +22,9 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/KimMachineGun/automemlimit/memlimit"
 	"github.com/go-logr/logr"
+	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util"
 	wh "github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/webhook"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/version"
@@ -56,6 +58,8 @@ var (
 	metadataSidecarImage                    = flag.String("metadata-sidecar-image", "", "The metadata prefetch sidecar container image.")
 	injectSAVol                             = flag.Bool("should-inject-sa-vol", false, "Inject projected service account volume when true")
 	enableGcsfuseProfiles                   = flag.Bool("enable-gcsfuse-profiles", false, "Enable gcsfuse profiles when true")
+	enableAutoGoMemLimit                    = flag.Bool("enable-auto-gomemlimit", false, "Automatically set GOMEMLIMIT to a percentage of the container's cgroup memory limit.")
+	autoGoMemLimitRatio                     = flag.Float64("auto-gomemlimit-ratio", util.GoMemLimitCgroupPercentage, "The ratio of the container's cgroup memory limit to set as GOMEMLIMIT when enable-auto-gomemlimit is enabled.")
 	metadataMemoryRequest                   = flag.String("metadata-sidecar-memory-request", "10Mi", "Flag to use default value for gcsfuse memory prefetch sidecar container memory request.")
 	metadataMemoryLimit                     = flag.String("metadata-sidecar-memory-limit", "10Mi", "Flag to use default value for gcsfuse memory prefetch sidecar container memory limit.")
 	metadataPrefetchCPURequest              = flag.String("metadata-sidecar-cpu-request", "10m", "The default cpu request for gcsfuse memory prefetch sidecar container cpu request.")
@@ -77,6 +81,20 @@ func main() {
 	// Thanks to the PR https://github.com/solo-io/gloo/pull/8549
 	// This line prevents controller-runtime from complaining about log.SetLogger never being called
 	log.SetLogger(logr.New(log.NullLogSink{}))
+
+	if *enableAutoGoMemLimit {
+		// Sets GOMEMLIMIT to a percentage of the cgroup limit.
+		// If cgroup limits are unavailable, it falls back to doing nothing
+		// (no limit).
+		if _, err := memlimit.SetGoMemLimitWithOpts(
+			memlimit.WithRatio(*autoGoMemLimitRatio),
+			memlimit.WithProvider(memlimit.FromCgroup),
+		); err != nil {
+			// This can happen if the gcs-fuse-csi-driver-webhook container
+			// memory limit is not set.
+			klog.Warningf("Failed to automatically set GOMEMLIMIT: %v", err)
+		}
+	}
 
 	klog.Infof("Running Google Cloud Storage FUSE CSI driver admission webhook version %v, sidecar container image %v", webhookVersion, *sidecarImage)
 

--- a/deploy/base/controller/controller.yaml
+++ b/deploy/base/controller/controller.yaml
@@ -45,6 +45,8 @@ spec:
             - "--cluster-location=$(CLUSTER_LOCATION)"
             - "--project-number=$(PROJECT_NUMBER)"
             - "--http-endpoint=:29633"
+            - "--enable-auto-gomemlimit=true"
+            - "--auto-gomemlimit-ratio=0.95"
           ports:
             - containerPort: 29633
               name: http-endpoint

--- a/deploy/base/node/node.yaml
+++ b/deploy/base/node/node.yaml
@@ -62,6 +62,8 @@ spec:
             - --enable-gcsfuse-profiles-internal=true
             - --stream-metrics-export=true
             - --enable-cloud-profiler-for-driver=true
+            - --enable-auto-gomemlimit=true
+            - --auto-gomemlimit-ratio=0.95
           ports:
           - containerPort: 9920
             name: metrics

--- a/deploy/base/webhook/deployment.yaml
+++ b/deploy/base/webhook/deployment.yaml
@@ -61,6 +61,8 @@ spec:
             - --health-probe-bind-address=:22031
             - --should-inject-sa-vol=true
             - --enable-gcsfuse-profiles=true
+            - --enable-auto-gomemlimit=true
+            - --auto-gomemlimit-ratio=0.95
           env:
             - name: SIDECAR_IMAGE_PULL_POLICY
               value: "IfNotPresent"

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	cloud.google.com/go/monitoring v1.24.2
 	cloud.google.com/go/profiler v0.4.3
 	cloud.google.com/go/storage v1.56.3
+	github.com/KimMachineGun/automemlimit v0.7.5
 	github.com/container-storage-interface/spec v1.11.0
 	github.com/distribution/reference v0.6.0
 	github.com/go-logr/logr v1.4.3
@@ -89,6 +90,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.27.0 // indirect
 	github.com/onsi/gomega v1.38.2 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
+	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.53.0/go.mod h1:jUZ5LYlw40WMd07qxcQJD5M40aUxrfwqQX1g7zxYnrQ=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.53.0 h1:Ron4zCA/yk6U7WOBXhTJcDpsUBG9npumK6xw2auFltQ=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.53.0/go.mod h1:cSgYe11MCNYunTnRXrKiR/tHc0eoKjICUuWpNZoVCOo=
+github.com/KimMachineGun/automemlimit v0.7.5 h1:RkbaC0MwhjL1ZuBKunGDjE/ggwAX43DwZrJqVwyveTk=
+github.com/KimMachineGun/automemlimit v0.7.5/go.mod h1:QZxpHaGOQoYvFhv/r4u3U0JTC2ZcOwbSr11UZF46UBM=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=
@@ -157,6 +159,8 @@ github.com/onsi/gomega v1.38.2 h1:eZCjf2xjZAqe+LeWvKb5weQ+NcPwX84kqJ0cZNxok2A=
 github.com/onsi/gomega v1.38.2/go.mod h1:W2MJcYxRGV63b418Ai34Ud0hEdTVXq9NW9+Sx6uXf3k=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
+github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 h1:onHthvaw9LFnH4t2DcNVpwGmV9E1BkGknEliJkfwQj0=
+github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58/go.mod h1:DXv8WO4yhMYhSNPKjeNKa5WY9YCIEBRbNzFFPJbWO6Y=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 h1:GFCKgmp0tecUJ0sJuv4pzYCqS9+RGSn52M3FUwPs+uo=

--- a/pkg/csi_driver/gcs_fuse_driver.go
+++ b/pkg/csi_driver/gcs_fuse_driver.go
@@ -45,9 +45,15 @@ type FeatureGCSFuseProfiles struct {
 	EnableGcsfuseProfilesInternal bool
 }
 
+type GoMemLimitOptions struct {
+	EnableAutoGoMemLimit bool
+	AutoGoMemLimitRatio  float64
+}
+
 type GCSDriverFeatureOptions struct {
 	EnableGCSFuseKernelParams bool
 	FeatureGCSFuseProfiles    *FeatureGCSFuseProfiles
+	GoMemLimitOptions         *GoMemLimitOptions
 }
 
 type GCSDriverConfig struct {

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -217,6 +217,42 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 		})
 	}
 
+	// Check if the user explicitly provided GOMEMLIMIT flags in their
+	// volume's mountOptions.
+	userProvidedAutoMemLimit := false
+	userProvidedRatio := false
+	for _, opt := range args.fuseMountOptions {
+		if opt == util.EnableAutoGoMemLimitConst || strings.HasPrefix(opt, util.EnableAutoGoMemLimitConst+"=") {
+			userProvidedAutoMemLimit = true
+		}
+		if strings.HasPrefix(opt, util.AutoGoMemLimitRatioConst+"=") {
+			userProvidedRatio = true
+		}
+	}
+
+	// Inject driver defaults if the sidecar supports the GOMEMLIMIT feature.
+	// We evaluate the ratio independently so users who manually opt-in via
+	// mountOptions without specifying a ratio still receive the driver's
+	// default.
+	if s.driver.isSidecarVersionSupportedForGivenFeature(gcsFuseSidecarImage, SidecarAutoGoMemLimitMinVersion) {
+		var extraOpts []string
+		enableAutoGoMemLimit := s.driver.config.FeatureOptions.GoMemLimitOptions != nil && s.driver.config.FeatureOptions.GoMemLimitOptions.EnableAutoGoMemLimit
+		if enableAutoGoMemLimit && !userProvidedAutoMemLimit {
+			extraOpts = append(extraOpts, util.EnableAutoGoMemLimitConst+"=true")
+		}
+		//  We check this to prevent injecting the ratio and adding unnecessary
+		// noise to the mount options when the feature is completely disabled.
+		sidecarFeatureWillBeEnabled := enableAutoGoMemLimit || userProvidedAutoMemLimit
+		if !userProvidedRatio && sidecarFeatureWillBeEnabled && s.driver.config.FeatureOptions.GoMemLimitOptions != nil {
+			autoGoMemLimitRatio := s.driver.config.FeatureOptions.GoMemLimitOptions.AutoGoMemLimitRatio
+			extraOpts = append(extraOpts, util.AutoGoMemLimitRatioConst+"="+strconv.FormatFloat(autoGoMemLimitRatio, 'f', -1, 64))
+		}
+
+		if len(extraOpts) > 0 {
+			args.fuseMountOptions = joinMountOptions(args.fuseMountOptions, extraOpts)
+		}
+	}
+
 	node, err := s.k8sClients.GetNode(s.driver.config.NodeID)
 	if err != nil {
 		return nil, status.Errorf(codes.NotFound, "failed to get node: %v", err)

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -396,6 +396,167 @@ func TestNodePublishVolumeMultiNIC(t *testing.T) {
 		})
 	}
 }
+func TestNodePublishVolumeEnableAutoGoMemLimit(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name                     string
+		enableAutoGoMemLimit     bool
+		autoGoMemLimitRatio      float64
+		assumeGoodSidecarVersion bool
+		userMountOptions         string
+		expectedOptions          []string
+	}{
+		{
+			name:                     "feature flag enabled, sidecar version supported, no user overrides, expect all driver defaults",
+			enableAutoGoMemLimit:     true,
+			autoGoMemLimitRatio:      0.95,
+			assumeGoodSidecarVersion: true,
+			expectedOptions:          []string{"enable-auto-gomemlimit=true", "auto-gomemlimit-ratio=0.95"},
+		},
+		{
+			name:                     "feature flag disabled, sidecar version supported, no user overrides, expect no driver defaults injected",
+			enableAutoGoMemLimit:     false,
+			autoGoMemLimitRatio:      0.95,
+			assumeGoodSidecarVersion: true,
+			expectedOptions:          []string{},
+		},
+		{
+			name:                     "feature flag enabled, sidecar version not supported, no user overrides, expect no driver defaults injected",
+			enableAutoGoMemLimit:     true,
+			autoGoMemLimitRatio:      0.95,
+			assumeGoodSidecarVersion: false,
+			expectedOptions:          []string{},
+		},
+		{
+			name:                     "feature flag enabled, sidecar version supported, user overrides enable flag, expect user enable flag and driver default ratio",
+			enableAutoGoMemLimit:     true,
+			autoGoMemLimitRatio:      0.95,
+			assumeGoodSidecarVersion: true,
+			userMountOptions:         "enable-auto-gomemlimit=false",
+			expectedOptions:          []string{"enable-auto-gomemlimit=false", "auto-gomemlimit-ratio=0.95"},
+		},
+		{
+			name:                     "feature flag enabled, sidecar version supported, user overrides ratio flag, expect driver default enable flag and user ratio",
+			enableAutoGoMemLimit:     true,
+			autoGoMemLimitRatio:      0.95,
+			assumeGoodSidecarVersion: true,
+			userMountOptions:         "auto-gomemlimit-ratio=0.8",
+			expectedOptions:          []string{"auto-gomemlimit-ratio=0.8", "enable-auto-gomemlimit=true"},
+		},
+		{
+			name:                     "feature flag enabled, sidecar version supported, user overrides both flags, expect no driver defaults injected",
+			enableAutoGoMemLimit:     true,
+			autoGoMemLimitRatio:      0.95,
+			assumeGoodSidecarVersion: true,
+			userMountOptions:         "enable-auto-gomemlimit=false,auto-gomemlimit-ratio=0.8",
+			expectedOptions:          []string{"enable-auto-gomemlimit=false", "auto-gomemlimit-ratio=0.8"},
+		},
+		{
+			// In this case, the sidecar will pass the flag to the gcsfuse binary, which will crash because it doesn't recognize it.
+			// This is the correct behavior and how it works with all other flags today.
+			name:                     "feature flag enabled, sidecar version not supported, user overrides enable flag, expect user enable flag and no driver defaults",
+			enableAutoGoMemLimit:     true,
+			autoGoMemLimitRatio:      0.95,
+			assumeGoodSidecarVersion: false,
+			userMountOptions:         "enable-auto-gomemlimit=false",
+			expectedOptions:          []string{"enable-auto-gomemlimit=false"},
+		},
+		{
+			// In this case, the sidecar will pass the flag to the gcsfuse binary, which will crash because it doesn't recognize it.
+			// This is the correct behavior and how it works with all other flags today.
+			name:                     "feature flag enabled, sidecar version not supported, user overrides ratio flag, expect user ratio flag and no driver defaults",
+			enableAutoGoMemLimit:     true,
+			autoGoMemLimitRatio:      0.95,
+			assumeGoodSidecarVersion: false,
+			userMountOptions:         "auto-gomemlimit-ratio=0.8",
+			expectedOptions:          []string{"auto-gomemlimit-ratio=0.8"},
+		},
+		{
+			name:                     "feature flag disabled, sidecar version supported, user overrides enable flag, expect user enable flag and driver default ratio",
+			enableAutoGoMemLimit:     false,
+			autoGoMemLimitRatio:      0.95,
+			assumeGoodSidecarVersion: true,
+			userMountOptions:         "enable-auto-gomemlimit=true",
+			expectedOptions:          []string{"enable-auto-gomemlimit=true", "auto-gomemlimit-ratio=0.95"},
+		},
+		{
+			name:                     "feature flag disabled, sidecar version supported, user overrides ratio flag, expect user ratio flag and no driver enable flag",
+			enableAutoGoMemLimit:     false,
+			autoGoMemLimitRatio:      0.95,
+			assumeGoodSidecarVersion: true,
+			userMountOptions:         "auto-gomemlimit-ratio=0.8",
+			expectedOptions:          []string{"auto-gomemlimit-ratio=0.8"},
+		},
+		{
+			name:                     "feature flag disabled, sidecar version supported, user overrides both flags, expect user flags and no driver defaults",
+			enableAutoGoMemLimit:     false,
+			autoGoMemLimitRatio:      0.95,
+			assumeGoodSidecarVersion: true,
+			userMountOptions:         "enable-auto-gomemlimit=true,auto-gomemlimit-ratio=0.8",
+			expectedOptions:          []string{"enable-auto-gomemlimit=true", "auto-gomemlimit-ratio=0.8"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			testTargetPath, cleanup := setupMountTarget(t)
+			defer cleanup()
+
+			volumeContext := map[string]string{
+				VolumeContextKeyPodName:      "test-pod",
+				VolumeContextKeyPodNamespace: "test-ns",
+			}
+			if tc.userMountOptions != "" {
+				volumeContext[VolumeContextKeyMountOptions] = tc.userMountOptions
+			}
+
+			req := &csi.NodePublishVolumeRequest{
+				VolumeId:         testVolumeID,
+				TargetPath:       testTargetPath,
+				VolumeCapability: testVolumeCapability,
+				VolumeContext:    volumeContext,
+			}
+			fakeMounter := mount.NewFakeMounter([]mount.MountPoint{})
+
+			driver := initTestDriver(t, fakeMounter)
+			s, _ := driver.config.StorageServiceManager.SetupService(context.TODO(), nil, "")
+			if _, err := s.CreateBucket(context.Background(), &storage.ServiceBucket{Name: testVolumeID}); err != nil {
+				t.Fatalf("failed to create the fake bucket: %v", err)
+			}
+
+			driver.config.FeatureOptions.GoMemLimitOptions = &GoMemLimitOptions{
+				EnableAutoGoMemLimit: tc.enableAutoGoMemLimit,
+				AutoGoMemLimitRatio:  tc.autoGoMemLimitRatio,
+			}
+			driver.config.AssumeGoodSidecarVersion = tc.assumeGoodSidecarVersion
+			ns := newNodeServer(driver, fakeMounter)
+
+			_, err := ns.NodePublishVolume(context.Background(), req)
+
+			if err != nil {
+				t.Fatalf("failed to publish volume: %v", err)
+			}
+
+			// 1. Use the existing helper to ensure all expected options are present
+			validateMountPoint(t, fakeMounter, &mount.MountPoint{
+				Device: testVolumeID,
+				Path:   testTargetPath,
+				Type:   "fuse",
+				Opts:   tc.expectedOptions,
+			}, nil)
+
+			// 2. Exact match check: ensure no extra options were injected
+			if len(fakeMounter.MountPoints) == 1 {
+				actualOpts := fakeMounter.MountPoints[0].Opts
+				if len(actualOpts) != len(tc.expectedOptions) {
+					t.Errorf("expected exactly %d options %v, but got %d options %v",
+						len(tc.expectedOptions), tc.expectedOptions, len(actualOpts), actualOpts)
+				}
+			}
+		})
+	}
+}
 
 func TestNodeUnpublishVolume(t *testing.T) {
 	t.Parallel()

--- a/pkg/csi_driver/utils.go
+++ b/pkg/csi_driver/utils.go
@@ -86,11 +86,10 @@ const (
 	GCSFuseFileCacheMediumMinVersion       = "v1.21.0-gke.0"
 	GCSFuseKernelParamsMinVersion          = "v1.22.0-gke.0"
 	MultiNICMinVersion                     = "v1.22.2-gke.0"
-	// TODO(amacaskill): update with actual 1.23.X patch version once the first PR is merged.
-	SidecarAutoGoMemLimitMinVersion = "v1.24.0-gke.0"
-	FlagFileForDefaultingPath       = "flags-for-defaulting"
-	GCSFuseProfileFlag              = "profile"
-	LocalSocketAddressArg           = "experimental-local-socket-address"
+	SidecarAutoGoMemLimitMinVersion        = "v1.23.11-gke.0"
+	FlagFileForDefaultingPath              = "flags-for-defaulting"
+	GCSFuseProfileFlag                     = "profile"
+	LocalSocketAddressArg                  = "experimental-local-socket-address"
 )
 
 var (

--- a/pkg/csi_driver/utils.go
+++ b/pkg/csi_driver/utils.go
@@ -86,9 +86,11 @@ const (
 	GCSFuseFileCacheMediumMinVersion       = "v1.21.0-gke.0"
 	GCSFuseKernelParamsMinVersion          = "v1.22.0-gke.0"
 	MultiNICMinVersion                     = "v1.22.2-gke.0"
-	FlagFileForDefaultingPath              = "flags-for-defaulting"
-	GCSFuseProfileFlag                     = "profile"
-	LocalSocketAddressArg                  = "experimental-local-socket-address"
+	// TODO(amacaskill): update with actual 1.23.X patch version once the first PR is merged.
+	SidecarAutoGoMemLimitMinVersion = "v1.24.0-gke.0"
+	FlagFileForDefaultingPath       = "flags-for-defaulting"
+	GCSFuseProfileFlag              = "profile"
+	LocalSocketAddressArg           = "experimental-local-socket-address"
 )
 
 var (

--- a/pkg/sidecar_mounter/sidecar_mounter.go
+++ b/pkg/sidecar_mounter/sidecar_mounter.go
@@ -40,6 +40,7 @@ import (
 	cpmeta "github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/metadata"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/storage"
 
+	"github.com/KimMachineGun/automemlimit/memlimit"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/clientset"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/metrics"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util"
@@ -141,6 +142,24 @@ func (m *Mounter) Mount(ctx context.Context, mc *MountConfig) error {
 	//nolint: gosec
 	klog.Infof("gcsfuse mounting with %s %v...", cmdName, args)
 	cmd := exec.CommandContext(ctx, cmdName, args...)
+
+	if mc.EnableAutoGoMemLimit {
+		//  Set for the sidecar mounter process
+		appliedLimit, err := memlimit.SetGoMemLimitWithOpts(
+			memlimit.WithRatio(mc.AutoGoMemLimitRatio),
+			memlimit.WithProvider(memlimit.FromCgroup),
+		)
+		if err != nil {
+			klog.V(4).Infof("GOMEMLIMIT not set (expected if gke-gcsfuse-sidecar memory limit is unset): %v", err)
+		} else if appliedLimit > 0 {
+			// Export GOMEMLIMIT for the gcsfuse child process.
+			// If appliedLimit is 0, it means GOMEMLIMIT was already set in
+			// the environment or there is no memory limit; in both cases we
+			// should not override.
+			cmd.Env = append(os.Environ(), fmt.Sprintf("GOMEMLIMIT=%d", appliedLimit))
+			klog.Infof("Successfully set GOMEMLIMIT=%d for gcsfuse and sidecar_mounter", appliedLimit)
+		}
+	}
 
 	cmd.ExtraFiles = []*os.File{os.NewFile(uintptr(mc.FileDescriptor), "/dev/fuse")}
 	cmd.Stdout = os.Stdout

--- a/pkg/sidecar_mounter/sidecar_mounter_config.go
+++ b/pkg/sidecar_mounter/sidecar_mounter_config.go
@@ -70,6 +70,8 @@ type MountConfig struct {
 	FileCacheMedium                string                `json:"-"`
 	GcsFuseNumaNode                int                   `json:"-"`
 	CustomEndpoint                 string                `json:"-"`
+	EnableAutoGoMemLimit           bool                  `json:"-"`
+	AutoGoMemLimitRatio            float64               `json:"-"`
 }
 
 // sidecarRetryConfig controls the retry configurations for sidecarRetry behivior for storage service creation and bucket access check.
@@ -117,12 +119,13 @@ func NewMountConfig(sp string, flagMapFromDriver map[string]string) *MountConfig
 	tempDir := filepath.Dir(sp)
 	volumeName := filepath.Base(tempDir)
 	mc := MountConfig{
-		VolumeName: volumeName,
-		BufferDir:  filepath.Join(webhook.SidecarContainerBufferVolumeMountPath, ".volumes", volumeName),
-		CacheDir:   filepath.Join(webhook.SidecarContainerCacheVolumeMountPath, ".volumes", volumeName),
-		TempDir:    tempDir,
-		ConfigFile: filepath.Join(webhook.SidecarContainerTmpVolumeMountPath, ".volumes", volumeName, "config.yaml"),
-		ErrWriter:  NewErrorWriter(filepath.Join(tempDir, "error")),
+		VolumeName:          volumeName,
+		BufferDir:           filepath.Join(webhook.SidecarContainerBufferVolumeMountPath, ".volumes", volumeName),
+		CacheDir:            filepath.Join(webhook.SidecarContainerCacheVolumeMountPath, ".volumes", volumeName),
+		TempDir:             tempDir,
+		ConfigFile:          filepath.Join(webhook.SidecarContainerTmpVolumeMountPath, ".volumes", volumeName, "config.yaml"),
+		ErrWriter:           NewErrorWriter(filepath.Join(tempDir, "error")),
+		AutoGoMemLimitRatio: util.GoMemLimitCgroupPercentage,
 	}
 
 	klog.Infof("connecting to socket %q", sp)
@@ -314,6 +317,19 @@ func (mc *MountConfig) prepareMountArgs() {
 
 		case util.EnableGCSFuseKernelParams:
 			mc.EnableGCSFuseKernelParams = value == util.TrueStr
+			continue
+
+		case util.EnableAutoGoMemLimitConst:
+			mc.EnableAutoGoMemLimit = value == util.TrueStr
+			continue
+
+		case util.AutoGoMemLimitRatioConst:
+			ratio, err := strconv.ParseFloat(value, 64)
+			if err != nil || ratio <= 0 || ratio > 1 {
+				invalidArgs = append(invalidArgs, arg)
+			} else {
+				mc.AutoGoMemLimitRatio = ratio
+			}
 			continue
 		}
 

--- a/pkg/sidecar_mounter/sidecar_mounter_config_test.go
+++ b/pkg/sidecar_mounter/sidecar_mounter_config_test.go
@@ -802,3 +802,60 @@ func TestPrepareConfigFile(t *testing.T) {
 		})
 	}
 }
+
+func TestPrepareMountArgs_AutoGoMemLimit(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name           string
+		options        []string
+		expectedEnable bool
+		expectedRatio  float64
+	}{
+		{
+			name:           "enable and ratio flags provided, expect both fields parsed correctly",
+			options:        []string{"enable-auto-gomemlimit=true", "auto-gomemlimit-ratio=0.85"},
+			expectedEnable: true,
+			expectedRatio:  0.85,
+		},
+		{
+			name:           "enable flag set to false, expect enable field false and ratio parsed correctly",
+			options:        []string{"enable-auto-gomemlimit=false", "auto-gomemlimit-ratio=0.9"},
+			expectedEnable: false,
+			expectedRatio:  0.9,
+		},
+		{
+			name:           "no gomemlimit flags provided, expect default ratio retained",
+			options:        []string{"some-other-flag=true"},
+			expectedEnable: false,
+			expectedRatio:  0.95, // 0.95 is the default we set prior to calling prepareMountArgs
+		},
+		{
+			name:           "invalid ratio string provided, expect default ratio retained",
+			options:        []string{"enable-auto-gomemlimit=true", "auto-gomemlimit-ratio=not-a-number"},
+			expectedEnable: true,
+			expectedRatio:  0.95,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mc := &MountConfig{
+				Options: tc.options,
+				// Simulate the default value set by NewMountConfig
+				AutoGoMemLimitRatio: 0.95,
+			}
+
+			// Execute the parsing logic
+			mc.prepareMountArgs()
+
+			if mc.EnableAutoGoMemLimit != tc.expectedEnable {
+				t.Errorf("Got EnableAutoGoMemLimit %v, expected %v", mc.EnableAutoGoMemLimit, tc.expectedEnable)
+			}
+
+			if mc.AutoGoMemLimitRatio != tc.expectedRatio {
+				t.Errorf("Got AutoGoMemLimitRatio %v, expected %v", mc.AutoGoMemLimitRatio, tc.expectedRatio)
+			}
+		})
+	}
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -66,6 +66,9 @@ const (
 	GCSFuseAppNameArg                   = "app-name"
 	CustomEndpointConfigFileFlag        = "gcs-connection:custom-endpoint"
 	CustomEndpointCLIFlag               = "custom-endpoint"
+	EnableAutoGoMemLimitConst           = "enable-auto-gomemlimit"
+	AutoGoMemLimitRatioConst            = "auto-gomemlimit-ratio"
+	GoMemLimitCgroupPercentage          = 0.95
 )
 
 var (

--- a/vendor/github.com/KimMachineGun/automemlimit/LICENSE
+++ b/vendor/github.com/KimMachineGun/automemlimit/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Geon Kim
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/KimMachineGun/automemlimit/memlimit/cgroups.go
+++ b/vendor/github.com/KimMachineGun/automemlimit/memlimit/cgroups.go
@@ -1,0 +1,441 @@
+package memlimit
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+var (
+	// ErrNoCgroup is returned when the process is not in cgroup.
+	ErrNoCgroup = errors.New("process is not in cgroup")
+	// ErrCgroupsNotSupported is returned when the system does not support cgroups.
+	ErrCgroupsNotSupported = errors.New("cgroups is not supported on this system")
+)
+
+// fromCgroup retrieves the memory limit from the cgroup.
+// The versionDetector function is used to detect the cgroup version from the mountinfo.
+func fromCgroup(versionDetector func(mis []mountInfo) (bool, bool)) (uint64, error) {
+	mf, err := os.Open("/proc/self/mountinfo")
+	if err != nil {
+		return 0, fmt.Errorf("failed to open /proc/self/mountinfo: %w", err)
+	}
+	defer mf.Close()
+
+	mis, err := parseMountInfo(mf)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse mountinfo: %w", err)
+	}
+
+	v1, v2 := versionDetector(mis)
+	if !(v1 || v2) {
+		return 0, ErrNoCgroup
+	}
+
+	cf, err := os.Open("/proc/self/cgroup")
+	if err != nil {
+		return 0, fmt.Errorf("failed to open /proc/self/cgroup: %w", err)
+	}
+	defer cf.Close()
+
+	chs, err := parseCgroupFile(cf)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse cgroup file: %w", err)
+	}
+
+	if v2 {
+		limit, err := getMemoryLimitV2(chs, mis)
+		if err == nil {
+			return limit, nil
+		} else if !v1 {
+			return 0, err
+		}
+	}
+
+	return getMemoryLimitV1(chs, mis)
+}
+
+// detectCgroupVersion detects the cgroup version from the mountinfo.
+func detectCgroupVersion(mis []mountInfo) (bool, bool) {
+	var v1, v2 bool
+	for _, mi := range mis {
+		switch mi.FilesystemType {
+		case "cgroup":
+			v1 = true
+		case "cgroup2":
+			v2 = true
+		}
+	}
+	return v1, v2
+}
+
+// getMemoryLimitV2 retrieves the memory limit from the cgroup v2 controller.
+func getMemoryLimitV2(chs []cgroupHierarchy, mis []mountInfo) (uint64, error) {
+	// find the cgroup v2 path for the memory controller.
+	// in cgroup v2, the paths are unified and the controller list is empty.
+	idx := slices.IndexFunc(chs, func(ch cgroupHierarchy) bool {
+		return ch.HierarchyID == "0" && ch.ControllerList == ""
+	})
+	if idx == -1 {
+		return 0, errors.New("cgroup v2 path not found")
+	}
+	relPath := chs[idx].CgroupPath
+
+	// find the mountpoint for the cgroup v2 controller.
+	idx = slices.IndexFunc(mis, func(mi mountInfo) bool {
+		return mi.FilesystemType == "cgroup2"
+	})
+	if idx == -1 {
+		return 0, errors.New("cgroup v2 mountpoint not found")
+	}
+	root, mountPoint := mis[idx].Root, mis[idx].MountPoint
+
+	// resolve the actual cgroup path
+	cgroupPath, err := resolveCgroupPath(mountPoint, root, relPath)
+	if err != nil {
+		return 0, err
+	}
+
+	// retrieve the memory limit from the memory.max recursively.
+	return walkCgroupV2Hierarchy(cgroupPath, mountPoint)
+}
+
+// readMemoryLimitV2FromPath reads the memory limit for cgroup v2 from the given path.
+// this function expects the path to be memory.max file.
+func readMemoryLimitV2FromPath(path string) (uint64, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return 0, ErrNoLimit
+		}
+		return 0, fmt.Errorf("failed to read memory.max: %w", err)
+	}
+
+	slimit := strings.TrimSpace(string(b))
+	if slimit == "max" {
+		return 0, ErrNoLimit
+	}
+
+	limit, err := strconv.ParseUint(slimit, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse memory.max value: %w", err)
+	}
+
+	return limit, nil
+}
+
+// walkCgroupV2Hierarchy walks up the cgroup v2 hierarchy to find the most restrictive memory limit.
+func walkCgroupV2Hierarchy(cgroupPath, mountPoint string) (uint64, error) {
+	var (
+		found              = false
+		minLimit    uint64 = math.MaxUint64
+		currentPath        = cgroupPath
+	)
+	for {
+		limit, err := readMemoryLimitV2FromPath(filepath.Join(currentPath, "memory.max"))
+		if err != nil && !errors.Is(err, ErrNoLimit) {
+			return 0, err
+		} else if err == nil {
+			found = true
+			minLimit = min(minLimit, limit)
+		}
+
+		if currentPath == mountPoint {
+			break
+		}
+
+		parent := filepath.Dir(currentPath)
+		if parent == currentPath {
+			break
+		}
+		currentPath = parent
+	}
+	if !found {
+		return 0, ErrNoLimit
+	}
+
+	return minLimit, nil
+}
+
+// getMemoryLimitV1 retrieves the memory limit from the cgroup v1 controller.
+func getMemoryLimitV1(chs []cgroupHierarchy, mis []mountInfo) (uint64, error) {
+	// find the cgroup v1 path for the memory controller.
+	idx := slices.IndexFunc(chs, func(ch cgroupHierarchy) bool {
+		return slices.Contains(strings.Split(ch.ControllerList, ","), "memory")
+	})
+	if idx == -1 {
+		return 0, errors.New("cgroup v1 path for memory controller not found")
+	}
+	relPath := chs[idx].CgroupPath
+
+	// find the mountpoint for the cgroup v1 controller.
+	idx = slices.IndexFunc(mis, func(mi mountInfo) bool {
+		return mi.FilesystemType == "cgroup" && slices.Contains(strings.Split(mi.SuperOptions, ","), "memory")
+	})
+	if idx == -1 {
+		return 0, errors.New("cgroup v1 mountpoint for memory controller not found")
+	}
+	root, mountPoint := mis[idx].Root, mis[idx].MountPoint
+
+	// resolve the actual cgroup path
+	cgroupPath, err := resolveCgroupPath(mountPoint, root, relPath)
+	if err != nil {
+		return 0, err
+	}
+
+	// retrieve the memory limit from the memory.stat and memory.limit_in_bytes files.
+	return readMemoryLimitV1FromPath(cgroupPath)
+}
+
+// getCgroupV1NoLimit returns the maximum value that is used to represent no limit in cgroup v1.
+// the max memory limit is max int64, but it should be multiple of the page size.
+func getCgroupV1NoLimit() uint64 {
+	ps := uint64(os.Getpagesize())
+	return math.MaxInt64 / ps * ps
+}
+
+// readMemoryLimitV1FromPath reads the memory limit for cgroup v1 from the given path.
+// this function expects the path to be the cgroup directory.
+func readMemoryLimitV1FromPath(cgroupPath string) (uint64, error) {
+	// read hierarchical_memory_limit and memory.limit_in_bytes files.
+	// but if hierarchical_memory_limit is not available, then use the max value as a fallback.
+	hml, err := readHierarchicalMemoryLimit(filepath.Join(cgroupPath, "memory.stat"))
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return 0, fmt.Errorf("failed to read hierarchical_memory_limit: %w", err)
+	} else if hml == 0 {
+		hml = math.MaxUint64
+	}
+
+	// read memory.limit_in_bytes file.
+	b, err := os.ReadFile(filepath.Join(cgroupPath, "memory.limit_in_bytes"))
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return 0, fmt.Errorf("failed to read memory.limit_in_bytes: %w", err)
+	}
+	lib, err := strconv.ParseUint(strings.TrimSpace(string(b)), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse memory.limit_in_bytes value: %w", err)
+	} else if lib == 0 {
+		hml = math.MaxUint64
+	}
+
+	// use the minimum value between hierarchical_memory_limit and memory.limit_in_bytes.
+	// if the limit is the maximum value, then it is considered as no limit.
+	limit := min(hml, lib)
+	if limit >= getCgroupV1NoLimit() {
+		return 0, ErrNoLimit
+	}
+
+	return limit, nil
+}
+
+// readHierarchicalMemoryLimit extracts hierarchical_memory_limit from memory.stat.
+// this function expects the path to be memory.stat file.
+func readHierarchicalMemoryLimit(path string) (uint64, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return 0, err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		fields := strings.Split(line, " ")
+		if len(fields) < 2 {
+			return 0, fmt.Errorf("failed to parse memory.stat %q: not enough fields", line)
+		}
+
+		if fields[0] == "hierarchical_memory_limit" {
+			if len(fields) > 2 {
+				return 0, fmt.Errorf("failed to parse memory.stat %q: too many fields for hierarchical_memory_limit", line)
+			}
+			return strconv.ParseUint(fields[1], 10, 64)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return 0, err
+	}
+
+	return 0, nil
+}
+
+// https://www.man7.org/linux/man-pages/man5/proc_pid_mountinfo.5.html
+// 731 771 0:59 /sysrq-trigger /proc/sysrq-trigger ro,nosuid,nodev,noexec,relatime - proc proc rw
+//
+// 36 35 98:0 /mnt1 /mnt2 rw,noatime master:1 - ext3 /dev/root rw,errors=continue
+// (1)(2)(3)   (4)   (5)      (6)      (7)   (8) (9)   (10)         (11)
+//
+// (1)  mount ID: a unique ID for the mount (may be reused after umount(2)).
+// (2)  parent ID: the ID of the parent mount (or of self for the root of this mount namespace's mount tree).
+// (3)  major:minor: the value of st_dev for files on this filesystem (see stat(2)).
+// (4)  root: the pathname of the directory in the filesystem which forms the root of this mount.
+// (5)  mount point: the pathname of the mount point relative to the process's root directory.
+// (6)  mount options: per-mount options (see mount(2)).
+// (7)  optional fields: zero or more fields of the form "tag[:value]"; see below.
+// (8)  separator: the end of the optional fields is marked by a single hyphen.
+// (9)  filesystem type: the filesystem type in the form "type[.subtype]".
+// (10) mount source: filesystem-specific information or "none".
+// (11) super options: per-superblock options (see mount(2)).
+type mountInfo struct {
+	Root           string
+	MountPoint     string
+	FilesystemType string
+	SuperOptions   string
+}
+
+// parseMountInfoLine parses a line from the mountinfo file.
+func parseMountInfoLine(line string) (mountInfo, error) {
+	if line == "" {
+		return mountInfo{}, errors.New("empty line")
+	}
+
+	fieldss := strings.SplitN(line, " - ", 2)
+	if len(fieldss) != 2 {
+		return mountInfo{}, fmt.Errorf("invalid separator")
+	}
+
+	fields1 := strings.SplitN(fieldss[0], " ", 7)
+	if len(fields1) < 6 {
+		return mountInfo{}, fmt.Errorf("not enough fields before separator: %v", fields1)
+	} else if len(fields1) == 6 {
+		fields1 = append(fields1, "")
+	}
+
+	fields2 := strings.SplitN(fieldss[1], " ", 3)
+	if len(fields2) < 3 {
+		return mountInfo{}, fmt.Errorf("not enough fields after separator: %v", fields2)
+	}
+
+	return mountInfo{
+		Root:           fields1[3],
+		MountPoint:     fields1[4],
+		FilesystemType: fields2[0],
+		SuperOptions:   fields2[2],
+	}, nil
+}
+
+// parseMountInfo parses the mountinfo file.
+func parseMountInfo(r io.Reader) ([]mountInfo, error) {
+	var (
+		s   = bufio.NewScanner(r)
+		mis []mountInfo
+	)
+	for s.Scan() {
+		line := s.Text()
+
+		mi, err := parseMountInfoLine(line)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse mountinfo file %q: %w", line, err)
+		}
+
+		mis = append(mis, mi)
+	}
+	if err := s.Err(); err != nil {
+		return nil, err
+	}
+
+	return mis, nil
+}
+
+// https://www.man7.org/linux/man-pages/man7/cgroups.7.html
+//
+// 5:cpuacct,cpu,cpuset:/daemons
+// (1)       (2)           (3)
+//
+// (1) hierarchy ID:
+//
+//	cgroups version 1 hierarchies, this field
+//	contains a unique hierarchy ID number that can be
+//	matched to a hierarchy ID in /proc/cgroups.  For the
+//	cgroups version 2 hierarchy, this field contains the
+//	value 0.
+//
+// (2) controller list:
+//
+//	For cgroups version 1 hierarchies, this field
+//	contains a comma-separated list of the controllers
+//	bound to the hierarchy.  For the cgroups version 2
+//	hierarchy, this field is empty.
+//
+// (3) cgroup path:
+//
+//	This field contains the pathname of the control group
+//	in the hierarchy to which the process belongs.  This
+//	pathname is relative to the mount point of the
+//	hierarchy.
+type cgroupHierarchy struct {
+	HierarchyID    string
+	ControllerList string
+	CgroupPath     string
+}
+
+// parseCgroupHierarchyLine parses a line from the cgroup file.
+func parseCgroupHierarchyLine(line string) (cgroupHierarchy, error) {
+	if line == "" {
+		return cgroupHierarchy{}, errors.New("empty line")
+	}
+
+	fields := strings.Split(line, ":")
+	if len(fields) < 3 {
+		return cgroupHierarchy{}, fmt.Errorf("not enough fields: %v", fields)
+	} else if len(fields) > 3 {
+		return cgroupHierarchy{}, fmt.Errorf("too many fields: %v", fields)
+	}
+
+	return cgroupHierarchy{
+		HierarchyID:    fields[0],
+		ControllerList: fields[1],
+		CgroupPath:     fields[2],
+	}, nil
+}
+
+// parseCgroupFile parses the cgroup file.
+func parseCgroupFile(r io.Reader) ([]cgroupHierarchy, error) {
+	var (
+		s   = bufio.NewScanner(r)
+		chs []cgroupHierarchy
+	)
+	for s.Scan() {
+		line := s.Text()
+
+		ch, err := parseCgroupHierarchyLine(line)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse cgroup file %q: %w", line, err)
+		}
+
+		chs = append(chs, ch)
+	}
+	if err := s.Err(); err != nil {
+		return nil, err
+	}
+
+	return chs, nil
+}
+
+// resolveCgroupPath resolves the actual cgroup path from the mountpoint, root, and cgroupRelPath.
+func resolveCgroupPath(mountpoint, root, cgroupRelPath string) (string, error) {
+	rel, err := filepath.Rel(root, cgroupRelPath)
+	if err != nil {
+		return "", err
+	}
+
+	// if the relative path is ".", then the cgroupRelPath is the root itself.
+	if rel == "." {
+		return mountpoint, nil
+	}
+
+	// if the relative path starts with "..", then it is outside the root.
+	if strings.HasPrefix(rel, "..") {
+		return "", fmt.Errorf("invalid cgroup path: %s is not under root %s", cgroupRelPath, root)
+	}
+
+	return filepath.Join(mountpoint, rel), nil
+}

--- a/vendor/github.com/KimMachineGun/automemlimit/memlimit/cgroups_linux.go
+++ b/vendor/github.com/KimMachineGun/automemlimit/memlimit/cgroups_linux.go
@@ -1,0 +1,32 @@
+//go:build linux
+// +build linux
+
+package memlimit
+
+// FromCgroup retrieves the memory limit from the cgroup.
+func FromCgroup() (uint64, error) {
+	return fromCgroup(detectCgroupVersion)
+}
+
+// FromCgroupV1 retrieves the memory limit from the cgroup v1 controller.
+// After v1.0.0, this function could be removed and FromCgroup should be used instead.
+func FromCgroupV1() (uint64, error) {
+	return fromCgroup(func(_ []mountInfo) (bool, bool) {
+		return true, false
+	})
+}
+
+// FromCgroupHybrid retrieves the memory limit from the cgroup v2 and v1 controller sequentially,
+// basically, it is equivalent to FromCgroup.
+// After v1.0.0, this function could be removed and FromCgroup should be used instead.
+func FromCgroupHybrid() (uint64, error) {
+	return FromCgroup()
+}
+
+// FromCgroupV2 retrieves the memory limit from the cgroup v2 controller.
+// After v1.0.0, this function could be removed and FromCgroup should be used instead.
+func FromCgroupV2() (uint64, error) {
+	return fromCgroup(func(_ []mountInfo) (bool, bool) {
+		return false, true
+	})
+}

--- a/vendor/github.com/KimMachineGun/automemlimit/memlimit/cgroups_unsupported.go
+++ b/vendor/github.com/KimMachineGun/automemlimit/memlimit/cgroups_unsupported.go
@@ -1,0 +1,20 @@
+//go:build !linux
+// +build !linux
+
+package memlimit
+
+func FromCgroup() (uint64, error) {
+	return 0, ErrCgroupsNotSupported
+}
+
+func FromCgroupV1() (uint64, error) {
+	return 0, ErrCgroupsNotSupported
+}
+
+func FromCgroupHybrid() (uint64, error) {
+	return 0, ErrCgroupsNotSupported
+}
+
+func FromCgroupV2() (uint64, error) {
+	return 0, ErrCgroupsNotSupported
+}

--- a/vendor/github.com/KimMachineGun/automemlimit/memlimit/exp_system.go
+++ b/vendor/github.com/KimMachineGun/automemlimit/memlimit/exp_system.go
@@ -1,0 +1,14 @@
+package memlimit
+
+import (
+	"github.com/pbnjay/memory"
+)
+
+// FromSystem returns the total memory of the system.
+func FromSystem() (uint64, error) {
+	limit := memory.TotalMemory()
+	if limit == 0 {
+		return 0, ErrNoLimit
+	}
+	return limit, nil
+}

--- a/vendor/github.com/KimMachineGun/automemlimit/memlimit/experiment.go
+++ b/vendor/github.com/KimMachineGun/automemlimit/memlimit/experiment.go
@@ -1,0 +1,59 @@
+package memlimit
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"strings"
+)
+
+const (
+	envAUTOMEMLIMIT_EXPERIMENT = "AUTOMEMLIMIT_EXPERIMENT"
+)
+
+// Experiments is a set of experiment flags.
+// It is used to enable experimental features.
+//
+// You can set the flags by setting the environment variable AUTOMEMLIMIT_EXPERIMENT.
+// The value of the environment variable is a comma-separated list of experiment names.
+//
+// The following experiment names are known:
+//
+//   - none: disable all experiments
+//   - system: enable fallback to system memory limit
+type Experiments struct {
+	// System enables fallback to system memory limit.
+	System bool
+}
+
+func parseExperiments() (Experiments, error) {
+	var exp Experiments
+
+	// Create a map of known experiment names.
+	names := make(map[string]func(bool))
+	rv := reflect.ValueOf(&exp).Elem()
+	rt := rv.Type()
+	for i := 0; i < rt.NumField(); i++ {
+		field := rv.Field(i)
+		names[strings.ToLower(rt.Field(i).Name)] = field.SetBool
+	}
+
+	// Parse names.
+	for _, f := range strings.Split(os.Getenv(envAUTOMEMLIMIT_EXPERIMENT), ",") {
+		if f == "" {
+			continue
+		}
+		if f == "none" {
+			exp = Experiments{}
+			continue
+		}
+		val := true
+		set, ok := names[f]
+		if !ok {
+			return Experiments{}, fmt.Errorf("unknown AUTOMEMLIMIT_EXPERIMENT %s", f)
+		}
+		set(val)
+	}
+
+	return exp, nil
+}

--- a/vendor/github.com/KimMachineGun/automemlimit/memlimit/logger.go
+++ b/vendor/github.com/KimMachineGun/automemlimit/memlimit/logger.go
@@ -1,0 +1,13 @@
+package memlimit
+
+import (
+	"context"
+	"log/slog"
+)
+
+type noopLogger struct{}
+
+func (noopLogger) Enabled(context.Context, slog.Level) bool  { return false }
+func (noopLogger) Handle(context.Context, slog.Record) error { return nil }
+func (d noopLogger) WithAttrs([]slog.Attr) slog.Handler      { return d }
+func (d noopLogger) WithGroup(string) slog.Handler           { return d }

--- a/vendor/github.com/KimMachineGun/automemlimit/memlimit/memlimit.go
+++ b/vendor/github.com/KimMachineGun/automemlimit/memlimit/memlimit.go
@@ -1,0 +1,285 @@
+package memlimit
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"math"
+	"os"
+	"runtime/debug"
+	"strconv"
+	"time"
+)
+
+const (
+	envGOMEMLIMIT   = "GOMEMLIMIT"
+	envAUTOMEMLIMIT = "AUTOMEMLIMIT"
+	// Deprecated: use memlimit.WithLogger instead
+	envAUTOMEMLIMIT_DEBUG = "AUTOMEMLIMIT_DEBUG"
+
+	defaultAUTOMEMLIMIT = 0.9
+)
+
+// ErrNoLimit is returned when the memory limit is not set.
+var ErrNoLimit = errors.New("memory is not limited")
+
+type config struct {
+	logger   *slog.Logger
+	ratio    float64
+	provider Provider
+	refresh  time.Duration
+}
+
+// Option is a function that configures the behavior of SetGoMemLimitWithOptions.
+type Option func(cfg *config)
+
+// WithRatio configures the ratio of the memory limit to set as GOMEMLIMIT.
+//
+// Default: 0.9
+func WithRatio(ratio float64) Option {
+	return func(cfg *config) {
+		cfg.ratio = ratio
+	}
+}
+
+// WithProvider configures the provider.
+//
+// Default: FromCgroup
+func WithProvider(provider Provider) Option {
+	return func(cfg *config) {
+		cfg.provider = provider
+	}
+}
+
+// WithLogger configures the logger.
+// It automatically attaches the "package" attribute to the logs.
+//
+// Default: slog.New(noopLogger{})
+func WithLogger(logger *slog.Logger) Option {
+	return func(cfg *config) {
+		cfg.logger = memlimitLogger(logger)
+	}
+}
+
+// WithRefreshInterval configures the refresh interval for automemlimit.
+// If a refresh interval is greater than 0, automemlimit periodically fetches
+// the memory limit from the provider and reapplies it if it has changed.
+// If the provider returns an error, it logs the error and continues.
+// ErrNoLimit is treated as math.MaxInt64.
+//
+// Default: 0 (no refresh)
+func WithRefreshInterval(refresh time.Duration) Option {
+	return func(cfg *config) {
+		cfg.refresh = refresh
+	}
+}
+
+// WithEnv configures whether to use environment variables.
+//
+// Default: false
+//
+// Deprecated: currently this does nothing.
+func WithEnv() Option {
+	return func(cfg *config) {}
+}
+
+func memlimitLogger(logger *slog.Logger) *slog.Logger {
+	if logger == nil {
+		return slog.New(noopLogger{})
+	}
+	return logger.With(slog.String("package", "github.com/KimMachineGun/automemlimit/memlimit"))
+}
+
+// SetGoMemLimitWithOpts sets GOMEMLIMIT with options and environment variables.
+//
+// You can configure how much memory of the cgroup's memory limit to set as GOMEMLIMIT
+// through AUTOMEMLIMIT environment variable in the half-open range (0.0,1.0].
+//
+// If AUTOMEMLIMIT is not set, it defaults to 0.9. (10% is the headroom for memory sources the Go runtime is unaware of.)
+// If GOMEMLIMIT is already set or AUTOMEMLIMIT=off, this function does nothing.
+//
+// If AUTOMEMLIMIT_EXPERIMENT is set, it enables experimental features.
+// Please see the documentation of Experiments for more details.
+//
+// Options:
+//   - WithRatio
+//   - WithProvider
+//   - WithLogger
+func SetGoMemLimitWithOpts(opts ...Option) (_ int64, _err error) {
+	// init config
+	cfg := &config{
+		logger:   slog.New(noopLogger{}),
+		ratio:    defaultAUTOMEMLIMIT,
+		provider: FromCgroup,
+	}
+	// TODO: remove this
+	if debug, ok := os.LookupEnv(envAUTOMEMLIMIT_DEBUG); ok {
+		defaultLogger := memlimitLogger(slog.Default())
+		defaultLogger.Warn("AUTOMEMLIMIT_DEBUG is deprecated, use memlimit.WithLogger instead")
+		if debug == "true" {
+			cfg.logger = defaultLogger
+		}
+	}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	// log error if any on return
+	defer func() {
+		if _err != nil {
+			cfg.logger.Error("failed to set GOMEMLIMIT", slog.Any("error", _err))
+		}
+	}()
+
+	// parse experiments
+	exps, err := parseExperiments()
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse experiments: %w", err)
+	}
+	if exps.System {
+		cfg.logger.Info("system experiment is enabled: using system memory limit as a fallback")
+		cfg.provider = ApplyFallback(cfg.provider, FromSystem)
+	}
+
+	// rollback to previous memory limit on panic
+	snapshot := debug.SetMemoryLimit(-1)
+	defer rollbackOnPanic(cfg.logger, snapshot, &_err)
+
+	// check if GOMEMLIMIT is already set
+	if val, ok := os.LookupEnv(envGOMEMLIMIT); ok {
+		cfg.logger.Info("GOMEMLIMIT is already set, skipping", slog.String(envGOMEMLIMIT, val))
+		return 0, nil
+	}
+
+	// parse AUTOMEMLIMIT
+	ratio := cfg.ratio
+	if val, ok := os.LookupEnv(envAUTOMEMLIMIT); ok {
+		if val == "off" {
+			cfg.logger.Info("AUTOMEMLIMIT is set to off, skipping")
+			return 0, nil
+		}
+		ratio, err = strconv.ParseFloat(val, 64)
+		if err != nil {
+			return 0, fmt.Errorf("cannot parse AUTOMEMLIMIT: %s", val)
+		}
+	}
+
+	// apply ratio to the provider
+	provider := capProvider(ApplyRatio(cfg.provider, ratio))
+
+	// set the memory limit and start refresh
+	limit, err := updateGoMemLimit(uint64(snapshot), provider, cfg.logger)
+	refresh(provider, cfg.logger, cfg.refresh)
+	if err != nil {
+		if errors.Is(err, ErrNoLimit) {
+			cfg.logger.Info("memory is not limited, skipping")
+			// TODO: consider returning the snapshot
+			return 0, nil
+		}
+		return 0, fmt.Errorf("failed to set GOMEMLIMIT: %w", err)
+	}
+
+	return int64(limit), nil
+}
+
+// updateGoMemLimit updates the Go's memory limit, if it has changed.
+func updateGoMemLimit(currLimit uint64, provider Provider, logger *slog.Logger) (uint64, error) {
+	newLimit, err := provider()
+	if err != nil {
+		return 0, err
+	}
+
+	if newLimit == currLimit {
+		logger.Debug("GOMEMLIMIT is not changed, skipping", slog.Uint64(envGOMEMLIMIT, newLimit))
+		return newLimit, nil
+	}
+
+	debug.SetMemoryLimit(int64(newLimit))
+	logger.Info("GOMEMLIMIT is updated", slog.Uint64(envGOMEMLIMIT, newLimit), slog.Uint64("previous", currLimit))
+
+	return newLimit, nil
+}
+
+// refresh spawns a goroutine that runs every refresh duration and updates the GOMEMLIMIT if it has changed.
+// See more details in the documentation of WithRefreshInterval.
+func refresh(provider Provider, logger *slog.Logger, refresh time.Duration) {
+	if refresh == 0 {
+		return
+	}
+
+	provider = noErrNoLimitProvider(provider)
+
+	t := time.NewTicker(refresh)
+	go func() {
+		for range t.C {
+			err := func() (_err error) {
+				snapshot := debug.SetMemoryLimit(-1)
+				defer rollbackOnPanic(logger, snapshot, &_err)
+
+				_, err := updateGoMemLimit(uint64(snapshot), provider, logger)
+				if err != nil {
+					return err
+				}
+
+				return nil
+			}()
+			if err != nil {
+				logger.Error("failed to refresh GOMEMLIMIT", slog.Any("error", err))
+			}
+		}
+	}()
+}
+
+// rollbackOnPanic rollbacks to the snapshot on panic.
+// Since it uses recover, it should be called in a deferred function.
+func rollbackOnPanic(logger *slog.Logger, snapshot int64, err *error) {
+	panicErr := recover()
+	if panicErr != nil {
+		if *err != nil {
+			logger.Error("failed to set GOMEMLIMIT", slog.Any("error", *err))
+		}
+		*err = fmt.Errorf("panic during setting the Go's memory limit, rolling back to previous limit %d: %v",
+			snapshot, panicErr,
+		)
+		debug.SetMemoryLimit(snapshot)
+	}
+}
+
+// SetGoMemLimitWithEnv sets GOMEMLIMIT with the value from the environment variables.
+// Since WithEnv is deprecated, this function is equivalent to SetGoMemLimitWithOpts().
+// Deprecated: use SetGoMemLimitWithOpts instead.
+func SetGoMemLimitWithEnv() {
+	_, _ = SetGoMemLimitWithOpts()
+}
+
+// SetGoMemLimit sets GOMEMLIMIT with the value from the cgroup's memory limit and given ratio.
+func SetGoMemLimit(ratio float64) (int64, error) {
+	return SetGoMemLimitWithOpts(WithRatio(ratio))
+}
+
+// SetGoMemLimitWithProvider sets GOMEMLIMIT with the value from the given provider and ratio.
+func SetGoMemLimitWithProvider(provider Provider, ratio float64) (int64, error) {
+	return SetGoMemLimitWithOpts(WithProvider(provider), WithRatio(ratio))
+}
+
+func noErrNoLimitProvider(provider Provider) Provider {
+	return func() (uint64, error) {
+		limit, err := provider()
+		if errors.Is(err, ErrNoLimit) {
+			return math.MaxInt64, nil
+		}
+		return limit, err
+	}
+}
+
+func capProvider(provider Provider) Provider {
+	return func() (uint64, error) {
+		limit, err := provider()
+		if err != nil {
+			return 0, err
+		} else if limit > math.MaxInt64 {
+			return math.MaxInt64, nil
+		}
+		return limit, nil
+	}
+}

--- a/vendor/github.com/KimMachineGun/automemlimit/memlimit/provider.go
+++ b/vendor/github.com/KimMachineGun/automemlimit/memlimit/provider.go
@@ -1,0 +1,43 @@
+package memlimit
+
+import (
+	"fmt"
+)
+
+// Provider is a function that returns the memory limit.
+type Provider func() (uint64, error)
+
+// Limit is a helper Provider function that returns the given limit.
+func Limit(limit uint64) func() (uint64, error) {
+	return func() (uint64, error) {
+		return limit, nil
+	}
+}
+
+// ApplyRationA is a helper Provider function that applies the given ratio to the given provider.
+func ApplyRatio(provider Provider, ratio float64) Provider {
+	if ratio == 1 {
+		return provider
+	}
+	return func() (uint64, error) {
+		if ratio <= 0 || ratio > 1 {
+			return 0, fmt.Errorf("invalid ratio: %f, ratio should be in the range (0.0,1.0]", ratio)
+		}
+		limit, err := provider()
+		if err != nil {
+			return 0, err
+		}
+		return uint64(float64(limit) * ratio), nil
+	}
+}
+
+// ApplyFallback is a helper Provider function that sets the fallback provider.
+func ApplyFallback(provider Provider, fallback Provider) Provider {
+	return func() (uint64, error) {
+		limit, err := provider()
+		if err != nil {
+			return fallback()
+		}
+		return limit, nil
+	}
+}

--- a/vendor/github.com/pbnjay/memory/LICENSE
+++ b/vendor/github.com/pbnjay/memory/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2017, Jeremy Jay
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/pbnjay/memory/README.md
+++ b/vendor/github.com/pbnjay/memory/README.md
@@ -1,0 +1,41 @@
+# memory
+
+Package `memory` provides two methods reporting total physical system memory
+accessible to the kernel, and free memory available to the running application.
+
+This package has no external dependency besides the standard library and default operating system tools.
+
+Documentation:
+[![GoDoc](https://godoc.org/github.com/pbnjay/memory?status.svg)](https://godoc.org/github.com/pbnjay/memory)
+
+This is useful for dynamic code to minimize thrashing and other contention, similar to the stdlib `runtime.NumCPU`
+See some history of the proposal at https://github.com/golang/go/issues/21816
+
+
+## Example
+
+```go
+fmt.Printf("Total system memory: %d\n", memory.TotalMemory())
+fmt.Printf("Free memory: %d\n", memory.FreeMemory())
+```
+
+
+## Testing
+
+Tested/working on:
+ - macOS 10.12.6 (16G29), 10.15.7 (19H2)
+ - Windows 10 1511 (10586.1045)
+ - Linux RHEL (3.10.0-327.3.1.el7.x86_64)
+ - Raspberry Pi 3 (ARMv8) on Raspbian, ODROID-C1+ (ARMv7) on Ubuntu, C.H.I.P
+   (ARMv7).
+ - Amazon Linux 2 aarch64 (m6a.large, 4.14.203-156.332.amzn2.aarch64)
+
+Tested on virtual machines:
+ - Windows 7 SP1 386
+ - Debian stretch 386
+ - NetBSD 7.1 amd64 + 386
+ - OpenBSD 6.1 amd64 + 386
+ - FreeBSD 11.1 amd64 + 386
+ - DragonFly BSD 4.8.1 amd64
+
+If you have access to untested systems please test and report success/bugs.

--- a/vendor/github.com/pbnjay/memory/doc.go
+++ b/vendor/github.com/pbnjay/memory/doc.go
@@ -1,0 +1,24 @@
+// Package memory provides a single method reporting total system memory
+// accessible to the kernel.
+package memory
+
+// TotalMemory returns the total accessible system memory in bytes.
+//
+// The total accessible memory is installed physical memory size minus reserved
+// areas for the kernel and hardware, if such reservations are reported by
+// the operating system.
+//
+// If accessible memory size could not be determined, then 0 is returned.
+func TotalMemory() uint64 {
+	return sysTotalMemory()
+}
+
+// FreeMemory returns the total free system memory in bytes.
+//
+// The total free memory is installed physical memory size minus reserved
+// areas for other applications running on the same system.
+//
+// If free memory size could not be determined, then 0 is returned.
+func FreeMemory() uint64 {
+	return sysFreeMemory()
+}

--- a/vendor/github.com/pbnjay/memory/memory_bsd.go
+++ b/vendor/github.com/pbnjay/memory/memory_bsd.go
@@ -1,0 +1,19 @@
+// +build freebsd openbsd dragonfly netbsd
+
+package memory
+
+func sysTotalMemory() uint64 {
+	s, err := sysctlUint64("hw.physmem")
+	if err != nil {
+		return 0
+	}
+	return s
+}
+
+func sysFreeMemory() uint64 {
+	s, err := sysctlUint64("hw.usermem")
+	if err != nil {
+		return 0
+	}
+	return s
+}

--- a/vendor/github.com/pbnjay/memory/memory_darwin.go
+++ b/vendor/github.com/pbnjay/memory/memory_darwin.go
@@ -1,0 +1,49 @@
+// +build darwin
+
+package memory
+
+import (
+	"os/exec"
+	"regexp"
+	"strconv"
+)
+
+func sysTotalMemory() uint64 {
+	s, err := sysctlUint64("hw.memsize")
+	if err != nil {
+		return 0
+	}
+	return s
+}
+
+func sysFreeMemory() uint64 {
+	cmd := exec.Command("vm_stat")
+	outBytes, err := cmd.Output()
+	if err != nil {
+		return 0
+	}
+
+	rePageSize := regexp.MustCompile("page size of ([0-9]*) bytes")
+	reFreePages := regexp.MustCompile("Pages free: *([0-9]*)\\.")
+
+	// default: page size of 4096 bytes
+	matches := rePageSize.FindSubmatchIndex(outBytes)
+	pageSize := uint64(4096)
+	if len(matches) == 4 {
+		pageSize, err = strconv.ParseUint(string(outBytes[matches[2]:matches[3]]), 10, 64)
+		if err != nil {
+			return 0
+		}
+	}
+
+	// ex: Pages free:                             1126961.
+	matches = reFreePages.FindSubmatchIndex(outBytes)
+	freePages := uint64(0)
+	if len(matches) == 4 {
+		freePages, err = strconv.ParseUint(string(outBytes[matches[2]:matches[3]]), 10, 64)
+		if err != nil {
+			return 0
+		}
+	}
+	return freePages * pageSize
+}

--- a/vendor/github.com/pbnjay/memory/memory_linux.go
+++ b/vendor/github.com/pbnjay/memory/memory_linux.go
@@ -1,0 +1,29 @@
+// +build linux
+
+package memory
+
+import "syscall"
+
+func sysTotalMemory() uint64 {
+	in := &syscall.Sysinfo_t{}
+	err := syscall.Sysinfo(in)
+	if err != nil {
+		return 0
+	}
+	// If this is a 32-bit system, then these fields are
+	// uint32 instead of uint64.
+	// So we always convert to uint64 to match signature.
+	return uint64(in.Totalram) * uint64(in.Unit)
+}
+
+func sysFreeMemory() uint64 {
+	in := &syscall.Sysinfo_t{}
+	err := syscall.Sysinfo(in)
+	if err != nil {
+		return 0
+	}
+	// If this is a 32-bit system, then these fields are
+	// uint32 instead of uint64.
+	// So we always convert to uint64 to match signature.
+	return uint64(in.Freeram) * uint64(in.Unit)
+}

--- a/vendor/github.com/pbnjay/memory/memory_windows.go
+++ b/vendor/github.com/pbnjay/memory/memory_windows.go
@@ -1,0 +1,60 @@
+// +build windows
+
+package memory
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+// omitting a few fields for brevity...
+// https://msdn.microsoft.com/en-us/library/windows/desktop/aa366589(v=vs.85).aspx
+type memStatusEx struct {
+	dwLength     uint32
+	dwMemoryLoad uint32
+	ullTotalPhys uint64
+	ullAvailPhys uint64
+	unused       [5]uint64
+}
+
+func sysTotalMemory() uint64 {
+	kernel32, err := syscall.LoadDLL("kernel32.dll")
+	if err != nil {
+		return 0
+	}
+	// GetPhysicallyInstalledSystemMemory is simpler, but broken on
+	// older versions of windows (and uses this under the hood anyway).
+	globalMemoryStatusEx, err := kernel32.FindProc("GlobalMemoryStatusEx")
+	if err != nil {
+		return 0
+	}
+	msx := &memStatusEx{
+		dwLength: 64,
+	}
+	r, _, _ := globalMemoryStatusEx.Call(uintptr(unsafe.Pointer(msx)))
+	if r == 0 {
+		return 0
+	}
+	return msx.ullTotalPhys
+}
+
+func sysFreeMemory() uint64 {
+	kernel32, err := syscall.LoadDLL("kernel32.dll")
+	if err != nil {
+		return 0
+	}
+	// GetPhysicallyInstalledSystemMemory is simpler, but broken on
+	// older versions of windows (and uses this under the hood anyway).
+	globalMemoryStatusEx, err := kernel32.FindProc("GlobalMemoryStatusEx")
+	if err != nil {
+		return 0
+	}
+	msx := &memStatusEx{
+		dwLength: 64,
+	}
+	r, _, _ := globalMemoryStatusEx.Call(uintptr(unsafe.Pointer(msx)))
+	if r == 0 {
+		return 0
+	}
+	return msx.ullAvailPhys
+}

--- a/vendor/github.com/pbnjay/memory/memsysctl.go
+++ b/vendor/github.com/pbnjay/memory/memsysctl.go
@@ -1,0 +1,21 @@
+// +build darwin freebsd openbsd dragonfly netbsd
+
+package memory
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+func sysctlUint64(name string) (uint64, error) {
+	s, err := syscall.Sysctl(name)
+	if err != nil {
+		return 0, err
+	}
+	// hack because the string conversion above drops a \0
+	b := []byte(s)
+	if len(b) < 8 {
+		b = append(b, 0)
+	}
+	return *(*uint64)(unsafe.Pointer(&b[0])), nil
+}

--- a/vendor/github.com/pbnjay/memory/stub.go
+++ b/vendor/github.com/pbnjay/memory/stub.go
@@ -1,0 +1,10 @@
+// +build !linux,!darwin,!windows,!freebsd,!dragonfly,!netbsd,!openbsd
+
+package memory
+
+func sysTotalMemory() uint64 {
+	return 0
+}
+func sysFreeMemory() uint64 {
+	return 0
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -71,6 +71,9 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric
 # github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.53.0
 ## explicit; go 1.23.0
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping
+# github.com/KimMachineGun/automemlimit v0.7.5
+## explicit; go 1.22.0
+github.com/KimMachineGun/automemlimit/memlimit
 # github.com/antlr4-go/antlr/v4 v4.13.0
 ## explicit; go 1.20
 github.com/antlr4-go/antlr/v4
@@ -320,6 +323,9 @@ github.com/munnerz/goautoneg
 # github.com/opencontainers/go-digest v1.0.0
 ## explicit; go 1.13
 github.com/opencontainers/go-digest
+# github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
+## explicit; go 1.16
+github.com/pbnjay/memory
 # github.com/pkg/errors v0.9.1
 ## explicit
 github.com/pkg/errors


### PR DESCRIPTION
Cherry pick of #1364 on release-1.23.

#1364: Set GOMEMLIMIT  to be 95% of whatever the c group memory limit is

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Set GOMEMLIMIT  to be 95% of whatever the c group memory limit is for gcsfusecsi driver (node and controller), sidecar, webhook, and prefetch container to prompt the go garbage collector to run more frequently to keep the peak memory within the limit during traffic spikes to prevent OOMs. 
```