### PR TITLE
Fix unit tests failing

### DIFF
--- a/pkg/sidecar_mounter/sidecar_mounter_config_test.go
+++ b/pkg/sidecar_mounter/sidecar_mounter_config_test.go
@@ -61,7 +61,7 @@ var (
 )
 
 func TestPrepareMountArgs(t *testing.T) {
-	t.Parallel()
+	// Do not parallelize [e.g t.Parallel()] because all testcases share testPrometheusPort.
 
 	testCases := []struct {
 		name                   string
@@ -550,7 +550,6 @@ func TestPrepareMountArgs(t *testing.T) {
 	testPrometheusPort := prometheusPort
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Do not parallelize [e.g t.Parallel()] because all testcases share testPrometheusPort.
 			found := slices.Contains(tc.mc.Options, util.DisableMetricsForGKE+":true")
 			if !found {
 				tc.expectedArgs["prometheus-port"] = strconv.Itoa(testPrometheusPort)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
There was a comment here warning us to not parallelize the test, but at the same time, the test was also parallelized. I don't know why it just started failing recently, I suspect that it's because some new unit test finally introduced the scenario where the parallelization makes the prometheus test port verification fail

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```