### PR TITLE
Modify webhook logic to support native prefetch

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -42,24 +42,26 @@ import (
 )
 
 var (
-	port                                    = flag.Int("port", 443, "The port that the webhook server serves at.")
-	healthProbeBindAddress                  = flag.String("health-probe-bind-address", ":8080", "The TCP address that the controller should bind to for serving health probes.")
-	certDir                                 = flag.String("cert-dir", "/etc/tls-certs", "The directory that contains the server key and certificate.")
-	certName                                = flag.String("cert-name", "cert.pem", "The server certificate name.")
-	keyName                                 = flag.String("key-name", "key.pem", "The server key name.")
-	imagePullPolicy                         = flag.String("sidecar-image-pull-policy", "IfNotPresent", "The default image pull policy for gcsfuse sidecar container.")
-	cpuRequest                              = flag.String("sidecar-cpu-request", "250m", "The default CPU request for gcsfuse sidecar container.")
-	cpuLimit                                = flag.String("sidecar-cpu-limit", "250m", "The default CPU limit for gcsfuse sidecar container.")
-	memoryRequest                           = flag.String("sidecar-memory-request", "256Mi", "The default memory request for gcsfuse sidecar container.")
-	memoryLimit                             = flag.String("sidecar-memory-limit", "256Mi", "The default memory limit for gcsfuse sidecar container.")
-	ephemeralStorageRequest                 = flag.String("sidecar-ephemeral-storage-request", "5Gi", "The default ephemeral storage request for gcsfuse sidecar container.")
-	ephemeralStorageLimit                   = flag.String("sidecar-ephemeral-storage-limit", "5Gi", "The default ephemeral storage limit for gcsfuse sidecar container.")
-	sidecarImage                            = flag.String("sidecar-image", "", "The gcsfuse sidecar container image.")
-	metadataSidecarImage                    = flag.String("metadata-sidecar-image", "", "The metadata prefetch sidecar container image.")
-	injectSAVol                             = flag.Bool("should-inject-sa-vol", false, "Inject projected service account volume when true")
-	enableGcsfuseProfiles                   = flag.Bool("enable-gcsfuse-profiles", false, "Enable gcsfuse profiles when true")
-	enableAutoGoMemLimit                    = flag.Bool("enable-auto-gomemlimit", false, "Automatically set GOMEMLIMIT to a percentage of the container's cgroup memory limit.")
-	autoGoMemLimitRatio                     = flag.Float64("auto-gomemlimit-ratio", util.GoMemLimitCgroupPercentage, "The ratio of the container's cgroup memory limit to set as GOMEMLIMIT when enable-auto-gomemlimit is enabled.")
+	port                          = flag.Int("port", 443, "The port that the webhook server serves at.")
+	healthProbeBindAddress        = flag.String("health-probe-bind-address", ":8080", "The TCP address that the controller should bind to for serving health probes.")
+	certDir                       = flag.String("cert-dir", "/etc/tls-certs", "The directory that contains the server key and certificate.")
+	certName                      = flag.String("cert-name", "cert.pem", "The server certificate name.")
+	keyName                       = flag.String("key-name", "key.pem", "The server key name.")
+	imagePullPolicy               = flag.String("sidecar-image-pull-policy", "IfNotPresent", "The default image pull policy for gcsfuse sidecar container.")
+	cpuRequest                    = flag.String("sidecar-cpu-request", "250m", "The default CPU request for gcsfuse sidecar container.")
+	cpuLimit                      = flag.String("sidecar-cpu-limit", "250m", "The default CPU limit for gcsfuse sidecar container.")
+	memoryRequest                 = flag.String("sidecar-memory-request", "256Mi", "The default memory request for gcsfuse sidecar container.")
+	memoryLimit                   = flag.String("sidecar-memory-limit", "256Mi", "The default memory limit for gcsfuse sidecar container.")
+	ephemeralStorageRequest       = flag.String("sidecar-ephemeral-storage-request", "5Gi", "The default ephemeral storage request for gcsfuse sidecar container.")
+	ephemeralStorageLimit         = flag.String("sidecar-ephemeral-storage-limit", "5Gi", "The default ephemeral storage limit for gcsfuse sidecar container.")
+	sidecarImage                  = flag.String("sidecar-image", "", "The gcsfuse sidecar container image.")
+	metadataSidecarImage          = flag.String("metadata-sidecar-image", "", "The metadata prefetch sidecar container image.")
+	injectSAVol                   = flag.Bool("should-inject-sa-vol", false, "Inject projected service account volume when true")
+	enableGcsfuseProfiles         = flag.Bool("enable-gcsfuse-profiles", false, "Enable gcsfuse profiles when true")
+	enableAutoGoMemLimit          = flag.Bool("enable-auto-gomemlimit", false, "Automatically set GOMEMLIMIT to a percentage of the container's cgroup memory limit.")
+	autoGoMemLimitRatio           = flag.Float64("auto-gomemlimit-ratio", util.GoMemLimitCgroupPercentage, "The ratio of the container's cgroup memory limit to set as GOMEMLIMIT when enable-auto-gomemlimit is enabled.")
+	enableGCSFuseMetadataPrefetch = flag.Bool("enable-gcsfuse-metadata-prefetch", false, "Enable native GCSFuse metadata prefetch")
+
 	metadataMemoryRequest                   = flag.String("metadata-sidecar-memory-request", "10Mi", "Flag to use default value for gcsfuse memory prefetch sidecar container memory request.")
 	metadataMemoryLimit                     = flag.String("metadata-sidecar-memory-limit", "10Mi", "Flag to use default value for gcsfuse memory prefetch sidecar container memory limit.")
 	metadataPrefetchCPURequest              = flag.String("metadata-sidecar-cpu-request", "10m", "The default cpu request for gcsfuse memory prefetch sidecar container cpu request.")
@@ -177,16 +179,17 @@ func main() {
 	klog.Info("Registering webhooks to the webhook server.")
 	hookServer.Register("/inject", &webhook.Admission{
 		Handler: &wh.SidecarInjector{
-			Client:                 mgr.GetClient(),
-			Config:                 fuseSideCarConfig,
-			MetadataPrefetchConfig: metadataPrefetchSideCarConfig,
-			Decoder:                admission.NewDecoder(runtime.NewScheme()),
-			NodeLister:             nodeLister,
-			PvLister:               pvLister,
-			PvcLister:              pvcLister,
-			ScLister:               scLister,
-			ServerVersion:          serverVersion,
-			K8SClient:              client,
+			Client:                        mgr.GetClient(),
+			Config:                        fuseSideCarConfig,
+			MetadataPrefetchConfig:        metadataPrefetchSideCarConfig,
+			Decoder:                       admission.NewDecoder(runtime.NewScheme()),
+			NodeLister:                    nodeLister,
+			PvLister:                      pvLister,
+			PvcLister:                     pvcLister,
+			ScLister:                      scLister,
+			ServerVersion:                 serverVersion,
+			K8SClient:                     client,
+			EnableGCSFuseMetadataPrefetch: *enableGCSFuseMetadataPrefetch,
 		},
 	})
 

--- a/deploy/base/webhook/deployment.yaml
+++ b/deploy/base/webhook/deployment.yaml
@@ -63,6 +63,7 @@ spec:
             - --enable-gcsfuse-profiles=true
             - --enable-auto-gomemlimit=true
             - --auto-gomemlimit-ratio=0.95
+            - --enable-gcsfuse-metadata-prefetch=false
           env:
             - name: SIDECAR_IMAGE_PULL_POLICY
               value: "IfNotPresent"

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	golang.org/x/oauth2 v0.34.0
 	golang.org/x/sys v0.40.0
 	golang.org/x/time v0.12.0
+	gomodules.xyz/jsonpatch/v2 v2.4.0
 	google.golang.org/api v0.247.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20251202230838-ff82c1b0f217
 	google.golang.org/grpc v1.79.3
@@ -117,7 +118,6 @@ require (
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/term v0.38.0 // indirect
 	golang.org/x/text v0.32.0 // indirect
-	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20250603155806-513f23925822 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -356,7 +356,7 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 	}
 
 	// Unlike other features, we'll assume multi NIC can be used unless we know for certain we have a version mismatch.
-	canUseMultiNIC := !isManagedSidecarImage(gcsFuseSidecarImage) || s.driver.isSidecarVersionSupportedForGivenFeature(gcsFuseSidecarImage, MultiNICMinVersion)
+	canUseMultiNIC := !util.IsManagedSidecarImage(gcsFuseSidecarImage) || s.driver.isSidecarVersionSupportedForGivenFeature(gcsFuseSidecarImage, MultiNICMinVersion)
 	if err := s.setupMultiNIC(&args, pod, canUseMultiNIC); err != nil {
 		return nil, err
 	}

--- a/pkg/csi_driver/utils.go
+++ b/pkg/csi_driver/utils.go
@@ -93,10 +93,6 @@ const (
 )
 
 var (
-	managedSidecarPatternAR  = `.*/gke-release(-staging)?/gcs-fuse-csi-driver-sidecar-mounter:v\d+\.\d+\.\d+-gke\.\d+\.*`
-	managedSidecarRegexAR    = regexp.MustCompile(managedSidecarPatternAR)
-	managedSidecarPatternGCR = `^(gke|staging-gke|master-gke)\.gcr\.io/gcs-fuse-csi-driver-sidecar-mounter:v\d+\.\d+\.\d+-gke\.\d+.*`
-	managedSidecarRegexGCR   = regexp.MustCompile(managedSidecarPatternGCR)
 	// Regex to detect deprecated flag error messages from gcsfuse. Should match the flags using .MarkDeprecated() in https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/cfg/config.go
 	deprecatedFlagPatterns = regexp.MustCompile(`Flag .*? has been deprecated`)
 	// Regex to detect invalid argument error messages from gcsfuse. Should match the flags using InvalidValueError in https://github.com/spf13/pflag/blob/b85eb9e15911a41cd7c05d955503542e9befadf4/errors.go#L116,
@@ -606,10 +602,6 @@ func getSidecarContainerStatus(isInitContainer bool, pod *corev1.Pod) (*corev1.C
 	return nil, errors.New("the sidecar container was not found")
 }
 
-func isManagedSidecarImage(imageName string) bool {
-	return managedSidecarRegexAR.MatchString(imageName) || managedSidecarRegexGCR.MatchString(imageName)
-}
-
 func (d *GCSDriver) isSidecarVersionSupportedForGivenFeature(imageName string, sidecarMinSupportedVersion string) bool {
 	if imageName == "" {
 		return false
@@ -627,7 +619,7 @@ func (d *GCSDriver) isSidecarVersionSupportedForGivenFeature(imageName string, s
 		return true
 	}
 
-	if !isManagedSidecarImage(imageName) {
+	if !util.IsManagedSidecarImage(imageName) {
 		klog.Warningf("sidecarMinSupportedVersion check skipped since this %q is not a GKE managed image", imageName)
 		return false
 	}

--- a/pkg/sidecar_mounter/sidecar_mounter_config.go
+++ b/pkg/sidecar_mounter/sidecar_mounter_config.go
@@ -72,6 +72,8 @@ type MountConfig struct {
 	CustomEndpoint                 string                `json:"-"`
 	EnableAutoGoMemLimit           bool                  `json:"-"`
 	AutoGoMemLimitRatio            float64               `json:"-"`
+	WebhookHandledPrefetch         bool                  `json:"-"`
+	PrefetchRequested              bool                  `json:"-"`
 }
 
 // sidecarRetryConfig controls the retry configurations for sidecarRetry behivior for storage service creation and bucket access check.
@@ -119,13 +121,15 @@ func NewMountConfig(sp string, flagMapFromDriver map[string]string) *MountConfig
 	tempDir := filepath.Dir(sp)
 	volumeName := filepath.Base(tempDir)
 	mc := MountConfig{
-		VolumeName:          volumeName,
-		BufferDir:           filepath.Join(webhook.SidecarContainerBufferVolumeMountPath, ".volumes", volumeName),
-		CacheDir:            filepath.Join(webhook.SidecarContainerCacheVolumeMountPath, ".volumes", volumeName),
-		TempDir:             tempDir,
-		ConfigFile:          filepath.Join(webhook.SidecarContainerTmpVolumeMountPath, ".volumes", volumeName, "config.yaml"),
-		ErrWriter:           NewErrorWriter(filepath.Join(tempDir, "error")),
-		AutoGoMemLimitRatio: util.GoMemLimitCgroupPercentage,
+		VolumeName:             volumeName,
+		BufferDir:              filepath.Join(webhook.SidecarContainerBufferVolumeMountPath, ".volumes", volumeName),
+		CacheDir:               filepath.Join(webhook.SidecarContainerCacheVolumeMountPath, ".volumes", volumeName),
+		TempDir:                tempDir,
+		ConfigFile:             filepath.Join(webhook.SidecarContainerTmpVolumeMountPath, ".volumes", volumeName, "config.yaml"),
+		ErrWriter:              NewErrorWriter(filepath.Join(tempDir, "error")),
+		AutoGoMemLimitRatio:    util.GoMemLimitCgroupPercentage,
+		WebhookHandledPrefetch: os.Getenv(util.WebhookHandledPrefetchEnvVar) == "true",
+		PrefetchRequested:      os.Getenv(util.PrefetchRequestedEnvVar) == "true",
 	}
 
 	klog.Infof("connecting to socket %q", sp)
@@ -210,6 +214,16 @@ func (mc *MountConfig) prepareMountArgs() {
 	}
 
 	mc.GcsFuseNumaNode = -1
+
+	// WebhookHandledPrefetch is false when an older webhook injects the legacy prefetch
+	// container. To prevent the double execution of the legacy prefetch container and the
+	// GCSFuse native prefetch when version skew issues happen (older webhook + newer sidecar),
+	// disable native prefetch here.
+	if !mc.WebhookHandledPrefetch && mc.PrefetchRequested {
+		klog.Infof("Legacy prefetch is used, disable native prefetch in GCSFuse to prevent double execution.")
+		mc.Options = append(mc.Options, "metadata-cache:enable-metadata-prefetch:false")
+	}
+
 	for _, arg := range mc.Options {
 		klog.Infof("processing mount arg %v", arg)
 

--- a/pkg/sidecar_mounter/sidecar_mounter_config_test.go
+++ b/pkg/sidecar_mounter/sidecar_mounter_config_test.go
@@ -858,3 +858,54 @@ func TestPrepareMountArgs_AutoGoMemLimit(t *testing.T) {
 		})
 	}
 }
+
+func TestPrepareMountArgs_MetadataPrefetch(t *testing.T) {
+	testCases := []struct {
+		name                   string
+		webhookHandledPrefetch bool
+		prefetchRequested      bool
+		expectedConfigMapArgs  map[string]string
+	}{
+		{
+			name:              "WebhookHandledPrefetch=false, PrefetchRequested=true -> force disable",
+			prefetchRequested: true,
+			expectedConfigMapArgs: map[string]string{
+				"logging:file-path": "/dev/fd/1",
+				"logging:format":    "json",
+				"cache-dir":         "",
+				"metadata-cache:enable-metadata-prefetch": "false",
+			},
+		},
+		{
+			name:                  "WebhookHandledPrefetch=false, PrefetchRequested=false -> no force disable",
+			expectedConfigMapArgs: defaultConfigFileFlagMap,
+		},
+		{
+			name:                   "WebhookHandledPrefetch=true, PrefetchRequested=true -> no force disable",
+			webhookHandledPrefetch: true,
+			prefetchRequested:      true,
+			expectedConfigMapArgs:  defaultConfigFileFlagMap,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mc := &MountConfig{
+				BucketName:             "test-bucket",
+				BufferDir:              "test-buffer-dir",
+				CacheDir:               "test-cache-dir",
+				ConfigFile:             "test-config-file",
+				WebhookHandledPrefetch: tc.webhookHandledPrefetch,
+				PrefetchRequested:      tc.prefetchRequested,
+			}
+
+			mc.prepareMountArgs()
+
+			for k, v := range tc.expectedConfigMapArgs {
+				if got := mc.ConfigFileFlagMap[k]; got != v {
+					t.Errorf("expected config map arg %q to be %q, but got %q", k, v, got)
+				}
+			}
+		})
+	}
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -36,6 +36,9 @@ import (
 )
 
 const (
+	managedSidecarPatternAR  = `.*/gke-release(-staging)?/gcs-fuse-csi-driver-sidecar-mounter:v\d+\.\d+\.\d+-gke\.\d+\.*`
+	managedSidecarPatternGCR = `^(gke|staging-gke|master-gke)\.gcr\.io/gcs-fuse-csi-driver-sidecar-mounter:v\d+\.\d+\.\d+-gke\.\d+.*`
+
 	Mb = 1024 * 1024
 
 	TrueStr  = "true"
@@ -69,9 +72,13 @@ const (
 	EnableAutoGoMemLimitConst           = "enable-auto-gomemlimit"
 	AutoGoMemLimitRatioConst            = "auto-gomemlimit-ratio"
 	GoMemLimitCgroupPercentage          = 0.95
+	WebhookHandledPrefetchEnvVar        = "WEBHOOK_HANDLED_PREFETCH"
+	PrefetchRequestedEnvVar             = "PREFETCH_REQUESTED"
 )
 
 var (
+	managedSidecarRegexAR    = regexp.MustCompile(managedSidecarPatternAR)
+	managedSidecarRegexGCR   = regexp.MustCompile(managedSidecarPatternGCR)
 	volumeIDRegEx            = regexp.MustCompile(`:.*$`)
 	targetPathRegexp         = regexp.MustCompile(`/var/lib/kubelet/pods/(.*)/volumes/kubernetes\.io~csi/(.*)/mount`)
 	emptyReplacementRegexp   = regexp.MustCompile(`kubernetes\.io~csi/(.*)/mount`)
@@ -309,6 +316,29 @@ func ParseBool(str string) (bool, error) {
 	}
 }
 
+// ParsePrefetchOverride parses a single mount option string.
+// If the option matches "metadata-cache:enable-metadata-prefetch", it returns (true, value, nil).
+// It is robust against spaces and supports both ":" and "=" as delimiters.
+// E.g., "metadata-cache:enable-metadata-prefetch : true " -> (true, true, nil)
+func ParsePrefetchOverride(opt string) (bool, bool, error) {
+	opt = strings.TrimSpace(opt)
+	normalized := strings.ReplaceAll(opt, "=", ":")
+	parts := strings.Split(normalized, ":")
+	for i := range parts {
+		parts[i] = strings.TrimSpace(parts[i])
+	}
+
+	if len(parts) == 3 && parts[0] == "metadata-cache" && parts[1] == "enable-metadata-prefetch" {
+		val, err := ParseBool(parts[2])
+		if err != nil {
+			return true, false, fmt.Errorf("invalid boolean value for prefetch override in option %q: %w", opt, err)
+		}
+		return true, val, nil
+	}
+
+	return false, false, nil
+}
+
 // CustomEndpointFromOpts parses a list of mount options to extract the custom endpoint value.
 // It looks for options in two formats:
 // 1. Config file format (e.g., "gcs-connection:custom-endpoint:storage.example.com:443")
@@ -359,4 +389,8 @@ func CheckNotSymlink(path string) error {
 		return fmt.Errorf("security error: path %q is a symlink", path)
 	}
 	return nil
+}
+
+func IsManagedSidecarImage(imageName string) bool {
+	return managedSidecarRegexAR.MatchString(imageName) || managedSidecarRegexGCR.MatchString(imageName)
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -679,3 +679,75 @@ func TestCheckNotSymlink(t *testing.T) {
 		})
 	}
 }
+
+func TestParsePrefetchOverride(t *testing.T) {
+	testCases := []struct {
+		name          string
+		input         string
+		expectMatched bool
+		expectValue   bool
+		expectError   bool
+	}{
+		{
+			name:          "Standard colon true",
+			input:         "metadata-cache:enable-metadata-prefetch:true",
+			expectMatched: true,
+			expectValue:   true,
+		},
+		{
+			name:          "Standard colon false",
+			input:         "metadata-cache:enable-metadata-prefetch:false",
+			expectMatched: true,
+			expectValue:   false,
+		},
+		{
+			name:          "Standard equal sign true",
+			input:         "metadata-cache:enable-metadata-prefetch=true",
+			expectMatched: true,
+			expectValue:   true,
+		},
+		{
+			name:          "With inner spaces",
+			input:         "metadata-cache : enable-metadata-prefetch : false ",
+			expectMatched: true,
+			expectValue:   false,
+		},
+		{
+			name:          "With casing",
+			input:         "metadata-cache:enable-metadata-prefetch:True",
+			expectMatched: true,
+			expectValue:   true,
+		},
+		{
+			name:          "Other unrelated flag",
+			input:         "implicit-dirs",
+			expectMatched: false,
+		},
+		{
+			name:          "Other unrelated config flag",
+			input:         "logging:severity:error",
+			expectMatched: false,
+		},
+		{
+			name:          "Invalid boolean value",
+			input:         "metadata-cache:enable-metadata-prefetch:yes",
+			expectMatched: true,
+			expectError:   true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			matched, val, err := ParsePrefetchOverride(tc.input)
+			if matched != tc.expectMatched {
+				t.Errorf("expected matched to be %v, got %v", tc.expectMatched, matched)
+			}
+			if val != tc.expectValue {
+				t.Errorf("expected value to be %v, got %v", tc.expectValue, val)
+			}
+			if (err != nil) != tc.expectError {
+				t.Errorf("expected error presence to be %v, got error: %v", tc.expectError, err)
+			}
+		})
+	}
+}

--- a/pkg/webhook/injection.go
+++ b/pkg/webhook/injection.go
@@ -20,6 +20,7 @@ package webhook
 import (
 	"fmt"
 
+	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/version"
@@ -98,8 +99,8 @@ func (si *SidecarInjector) supportsNativeSidecar() (bool, error) {
 	return supportsNativeSidecar, nil
 }
 
-// InjectSidecarContainer injects a sidecar container into the pod and returns error if unexpected event occurs.
-func (si *SidecarInjector) injectSidecarContainer(containerName string, pod *corev1.Pod, injectAsNativeSidecar bool, credentialConfig *SidecarContainerCredentialConfiguration) error {
+// injectSidecarContainer injects a sidecar container into the pod and returns error if unexpected event occurs.
+func (si *SidecarInjector) injectSidecarContainer(containerName string, pod *corev1.Pod, injectAsNativeSidecar bool, credentialConfig *SidecarContainerCredentialConfiguration, webhookHandledPrefetch bool, prefetchRequested bool) error {
 	var containerSpec corev1.Container
 	var index int
 	config, err := si.prepareConfig(sidecarPrefixMap[containerName], *pod)
@@ -124,6 +125,15 @@ func (si *SidecarInjector) injectSidecarContainer(containerName string, pod *cor
 	} else {
 		containerSpec = si.getContainerSpec(containerName, pod, config, credentialConfig)
 		index = getInjectIndexAfterContainer(pod.Spec.Containers, containerIndexOrderMap[containerName])
+	}
+
+	if containerName == GcsFuseSidecarName {
+		if webhookHandledPrefetch {
+			containerSpec.Env = append(containerSpec.Env, corev1.EnvVar{Name: util.WebhookHandledPrefetchEnvVar, Value: "true"})
+		}
+		if prefetchRequested {
+			containerSpec.Env = append(containerSpec.Env, corev1.EnvVar{Name: util.PrefetchRequestedEnvVar, Value: "true"})
+		}
 	}
 
 	// Skip metadata prefetch sidecar injection if no volumes are requesting metadata prefetch.
@@ -202,4 +212,17 @@ func containerPresent(containers []corev1.Container, container string) (int, boo
 	}
 
 	return -1, false
+}
+
+func (si *SidecarInjector) hasPrefetchRequested(pod *corev1.Pod) bool {
+	if pod == nil {
+		return false
+	}
+	config, err := si.prepareConfig(sidecarPrefixMap[MetadataPrefetchSidecarName], *pod)
+	if err != nil {
+		klog.Errorf("failed to prepare config for prefetch check: %v", err)
+		return false
+	}
+	container := si.GetMetadataPrefetchSidecarContainerSpec(pod, config)
+	return len(container.VolumeMounts) > 0
 }

--- a/pkg/webhook/injection_test.go
+++ b/pkg/webhook/injection_test.go
@@ -546,6 +546,9 @@ func TestInjectSidecarMounter(t *testing.T) {
 		if custom.Image != "" {
 			container.Image = custom.Image
 		}
+		if len(custom.Env) > 0 {
+			container.Env = append(container.Env, custom.Env...)
+		}
 		if custom.SecurityContext != nil {
 			if custom.SecurityContext.Capabilities != nil {
 				container.SecurityContext.Capabilities = custom.SecurityContext.Capabilities
@@ -558,9 +561,11 @@ func TestInjectSidecarMounter(t *testing.T) {
 	}
 
 	for _, tc := range []struct {
-		name        string
-		pod         *corev1.Pod
-		expectedPod *corev1.Pod
+		name                   string
+		pod                    *corev1.Pod
+		expectedPod            *corev1.Pod
+		webhookHandledPrefetch bool
+		prefetchRequested      bool
 	}{
 		{
 			name: "simple",
@@ -707,6 +712,67 @@ func TestInjectSidecarMounter(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:                   "prefetchRequested but not webhookHandledPrefetch",
+			webhookHandledPrefetch: false,
+			prefetchRequested:      true,
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "workload",
+						},
+					},
+				},
+			},
+			expectedPod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						extendSidecarContainer(corev1.Container{
+							Env: []v1.EnvVar{
+								{Name: "PREFETCH_REQUESTED", Value: "true"},
+							},
+						}),
+					},
+					Containers: []corev1.Container{
+						{
+							Name: "workload",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:                   "both webhookHandledPrefetch and prefetchRequested",
+			webhookHandledPrefetch: true,
+			prefetchRequested:      true,
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "workload",
+						},
+					},
+				},
+			},
+			expectedPod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						extendSidecarContainer(corev1.Container{
+							Env: []v1.EnvVar{
+								{Name: "WEBHOOK_HANDLED_PREFETCH", Value: "true"},
+								{Name: "PREFETCH_REQUESTED", Value: "true"},
+							},
+						}),
+					},
+					Containers: []corev1.Container{
+						{
+							Name: "workload",
+						},
+					},
+				},
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -714,7 +780,7 @@ func TestInjectSidecarMounter(t *testing.T) {
 				Config:                 &Config{},
 				MetadataPrefetchConfig: FakeConfig(),
 			}
-			err := si.injectSidecarContainer(GcsFuseSidecarName, tc.pod, true, nil /*credentialConfig*/)
+			err := si.injectSidecarContainer(GcsFuseSidecarName, tc.pod, true, nil /*credentialConfig*/, tc.webhookHandledPrefetch, tc.prefetchRequested)
 			if err != nil {
 				t.Errorf("Expected no error, but got %v", err)
 			}
@@ -1760,7 +1826,7 @@ func TestInjectMetadataPrefetchSidecar(t *testing.T) {
 				tc.nativeSidecar = ptr.To(true)
 			}
 			si := SidecarInjector{MetadataPrefetchConfig: FakePrefetchConfig()}
-			err := si.injectSidecarContainer(MetadataPrefetchSidecarName, tc.pod, *tc.nativeSidecar, nil /*credentialConfig*/)
+			err := si.injectSidecarContainer(MetadataPrefetchSidecarName, tc.pod, *tc.nativeSidecar, nil /*credentialConfig*/, false /*webhookHandledPrefetch*/, false /*prefetchRequested*/)
 			if !tc.expectError && err != nil {
 				t.Errorf("Expected no error, but got %v", err)
 			} else if tc.expectError && err == nil {
@@ -1973,7 +2039,7 @@ func TestInjectMetadataPrefetchSidecarWithSC(t *testing.T) {
 
 			informer.WaitForCacheSync(ctx.Done())
 
-			err = si.injectSidecarContainer(MetadataPrefetchSidecarName, tc.pod, *tc.nativeSidecar, nil)
+			err = si.injectSidecarContainer(MetadataPrefetchSidecarName, tc.pod, *tc.nativeSidecar, nil, false, false)
 			t.Logf("%s resulted in %v and error: %v", tc.testName, err == nil, err)
 			if !reflect.DeepEqual(tc.pod, tc.expectedPod) {
 				t.Errorf(`failed to run %s, expected: "%v", but got "%v". Diff: %s`, tc.testName, tc.expectedPod, tc.pod, cmp.Diff(tc.expectedPod, tc.pod))

--- a/pkg/webhook/mutatingwebhook.go
+++ b/pkg/webhook/mutatingwebhook.go
@@ -66,15 +66,16 @@ var (
 type SidecarInjector struct {
 	Client client.Client
 	// default sidecar container config values, can be overwritten by the pod annotations
-	Config                 *Config
-	MetadataPrefetchConfig *Config
-	Decoder                admission.Decoder
-	NodeLister             listersv1.NodeLister
-	PvcLister              listersv1.PersistentVolumeClaimLister
-	PvLister               listersv1.PersistentVolumeLister
-	ScLister               listerstoragev1.StorageClassLister
-	ServerVersion          *version.Version
-	K8SClient              kubernetes.Interface
+	Config                        *Config
+	MetadataPrefetchConfig        *Config
+	Decoder                       admission.Decoder
+	NodeLister                    listersv1.NodeLister
+	PvcLister                     listersv1.PersistentVolumeClaimLister
+	PvLister                      listersv1.PersistentVolumeLister
+	ScLister                      listerstoragev1.StorageClassLister
+	ServerVersion                 *version.Version
+	K8SClient                     kubernetes.Interface
+	EnableGCSFuseMetadataPrefetch bool
 }
 
 // Handle injects a gcsfuse sidecar container and a emptyDir to incoming qualified pods.
@@ -159,10 +160,66 @@ func (si *SidecarInjector) Handle(ctx context.Context, req admission.Request) ad
 		klog.Infof("Injected GCP workload identity credential configuration configMap %s in namespace %s", configMapName, pod.Namespace)
 	}
 
+	gcsfuseImage := si.Config.ContainerImage
+	if index, ok := containerPresent(pod.Spec.Containers, GcsFuseSidecarName); ok && pod.Spec.Containers[index].Image != "" {
+		gcsfuseImage = pod.Spec.Containers[index].Image
+	} else if index, ok := containerPresent(pod.Spec.InitContainers, GcsFuseSidecarName); ok && pod.Spec.InitContainers[index].Image != "" {
+		gcsfuseImage = pod.Spec.InitContainers[index].Image
+	}
+	isCustom := !util.IsManagedSidecarImage(gcsfuseImage)
+	sidecarVersion, err := parseImageVersion(gcsfuseImage)
+	if err != nil {
+		klog.Warningf("failed to parse sidecar image version %q: %v, assuming old version", gcsfuseImage, err)
+		sidecarVersion = version.MustParseGeneric("0.0.0")
+	}
+
+	supportsNativePrefetch := sidecarVersion.AtLeast(nativePrefetchMinVersion)
+	prefetchRequested := si.hasPrefetchRequested(pod)
+	nativePrefetchEnabledByUser, nativePrefetchDisabledByUser := si.getNativePrefetchOverrides(pod)
+
+	// Use native prefetch when: the feature is enabled, the sidecar version supports it,
+	// the user is not running a custom image, native prefetch was not disabled by user explicitly,
+	// and prefetch is requested.
+	useNativePrefetch := si.EnableGCSFuseMetadataPrefetch &&
+		supportsNativePrefetch &&
+		!isCustom &&
+		!nativePrefetchDisabledByUser &&
+		prefetchRequested
+
+	// Determine whether to inject the legacy prefetch sidecar and whether
+	// the webhook has taken responsibility for prefetch configuration.
+	//
+	// WEBHOOK_HANDLED_PREFETCH prevents version skew issues (older webhook + newer sidecar)
+	// that could cause both prefetch mechanisms to run simultaneously.
+	// - true: Webhook handled prefetch logic; sidecar must NOT force-disable native prefetch.
+	// - false: Webhook injected legacy prefetch; sidecar MUST force-disable native prefetch.
+	var injectLegacyPrefetch bool
+	var webhookHandledPrefetch bool
+	if useNativePrefetch {
+		// Native prefetch is fully managed by the webhook; no legacy injection needed.
+		injectLegacyPrefetch = false
+		webhookHandledPrefetch = true
+	} else if nativePrefetchEnabledByUser && prefetchRequested {
+		// User explicitly enabled native prefetch via mount options AND requested prefetch
+		// via the volume attribute. Skip legacy injection and let the sidecar respect the
+		// user's override directly.
+		injectLegacyPrefetch = false
+		webhookHandledPrefetch = true
+	} else {
+		// Native prefetch is not available or not requested. Fall back to legacy
+		// prefetch injection if the pod annotation requested it.
+		webhookHandledPrefetch = false
+		if prefetchRequested {
+			injectLegacyPrefetch = true
+		} else {
+			injectLegacyPrefetch = false
+		}
+	}
+
 	// Inject Fuse Side Car container.
 	injected, _ := validatePodHasSidecarContainerInjected(GcsFuseSidecarName, pod, []corev1.Volume{tmpVolume}, []corev1.VolumeMount{TmpVolumeMount})
 	if !injected {
-		err = si.injectSidecarContainer(GcsFuseSidecarName, pod, injectAsNativeSidecar, sidecarCredentialConfig)
+		err = si.injectSidecarContainer(GcsFuseSidecarName, pod, injectAsNativeSidecar, sidecarCredentialConfig, webhookHandledPrefetch, prefetchRequested)
 	}
 	if err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
@@ -181,12 +238,14 @@ func (si *SidecarInjector) Handle(ctx context.Context, req admission.Request) ad
 	pod.Spec.Volumes = append(GetSidecarContainerVolumeSpec(pod.Spec.Volumes...), pod.Spec.Volumes...)
 
 	// Inject metadata prefetch sidecar.
-	injected, _ = validatePodHasSidecarContainerInjected(MetadataPrefetchSidecarName, pod, []corev1.Volume{}, []corev1.VolumeMount{})
-	if !injected {
-		err = si.injectSidecarContainer(MetadataPrefetchSidecarName, pod, injectAsNativeSidecar, nil /*credentialConfig*/)
-	}
-	if err != nil {
-		return admission.Errored(http.StatusBadRequest, err)
+	if injectLegacyPrefetch {
+		injected, _ = validatePodHasSidecarContainerInjected(MetadataPrefetchSidecarName, pod, []corev1.Volume{}, []corev1.VolumeMount{})
+		if !injected {
+			err = si.injectSidecarContainer(MetadataPrefetchSidecarName, pod, injectAsNativeSidecar, nil /*credentialConfig*/, false /*webhookHandledPrefetch*/, false /*prefetchRequested*/)
+		}
+		if err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
 	}
 
 	if si.Config.EnableGcsfuseProfiles {

--- a/pkg/webhook/mutatingwebhook_test.go
+++ b/pkg/webhook/mutatingwebhook_test.go
@@ -23,6 +23,8 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -30,6 +32,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	putil "github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/profiles/util"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util"
+	"gomodules.xyz/jsonpatch/v2"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	admissionv1 "k8s.io/api/admission/v1"
@@ -348,11 +351,14 @@ func TestValidateMutatingWebhookResponse(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
-		name         string
-		inputPod     *corev1.Pod
-		operation    admissionv1.Operation
-		wantResponse admission.Response
-		nodes        []corev1.Node
+		name                          string
+		inputPod                      *corev1.Pod
+		operation                     admissionv1.Operation
+		wantResponse                  admission.Response
+		nodes                         []corev1.Node
+		pvcs                          []*corev1.PersistentVolumeClaim
+		pvs                           []*corev1.PersistentVolume
+		enableGCSFuseMetadataPrefetch bool
 	}{
 		{
 			name:         "Empty request test.",
@@ -595,6 +601,231 @@ func TestValidateMutatingWebhookResponse(t *testing.T) {
 			wantResponse: wantResponse(t, false, false, true),
 			nodes:        nativeSupportNodes(),
 		},
+		{
+			name:                          "native prefetch: enabled via PVC/PV volume attributes",
+			operation:                     admissionv1.Create,
+			inputPod:                      validInputPodWithImageAndPVC("my-pvc-default", "gke.gcr.io/gcs-fuse-csi-driver-sidecar-mounter:v999.999.999-gke.0"),
+			wantResponse:                  wantResponseWithNativePrefetch(t, validInputPodWithImageAndPVC("my-pvc-default", "gke.gcr.io/gcs-fuse-csi-driver-sidecar-mounter:v999.999.999-gke.0"), true, false, true),
+			nodes:                         nativeSupportNodes(),
+			enableGCSFuseMetadataPrefetch: true,
+			pvcs: []*corev1.PersistentVolumeClaim{
+				makePrefetchPVC("my-pvc-default", "default", "my-pv-default"),
+			},
+			pvs: []*corev1.PersistentVolume{
+				makePrefetchPV("my-pv-default", nil, map[string]string{
+					gcsFuseMetadataPrefetchOnMountVolumeAttribute: "true",
+				}),
+			},
+		},
+		{
+			name:                          "native prefetch: disabled automatically when no volume requests prefetch",
+			operation:                     admissionv1.Create,
+			inputPod:                      validInputPod(),
+			wantResponse:                  wantResponse(t, false, false, true),
+			nodes:                         nativeSupportNodes(),
+			enableGCSFuseMetadataPrefetch: true,
+		},
+		{
+			name:                          "native prefetch: enabled via inline CSI ephemeral volume",
+			operation:                     admissionv1.Create,
+			inputPod:                      validInputPodWithImageAndEphemeral("gke.gcr.io/gcs-fuse-csi-driver-sidecar-mounter:v999.999.999-gke.0", ""),
+			wantResponse:                  wantResponseWithNativePrefetch(t, validInputPodWithImageAndEphemeral("gke.gcr.io/gcs-fuse-csi-driver-sidecar-mounter:v999.999.999-gke.0", ""), true, false, true),
+			nodes:                         nativeSupportNodes(),
+			enableGCSFuseMetadataPrefetch: true,
+		},
+		{
+			name:                          "native prefetch: legacy fallback when explicitly disabled via ephemeral volume attributes",
+			operation:                     admissionv1.Create,
+			inputPod:                      validInputPodWithEphemeralVolumeMountOptions("metadata-cache:enable-metadata-prefetch:false"),
+			wantResponse:                  wantResponseWithLegacyPrefetch(t, validInputPodWithEphemeralVolumeMountOptions("metadata-cache:enable-metadata-prefetch:false"), []string{"gcsfuse-volume"}, false, false, true),
+			nodes:                         nativeSupportNodes(),
+			enableGCSFuseMetadataPrefetch: true,
+		},
+		{
+			name:                          "native prefetch: enabled automatically and parses mountOptions from PV VolumeAttributes correctly",
+			operation:                     admissionv1.Create,
+			inputPod:                      validInputPodWithPVC("my-pvc-vol-opts"),
+			wantResponse:                  wantResponseWithNativePrefetch(t, validInputPodWithPVC("my-pvc-vol-opts"), false, false, true),
+			nodes:                         nativeSupportNodes(),
+			enableGCSFuseMetadataPrefetch: true,
+			pvcs: []*corev1.PersistentVolumeClaim{
+				makePrefetchPVC("my-pvc-vol-opts", "default", "my-pv-vol-opts"),
+			},
+			pvs: []*corev1.PersistentVolume{
+				makePrefetchPV("my-pv-vol-opts", nil, map[string]string{
+					gcsFuseMetadataPrefetchOnMountVolumeAttribute: "true",
+					"mountOptions": "metadata-cache:enable-metadata-prefetch:true",
+				}),
+			},
+		},
+		{
+			name:                          "native prefetch: legacy fallback when explicitly disabled via PV mount options",
+			operation:                     admissionv1.Create,
+			inputPod:                      validInputPodWithPVC("my-pvc-fallback"),
+			wantResponse:                  wantResponseWithLegacyPrefetch(t, validInputPodWithPVC("my-pvc-fallback"), []string{"gcsfuse-volume"}, false, false, true),
+			nodes:                         nativeSupportNodes(),
+			enableGCSFuseMetadataPrefetch: true,
+			pvcs: []*corev1.PersistentVolumeClaim{
+				makePrefetchPVC("my-pvc-fallback", "default", "my-pv-fallback"),
+			},
+			pvs: []*corev1.PersistentVolume{
+				makePrefetchPV("my-pv-fallback", []string{"metadata-cache:enable-metadata-prefetch:false"}, map[string]string{
+					gcsFuseMetadataPrefetchOnMountVolumeAttribute: "true",
+				}),
+			},
+		},
+		{
+			name:                          "native prefetch: falls back to injecting legacy prefetch container when enableGCSFuseMetadataPrefetch is false",
+			operation:                     admissionv1.Create,
+			inputPod:                      validInputPodWithPVC("my-pvc-unsupported"),
+			wantResponse:                  wantResponseWithLegacyPrefetch(t, validInputPodWithPVC("my-pvc-unsupported"), []string{"gcsfuse-volume"}, false, false, true),
+			nodes:                         nativeSupportNodes(),
+			enableGCSFuseMetadataPrefetch: false,
+			pvcs: []*corev1.PersistentVolumeClaim{
+				makePrefetchPVC("my-pvc-unsupported", "default", "my-pv-unsupported"),
+			},
+			pvs: []*corev1.PersistentVolume{
+				makePrefetchPV("my-pv-unsupported", nil, map[string]string{
+					gcsFuseMetadataPrefetchOnMountVolumeAttribute: "true",
+				}),
+			},
+		},
+		{
+			name:                          "native prefetch: user override forces native prefetch even if feature gate is disabled",
+			operation:                     admissionv1.Create,
+			inputPod:                      validInputPodWithPVC("my-pvc-unsupported-override"),
+			wantResponse:                  wantResponseWithNativePrefetch(t, validInputPodWithPVC("my-pvc-unsupported-override"), false, false, true),
+			nodes:                         nativeSupportNodes(),
+			enableGCSFuseMetadataPrefetch: false,
+			pvcs: []*corev1.PersistentVolumeClaim{
+				makePrefetchPVC("my-pvc-unsupported-override", "default", "my-pv-unsupported-override"),
+			},
+			pvs: []*corev1.PersistentVolume{
+				makePrefetchPV("my-pv-unsupported-override", []string{"metadata-cache:enable-metadata-prefetch:true"}, map[string]string{
+					gcsFuseMetadataPrefetchOnMountVolumeAttribute: "true",
+				}),
+			},
+		},
+		{
+			name:                          "native prefetch: legacy fallback for custom sidecar image",
+			operation:                     admissionv1.Create,
+			inputPod:                      validInputPodWithImageAndPVC("my-pvc-custom-image", "private-repo/fake-sidecar-image:v999.999.999"),
+			wantResponse:                  wantResponseWithLegacyPrefetch(t, validInputPodWithImageAndPVC("my-pvc-custom-image", "private-repo/fake-sidecar-image:v999.999.999"), []string{"gcsfuse-volume"}, true, false, true),
+			nodes:                         nativeSupportNodes(),
+			enableGCSFuseMetadataPrefetch: true,
+			pvcs: []*corev1.PersistentVolumeClaim{
+				makePrefetchPVC("my-pvc-custom-image", "default", "my-pv-custom-image"),
+			},
+			pvs: []*corev1.PersistentVolume{
+				makePrefetchPV("my-pv-custom-image", nil, map[string]string{
+					gcsFuseMetadataPrefetchOnMountVolumeAttribute: "true",
+				}),
+			},
+		},
+		{
+			name:                          "native prefetch: user override forces native prefetch for custom sidecar image",
+			operation:                     admissionv1.Create,
+			inputPod:                      validInputPodWithImageAndPVC("my-pvc-custom-image-override", "private-repo/fake-sidecar-image:v999.999.999"),
+			wantResponse:                  wantResponseWithNativePrefetch(t, validInputPodWithImageAndPVC("my-pvc-custom-image-override", "private-repo/fake-sidecar-image:v999.999.999"), true, false, true),
+			nodes:                         nativeSupportNodes(),
+			enableGCSFuseMetadataPrefetch: true,
+			pvcs: []*corev1.PersistentVolumeClaim{
+				makePrefetchPVC("my-pvc-custom-image-override", "default", "my-pv-custom-image-override"),
+			},
+			pvs: []*corev1.PersistentVolume{
+				makePrefetchPV("my-pv-custom-image-override", []string{"metadata-cache:enable-metadata-prefetch:true"}, map[string]string{
+					gcsFuseMetadataPrefetchOnMountVolumeAttribute: "true",
+				}),
+			},
+		},
+		{
+			name:                          "native prefetch: legacy fallback when managed sidecar image version is unsupported",
+			operation:                     admissionv1.Create,
+			inputPod:                      validInputPodWithImageAndPVC("my-pvc-old-version", "gke.gcr.io/gcs-fuse-csi-driver-sidecar-mounter:v1.0.0-gke.0"),
+			wantResponse:                  wantResponseWithLegacyPrefetch(t, validInputPodWithImageAndPVC("my-pvc-old-version", "gke.gcr.io/gcs-fuse-csi-driver-sidecar-mounter:v1.0.0-gke.0"), []string{"gcsfuse-volume"}, true, false, true),
+			nodes:                         nativeSupportNodes(),
+			enableGCSFuseMetadataPrefetch: true,
+			pvcs: []*corev1.PersistentVolumeClaim{
+				makePrefetchPVC("my-pvc-old-version", "default", "my-pv-old-version"),
+			},
+			pvs: []*corev1.PersistentVolume{
+				makePrefetchPV("my-pv-old-version", nil, map[string]string{
+					gcsFuseMetadataPrefetchOnMountVolumeAttribute: "true",
+				}),
+			},
+		},
+		{
+			name:                          "native prefetch: user override forces native prefetch for unsupported sidecar version",
+			operation:                     admissionv1.Create,
+			inputPod:                      validInputPodWithImageAndPVC("my-pvc-old-version-override", "gke.gcr.io/gcs-fuse-csi-driver-sidecar-mounter:v1.0.0-gke.0"),
+			wantResponse:                  wantResponseWithNativePrefetch(t, validInputPodWithImageAndPVC("my-pvc-old-version-override", "gke.gcr.io/gcs-fuse-csi-driver-sidecar-mounter:v1.0.0-gke.0"), true, false, true),
+			nodes:                         nativeSupportNodes(),
+			enableGCSFuseMetadataPrefetch: true,
+			pvcs: []*corev1.PersistentVolumeClaim{
+				makePrefetchPVC("my-pvc-old-version-override", "default", "my-pv-old-version-override"),
+			},
+			pvs: []*corev1.PersistentVolume{
+				makePrefetchPV("my-pv-old-version-override", []string{"metadata-cache:enable-metadata-prefetch:true"}, map[string]string{
+					gcsFuseMetadataPrefetchOnMountVolumeAttribute: "true",
+				}),
+			},
+		},
+		{
+			name:                          "native prefetch: enabled when all ephemeral volume overrides are true",
+			operation:                     admissionv1.Create,
+			inputPod:                      validInputPodWithMultipleEphemeralVolumes("metadata-cache:enable-metadata-prefetch:true", "metadata-cache:enable-metadata-prefetch:true"),
+			wantResponse:                  wantResponseWithNativePrefetch(t, validInputPodWithMultipleEphemeralVolumes("metadata-cache:enable-metadata-prefetch:true", "metadata-cache:enable-metadata-prefetch:true"), false, false, true),
+			nodes:                         nativeSupportNodes(),
+			enableGCSFuseMetadataPrefetch: true,
+		},
+		{
+			name:                          "native prefetch: legacy fallback when all ephemeral volume overrides are false",
+			operation:                     admissionv1.Create,
+			inputPod:                      validInputPodWithMultipleEphemeralVolumes("metadata-cache:enable-metadata-prefetch:false", "metadata-cache:enable-metadata-prefetch:false"),
+			wantResponse:                  wantResponseWithLegacyPrefetch(t, validInputPodWithMultipleEphemeralVolumes("metadata-cache:enable-metadata-prefetch:false", "metadata-cache:enable-metadata-prefetch:false"), []string{"gcsfuse-volume-1", "gcsfuse-volume-2"}, false, false, true),
+			nodes:                         nativeSupportNodes(),
+			enableGCSFuseMetadataPrefetch: true,
+		},
+		{
+			name:                          "native prefetch: enabled when all PVC/PV overrides are true",
+			operation:                     admissionv1.Create,
+			inputPod:                      validInputPodWithMultiplePVCs("my-pvc-1", "my-pvc-2"),
+			wantResponse:                  wantResponseWithNativePrefetch(t, validInputPodWithMultiplePVCs("my-pvc-1", "my-pvc-2"), false, false, true),
+			nodes:                         nativeSupportNodes(),
+			enableGCSFuseMetadataPrefetch: true,
+			pvcs: []*corev1.PersistentVolumeClaim{
+				makePrefetchPVC("my-pvc-1", "default", "my-pv-1"),
+				makePrefetchPVC("my-pvc-2", "default", "my-pv-2"),
+			},
+			pvs: []*corev1.PersistentVolume{
+				makePrefetchPV("my-pv-1", []string{"metadata-cache:enable-metadata-prefetch:true"}, map[string]string{
+					gcsFuseMetadataPrefetchOnMountVolumeAttribute: "true",
+				}),
+				makePrefetchPV("my-pv-2", []string{"metadata-cache:enable-metadata-prefetch:true"}, map[string]string{
+					gcsFuseMetadataPrefetchOnMountVolumeAttribute: "true",
+				}),
+			},
+		},
+		{
+			name:                          "native prefetch: legacy fallback when all PVC/PV overrides are false",
+			operation:                     admissionv1.Create,
+			inputPod:                      validInputPodWithMultiplePVCs("my-pvc-1", "my-pvc-2"),
+			wantResponse:                  wantResponseWithLegacyPrefetch(t, validInputPodWithMultiplePVCs("my-pvc-1", "my-pvc-2"), []string{"gcsfuse-volume-0", "gcsfuse-volume-1"}, false, false, true),
+			nodes:                         nativeSupportNodes(),
+			enableGCSFuseMetadataPrefetch: true,
+			pvcs: []*corev1.PersistentVolumeClaim{
+				makePrefetchPVC("my-pvc-1", "default", "my-pv-1"),
+				makePrefetchPVC("my-pvc-2", "default", "my-pv-2"),
+			},
+			pvs: []*corev1.PersistentVolume{
+				makePrefetchPV("my-pv-1", []string{"metadata-cache:enable-metadata-prefetch:false"}, map[string]string{
+					gcsFuseMetadataPrefetchOnMountVolumeAttribute: "true",
+				}),
+				makePrefetchPV("my-pv-2", []string{"metadata-cache:enable-metadata-prefetch:false"}, map[string]string{
+					gcsFuseMetadataPrefetchOnMountVolumeAttribute: "true",
+				}),
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -609,6 +840,19 @@ func TestValidateMutatingWebhookResponse(t *testing.T) {
 				_, err := fakeClient.CoreV1().Nodes().Create(context.Background(), &n, metav1.CreateOptions{})
 				if err != nil {
 					t.Error("failed to setup/create nodes")
+				}
+			}
+
+			for _, pv := range tc.pvs {
+				_, err := fakeClient.CoreV1().PersistentVolumes().Create(context.Background(), pv, metav1.CreateOptions{})
+				if err != nil {
+					t.Fatalf("failed to setup test PV: %v", err)
+				}
+			}
+			for _, pvc := range tc.pvcs {
+				_, err := fakeClient.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(context.Background(), pvc, metav1.CreateOptions{})
+				if err != nil {
+					t.Fatalf("failed to setup test PVC: %v", err)
 				}
 			}
 
@@ -638,14 +882,19 @@ func TestValidateMutatingWebhookResponse(t *testing.T) {
 
 			informerFactory := informers.NewSharedInformerFactoryWithOptions(fakeClient, time.Second*1, informers.WithNamespace(metav1.NamespaceAll))
 			lister := informerFactory.Core().V1().Nodes().Lister()
+			pvLister := informerFactory.Core().V1().PersistentVolumes().Lister()
+			pvcLister := informerFactory.Core().V1().PersistentVolumeClaims().Lister()
 
 			si := SidecarInjector{
-				Client:                 nil,
-				Config:                 FakeConfig(),
-				MetadataPrefetchConfig: FakePrefetchConfig(),
-				Decoder:                admission.NewDecoder(runtime.NewScheme()),
-				NodeLister:             lister,
-				K8SClient:              fakeClient,
+				Client:                        nil,
+				Config:                        FakeConfig(),
+				MetadataPrefetchConfig:        FakePrefetchConfig(),
+				Decoder:                       admission.NewDecoder(runtime.NewScheme()),
+				NodeLister:                    lister,
+				PvLister:                      pvLister,
+				PvcLister:                     pvcLister,
+				K8SClient:                     fakeClient,
+				EnableGCSFuseMetadataPrefetch: tc.enableGCSFuseMetadataPrefetch,
 			}
 
 			stopCh := make(<-chan struct{})
@@ -858,20 +1107,17 @@ func compareResponses(wantResponse, gotResponse admission.Response) error {
 	if len(wantResponse.Patches) != len(gotResponse.Patches) {
 		return fmt.Errorf("expecting %d patches, got %d patches", len(wantResponse.Patches), len(gotResponse.Patches))
 	}
-	wantPaths := []string{}
-	gotPaths := []string{}
-	for i := range len(wantResponse.Patches) {
-		wantPaths = append(wantPaths, wantResponse.Patches[i].Path)
-		gotPaths = append(gotPaths, gotResponse.Patches[i].Path)
-	}
-
-	if len(wantPaths) > 0 && len(gotPaths) > 0 {
-		less := func(a, b string) bool { return a > b }
-		if diff := cmp.Diff(gotPaths, wantPaths, cmpopts.SortSlices(less)); diff != "" {
-			return fmt.Errorf("unexpected pod args (-got, +want)\n%s", diff)
+	if len(wantResponse.Patches) > 0 {
+		less := func(a, b jsonpatch.JsonPatchOperation) bool {
+			if a.Path != b.Path {
+				return a.Path < b.Path
+			}
+			return a.Operation < b.Operation
+		}
+		if diff := cmp.Diff(gotResponse.Patches, wantResponse.Patches, cmpopts.SortSlices(less)); diff != "" {
+			return fmt.Errorf("unexpected patches (-got, +want)\n%s", diff)
 		}
 	}
-
 	return nil
 }
 
@@ -907,6 +1153,7 @@ func getDuplicateDeclarationPodSpec() *corev1.Pod {
 			TerminationGracePeriodSeconds: ptr.To[int64](60),
 		},
 		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
 			Annotations: map[string]string{
 				GcsFuseVolumeEnableAnnotation: "true",
 			},
@@ -915,7 +1162,7 @@ func getDuplicateDeclarationPodSpec() *corev1.Pod {
 }
 
 func getDuplicateDeclarationPodSpecResponse(nativeCustomImage bool) *corev1.Pod {
-	result := modifySpec(*validInputPodWithCustomImage(nativeCustomImage), true, nativeCustomImage, true)
+	result := modifySpec(*validInputPodWithCustomImage(nativeCustomImage), true, nativeCustomImage, true, false, false)
 
 	return result
 }
@@ -949,6 +1196,7 @@ func validInputPodWithSettings(customImage, native bool) *corev1.Pod {
 			TerminationGracePeriodSeconds: ptr.To[int64](60),
 		},
 		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
 			Annotations: map[string]string{
 				GcsFuseVolumeEnableAnnotation: "true",
 			},
@@ -1013,7 +1261,7 @@ func validInputPodWithIstio(customImage, nativeCustomImage, nativeIstio bool) *c
 func wantResponse(t *testing.T, customImage bool, nativeCustomImage bool, native bool) admission.Response {
 	t.Helper()
 	pod := validInputPodWithSettings(customImage, nativeCustomImage)
-	newPod := *modifySpec(*validInputPodWithSettings(customImage, nativeCustomImage), customImage, nativeCustomImage, native)
+	newPod := *modifySpec(*validInputPodWithSettings(customImage, nativeCustomImage), customImage, nativeCustomImage, native, false, false)
 
 	return generatePatch(t, pod, &newPod)
 }
@@ -1021,12 +1269,12 @@ func wantResponse(t *testing.T, customImage bool, nativeCustomImage bool, native
 func wantResponseWithPrefetch(t *testing.T, customImage bool, nativeCustomImage bool, native bool) admission.Response {
 	t.Helper()
 	pod := validInputPodWithPrefetchIncluded()
-	newPod := *modifySpec(*validInputPodWithPrefetchIncluded(), customImage, nativeCustomImage, native)
+	newPod := *modifySpec(*validInputPodWithPrefetchIncluded(), customImage, nativeCustomImage, native, false, false)
 
 	return generatePatch(t, pod, &newPod)
 }
 
-func modifySpec(newPod corev1.Pod, customImage bool, nativeCustomImage, native bool) *corev1.Pod {
+func modifySpec(newPod corev1.Pod, customImage bool, nativeCustomImage, native, webhookHandledPrefetch, prefetchRequested bool) *corev1.Pod {
 	config := FakeConfig()
 	if customImage {
 		if nativeCustomImage {
@@ -1038,10 +1286,24 @@ func modifySpec(newPod corev1.Pod, customImage bool, nativeCustomImage, native b
 		}
 	}
 
+	var sidecar corev1.Container
 	if native {
-		newPod.Spec.InitContainers = append([]corev1.Container{GetNativeSidecarContainerSpec(config, nil)}, newPod.Spec.InitContainers...)
+		sidecar = GetNativeSidecarContainerSpec(config, nil)
 	} else {
-		newPod.Spec.Containers = append([]corev1.Container{GetSidecarContainerSpec(config, nil /*credentialConfig*/)}, newPod.Spec.Containers...)
+		sidecar = GetSidecarContainerSpec(config, nil /*credentialConfig*/)
+	}
+
+	if webhookHandledPrefetch {
+		sidecar.Env = append(sidecar.Env, corev1.EnvVar{Name: util.WebhookHandledPrefetchEnvVar, Value: "true"})
+	}
+	if prefetchRequested {
+		sidecar.Env = append(sidecar.Env, corev1.EnvVar{Name: util.PrefetchRequestedEnvVar, Value: "true"})
+	}
+
+	if native {
+		newPod.Spec.InitContainers = append([]corev1.Container{sidecar}, newPod.Spec.InitContainers...)
+	} else {
+		newPod.Spec.Containers = append([]corev1.Container{sidecar}, newPod.Spec.Containers...)
 	}
 	newPod.Spec.Volumes = append(GetSidecarContainerVolumeSpec(newPod.Spec.Volumes...), newPod.Spec.Volumes...)
 
@@ -1826,7 +2088,7 @@ func TestOIDCAuthenticationWithHostNetwork(t *testing.T) {
 				if resp.Allowed {
 					t.Errorf("Expected request to be denied, but it was allowed")
 				}
-				if tc.expectedErrorSubstr != "" && !stringContains(resp.Result.Message, tc.expectedErrorSubstr) {
+				if tc.expectedErrorSubstr != "" && !strings.Contains(resp.Result.Message, tc.expectedErrorSubstr) {
 					t.Errorf("Expected error message to contain %q, but got: %q", tc.expectedErrorSubstr, resp.Result.Message)
 				}
 				if resp.Result.Code != http.StatusBadRequest {
@@ -1841,15 +2103,161 @@ func TestOIDCAuthenticationWithHostNetwork(t *testing.T) {
 	}
 }
 
-// Helper function to check if a string contains a substring
-func stringContains(s, substr string) bool {
-	if len(substr) == 0 {
-		return true
+// wantResponseWithNativePrefetch constructs the expected mutated Pod spec patch where
+// native prefetching is enabled (WEBHOOK_HANDLED_PREFETCH=true and PREFETCH_REQUESTED=true).
+func wantResponseWithNativePrefetch(t *testing.T, pod *corev1.Pod, customImage, nativeCustomImage, native bool) admission.Response {
+	t.Helper()
+	newPod := *modifySpec(*pod, customImage, nativeCustomImage, native, true, true)
+	return generatePatch(t, pod, &newPod)
+}
+
+func validInputPodWithEphemeralVolumeMountOptions(mountOptions string) *corev1.Pod {
+	pod := validInputPodWithSettings(false, false)
+	pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
+		Name: "gcsfuse-volume",
+		VolumeSource: corev1.VolumeSource{
+			CSI: &corev1.CSIVolumeSource{
+				Driver: gcsFuseCsiDriverName,
+				VolumeAttributes: map[string]string{
+					gcsFuseMetadataPrefetchOnMountVolumeAttribute: "true",
+					"mountOptions": mountOptions,
+				},
+			},
+		},
+	})
+	return pod
+}
+
+func validInputPodWithImageAndEphemeral(imageName, mountOptions string) *corev1.Pod {
+	pod := validInputPodWithEphemeralVolumeMountOptions(mountOptions)
+	pod.Spec.Containers = append(pod.Spec.Containers, corev1.Container{
+		Name:  GcsFuseSidecarName,
+		Image: imageName,
+	})
+	return pod
+}
+
+func validInputPodWithPVC(pvcName string) *corev1.Pod {
+	pod := validInputPodWithSettings(false, false)
+	pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
+		Name: "gcsfuse-volume",
+		VolumeSource: corev1.VolumeSource{
+			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+				ClaimName: pvcName,
+			},
+		},
+	})
+	return pod
+}
+
+func makePrefetchPVC(name, namespace, pvName string) *corev1.PersistentVolumeClaim {
+	return &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			VolumeName: pvName,
+		},
 	}
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
+}
+
+func makePrefetchPV(name string, mountOptions []string, volumeAttributes map[string]string) *corev1.PersistentVolume {
+	return &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: corev1.PersistentVolumeSpec{
+			MountOptions: mountOptions,
+			PersistentVolumeSource: corev1.PersistentVolumeSource{
+				CSI: &corev1.CSIPersistentVolumeSource{
+					Driver:           gcsFuseCsiDriverName,
+					VolumeAttributes: volumeAttributes,
+				},
+			},
+		},
 	}
-	return false
+}
+
+// wantResponseWithLegacyPrefetch constructs the expected mutated Pod spec patch where
+// legacy prefetching sidecar container injection is expected (WEBHOOK_HANDLED_PREFETCH=false and PREFETCH_REQUESTED=true).
+func wantResponseWithLegacyPrefetch(t *testing.T, pod *corev1.Pod, volumeNames []string, customImage bool, nativeCustomImage bool, native bool) admission.Response {
+	t.Helper()
+	newPod := *modifySpec(*pod, customImage, nativeCustomImage, native, false, true)
+
+	limits, requests := prepareResourceList(FakePrefetchConfig())
+	legacyPrefetchContainer := corev1.Container{
+		Name:            MetadataPrefetchSidecarName,
+		SecurityContext: GetSecurityContext(FakePrefetchConfig()),
+		Image:           FakePrefetchConfig().ContainerImage,
+		ImagePullPolicy: corev1.PullPolicy(FakePrefetchConfig().ImagePullPolicy),
+		Resources: corev1.ResourceRequirements{
+			Requests: requests,
+			Limits:   limits,
+		},
+		VolumeMounts: []corev1.VolumeMount{},
+	}
+
+	for _, vn := range volumeNames {
+		legacyPrefetchContainer.VolumeMounts = append(legacyPrefetchContainer.VolumeMounts, corev1.VolumeMount{
+			Name:      vn,
+			ReadOnly:  true,
+			MountPath: filepath.Join("/volumes/", vn),
+		})
+	}
+
+	if native {
+		legacyPrefetchContainer.Env = []corev1.EnvVar{{Name: "NATIVE_SIDECAR", Value: "TRUE"}}
+		legacyPrefetchContainer.RestartPolicy = ptr.To(corev1.ContainerRestartPolicyAlways)
+		// Insert legacy prefetch container at index 1 (right after main sidecar which is at index 0)
+		newPod.Spec.InitContainers = append(newPod.Spec.InitContainers[:1], append([]corev1.Container{legacyPrefetchContainer}, newPod.Spec.InitContainers[1:]...)...)
+	} else {
+		// Insert legacy prefetch container at index 1 (right after main sidecar which is at index 0)
+		newPod.Spec.Containers = append(newPod.Spec.Containers[:1], append([]corev1.Container{legacyPrefetchContainer}, newPod.Spec.Containers[1:]...)...)
+	}
+
+	return generatePatch(t, pod, &newPod)
+}
+
+func validInputPodWithImageAndPVC(pvcName string, imageName string) *corev1.Pod {
+	pod := validInputPodWithPVC(pvcName)
+	pod.Spec.Containers = append(pod.Spec.Containers, corev1.Container{
+		Name:  GcsFuseSidecarName,
+		Image: imageName,
+	})
+	return pod
+}
+
+func validInputPodWithMultipleEphemeralVolumes(prefetchOpts ...string) *corev1.Pod {
+	pod := validInputPodWithSettings(false, false)
+	for i, opt := range prefetchOpts {
+		pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
+			Name: fmt.Sprintf("gcsfuse-volume-%d", i+1),
+			VolumeSource: corev1.VolumeSource{
+				CSI: &corev1.CSIVolumeSource{
+					Driver: gcsFuseCsiDriverName,
+					VolumeAttributes: map[string]string{
+						gcsFuseMetadataPrefetchOnMountVolumeAttribute: "true",
+						"mountOptions": opt,
+					},
+				},
+			},
+		})
+	}
+	return pod
+}
+
+func validInputPodWithMultiplePVCs(pvcNames ...string) *corev1.Pod {
+	pod := validInputPodWithSettings(false, false)
+	for i, name := range pvcNames {
+		pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
+			Name: fmt.Sprintf("gcsfuse-volume-%d", i),
+			VolumeSource: corev1.VolumeSource{
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+					ClaimName: name,
+				},
+			},
+		})
+	}
+	return pod
 }

--- a/pkg/webhook/parsers.go
+++ b/pkg/webhook/parsers.go
@@ -26,6 +26,18 @@ import (
 )
 
 var minimumSupportedVersion = version.MustParseGeneric("1.29.0")
+var nativePrefetchMinVersion = version.MustParseGeneric("999.0.0")
+
+func parseImageVersion(image string) (*version.Version, error) {
+	_, tag, _, err := parseImageName(image)
+	if err != nil {
+		return nil, err
+	}
+	if tag == "" {
+		return nil, fmt.Errorf("no tag found in image %q", image)
+	}
+	return version.ParseGeneric(tag)
+}
 
 func ParseBool(str string) (bool, error) {
 	switch str {

--- a/pkg/webhook/volumes.go
+++ b/pkg/webhook/volumes.go
@@ -18,6 +18,9 @@ limitations under the License.
 package webhook
 
 import (
+	"strings"
+
+	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 )
@@ -80,4 +83,51 @@ func (si *SidecarInjector) isGcsFuseCSIVolume(volume corev1.Volume, namespace st
 	}
 
 	return false, false, nil, nil, nil
+}
+
+func (si *SidecarInjector) getNativePrefetchOverrides(pod *corev1.Pod) (bool, bool) {
+	if pod == nil {
+		return false, false
+	}
+	var hasEnabled, hasDisabled bool
+	for _, v := range pod.Spec.Volumes {
+		isGcsFuse, _, volumeAttributes, pv, err := si.isGcsFuseCSIVolume(v, pod.Namespace)
+		if err != nil || !isGcsFuse {
+			continue
+		}
+		if volumeAttributes != nil {
+			if mountOptions, ok := volumeAttributes["mountOptions"]; ok {
+				options := strings.Split(mountOptions, ",")
+				for _, opt := range options {
+					if matched, val, err := util.ParsePrefetchOverride(opt); matched {
+						if err != nil {
+							klog.Warning(err)
+							continue
+						}
+						if val {
+							hasEnabled = true
+						} else {
+							hasDisabled = true
+						}
+					}
+				}
+			}
+		}
+		if pv != nil && pv.Spec.MountOptions != nil {
+			for _, opt := range pv.Spec.MountOptions {
+				if matched, val, err := util.ParsePrefetchOverride(opt); matched {
+					if err != nil {
+						klog.Warningf("failed to parse prefetch override from PV mountOptions: %v", err)
+						continue
+					}
+					if val {
+						hasEnabled = true
+					} else {
+						hasDisabled = true
+					}
+				}
+			}
+		}
+	}
+	return hasEnabled, hasDisabled
 }

--- a/pkg/webhook/volumes_test.go
+++ b/pkg/webhook/volumes_test.go
@@ -1,0 +1,285 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestGetNativePrefetchOverrides(t *testing.T) {
+	t.Parallel()
+
+	const namespace = "test-namespace"
+
+	testCases := []struct {
+		name         string
+		volumes      []corev1.Volume
+		pvcs         []*corev1.PersistentVolumeClaim
+		pvs          []*corev1.PersistentVolume
+		wantEnabled  bool
+		wantDisabled bool
+	}{
+		{
+			name: "unspecified/no overrides",
+			volumes: []corev1.Volume{
+				{
+					Name: "gcsfuse-inline",
+					VolumeSource: corev1.VolumeSource{
+						CSI: &corev1.CSIVolumeSource{
+							Driver:           gcsFuseCsiDriverName,
+							VolumeAttributes: map[string]string{"mountOptions": "rw,noatime"},
+						},
+					},
+				},
+			},
+			wantEnabled:  false,
+			wantDisabled: false,
+		},
+		{
+			name: "inline csi: enable-metadata-prefetch=true",
+			volumes: []corev1.Volume{
+				{
+					Name: "gcsfuse-inline",
+					VolumeSource: corev1.VolumeSource{
+						CSI: &corev1.CSIVolumeSource{
+							Driver:           gcsFuseCsiDriverName,
+							VolumeAttributes: map[string]string{"mountOptions": "metadata-cache:enable-metadata-prefetch:true"},
+						},
+					},
+				},
+			},
+			wantEnabled:  true,
+			wantDisabled: false,
+		},
+		{
+			name: "inline csi: enable-metadata-prefetch=false",
+			volumes: []corev1.Volume{
+				{
+					Name: "gcsfuse-inline",
+					VolumeSource: corev1.VolumeSource{
+						CSI: &corev1.CSIVolumeSource{
+							Driver:           gcsFuseCsiDriverName,
+							VolumeAttributes: map[string]string{"mountOptions": "metadata-cache:enable-metadata-prefetch:false"},
+						},
+					},
+				},
+			},
+			wantEnabled:  false,
+			wantDisabled: true,
+		},
+		{
+			name: "multiple inline volumes: conflict (one true, one false)",
+			volumes: []corev1.Volume{
+				{
+					Name: "gcsfuse-inline-1",
+					VolumeSource: corev1.VolumeSource{
+						CSI: &corev1.CSIVolumeSource{
+							Driver:           gcsFuseCsiDriverName,
+							VolumeAttributes: map[string]string{"mountOptions": "metadata-cache:enable-metadata-prefetch:true"},
+						},
+					},
+				},
+				{
+					Name: "gcsfuse-inline-2",
+					VolumeSource: corev1.VolumeSource{
+						CSI: &corev1.CSIVolumeSource{
+							Driver:           gcsFuseCsiDriverName,
+							VolumeAttributes: map[string]string{"mountOptions": "metadata-cache:enable-metadata-prefetch:false"},
+						},
+					},
+				},
+			},
+			wantEnabled:  true,
+			wantDisabled: true,
+		},
+		{
+			name: "pvc: pv enable-metadata-prefetch=true",
+			volumes: []corev1.Volume{
+				{
+					Name: "gcsfuse-pvc",
+					VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+							ClaimName: "my-pvc",
+						},
+					},
+				},
+			},
+			pvcs: []*corev1.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-pvc", Namespace: namespace},
+					Spec:       corev1.PersistentVolumeClaimSpec{VolumeName: "my-pv"},
+				},
+			},
+			pvs: []*corev1.PersistentVolume{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-pv"},
+					Spec: corev1.PersistentVolumeSpec{
+						PersistentVolumeSource: corev1.PersistentVolumeSource{
+							CSI: &corev1.CSIPersistentVolumeSource{Driver: gcsFuseCsiDriverName},
+						},
+						MountOptions: []string{"metadata-cache:enable-metadata-prefetch:true"},
+					},
+				},
+			},
+			wantEnabled:  true,
+			wantDisabled: false,
+		},
+		{
+			name: "pvc: pv enable-metadata-prefetch=false",
+			volumes: []corev1.Volume{
+				{
+					Name: "gcsfuse-pvc",
+					VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+							ClaimName: "my-pvc",
+						},
+					},
+				},
+			},
+			pvcs: []*corev1.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-pvc", Namespace: namespace},
+					Spec:       corev1.PersistentVolumeClaimSpec{VolumeName: "my-pv"},
+				},
+			},
+			pvs: []*corev1.PersistentVolume{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-pv"},
+					Spec: corev1.PersistentVolumeSpec{
+						PersistentVolumeSource: corev1.PersistentVolumeSource{
+							CSI: &corev1.CSIPersistentVolumeSource{Driver: gcsFuseCsiDriverName},
+						},
+						MountOptions: []string{"metadata-cache:enable-metadata-prefetch:false"},
+					},
+				},
+			},
+			wantEnabled:  false,
+			wantDisabled: true,
+		},
+		{
+			name: "multiple pvcs: conflict (one pv true, one pv false)",
+			volumes: []corev1.Volume{
+				{
+					Name: "gcsfuse-pvc-1",
+					VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+							ClaimName: "my-pvc-1",
+						},
+					},
+				},
+				{
+					Name: "gcsfuse-pvc-2",
+					VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+							ClaimName: "my-pvc-2",
+						},
+					},
+				},
+			},
+			pvcs: []*corev1.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-pvc-1", Namespace: namespace},
+					Spec:       corev1.PersistentVolumeClaimSpec{VolumeName: "my-pv-1"},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-pvc-2", Namespace: namespace},
+					Spec:       corev1.PersistentVolumeClaimSpec{VolumeName: "my-pv-2"},
+				},
+			},
+			pvs: []*corev1.PersistentVolume{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-pv-1"},
+					Spec: corev1.PersistentVolumeSpec{
+						PersistentVolumeSource: corev1.PersistentVolumeSource{
+							CSI: &corev1.CSIPersistentVolumeSource{Driver: gcsFuseCsiDriverName},
+						},
+						MountOptions: []string{"metadata-cache:enable-metadata-prefetch:true"},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-pv-2"},
+					Spec: corev1.PersistentVolumeSpec{
+						PersistentVolumeSource: corev1.PersistentVolumeSource{
+							CSI: &corev1.CSIPersistentVolumeSource{Driver: gcsFuseCsiDriverName},
+						},
+						MountOptions: []string{"metadata-cache:enable-metadata-prefetch:false"},
+					},
+				},
+			},
+			wantEnabled:  true,
+			wantDisabled: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			fakeClient := fake.NewSimpleClientset()
+			for _, pv := range tc.pvs {
+				_, err := fakeClient.CoreV1().PersistentVolumes().Create(context.TODO(), pv, metav1.CreateOptions{})
+				if err != nil {
+					t.Fatalf("failed to create fake PV: %v", err)
+				}
+			}
+			for _, pvc := range tc.pvcs {
+				_, err := fakeClient.CoreV1().PersistentVolumeClaims(namespace).Create(context.TODO(), pvc, metav1.CreateOptions{})
+				if err != nil {
+					t.Fatalf("failed to create fake PVC: %v", err)
+				}
+			}
+
+			informerFactory := informers.NewSharedInformerFactoryWithOptions(fakeClient, time.Second*1, informers.WithNamespace(metav1.NamespaceAll))
+			pvLister := informerFactory.Core().V1().PersistentVolumes().Lister()
+			pvcLister := informerFactory.Core().V1().PersistentVolumeClaims().Lister()
+
+			si := &SidecarInjector{
+				PvLister:  pvLister,
+				PvcLister: pvcLister,
+			}
+
+			informerFactory.Start(ctx.Done())
+			informerFactory.WaitForCacheSync(ctx.Done())
+
+			var pod *corev1.Pod
+			if tc.volumes != nil {
+				pod = &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{Namespace: namespace},
+					Spec: corev1.PodSpec{
+						Volumes: tc.volumes,
+					},
+				}
+			}
+
+			gotEnabled, gotDisabled := si.getNativePrefetchOverrides(pod)
+			if gotEnabled != tc.wantEnabled || gotDisabled != tc.wantDisabled {
+				t.Errorf("getNativePrefetchOverrides() got = (%v, %v), want = (%v, %v)", gotEnabled, gotDisabled, tc.wantEnabled, tc.wantDisabled)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR modifies the webhook logic to support native GCSFuse metadata prefetch, allowing prefetch to be handled directly by the GCSFuse sidecar instead of requiring a separate legacy metadata prefetch sidecar container.

Key changes:

1. **Webhook decision logic** (`mutatingwebhook.go`): Adds a decision matrix to determine whether to use native prefetch (handled by GCSFuse sidecar) or fall back to legacy prefetch (separate sidecar container injection). The decision considers:
   - Whether the `--enable-gcsfuse-metadata-prefetch` feature flag is enabled
   - Whether the sidecar image version supports native prefetch
   - Whether the user is using a custom (non-managed) sidecar image
   - Whether the user explicitly enabled/disabled native prefetch via mount options

2. **Version skew protection** (`sidecar_mounter_config.go`): Introduces `WEBHOOK_HANDLED_PREFETCH` and `PREFETCH_REQUESTED` environment variables to coordinate between the webhook and the sidecar container:
   - `PREFETCH_REQUESTED`: Injected by the webhook to indicate whether any volume in the pod requested metadata prefetching by specifying ``.
   - `WEBHOOK_HANDLED_PREFETCH`: Injected only by the newer version of the webhook. It signals to the sidecar that the webhook has taken responsibility for deciding whether to enable native prefetch or fall back to legacy prefetch.
   - **Double Execution Avoidance**: When a newer GCSFuse sidecar container starts up and detects `PREFETCH_REQUESTED = true` but `WEBHOOK_HANDLED_PREFETCH = false` (which occurs when an older webhook has injected the legacy prefetch helper container), it automatically adds `metadata-cache:enable-metadata-prefetch:false` to the GCSFuse mount options to force-disable the native prefetch. This prevents running both prefetch mechanisms simultaneously.

3. **Mount option parsing** (`injection.go`, `util.go`): Adds `getNativePrefetchOverride()` to parse `metadata-cache:enable-metadata-prefetch` from volume mount options (both inline CSI ephemeral volumes and PVC/PV), allowing users to explicitly opt-in or opt-out of native prefetch.

4. **Code deduplication** (`util.go`, `csi_driver/utils.go`): Moves `IsManagedSidecarImage()` and associated regex patterns to `pkg/util` for reuse across packages.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

- `nativePrefetchMinVersion` is set to `999.0.0` as a placeholder, and the `--enable-gcsfuse-metadata-prefetch` feature flag is set to `false` by default in `deployment.yaml`. We will change the value if we decide to roll out this PR.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add webhook support for native GCSFuse metadata prefetch, gated behind the --enable-gcsfuse-metadata-prefetch flag. When enabled, metadata prefetch is handled directly by the GCSFuse sidecar instead of a separate sidecar container. Users can override the behavior via the metadata-cache:enable-metadata-prefetch mount option.
```
