### PR TITLE
test: use maps.Clone in TestPrepareMountArgs to prevent mutating shar…

### DIFF
--- a/pkg/sidecar_mounter/sidecar_mounter_config_test.go
+++ b/pkg/sidecar_mounter/sidecar_mounter_config_test.go
@@ -18,6 +18,7 @@ limitations under the License.
 package sidecarmounter
 
 import (
+	"maps"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -526,16 +527,17 @@ func TestPrepareMountArgs(t *testing.T) {
 	testPrometheusPort := prometheusPort
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			expectedArgs := maps.Clone(tc.expectedArgs)
 			found := slices.Contains(tc.mc.Options, util.DisableMetricsForGKE+":true")
 			if !found {
-				tc.expectedArgs["prometheus-port"] = strconv.Itoa(testPrometheusPort)
+				expectedArgs["prometheus-port"] = strconv.Itoa(testPrometheusPort)
 			}
 			// Increase port value to match behavior of prepareMountArgs()
 			testPrometheusPort++
 
 			tc.mc.prepareMountArgs()
-			if !reflect.DeepEqual(tc.mc.FlagMap, tc.expectedArgs) {
-				t.Errorf("Got args %v, but expected %v", tc.mc.FlagMap, tc.expectedArgs)
+			if !reflect.DeepEqual(tc.mc.FlagMap, expectedArgs) {
+				t.Errorf("Got args %v, but expected %v", tc.mc.FlagMap, expectedArgs)
 			}
 
 			if !reflect.DeepEqual(tc.mc.ConfigFileFlagMap, tc.expectedConfigMapArgs) {

--- a/pkg/webhook/injection_test.go
+++ b/pkg/webhook/injection_test.go
@@ -1940,38 +1940,35 @@ func TestInjectMetadataPrefetchSidecarWithSC(t *testing.T) {
 			si.PvLister = informer.Core().V1().PersistentVolumes().Lister()
 			si.PvcLister = informer.Core().V1().PersistentVolumeClaims().Lister()
 			informer.Start(ctx.Done())
-			_, err := fakeClient.StorageV1().StorageClasses().Create(context.TODO(), tc.sc, metav1.CreateOptions{})
-
+			err := informer.Storage().V1().StorageClasses().Informer().GetStore().Add(tc.sc)
 			if err != nil {
 				t.Fatalf("failed to setup test SC: %v", err)
 			}
-			_, err = fakeClient.CoreV1().PersistentVolumes().Create(context.TODO(), tc.pv, metav1.CreateOptions{})
+			err = informer.Core().V1().PersistentVolumes().Informer().GetStore().Add(tc.pv)
 			if err != nil {
 				t.Fatalf("failed to setup test PV: %v", err)
 			}
-			_, err = fakeClient.CoreV1().PersistentVolumes().Create(context.TODO(), &corev1.PersistentVolume{
+			err = informer.Core().V1().PersistentVolumes().Informer().GetStore().Add(&corev1.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "pv-mention-prefetch",
-				}}, metav1.CreateOptions{})
+				}})
 			if err != nil {
 				t.Fatalf("failed to setup test PV: %v", err)
 			}
 
-			_, err = fakeClient.CoreV1().PersistentVolumeClaims("").Create(context.TODO(), tc.pvc, metav1.CreateOptions{})
+			err = informer.Core().V1().PersistentVolumeClaims().Informer().GetStore().Add(tc.pvc)
 			if err != nil {
 				t.Fatalf("failed to setup test PVC: %v", err)
 			}
-			_, err = fakeClient.CoreV1().PersistentVolumeClaims("").Create(context.TODO(), &corev1.PersistentVolumeClaim{
+			err = informer.Core().V1().PersistentVolumeClaims().Informer().GetStore().Add(&corev1.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "pvc-mention-prefetch",
 				}, Spec: corev1.PersistentVolumeClaimSpec{
 					VolumeName: "pv-mention-prefetch",
-				}}, metav1.CreateOptions{})
+				}})
 			if err != nil {
 				t.Fatalf("failed to setup test PVC: %v", err)
 			}
-
-			informer.WaitForCacheSync(ctx.Done())
 
 			err = si.injectSidecarContainer(MetadataPrefetchSidecarName, tc.pod, *tc.nativeSidecar, nil)
 			t.Logf("%s resulted in %v and error: %v", tc.testName, err == nil, err)


### PR DESCRIPTION
**What type of PR is this?**
/kind flake
**What this PR does / why we need it**:
This PR uses `maps.Clone` to clone `expectedArgs` inside each `t.Run` subtest block of `TestPrepareMountArgs`. 
Prior to this, `expectedArgs` referenced the shared package-level map `defaultFlagMap`. During test runs, the tests mutated `defaultFlagMap` in-place to insert `"prometheus-port"`. Since multiple test cases share this map, they mutated the same underlying map reference, causing shared state contamination and flaky test assertions.
Cloning the map for each test case isolates the mutation to that specific test run.
**Which issue(s) this PR fixes**:
Fixes b/517536620
**Special notes for your reviewer**:
None
**Does this PR introduce a user-facing change?**:
```release-note
NONE