### PR TITLE
Automated cherry pick of #1261: Add retry to metadataservice client creation
#1287: Fix error string for better SLO categorization

### DIFF
--- a/cmd/sidecar_mounter/main.go
+++ b/cmd/sidecar_mounter/main.go
@@ -95,17 +95,15 @@ func main() {
 		}
 		if mc != nil {
 			if mc.EnableSidecarBucketAccessCheck {
-				tm, ssm, err := mounter.SetupTokenAndStorageManager(nil /*k8sClientset*/, mc)
-				if err != nil {
-					klog.Fatalf("Failed to fetch identity pool and identity provider details required for bucket access check, got error %v", err)
-				}
-				mounter.TokenManager = tm
-				mounter.StorageServiceManager = ssm
 				mc.SidecarRetryConfig.Cap = *storageServiceAndBucketAccessCap
 				mc.SidecarRetryConfig.Steps = *storageServiceAndBucketAccessSteps
 				mc.SidecarRetryConfig.Factor = *storageServiceAndBucketAccessFactor
 				mc.SidecarRetryConfig.Duration = *storageServiceAndBucketAccessDuration
 				mc.SidecarRetryConfig.Jitter = *storageServiceAndBucketAccessJitter
+				err := mounter.SetupTokenAndStorageManager(ctx, nil /*k8sClientset*/, mc)
+				if err != nil {
+					klog.Fatalf("Failed to fetch identity pool and identity provider details required for bucket access check, got error %v", err)
+				}
 			}
 			if err := mounter.Mount(ctx, mc); err != nil {
 				mc.ErrWriter.WriteMsg(fmt.Sprintf("failed to mount bucket %q for volume %q: %v\n", mc.BucketName, mc.VolumeName, err))

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -207,14 +207,14 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 		return nil, status.Errorf(codes.NotFound, "failed to get node: %v", err)
 	}
 
-	// if s.driver.config.WINodeLabelCheck {
-	// 	val, ok := node.Labels[clientset.GkeMetaDataServerKey]
-	// 	// If Workload Identity is not enabled, the key should be missing; the check for "val == false" is just for extra caution
-	// 	isWorkloadIdentityDisabled := val != "true" || !ok
-	// 	if isWorkloadIdentityDisabled && !pod.Spec.HostNetwork {
-	// 		return nil, status.Errorf(codes.FailedPrecondition, "Workload Identity Federation is not enabled on node. Please make sure this is enabled on both cluster and node pool level (https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity)")
-	// 	}
-	// }
+	if s.driver.config.WINodeLabelCheck {
+		val, ok := node.Labels[clientset.GkeMetaDataServerKey]
+		// If Workload Identity is not enabled, the key should be missing; the check for "val == false" is just for extra caution
+		isWorkloadIdentityDisabled := val != "true" || !ok
+		if isWorkloadIdentityDisabled && !pod.Spec.HostNetwork {
+			return nil, status.Errorf(codes.FailedPrecondition, "Workload Identity Federation is not enabled on node. Please make sure this is enabled on both cluster and node pool level (https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity)")
+		}
+	}
 
 	// Since the webhook mutating ordering is not definitive,
 	// the sidecar position is not checked in the ValidatePodHasSidecarContainerInjected func.

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -207,14 +207,14 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 		return nil, status.Errorf(codes.NotFound, "failed to get node: %v", err)
 	}
 
-	if s.driver.config.WINodeLabelCheck {
-		val, ok := node.Labels[clientset.GkeMetaDataServerKey]
-		// If Workload Identity is not enabled, the key should be missing; the check for "val == false" is just for extra caution
-		isWorkloadIdentityDisabled := val != "true" || !ok
-		if isWorkloadIdentityDisabled && !pod.Spec.HostNetwork {
-			return nil, status.Errorf(codes.FailedPrecondition, "Workload Identity Federation is not enabled on node. Please make sure this is enabled on both cluster and node pool level (https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity)")
-		}
-	}
+	// if s.driver.config.WINodeLabelCheck {
+	// 	val, ok := node.Labels[clientset.GkeMetaDataServerKey]
+	// 	// If Workload Identity is not enabled, the key should be missing; the check for "val == false" is just for extra caution
+	// 	isWorkloadIdentityDisabled := val != "true" || !ok
+	// 	if isWorkloadIdentityDisabled && !pod.Spec.HostNetwork {
+	// 		return nil, status.Errorf(codes.FailedPrecondition, "Workload Identity Federation is not enabled on node. Please make sure this is enabled on both cluster and node pool level (https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity)")
+	// 	}
+	// }
 
 	// Since the webhook mutating ordering is not definitive,
 	// the sidecar position is not checked in the ValidatePodHasSidecarContainerInjected func.

--- a/pkg/csi_driver/utils.go
+++ b/pkg/csi_driver/utils.go
@@ -468,7 +468,7 @@ func extractErrorFromGcsFuseErrorFile(errMsg []byte, err error) (codes.Code, err
 		}
 		if strings.Contains(errMsgStr, util.SidecarBucketAccessCheckErrorPrefix) {
 			if code == codes.Internal {
-				code = codes.Unavailable // Sidecar bucket access check retries on any failure to connect to the bucket so mark these as Unavailable to avoid SLO false triggers.
+				code = codes.Unavailable // Sidecar bucket access check retries on any failure to connect to the bucket or metadata service setup retries on any failure, so mark these as Unavailable to avoid SLO false triggers.
 			}
 			return code, fmt.Errorf("%v", errMsgStr) // Remember the error string already contains SidecarBucketAccessCheckErrorPrefix
 		}

--- a/pkg/csi_driver/utils.go
+++ b/pkg/csi_driver/utils.go
@@ -467,6 +467,9 @@ func extractErrorFromGcsFuseErrorFile(errMsg []byte, err error) (codes.Code, err
 			code = codes.Unauthenticated
 		}
 		if strings.Contains(errMsgStr, util.SidecarBucketAccessCheckErrorPrefix) {
+			if code == codes.Internal {
+				code = codes.Unavailable // Sidecar bucket access check retries on any failure to connect to the bucket so mark these as Unavailable to avoid SLO false triggers.
+			}
 			return code, fmt.Errorf("%v", errMsgStr) // Remember the error string already contains SidecarBucketAccessCheckErrorPrefix
 		}
 		return code, fmt.Errorf("gcsfuse failed with error: %v", errMsgStr)

--- a/pkg/sidecar_mounter/sidecar_mounter.go
+++ b/pkg/sidecar_mounter/sidecar_mounter.go
@@ -421,7 +421,7 @@ func (m *Mounter) executeFuncWithRetry(ctx context.Context, mc *MountConfig, f f
 	}
 	err := wait.ExponentialBackoffWithContext(ctx, backoff, f)
 	if err != nil {
-		return fmt.Errorf("bucket access check failed after retries: %w", err)
+		return fmt.Errorf("operation failed after retries: %w", err)
 	}
 	return nil
 }
@@ -458,7 +458,6 @@ func (m *Mounter) checkBucketAccessWithRetry(ctx context.Context, tokenSource oa
 	if err := m.executeFuncWithRetry(ctx, mc, ssCreateAndBucketCheckFunc); err != nil {
 		return err
 	}
-	klog.V(4).Infof("Completed access check for bucket %s", bucketName)
 	return nil
 }
 
@@ -489,14 +488,14 @@ func (m *Mounter) SetupTokenAndStorageManager(ctx context.Context, clientset cli
 		setupTokenAndStorageManagerFunc := func(ctx context.Context) (bool, error) {
 			meta, err := cpmeta.NewMetadataService(mc.TokenServerIdentityPool, mc.TokenServerIdentityProvider)
 			if err != nil {
-				mc.ErrWriter.WriteMsg(fmt.Sprintf("Failed to set up metadata service: %v for identity pool %s and identity provider %s, retrying....", err, mc.TokenServerIdentityPool, mc.TokenServerIdentityProvider))
+				mc.ErrWriter.WriteMsg(fmt.Sprintf("Failed to setup metadata service: %v for identity pool %s and identity provider %s, retrying....", err, mc.TokenServerIdentityPool, mc.TokenServerIdentityProvider))
 				return false, nil
 			}
 
 			tm = auth.NewTokenManager(meta, clientset)
 			ssm, err = storage.NewGCSServiceManager()
 			if err != nil {
-				mc.ErrWriter.WriteMsg(fmt.Sprintf("Failed to set up storage service manager, got error: %v for identity pool %s and identity provider %s, retrying...", err, mc.TokenServerIdentityPool, mc.TokenServerIdentityProvider))
+				mc.ErrWriter.WriteMsg(fmt.Sprintf("Failed to setup storage service manager, got error: %v for identity pool %s and identity provider %s, retrying...", err, mc.TokenServerIdentityPool, mc.TokenServerIdentityProvider))
 				return false, nil
 			}
 			m.TokenManager = tm
@@ -506,10 +505,10 @@ func (m *Mounter) SetupTokenAndStorageManager(ctx context.Context, clientset cli
 		if err := m.executeFuncWithRetry(ctx, mc, setupTokenAndStorageManagerFunc); err != nil {
 			return err
 		}
-		klog.V(6).Infof("Setup complete for token manager and storage service manager %v and %v", m.TokenManager, m.StorageServiceManager)
+		klog.V(4).Infof("Setup complete for token manager and storage service manager %v and %v", m.TokenManager, m.StorageServiceManager)
 		return nil
 	}
-	return fmt.Errorf("Either of identity-pool %s or identity-provider %s were not provided", mc.TokenServerIdentityPool, mc.TokenServerIdentityProvider)
+	return fmt.Errorf("Verify both identity pool and identity provider are provided, got: %s and %s respectively", mc.TokenServerIdentityPool, mc.TokenServerIdentityProvider)
 }
 
 func fetchIdentityBindingToken(ctx context.Context, k8sSAToken string, identityProvider string) (*oauth2.Token, error) {

--- a/pkg/sidecar_mounter/sidecar_mounter.go
+++ b/pkg/sidecar_mounter/sidecar_mounter.go
@@ -492,7 +492,6 @@ func (m *Mounter) SetupTokenAndStorageManager(ctx context.Context, clientset cli
 				mc.ErrWriter.WriteMsg(fmt.Sprintf("Failed to set up metadata service: %v for identity pool %s and identity provider %s, retrying....", err, mc.TokenServerIdentityPool, mc.TokenServerIdentityProvider))
 				return false, nil
 			}
-			mc.ErrWriter.WriteMsg(fmt.Sprintf("Sneha: Did not get any error; created metadata service successfully"))
 
 			tm = auth.NewTokenManager(meta, clientset)
 			ssm, err = storage.NewGCSServiceManager()
@@ -500,7 +499,6 @@ func (m *Mounter) SetupTokenAndStorageManager(ctx context.Context, clientset cli
 				mc.ErrWriter.WriteMsg(fmt.Sprintf("Failed to set up storage service manager, got error: %v for identity pool %s and identity provider %s, retrying...", err, mc.TokenServerIdentityPool, mc.TokenServerIdentityProvider))
 				return false, nil
 			}
-			mc.ErrWriter.WriteMsg(fmt.Sprintf("Sneha: Did not get any error; token manager and SSM created successfully %v and %v", tm, ssm))
 			m.TokenManager = tm
 			m.StorageServiceManager = ssm
 			return true, nil
@@ -508,8 +506,7 @@ func (m *Mounter) SetupTokenAndStorageManager(ctx context.Context, clientset cli
 		if err := m.executeFuncWithRetry(ctx, mc, setupTokenAndStorageManagerFunc); err != nil {
 			return err
 		}
-		//TODO: Sneha to update this log info to V6
-		klog.Infof("Setup complete for token manager and storage service manager %v and %v", m.TokenManager, m.StorageServiceManager)
+		klog.V(6).Infof("Setup complete for token manager and storage service manager %v and %v", m.TokenManager, m.StorageServiceManager)
 		return nil
 	}
 	return fmt.Errorf("Either of identity-pool %s or identity-provider %s were not provided", mc.TokenServerIdentityPool, mc.TokenServerIdentityProvider)

--- a/pkg/sidecar_mounter/sidecar_mounter.go
+++ b/pkg/sidecar_mounter/sidecar_mounter.go
@@ -434,7 +434,7 @@ func (m *Mounter) checkBucketAccessWithRetry(ctx context.Context, tokenSource oa
 		if ss == nil {
 			ss, err = m.StorageServiceManager.SetupStorageServiceForSidecar(ctx, tokenSource)
 			if err != nil {
-				mc.ErrWriter.WriteMsg(fmt.Sprintf("%q: %q: %v %v, retrying...", util.SidecarBucketAccessCheckErrorPrefix, util.StorageServiceErrorStr, storage.ParseErrCode(err), err))
+				mc.ErrWriter.WriteMsg(retryableError(fmt.Sprintf("%q: %v %v, retrying...", util.StorageServiceErrorStr, storage.ParseErrCode(err), err)))
 				return false, nil
 			}
 			klog.V(4).Infof("Created storage service %v", ss)
@@ -442,7 +442,7 @@ func (m *Mounter) checkBucketAccessWithRetry(ctx context.Context, tokenSource oa
 
 		if bucketName != "_" {
 			if exist, err := ss.CheckBucketExists(ctx, &storage.ServiceBucket{Name: bucketName}); !exist {
-				mc.ErrWriter.WriteMsg(fmt.Sprintf("%q: failed to get GCS bucket %q: %v %v", util.SidecarBucketAccessCheckErrorPrefix, bucketName, storage.ParseErrCode(err), err))
+				mc.ErrWriter.WriteMsg(retryableError(fmt.Sprintf("failed to get GCS bucket %q: %v %v", bucketName, storage.ParseErrCode(err), err)))
 				return false, nil
 			}
 			klog.V(4).Infof("Bucket access check passed for %s", bucketName)
@@ -488,14 +488,14 @@ func (m *Mounter) SetupTokenAndStorageManager(ctx context.Context, clientset cli
 		setupTokenAndStorageManagerFunc := func(ctx context.Context) (bool, error) {
 			meta, err := cpmeta.NewMetadataService(mc.TokenServerIdentityPool, mc.TokenServerIdentityProvider)
 			if err != nil {
-				mc.ErrWriter.WriteMsg(fmt.Sprintf("Failed to setup metadata service: %v for identity pool %s and identity provider %s, retrying....", err, mc.TokenServerIdentityPool, mc.TokenServerIdentityProvider))
+				mc.ErrWriter.WriteMsg(retryableError(fmt.Sprintf("failed to setup metadata service, got error: %v for identity pool %q and identity provider %q, retrying....", err, mc.TokenServerIdentityPool, mc.TokenServerIdentityProvider)))
 				return false, nil
 			}
 
 			tm = auth.NewTokenManager(meta, clientset)
 			ssm, err = storage.NewGCSServiceManager()
 			if err != nil {
-				mc.ErrWriter.WriteMsg(fmt.Sprintf("Failed to setup storage service manager, got error: %v for identity pool %s and identity provider %s, retrying...", err, mc.TokenServerIdentityPool, mc.TokenServerIdentityProvider))
+				mc.ErrWriter.WriteMsg(retryableError(fmt.Sprintf("failed to setup storage service manager, got error: %v for identity pool %q and identity provider %q, retrying...", err, mc.TokenServerIdentityPool, mc.TokenServerIdentityProvider)))
 				return false, nil
 			}
 			m.TokenManager = tm
@@ -508,7 +508,7 @@ func (m *Mounter) SetupTokenAndStorageManager(ctx context.Context, clientset cli
 		klog.V(4).Infof("Setup complete for token manager and storage service manager %v and %v", m.TokenManager, m.StorageServiceManager)
 		return nil
 	}
-	return fmt.Errorf("Verify both identity pool and identity provider are provided, got: %s and %s respectively", mc.TokenServerIdentityPool, mc.TokenServerIdentityProvider)
+	return errors.New(retryableError(fmt.Sprintf("both identity pool and identity provider must be provided, got: %q and %q respectively", mc.TokenServerIdentityPool, mc.TokenServerIdentityProvider)))
 }
 
 func fetchIdentityBindingToken(ctx context.Context, k8sSAToken string, identityProvider string) (*oauth2.Token, error) {
@@ -541,4 +541,8 @@ func fetchIdentityBindingToken(ctx context.Context, k8sSAToken string, identityP
 		TokenType:   stsResponse.TokenType,
 		Expiry:      time.Now().Add(time.Second * time.Duration(stsResponse.ExpiresIn)),
 	}, nil
+}
+
+func retryableError(inputErr string) string {
+	return fmt.Sprintf("%s: %v", util.SidecarBucketAccessCheckErrorPrefix, inputErr)
 }

--- a/pkg/sidecar_mounter/sidecar_mounter.go
+++ b/pkg/sidecar_mounter/sidecar_mounter.go
@@ -97,7 +97,7 @@ func (m *Mounter) Mount(ctx context.Context, mc *MountConfig) error {
 		}
 	}
 	if mc.EnableSidecarBucketAccessCheck {
-		err := m.checkBucketAccessWithRetry(ctx, m.StorageServiceManager, tokenSource, m.TokenManager, mc.BucketName, mc.TokenServerIdentityProvider, mc)
+		err := m.checkBucketAccessWithRetry(ctx, tokenSource, mc.BucketName, mc.TokenServerIdentityProvider, mc)
 		if err != nil {
 			return status.Errorf(codes.Unauthenticated, "failed to prepare storage service or check bucket access, failed with error: %v", err)
 		}
@@ -411,8 +411,7 @@ func StartTokenServer(ctx context.Context, tokenURLBasePath, tokenSocketName str
 	}
 }
 
-// checkBucketAccessWithRetry prepares the GCS Storage Service using the Kubernetes Service Account from VolumeContext and validates bucket access.
-func (m *Mounter) checkBucketAccessWithRetry(ctx context.Context, storageServiceManager storage.ServiceManager, tokenSource oauth2.TokenSource, tm auth.TokenManager, bucketName string, tokenProvider string, mc *MountConfig) error {
+func (m *Mounter) executeFuncWithRetry(ctx context.Context, mc *MountConfig, f func(ctx context.Context) (bool, error)) error {
 	backoff := wait.Backoff{
 		Duration: mc.SidecarRetryConfig.Duration,
 		Factor:   mc.SidecarRetryConfig.Factor,
@@ -420,9 +419,17 @@ func (m *Mounter) checkBucketAccessWithRetry(ctx context.Context, storageService
 		Steps:    mc.SidecarRetryConfig.Steps,
 		Jitter:   mc.SidecarRetryConfig.Jitter, // Adds randomness, this will give +/- 10% of the current delay
 	}
+	err := wait.ExponentialBackoffWithContext(ctx, backoff, f)
+	if err != nil {
+		return fmt.Errorf("bucket access check failed after retries: %w", err)
+	}
+	return nil
+}
 
-	var ss storage.Service
+// checkBucketAccessWithRetry prepares the GCS Storage Service using the Kubernetes Service Account from VolumeContext and validates bucket access.
+func (m *Mounter) checkBucketAccessWithRetry(ctx context.Context, tokenSource oauth2.TokenSource, bucketName string, tokenProvider string, mc *MountConfig) error {
 	var err error
+	var ss storage.Service
 	ssCreateAndBucketCheckFunc := func(ctx context.Context) (bool, error) {
 		if ss == nil {
 			ss, err = m.StorageServiceManager.SetupStorageServiceForSidecar(ctx, tokenSource)
@@ -448,9 +455,8 @@ func (m *Mounter) checkBucketAccessWithRetry(ctx context.Context, storageService
 		}
 	}
 
-	err = wait.ExponentialBackoffWithContext(ctx, backoff, ssCreateAndBucketCheckFunc)
-	if err != nil {
-		return fmt.Errorf("bucket access check failed after retries: %w", err)
+	if err := m.executeFuncWithRetry(ctx, mc, ssCreateAndBucketCheckFunc); err != nil {
+		return err
 	}
 	klog.V(4).Infof("Completed access check for bucket %s", bucketName)
 	return nil
@@ -476,21 +482,37 @@ func getAudienceFromContextAndIdentityProvider(ctx context.Context, identityProv
 	return identityProvider, nil
 }
 
-func (m *Mounter) SetupTokenAndStorageManager(clientset clientset.Interface, mc *MountConfig) (auth.TokenManager, storage.ServiceManager, error) {
+func (m *Mounter) SetupTokenAndStorageManager(ctx context.Context, clientset clientset.Interface, mc *MountConfig) error {
 	if mc.TokenServerIdentityPool != "" && mc.TokenServerIdentityProvider != "" {
-		meta, err := cpmeta.NewMetadataService(mc.TokenServerIdentityPool, mc.TokenServerIdentityProvider)
-		if err != nil {
-			return nil, nil, fmt.Errorf("Failed to set up metadata service: %v for identity pool %s and identity provider %s", err, mc.TokenServerIdentityPool, mc.TokenServerIdentityProvider)
-		}
+		var tm auth.TokenManager
+		var ssm storage.ServiceManager
+		setupTokenAndStorageManagerFunc := func(ctx context.Context) (bool, error) {
+			meta, err := cpmeta.NewMetadataService(mc.TokenServerIdentityPool, mc.TokenServerIdentityProvider)
+			if err != nil {
+				mc.ErrWriter.WriteMsg(fmt.Sprintf("Failed to set up metadata service: %v for identity pool %s and identity provider %s, retrying....", err, mc.TokenServerIdentityPool, mc.TokenServerIdentityProvider))
+				return false, nil
+			}
+			mc.ErrWriter.WriteMsg(fmt.Sprintf("Sneha: Did not get any error; created metadata service successfully"))
 
-		tm := auth.NewTokenManager(meta, clientset)
-		ssm, err := storage.NewGCSServiceManager()
-		if err != nil {
-			return nil, nil, fmt.Errorf("Failed to set up storage service manager, got error: %v for identity pool %s and identity provider %s", err, mc.TokenServerIdentityPool, mc.TokenServerIdentityProvider)
+			tm = auth.NewTokenManager(meta, clientset)
+			ssm, err = storage.NewGCSServiceManager()
+			if err != nil {
+				mc.ErrWriter.WriteMsg(fmt.Sprintf("Failed to set up storage service manager, got error: %v for identity pool %s and identity provider %s, retrying...", err, mc.TokenServerIdentityPool, mc.TokenServerIdentityProvider))
+				return false, nil
+			}
+			mc.ErrWriter.WriteMsg(fmt.Sprintf("Sneha: Did not get any error; token manager and SSM created successfully %v and %v", tm, ssm))
+			m.TokenManager = tm
+			m.StorageServiceManager = ssm
+			return true, nil
 		}
-		return tm, ssm, nil
+		if err := m.executeFuncWithRetry(ctx, mc, setupTokenAndStorageManagerFunc); err != nil {
+			return err
+		}
+		//TODO: Sneha to update this log info to V6
+		klog.Infof("Setup complete for token manager and storage service manager %v and %v", m.TokenManager, m.StorageServiceManager)
+		return nil
 	}
-	return nil, nil, fmt.Errorf("Either of identity-pool %s or identity-provider %s were not provided", mc.TokenServerIdentityPool, mc.TokenServerIdentityProvider)
+	return fmt.Errorf("Either of identity-pool %s or identity-provider %s were not provided", mc.TokenServerIdentityPool, mc.TokenServerIdentityProvider)
 }
 
 func fetchIdentityBindingToken(ctx context.Context, k8sSAToken string, identityProvider string) (*oauth2.Token, error) {


### PR DESCRIPTION
Cherry pick of #1261 #1287 on release-1.21.

#1261: Add retry to metadataservice client creation
#1287: Fix error string for better SLO categorization

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.


**Testing**
Tested failed mount test suite
```

make e2e-test E2E_TEST_USE_GKE_MANAGED_DRIVER=false E2E_TEST_BUILD_DRIVER=true BUILD_GCSFUSE_FROM_SOURCE=true GCSFUSE_TAG=v3.5.8  STAGINGVERSION=$STAGINGVERSION  REGISTRY=$REGISTRY E2E_TEST_FOCUS="failedMount.*"

-----
------------------------------
[ReportAfterSuite] PASSED [118.845 seconds]
[ReportAfterSuite] Autogenerated ReportAfterSuite for --junit-report
autogenerated by Ginkgo
------------------------------

Ran 41 of 458 Specs in 281.375 seconds
SUCCESS! -- 41 Passed | 0 Failed | 0 Pending | 417 Skipped


Ginkgo ran 1 suite in 5m38.213668404s
Test Suite Passed

```

```release-note
Adds retry to GCS Fuse sidecar to auto recover when metadata service is not yet up on the pods.
NONE
```