### PR TITLE
Optimize the cloud profiler E2E test suite by parallelizing the profi…

### DIFF
--- a/test/e2e/testsuites/cloud_profiler.go
+++ b/test/e2e/testsuites/cloud_profiler.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync"
 
 	"local/test/e2e/specs"
 	"local/test/e2e/utils"
@@ -34,6 +35,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	e2evolume "k8s.io/kubernetes/test/e2e/framework/volume"
 	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
 	admissionapi "k8s.io/pod-security-admission/api"
@@ -97,6 +99,10 @@ func (t *gcsFuseCSICloudProfilerTestSuite) DefineTests(driver storageframework.T
 	}
 
 	testCaseCloudProfilerProfileCreation := func(configPrefix string, disableGcsfuseProfiler bool) {
+		if zbEnabled(driver) {
+			e2eskipper.Skipf("skip cloud_profiler tests when Zonal Buckets is enabled")
+		}
+
 		init(configPrefix)
 		defer cleanup()
 
@@ -137,25 +143,44 @@ func (t *gcsFuseCSICloudProfilerTestSuite) DefineTests(driver storageframework.T
 		// Write a 10MB file to the mount path to generate activity for the profiler to capture.
 		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("head -c 10485760 </dev/urandom > %s/test.bin", mountPath))
 
-		ginkgo.By("Checking that sidecar profile is generated")
-		framework.Logf("Checking if sidecar profile exists for version %s", expectedVersion)
-		gomega.Eventually(ctx, func(g gomega.Gomega) {
-			// Check Sidecar Profile
-			sidecarOk, err := checkIfProfileExistForServiceAndVersion(ctx, sidecarServiceName, expectedVersion)
-			g.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("failed to check sidecar profile for version %s", expectedVersion))
-			g.Expect(sidecarOk).To(gomega.BeTrue(), fmt.Sprintf("sidecar profile does not exist yet for version %s", expectedVersion))
-		}, "10m", "10s").Should(gomega.Succeed())
+		ginkgo.By("Initializing Cloud Profiler client once")
+		profilerClient, err := cloudprofiler.NewService(ctx, option.WithScopes(cloudprofiler.CloudPlatformScope))
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to initialize cloudprofiler service client")
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+			defer ginkgo.GinkgoRecover()
+
+			ginkgo.By("Checking that sidecar profile is generated")
+			framework.Logf("Checking if sidecar profile exists for version %s", expectedVersion)
+			gomega.Eventually(ctx, func(g gomega.Gomega) {
+				// Check Sidecar Profile
+				sidecarOk, err := checkIfProfileExistForServiceAndVersion(ctx, profilerClient, sidecarServiceName, expectedVersion)
+				g.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("failed to check sidecar profile for version %s", expectedVersion))
+				g.Expect(sidecarOk).To(gomega.BeTrue(), fmt.Sprintf("sidecar profile does not exist yet for version %s", expectedVersion))
+			}, "10m", "10s").Should(gomega.Succeed())
+		}()
 
 		if !disableGcsfuseProfiler {
-			ginkgo.By("Checking that gcsfuse profile is generated")
-			framework.Logf("Checking if gcsfuse profile exists for version %s", expectedVersion)
-			gomega.Eventually(ctx, func(g gomega.Gomega) {
-				// Check GCSFuse Profile
-				gcsfuseOk, err := checkIfProfileExistForServiceAndVersion(ctx, gcsfuseServiceName, expectedVersion)
-				g.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("failed to check gcsfuse profile for version %s", expectedVersion))
-				g.Expect(gcsfuseOk).To(gomega.BeTrue(), fmt.Sprintf("gcsfuse profile does not exist yet for version %s", expectedVersion))
-			}, "10m", "10s").Should(gomega.Succeed())
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				defer ginkgo.GinkgoRecover()
+
+				ginkgo.By("Checking that gcsfuse profile is generated")
+				framework.Logf("Checking if gcsfuse profile exists for version %s", expectedVersion)
+				gomega.Eventually(ctx, func(g gomega.Gomega) {
+					// Check GCSFuse Profile
+					gcsfuseOk, err := checkIfProfileExistForServiceAndVersion(ctx, profilerClient, gcsfuseServiceName, expectedVersion)
+					g.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("failed to check gcsfuse profile for version %s", expectedVersion))
+					g.Expect(gcsfuseOk).To(gomega.BeTrue(), fmt.Sprintf("gcsfuse profile does not exist yet for version %s", expectedVersion))
+				}, "10m", "10s").Should(gomega.Succeed())
+			}()
 		}
+		wg.Wait()
 	}
 
 	ginkgo.It("cloud_profiler should create profiles for sidecar and gcsfuse", ginkgo.SpecPriority(10), func() {
@@ -167,27 +192,24 @@ func (t *gcsFuseCSICloudProfilerTestSuite) DefineTests(driver storageframework.T
 	})
 }
 
-func checkIfProfileExistForServiceAndVersion(ctx context.Context, serviceName, version string) (bool, error) {
+func checkIfProfileExistForServiceAndVersion(ctx context.Context, service *cloudprofiler.Service, serviceName, version string) (bool, error) {
 	framework.Logf("Checking if profile exists for service %q and version %q", serviceName, version)
-	service, err := cloudprofiler.NewService(ctx, option.WithScopes(cloudprofiler.CloudPlatformScope))
-	if err != nil {
-		return false, err
-	}
 	projectID := os.Getenv(utils.ProjectEnvVar)
 	parent := "projects/" + projectID
-
 	call := service.Projects.Profiles.List(parent)
 
 	var found bool
 	stopErr := fmt.Errorf("stop iteration")
+	var pageIndex int
+
 	// Use Pages to iterate through all profiles, handling pagination automatically.
-	err = call.Pages(ctx, func(page *cloudprofiler.ListProfilesResponse) error {
-		framework.Logf("Scanning profiles for service %q", serviceName)
+	err := call.Pages(ctx, func(page *cloudprofiler.ListProfilesResponse) error {
+		pageIndex++
+		framework.Logf("Scanning page %d of profiles for service %q and version %q", pageIndex, serviceName, version)
 		for _, profile := range page.Profiles {
 			if profile.Deployment != nil && profile.Deployment.Target == serviceName && profile.Deployment.Labels != nil && profile.Deployment.Labels["version"] == version {
 				found = true
-				framework.Logf("Found profile for service %q and version %q", serviceName, version)
-				// Return a specific error to break out of the pagination early.
+				framework.Logf("Found profile for service %q and version %q on page %d", serviceName, version, pageIndex)
 				return stopErr
 			}
 		}

--- a/test/e2e/testsuites/istio.go
+++ b/test/e2e/testsuites/istio.go
@@ -23,6 +23,9 @@ import (
 	"os"
 	"strconv"
 
+	"local/test/e2e/specs"
+	"local/test/e2e/utils"
+
 	"github.com/onsi/ginkgo/v2"
 	"google.golang.org/grpc/codes"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -32,8 +35,6 @@ import (
 	e2evolume "k8s.io/kubernetes/test/e2e/framework/volume"
 	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
 	admissionapi "k8s.io/pod-security-admission/api"
-	"local/test/e2e/specs"
-	"local/test/e2e/utils"
 )
 
 type gcsFuseCSIIstioTestSuite struct {
@@ -110,6 +111,10 @@ func (t *gcsFuseCSIIstioTestSuite) DefineTests(driver storageframework.TestDrive
 			tPod.SetAnnotations(map[string]string{"traffic.sidecar.istio.io/excludeOutboundIPRanges": "169.254.169.254/32"})
 			specs.DeployIstioSidecar(f.Namespace.Name)
 			specs.DeployIstioServiceEntry(f.Namespace.Name)
+		}
+
+		if zbEnabled(driver) {
+			tPod.SetAnnotations(map[string]string{"traffic.sidecar.istio.io/excludeOutboundPorts": "443"})
 		}
 
 		ginkgo.By("Deploying the pod")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind failing-test
/kind flake

**What this PR does / why we need it**:
This PR resolves the test hang in Istio Zonal Bucket E2E tests, and introduces execution improvements for the Cloud Profiler test suite.

### 1. Fix Infinite Hangs in Istio Tests with Zonal Buckets 
* **The Problem:** Zonal Buckets exclusively use gRPC and cannot fallback to HTTP. When Istio is injected, Envoy intercepts GCS FUSE outbound traffic on port `443` and leads to the following error
```
Retrying for the error: rpc error: code = Unavailable desc = name resolver error: [xDS node id: C2P-1716144904150986009]: rpc error: code = Unavailable desc = listener resource error: [xDS node id: C2P-1716144904150986009]: [xDS node id: C2P-1716144904150986009]: xds: error received from xDS stream: rpc error: code = Unavailable desc = connection error: desc = "transport: authentication handshake failed: read tcp 10.60.4.54:41720->64.233.181.95:443: read: connection reset by peer"
```
  Crucially, the FUSE mount system call itself succeeds at the OS level, allowing the test Pod to transition to the **`Running`** status. However, when the workload actually attempts any read/write operations, the I/O hangs indefinitely. The test execution inside the Pod never fails or exits, causing the Ginkgo E2E test suite to hang silently until it hits the hard **4-hour suite timeout**.
* **The Fix:** Added the annotation `traffic.sidecar.istio.io/excludeOutboundPorts: "443"` when Zonal Buckets are enabled. This bypasses Envoy proxying for all port 443 outbound traffic, letting the DirectPath and GFE gRPC connections establish directly and stably.

### 2. Cloud Profiler Test Suite Improvements & Cleanups
* **Disabled on ZB:** Explicitly skips/disables the `cloud_profiler` tests when Zonal Buckets are enabled
* **Parallelized Profile Queries:** Parallelized the verification queries for GCSFuse and sidecar mounter profiles using concurrent goroutines. This significantly improves profile retrieval efficiency and prevents the tests from hitting transient timeouts.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
I have tested on non managed driver, gke version 1.36, GCSFuse version `3.9.1`
I tested istio 10 times to make sure no flakiness and all the test cases passed
```
export STAGINGVERSION=prow-gob-internal-boskos-yaozile-zb-dev
export REGISTRY=us-central1-docker.pkg.dev/yaozile-gke-dev/gcs-fuse-csi-driver
export ENABLE_ZB=true
export E2E_TEST_FOCUS=istio
export E2E_TEST_USE_GKE_MANAGED_DRIVER=false

make build-image-and-push-multi-arch
make e2e-test

  Ran 8 of 464 Specs in 47.921 seconds
  SUCCESS! -- 8 Passed | 0 Failed | 0 Pending | 456 Skipped


  Ginkgo ran 1 suite in 53.557267177s
  Test Suite Passed
```
I have verified that the cloud profiler test will be skipped in ZB enabled tests
```
S [SKIPPED] [1.008 seconds]
  E2E Test Suite [Driver: gcsfuse.csi.storage.gke.io] [Testpattern: CSI Ephemeral-volume (default fs)] cloudProfiler [It] cloud_profiler should only create profiles for sidecar when gcsfuse profiler is disabled
  /usr/local/google/home/yaozile/oss/gcs-fuse-csi-driver/test/e2e/testsuites/cloud_profiler.go:187

S [SKIPPED] [1.000 seconds]
E2E Test Suite [Driver: gcsfuse.csi.storage.gke.io] [Testpattern: CSI Ephemeral-volume (default fs)] cloudProfiler [It] cloud_profiler should create profiles for sidecar and gcsfuse
  /usr/local/google/home/yaozile/oss/gcs-fuse-csi-driver/test/e2e/testsuites/cloud_profiler.go:183
```
profiler test in non managed driver:
```
Ran 2 of 590 Specs in 1583.837 seconds
  SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 588 Skipped


  Ginkgo ran 1 suite in 26m38.371854753s
  Test Suite Passed
```

I also run the ZB enabled e2e test, all the test has been passed except the one in `workload-identity-federation`. This test has been keep failing in the non managed testgrid and will be fixed in another PR.
```
  Summarizing 1 Failure:
    [FAIL] E2E Test Suite [Driver: gcsfuse.csi.storage.gke.io] [Testpattern: CSI Ephemeral-volume (default fs)] workload-identity-federation [It] should fail GCS access after workload identity federation principal permissions are removed while pod is running
    /usr/local/google/home/yaozile/oss/gcs-fuse-csi-driver/test/e2e/testsuites/workload_identity_federation.go:334

  Ran 333 of 464 Specs in 3439.089 seconds
  FAIL -- 332 Passed | 1 Failed | 0 Pending | 131 Skipped


  Ginkgo ran 1 suite in 57m20.792985038s
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
