### PR TITLE
Automated cherry pick of #1393: Fix unit tests failing

### DIFF
--- a/pkg/sidecar_mounter/sidecar_mounter_config_test.go
+++ b/pkg/sidecar_mounter/sidecar_mounter_config_test.go
@@ -61,7 +61,7 @@ var (
 )
 
 func TestPrepareMountArgs(t *testing.T) {
-	t.Parallel()
+	// Do not parallelize [e.g t.Parallel()] because all testcases share testPrometheusPort.
 
 	testCases := []struct {
 		name                    string
@@ -526,7 +526,6 @@ func TestPrepareMountArgs(t *testing.T) {
 	testPrometheusPort := prometheusPort
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Do not parallelize [e.g t.Parallel()] because all testcases share testPrometheusPort.
 			found := slices.Contains(tc.mc.Options, util.DisableMetricsForGKE+":true")
 			if !found {
 				tc.expectedArgs["prometheus-port"] = strconv.Itoa(testPrometheusPort)


### PR DESCRIPTION
Cherry pick of #1393 on release-1.23.

#1393: Fix unit tests failing

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```