### PR TITLE
Fix unit-test and sanity-test Prow failures by setting GOTOOLCHAIN mi…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -334,10 +334,10 @@ verify:
 	hack/verify-all.sh
 
 unit-test:
-	go test -v -mod=vendor -timeout 30s "./pkg/..." -cover
+	GOTOOLCHAIN=go1.25.1+auto go test -v -mod=vendor -timeout 30s "./pkg/..." -cover
 
 sanity-test:
-	cd test && go mod tidy && go test -mod=readonly -v -timeout 30s "./sanity/" -run TestSanity
+	cd test && go mod tidy && GOTOOLCHAIN=go1.25.1+auto go test -mod=readonly -v -timeout 30s "./sanity/" -run TestSanity
 
 build-e2e-test:
 	cd test && go build -o ../bin/e2e-test-ci ./e2e


### PR DESCRIPTION
Copy of https://github.com/GoogleCloudPlatform/gcs-fuse-csi-driver/pull/1387

This prevents Go from auto-downloading the buggy Go 1.25.0 minimal toolchain in Prow, which contains a packaging bug where the 'covdata' tool is missing, causing '-cover' test builds to fail with 'go: no such tool "covdata"'.

Locking it to go1.25.1 (a bug-free patch release of Go 1.25) ensures Go compiles safely, while satisfying the Go >= 1.25.0 requirements pulled by transitive dependencies during sanity tests.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
/kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR fixes presubmit unit test build failures and sanity test failures by explicitly setting GOTOOLCHAIN=go1.25.1 in the Makefile.

Recently, the gcs-fuse-csi-unit presubmit job began failing with go: no such tool "covdata" when using -cover. Under GOTOOLCHAIN=auto, Go auto-downloaded a minimal version of go1.25.0 which suffered from a known packaging bug omitting the covdata tool.

Furthermore, running go mod tidy in sanity-test targets retrieves dependencies requiring Go >= 1.25.0. By explicitly locking GOTOOLCHAIN=go1.25.1 (a bug-free patch release of Go 1.25), we solve both problems: satisfying the Go 1.25 requirement while bypassing the packaging bug in Go 1.25.0.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
Fixes Prow presubmit unit test failures (Build ID: 2057610651404079104)



**Special notes for your reviewer**:
Validated the fix inside the exact Prow CI container (gcr.io/gke-test-infra/kubekins-e2e:latest-master) where the tests now compile, download go1.24.0 as expected, and pass all tests successfully.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```