### PR TITLE
1.5 bump gcsfuse

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,15 +48,15 @@ all: driver sidecar-mounter webhook
 
 driver:
 	mkdir -p ${BINDIR}
-	CGO_ENABLED=0 GOOS=linux GOARCH=$(shell dpkg --print-architecture) go build -mod vendor -ldflags "${LDFLAGS}" -o ${BINDIR}/${DRIVER_BINARY} cmd/csi_driver/main.go
+	CGO_ENABLED=0 GOOS=linux go build -mod vendor -ldflags "${LDFLAGS}" -o ${BINDIR}/${DRIVER_BINARY} cmd/csi_driver/main.go
 
 sidecar-mounter:
 	mkdir -p ${BINDIR}
-	CGO_ENABLED=0 GOOS=linux GOARCH=$(shell dpkg --print-architecture) go build -mod vendor -ldflags "${LDFLAGS}" -o ${BINDIR}/${SIDECAR_BINARY} cmd/sidecar_mounter/main.go
+	CGO_ENABLED=0 GOOS=linux go build -mod vendor -ldflags "${LDFLAGS}" -o ${BINDIR}/${SIDECAR_BINARY} cmd/sidecar_mounter/main.go
 
 webhook:
 	mkdir -p ${BINDIR}
-	CGO_ENABLED=0 GOOS=linux GOARCH=$(shell dpkg --print-architecture) go build -mod vendor -ldflags "${LDFLAGS}" -o ${BINDIR}/${WEBHOOK_BINARY} cmd/webhook/main.go
+	CGO_ENABLED=0 GOOS=linux go build -mod vendor -ldflags "${LDFLAGS}" -o ${BINDIR}/${WEBHOOK_BINARY} cmd/webhook/main.go
 
 download-gcsfuse:
 	mkdir -p ${BINDIR}/linux/amd64 ${BINDIR}/linux/arm64

--- a/cmd/csi_driver/Dockerfile
+++ b/cmd/csi_driver/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Build driver go binary
-FROM golang:1.22.5 AS driver-builder
+FROM --platform=$BUILDPLATFORM golang:1.22.5 AS driver-builder
 
 ARG STAGINGVERSION
 

--- a/cmd/csi_driver/Dockerfile
+++ b/cmd/csi_driver/Dockerfile
@@ -17,10 +17,11 @@
 FROM --platform=$BUILDPLATFORM golang:1.22.5 AS driver-builder
 
 ARG STAGINGVERSION
+ARG TARGETPLATFORM
 
 WORKDIR /gcs-fuse-csi-driver
 ADD . .
-RUN make driver BINDIR=/bin
+RUN GOARCH=$(echo $TARGETPLATFORM | cut -f2 -d '/') make driver BINDIR=/bin
 
 # Start from Kubernetes Debian base.
 FROM gke.gcr.io/debian-base:bookworm-v1.0.2-gke.2 AS debian

--- a/cmd/sidecar_mounter/Dockerfile
+++ b/cmd/sidecar_mounter/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Build sidecar-mounter go binary
-FROM golang:1.22.5 AS sidecar-mounter-builder
+FROM --platform=$BUILDPLATFORM golang:1.22.5 AS sidecar-mounter-builder
 
 ARG STAGINGVERSION
 

--- a/cmd/sidecar_mounter/Dockerfile
+++ b/cmd/sidecar_mounter/Dockerfile
@@ -17,10 +17,11 @@
 FROM --platform=$BUILDPLATFORM golang:1.22.5 AS sidecar-mounter-builder
 
 ARG STAGINGVERSION
+ARG TARGETPLATFORM
 
 WORKDIR /gcs-fuse-csi-driver
 ADD . .
-RUN make sidecar-mounter BINDIR=/bin
+RUN GOARCH=$(echo $TARGETPLATFORM | cut -f2 -d '/') make sidecar-mounter BINDIR=/bin
 
 # go/gke-releasing-policies#base-images
 # We use `gcr.io/distroless/base` because it includes glibc.

--- a/cmd/sidecar_mounter/gcsfuse_binary
+++ b/cmd/sidecar_mounter/gcsfuse_binary
@@ -1,1 +1,1 @@
-gs://gke-release-staging/gcsfuse/v2.4.0-gke.0/gcsfuse_bin
+gs://gke-release-staging/gcsfuse/v2.4.3-gke.0/gcsfuse_bin

--- a/cmd/webhook/Dockerfile
+++ b/cmd/webhook/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Build webhook go binary
-FROM golang:1.22.5 AS webhook-builder
+FROM --platform=$BUILDPLATFORM golang:1.22.5 AS webhook-builder
 
 ARG STAGINGVERSION
 

--- a/cmd/webhook/Dockerfile
+++ b/cmd/webhook/Dockerfile
@@ -17,10 +17,11 @@
 FROM --platform=$BUILDPLATFORM golang:1.22.5 AS webhook-builder
 
 ARG STAGINGVERSION
+ARG TARGETPLATFORM
 
 WORKDIR /gcs-fuse-csi-driver
 ADD . .
-RUN make webhook BINDIR=/bin
+RUN  GOARCH=$(echo $TARGETPLATFORM | cut -f2 -d '/') make webhook BINDIR=/bin
 
 FROM gcr.io/distroless/static
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Fix vulnerability in gcsfuse by bumping gcsfuse from 3.2.6 to 3.2.7
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Bump GCSFuse from 3.2.6 to 3.2.7
```