### PR TITLE
feat(sidecar): respect first appearance of enable-sidecar-bucket-acce…

### DIFF
--- a/pkg/csi_driver/utils_test.go
+++ b/pkg/csi_driver/utils_test.go
@@ -178,6 +178,41 @@ func TestJoinMountOptions(t *testing.T) {
 	}
 }
 
+func TestJoinMountOptionsSorting(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name            string
+		existingOptions []string
+		newOptions      []string
+		expectedOptions []string
+	}{
+		{
+			name:            "should sort enable-sidecar-bucket-access-check=true and false to false, true (first-wins false override)",
+			existingOptions: []string{"enable-sidecar-bucket-access-check=true"},
+			newOptions:      []string{"enable-sidecar-bucket-access-check=false"},
+			expectedOptions: []string{"enable-sidecar-bucket-access-check=false", "enable-sidecar-bucket-access-check=true"},
+		},
+		{
+			name:            "should sort enable-sidecar-bucket-access-check=false and true to false, true",
+			existingOptions: []string{"enable-sidecar-bucket-access-check=false"},
+			newOptions:      []string{"enable-sidecar-bucket-access-check=true"},
+			expectedOptions: []string{"enable-sidecar-bucket-access-check=false", "enable-sidecar-bucket-access-check=true"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			output := joinMountOptions(tc.existingOptions, tc.newOptions)
+			// Assert exact ordering of the returned slice without sorting it in comparison
+			if !reflect.DeepEqual(output, tc.expectedOptions) {
+				t.Errorf("unexpected options sorting: got %+v, expected %+v", output, tc.expectedOptions)
+			}
+		})
+	}
+}
+
 func TestIsSidecarVersionSupportedForGivenFeature(t *testing.T) {
 	t.Parallel()
 	t.Run("checking if sidecar version is supported for given version and feature", func(t *testing.T) {

--- a/pkg/sidecar_mounter/sidecar_mounter_config.go
+++ b/pkg/sidecar_mounter/sidecar_mounter_config.go
@@ -207,6 +207,7 @@ func (mc *MountConfig) prepareMountArgs() {
 	invalidArgs := []string{}
 
 	mc.GcsFuseNumaNode = -1
+	enableSidecarBucketAccessCheckParsed := false
 	for _, arg := range mc.Options {
 		klog.Infof("processing mount arg %v", arg)
 
@@ -276,7 +277,10 @@ func (mc *MountConfig) prepareMountArgs() {
 			continue
 
 		case util.EnableSidecarBucketAccessCheckConst:
-			mc.EnableSidecarBucketAccessCheck = value == util.TrueStr
+			if !enableSidecarBucketAccessCheckParsed {
+				mc.EnableSidecarBucketAccessCheck = value == util.TrueStr
+				enableSidecarBucketAccessCheckParsed = true
+			}
 			continue
 
 		case util.PodNamespaceConst:

--- a/pkg/sidecar_mounter/sidecar_mounter_config_test.go
+++ b/pkg/sidecar_mounter/sidecar_mounter_config_test.go
@@ -64,13 +64,14 @@ func TestPrepareMountArgs(t *testing.T) {
 	// Do not parallelize [e.g t.Parallel()] because all testcases share testPrometheusPort.
 
 	testCases := []struct {
-		name                    string
-		mc                      *MountConfig
-		expectedArgs            map[string]string
-		expectedConfigMapArgs   map[string]string
-		expectNumaNode          bool
-		expectedNumaNode        int
-		expectedStorageEndpoint string
+		name                                   string
+		mc                                     *MountConfig
+		expectedArgs                           map[string]string
+		expectedConfigMapArgs                  map[string]string
+		expectNumaNode                         bool
+		expectedNumaNode                       int
+		expectedStorageEndpoint                string
+		expectedEnableSidecarBucketAccessCheck bool
 	}{
 		{
 			name: "should return valid args correctly",
@@ -521,6 +522,58 @@ func TestPrepareMountArgs(t *testing.T) {
 				"cache-dir":         "",
 			},
 		},
+		{
+			name: "should respect enable-sidecar-bucket-access-check=true",
+			mc: &MountConfig{
+				BucketName: "test-bucket",
+				BufferDir:  "test-buffer-dir",
+				CacheDir:   "test-cache-dir",
+				ConfigFile: "test-config-file",
+				Options:    []string{"enable-sidecar-bucket-access-check=true"},
+			},
+			expectedArgs:                           defaultFlagMap,
+			expectedConfigMapArgs:                  defaultConfigFileFlagMap,
+			expectedEnableSidecarBucketAccessCheck: true,
+		},
+		{
+			name: "should respect enable-sidecar-bucket-access-check=false",
+			mc: &MountConfig{
+				BucketName: "test-bucket",
+				BufferDir:  "test-buffer-dir",
+				CacheDir:   "test-cache-dir",
+				ConfigFile: "test-config-file",
+				Options:    []string{"enable-sidecar-bucket-access-check=false"},
+			},
+			expectedArgs:                           defaultFlagMap,
+			expectedConfigMapArgs:                  defaultConfigFileFlagMap,
+			expectedEnableSidecarBucketAccessCheck: false,
+		},
+		{
+			name: "should respect first enable-sidecar-bucket-access-check=false when followed by true (due to alphabetical order)",
+			mc: &MountConfig{
+				BucketName: "test-bucket",
+				BufferDir:  "test-buffer-dir",
+				CacheDir:   "test-cache-dir",
+				ConfigFile: "test-config-file",
+				Options:    []string{"enable-sidecar-bucket-access-check=false", "enable-sidecar-bucket-access-check=true"},
+			},
+			expectedArgs:                           defaultFlagMap,
+			expectedConfigMapArgs:                  defaultConfigFileFlagMap,
+			expectedEnableSidecarBucketAccessCheck: false,
+		},
+		{
+			name: "should respect first enable-sidecar-bucket-access-check=true when followed by false",
+			mc: &MountConfig{
+				BucketName: "test-bucket",
+				BufferDir:  "test-buffer-dir",
+				CacheDir:   "test-cache-dir",
+				ConfigFile: "test-config-file",
+				Options:    []string{"enable-sidecar-bucket-access-check=true", "enable-sidecar-bucket-access-check=false"},
+			},
+			expectedArgs:                           defaultFlagMap,
+			expectedConfigMapArgs:                  defaultConfigFileFlagMap,
+			expectedEnableSidecarBucketAccessCheck: true,
+		},
 	}
 
 	testPrometheusPort := prometheusPort
@@ -553,6 +606,9 @@ func TestPrepareMountArgs(t *testing.T) {
 			}
 			if tc.expectedStorageEndpoint != "" && tc.expectedStorageEndpoint != tc.mc.StorageEndpoint {
 				t.Errorf("Got storage endpoint %s, but expected %s", tc.mc.StorageEndpoint, tc.expectedStorageEndpoint)
+			}
+			if tc.mc.EnableSidecarBucketAccessCheck != tc.expectedEnableSidecarBucketAccessCheck {
+				t.Errorf("Got EnableSidecarBucketAccessCheck %t, but expected %t", tc.mc.EnableSidecarBucketAccessCheck, tc.expectedEnableSidecarBucketAccessCheck)
 			}
 		})
 	}


### PR DESCRIPTION
…ss-check

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Currently, GCS FUSE CSI inline ephemeral volumes silently override user-specified overrides of `enable-sidecar-bucket-access-check=false` (or `skipCSIBucketAccessCheck: "true"`). This happens because the CSI driver appends its global default `enable-sidecar-bucket-access-check=true` after the user options. Because the sidecar processed the list sequentially and used the last-seen value, the default `true` always won, blocking non-Google auth flows from mounting GCS buckets via inline volumes.
This PR implements a fast-path sidecar fix to respect the first occurrence of `enable-sidecar-bucket-access-check` (first-wins parsing). Because mount options are sorted alphabetically by the CSI driver before being passed to the sidecar, `"enable-sidecar-bucket-access-check=false"` always sorts before `"true"` and is processed first. Using a state guard, we capture the first-seen value (user's false preference) and ignore subsequent ones.
This immediately unblocks customers using custom sidecar image overrides.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # b/495760030

**Special notes for your reviewer**:
This is the short-term sidecar-only fix meant to be released in a new sidecar container image immediately. The robust driver-side deduplication fix will follow as a separate PR for the next standard driver release.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed a bug where user-specified `enable-sidecar-bucket-access-check=false` mount option was ignored in GCS FUSE CSI inline ephemeral volumes.
```