### PR TITLE
Implement ControllerPublishVolume skeleton

### DIFF
--- a/pkg/csi_driver/controller.go
+++ b/pkg/csi_driver/controller.go
@@ -127,6 +127,43 @@ func (s *controllerServer) ValidateVolumeCapabilities(ctx context.Context, req *
 	}, nil
 }
 
+func (s *controllerServer) ControllerPublishVolume(ctx context.Context, req *csi.ControllerPublishVolumeRequest) (*csi.ControllerPublishVolumeResponse, error) {
+	// Validate arguments
+	volumeID := req.GetVolumeId()
+	if len(volumeID) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "ControllerPublishVolume Volume ID must be provided")
+	}
+	if err := s.driver.validateVolumeCapabilities([]*csi.VolumeCapability{req.GetVolumeCapability()}); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+	nodeID := req.GetNodeId()
+	if len(nodeID) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "ControllerPublishVolume Node ID must be provided")
+	}
+
+	// Acquires the lock for the volume on that node only, because we need to support the ability
+	// to publish the same volume onto different nodes concurrently
+	lockingVolumeID := fmt.Sprintf("%s/%s", nodeID, volumeID)
+	if acquired := s.volumeLocks.TryAcquire(lockingVolumeID); !acquired {
+		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, lockingVolumeID)
+	}
+	defer s.volumeLocks.Release(lockingVolumeID)
+
+	// Skip ControllerPublishVolume if the volume is not using the shared mount feature.
+	vc := req.GetVolumeContext()
+	if !sharedMount(vc) {
+		return &csi.ControllerPublishVolumeResponse{}, nil
+	}
+
+	// TODO(urielguzman): implement ControllerPublishVolume when sharedMount: true.
+	return &csi.ControllerPublishVolumeResponse{}, nil
+}
+
+// TODO(urielguzman): implement ControllerUnpublishVolume.
+func (s *controllerServer) ControllerUnpublishVolume(_ context.Context, _ *csi.ControllerUnpublishVolumeRequest) (*csi.ControllerUnpublishVolumeResponse, error) {
+	return &csi.ControllerUnpublishVolumeResponse{}, nil
+}
+
 func (s *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
 	// Validate arguments
 	name := req.GetName()

--- a/pkg/csi_driver/controller_test.go
+++ b/pkg/csi_driver/controller_test.go
@@ -31,6 +31,7 @@ import (
 
 const (
 	testVolumeID = "test-volume-id"
+	testNodeID   = "test-node-id"
 )
 
 func initTestController(t *testing.T) csi.ControllerServer {
@@ -162,5 +163,88 @@ func TestDeleteVolume(t *testing.T) {
 		if !reflect.DeepEqual(resp, test.resp) {
 			t.Errorf("test %q failed:\ngot resp %+v,\nexpected resp %+v", test.name, resp, test.resp)
 		}
+	}
+}
+
+func TestControllerPublishVolume(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name      string
+		req       *csi.ControllerPublishVolumeRequest
+		expectErr error
+	}{
+		{
+			name: "empty volume ID - should return error",
+			req: &csi.ControllerPublishVolumeRequest{
+				VolumeId:         "",
+				NodeId:           testNodeID,
+				VolumeCapability: testVolumeCapability,
+				VolumeContext:    map[string]string{},
+			},
+			expectErr: status.Error(codes.InvalidArgument, "ControllerPublishVolume Volume ID must be provided"),
+		},
+		{
+			name: "empty node ID - should return error",
+			req: &csi.ControllerPublishVolumeRequest{
+				VolumeId:         testVolumeID,
+				NodeId:           "",
+				VolumeCapability: testVolumeCapability,
+				VolumeContext:    map[string]string{},
+			},
+			expectErr: status.Error(codes.InvalidArgument, "ControllerPublishVolume Node ID must be provided"),
+		},
+		{
+			name: "empty volume capabilities - should return error",
+			req: &csi.ControllerPublishVolumeRequest{
+				VolumeId:         testVolumeID,
+				NodeId:           testNodeID,
+				VolumeCapability: nil,
+				VolumeContext:    map[string]string{},
+			},
+			expectErr: status.Error(codes.InvalidArgument, "volume capability must be provided"),
+		},
+		{
+			name: "missing sharedMount - should return success",
+			req: &csi.ControllerPublishVolumeRequest{
+				VolumeId:         testVolumeID,
+				NodeId:           testNodeID,
+				VolumeCapability: testVolumeCapability,
+				VolumeContext:    map[string]string{},
+			},
+			expectErr: nil,
+		},
+		{
+			name: "sharedMount true - should return success",
+			req: &csi.ControllerPublishVolumeRequest{
+				VolumeId:         testVolumeID,
+				NodeId:           testNodeID,
+				VolumeCapability: testVolumeCapability,
+				VolumeContext: map[string]string{
+					"sharedMount": "true",
+				},
+			},
+			expectErr: nil,
+		},
+		{
+			name: "sharedMount false - should return success",
+			req: &csi.ControllerPublishVolumeRequest{
+				VolumeId:         testVolumeID,
+				NodeId:           testNodeID,
+				VolumeCapability: testVolumeCapability,
+				VolumeContext: map[string]string{
+					"sharedMount": "false",
+				},
+			},
+			expectErr: nil,
+		},
+	}
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			s := initTestController(t)
+			_, err := s.ControllerPublishVolume(context.Background(), test.req)
+			if !errors.Is(err, test.expectErr) {
+				t.Errorf("Expected error: %v, got: %v", test.expectErr, err)
+			}
+		})
 	}
 }

--- a/pkg/csi_driver/shared_mount.go
+++ b/pkg/csi_driver/shared_mount.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import "github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util"
+
+// sharedMount checks if the VolumeContext enables the shared node mount feature
+// by checking the sharedMount: true volumeAttribute.
+func sharedMount(vc map[string]string) bool {
+	if v, ok := vc[VolumeContextSharedNodeMount]; ok && v == util.TrueStr {
+		return true
+	}
+	return false
+}

--- a/pkg/csi_driver/shared_mount_test.go
+++ b/pkg/csi_driver/shared_mount_test.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import "testing"
+
+func TestSharedMount(t *testing.T) {
+	testCases := []struct {
+		name          string
+		volumeContext map[string]string
+		expected      bool
+	}{
+		{
+			name:          "sharedMount true - should return true",
+			volumeContext: map[string]string{"sharedMount": "true"},
+			expected:      true,
+		},
+		{
+			name:          "sharedMount false - should return false",
+			volumeContext: map[string]string{"sharedMount": "false"},
+			expected:      false,
+		},
+		{
+			name:          "sharedMount missing - should return false",
+			volumeContext: map[string]string{},
+			expected:      false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			vc := tc.volumeContext
+			result := sharedMount(vc)
+			if result != tc.expected {
+				t.Errorf("Expected %v, but got %v", tc.expected, result)
+			}
+		})
+	}
+}

--- a/pkg/csi_driver/utils.go
+++ b/pkg/csi_driver/utils.go
@@ -66,6 +66,7 @@ const (
 	VolumeContextKeyIdentityPool               = "identityPool"
 	VolumeContextKeyMultiNICIndex              = "multiNICIndex"
 	VolumeContextEnableCloudProfilerForSidecar = "enableCloudProfilerForSidecar"
+	VolumeContextSharedNodeMount               = "sharedMount"
 	// Legacy key, kept for backward compatibility
 	//nolint:revive,stylecheck
 	VolumeContextKeyMetadataCacheTtlSeconds = "metadataCacheTtlSeconds"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR implements dummy code for ControllerPublishVolume for the upcoming shared node mount feature. It does a simple check to understand if the `sharedMount` has been passed or not from the VolumeContext.

Currently, this change is a no-op, because the driver has not yet implemented "attachRequired: true".

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```