### PR TITLE
upgrade golang to 1.25.10

### DIFF
--- a/cmd/csi_driver/Dockerfile
+++ b/cmd/csi_driver/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Build driver go binary
-FROM --platform=$BUILDPLATFORM golang:1.24.9 AS driver-builder
+FROM --platform=$BUILDPLATFORM golang:1.25.10 AS driver-builder
 
 ARG STAGINGVERSION
 ARG TARGETPLATFORM

--- a/cmd/metadata_prefetch/Dockerfile
+++ b/cmd/metadata_prefetch/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Build metadata-prefetch go binary
-FROM --platform=$BUILDPLATFORM golang:1.24.9 AS metadata-prefetch-builder
+FROM --platform=$BUILDPLATFORM golang:1.25.10 AS metadata-prefetch-builder
 
 ARG STAGINGVERSION
 ARG TARGETPLATFORM

--- a/cmd/sidecar_mounter/Dockerfile
+++ b/cmd/sidecar_mounter/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Build sidecar-mounter go binary
-FROM --platform=$BUILDPLATFORM golang:1.24.9 AS sidecar-mounter-builder
+FROM --platform=$BUILDPLATFORM golang:1.25.10 AS sidecar-mounter-builder
 
 ARG STAGINGVERSION
 ARG TARGETPLATFORM

--- a/cmd/webhook/Dockerfile
+++ b/cmd/webhook/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Build webhook go binary
-FROM --platform=$BUILDPLATFORM golang:1.24.9 AS webhook-builder
+FROM --platform=$BUILDPLATFORM golang:1.25.10 AS webhook-builder
 
 ARG STAGINGVERSION
 ARG TARGETPLATFORM


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Our team uses louhi flows to manage our release pipelines. Recently louhi updated to 1.25 golang which created a disparity between the version used by louhi and that of the release-1.21 branch. This causes our flows to fail. To fix we are upgrading golang to 1.25.10
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Upgrades golang to 1.25.10
```