### PR TITLE
Implement ControllerPublishVolume mounter pod name and namespace

### DIFF
--- a/pkg/cloud_provider/clientset/clientset.go
+++ b/pkg/cloud_provider/clientset/clientset.go
@@ -29,6 +29,7 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
@@ -51,6 +52,7 @@ type Interface interface {
 	GetPV(name string) (*corev1.PersistentVolume, error)
 	GetPVC(namespace string, name string) (*corev1.PersistentVolumeClaim, error)
 	GetSC(name string) (*storagev1.StorageClass, error)
+	ListPV() ([]*corev1.PersistentVolume, error)
 	CreateServiceAccountToken(ctx context.Context, namespace, name string, tokenRequest *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error)
 	GetGCPServiceAccountName(ctx context.Context, namespace, name string) (string, error)
 }
@@ -160,6 +162,7 @@ func (c *Clientset) ConfigurePVLister(ctx context.Context) {
 			},
 			Spec: corev1.PersistentVolumeSpec{
 				StorageClassName: pvObj.Spec.StorageClassName,
+				ClaimRef:         pvObj.Spec.ClaimRef,
 			},
 		}
 
@@ -364,6 +367,15 @@ func (c *Clientset) GetPV(name string) (*corev1.PersistentVolume, error) {
 	}
 
 	return c.pvLister.Get(name)
+}
+
+func (c *Clientset) ListPV() ([]*corev1.PersistentVolume, error) {
+	if c.pvLister == nil {
+		return nil, errors.New("pv informer is not ready")
+	}
+
+	// TODO(urielguzman): Optimize lister to only filter for a specific label.
+	return c.pvLister.List(labels.Everything())
 }
 
 func (c *Clientset) GetPVC(namespace, name string) (*corev1.PersistentVolumeClaim, error) {

--- a/pkg/cloud_provider/clientset/fake.go
+++ b/pkg/cloud_provider/clientset/fake.go
@@ -41,10 +41,12 @@ type FakePodConfig struct {
 }
 
 type FakePVConfig struct {
-	Annotations map[string]string
-	SCName      string
-	DriverName  string
-	Name        string
+	Annotations  map[string]string
+	SCName       string
+	DriverName   string
+	Name         string
+	VolumeHandle string
+	ClaimRef     *corev1.ObjectReference
 }
 
 type FakePVCConfig struct {
@@ -60,11 +62,12 @@ type FakeSCConfig struct {
 }
 
 type FakeClientset struct {
-	fakePod  *corev1.Pod
-	fakeNode *corev1.Node
-	fakePVs  map[string]*corev1.PersistentVolume
-	fakePVCs map[string]*corev1.PersistentVolumeClaim
-	fakeSCs  map[string]*storagev1.StorageClass
+	fakePod   *corev1.Pod
+	fakeNode  *corev1.Node
+	fakePVs   map[string]*corev1.PersistentVolume
+	fakePVCs  map[string]*corev1.PersistentVolumeClaim
+	fakeSCs   map[string]*storagev1.StorageClass
+	ListPVErr error
 }
 
 func NewFakeClientset() *FakeClientset {
@@ -160,9 +163,11 @@ func (c *FakeClientset) CreatePV(pvConfig FakePVConfig) {
 			StorageClassName: pvConfig.SCName,
 			PersistentVolumeSource: corev1.PersistentVolumeSource{
 				CSI: &corev1.CSIPersistentVolumeSource{
-					Driver: pvConfig.DriverName,
+					Driver:       pvConfig.DriverName,
+					VolumeHandle: pvConfig.VolumeHandle,
 				},
 			},
+			ClaimRef: pvConfig.ClaimRef,
 		},
 	}
 
@@ -222,6 +227,17 @@ func (c *FakeClientset) GetPV(name string) (*corev1.PersistentVolume, error) {
 	}
 
 	return c.fakePVs[""], nil
+}
+
+func (c *FakeClientset) ListPV() ([]*corev1.PersistentVolume, error) {
+	if c.ListPVErr != nil {
+		return nil, c.ListPVErr
+	}
+	var pvs []*corev1.PersistentVolume
+	for _, pv := range c.fakePVs {
+		pvs = append(pvs, pv)
+	}
+	return pvs, nil
 }
 
 func (c *FakeClientset) GetPVC(namespace, name string) (*corev1.PersistentVolumeClaim, error) {

--- a/pkg/csi_driver/controller.go
+++ b/pkg/csi_driver/controller.go
@@ -155,6 +155,32 @@ func (s *controllerServer) ControllerPublishVolume(ctx context.Context, req *csi
 		return &csi.ControllerPublishVolumeResponse{}, nil
 	}
 
+	// Find the workload namespace where the mounter pod should be created by identifying the PVC
+	// bound to this volume's PV.
+	clientset := s.driver.config.K8sClients
+	pv, err := pvFromVolumeID(clientset, volumeID)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	if pv.Spec.ClaimRef == nil {
+		// The PV should be bound if ControllerPublishVolume is called. Return error since this is unexpected.
+		return nil, status.Errorf(codes.Internal, "pv %q is not bound to any pvc", pv.Name)
+	}
+	pvcName := pv.Spec.ClaimRef.Name
+	pvcNamespace := pv.Spec.ClaimRef.Namespace
+	if pvcNamespace == "" || pvcName == "" {
+		return nil, status.Errorf(codes.Internal, "pv claimRef namespace and name can't be empty, namespace: %q, name: %q", pvcNamespace, pvcName)
+	}
+	mounterPodNamespace := pvcNamespace
+
+	// Prepare mounter pod config.
+	podName := createMounterPodName(nodeID, volumeID)
+	_ = &mounterPodConfig{
+		podName:   podName,
+		namespace: mounterPodNamespace,
+		nodeID:    nodeID,
+	}
+
 	// TODO(urielguzman): implement ControllerPublishVolume when sharedMount: true.
 	return &csi.ControllerPublishVolumeResponse{}, nil
 }

--- a/pkg/csi_driver/controller_test.go
+++ b/pkg/csi_driver/controller_test.go
@@ -19,24 +19,30 @@ package driver
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/clientset"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	corev1 "k8s.io/api/core/v1"
 )
 
 const (
-	testVolumeID = "test-volume-id"
-	testNodeID   = "test-node-id"
+	testVolumeID  = "test-volume-id"
+	testNodeID    = "test-node-id"
+	testPV        = "test-pv"
+	testPVC       = "test-pvc"
+	testNamespace = "test-namespace"
 )
 
-func initTestController(t *testing.T) csi.ControllerServer {
+func initTestController(t *testing.T, clientset clientset.Interface) csi.ControllerServer {
 	t.Helper()
-	driver := initTestDriver(t, nil)
+	driver := initTestDriver(t, nil, clientset)
 	cs, err := newControllerServer(driver, driver.config.StorageServiceManager, &GCSDriverFeatureOptions{FeatureGCSFuseProfiles: &FeatureGCSFuseProfiles{}})
 	if err != nil {
 		t.Fatalf("newControllerServer failed: %v", err)
@@ -98,7 +104,7 @@ func TestCreateVolume(t *testing.T) {
 	}
 
 	for _, test := range cases {
-		cs := initTestController(t)
+		cs := initTestController(t, clientset.NewFakeClientset())
 		resp, err := cs.CreateVolume(context.TODO(), test.req)
 		if test.expectErr == nil && err != nil {
 			t.Errorf("test %q failed:\ngot error %q,\nexpected error nil", test.name, err)
@@ -152,7 +158,7 @@ func TestDeleteVolume(t *testing.T) {
 	}
 
 	for _, test := range cases {
-		cs := initTestController(t)
+		cs := initTestController(t, clientset.NewFakeClientset())
 		resp, err := cs.DeleteVolume(context.TODO(), test.req)
 		if test.expectErr == nil && err != nil {
 			t.Errorf("test %q failed:\ngot error %q,\nexpected error nil", test.name, err)
@@ -171,6 +177,7 @@ func TestControllerPublishVolume(t *testing.T) {
 	cases := []struct {
 		name      string
 		req       *csi.ControllerPublishVolumeRequest
+		setupFake func() *clientset.FakeClientset
 		expectErr error
 	}{
 		{
@@ -181,6 +188,7 @@ func TestControllerPublishVolume(t *testing.T) {
 				VolumeCapability: testVolumeCapability,
 				VolumeContext:    map[string]string{},
 			},
+			setupFake: func() *clientset.FakeClientset { return clientset.NewFakeClientset() },
 			expectErr: status.Error(codes.InvalidArgument, "ControllerPublishVolume Volume ID must be provided"),
 		},
 		{
@@ -191,6 +199,7 @@ func TestControllerPublishVolume(t *testing.T) {
 				VolumeCapability: testVolumeCapability,
 				VolumeContext:    map[string]string{},
 			},
+			setupFake: func() *clientset.FakeClientset { return clientset.NewFakeClientset() },
 			expectErr: status.Error(codes.InvalidArgument, "ControllerPublishVolume Node ID must be provided"),
 		},
 		{
@@ -201,6 +210,7 @@ func TestControllerPublishVolume(t *testing.T) {
 				VolumeCapability: nil,
 				VolumeContext:    map[string]string{},
 			},
+			setupFake: func() *clientset.FakeClientset { return clientset.NewFakeClientset() },
 			expectErr: status.Error(codes.InvalidArgument, "volume capability must be provided"),
 		},
 		{
@@ -211,6 +221,7 @@ func TestControllerPublishVolume(t *testing.T) {
 				VolumeCapability: testVolumeCapability,
 				VolumeContext:    map[string]string{},
 			},
+			setupFake: func() *clientset.FakeClientset { return clientset.NewFakeClientset() },
 			expectErr: nil,
 		},
 		{
@@ -223,7 +234,85 @@ func TestControllerPublishVolume(t *testing.T) {
 					"sharedMount": "true",
 				},
 			},
+			setupFake: func() *clientset.FakeClientset {
+				fc := clientset.NewFakeClientset()
+				fc.CreatePV(clientset.FakePVConfig{Name: testPV, VolumeHandle: testVolumeID, ClaimRef: &corev1.ObjectReference{
+					Name:      "test-pvc",
+					Namespace: "test-namespace",
+				}})
+				return fc
+			},
 			expectErr: nil,
+		},
+		{
+			name: "sharedMount true - no pv found - should return error",
+			req: &csi.ControllerPublishVolumeRequest{
+				VolumeId:         testVolumeID,
+				NodeId:           testNodeID,
+				VolumeCapability: testVolumeCapability,
+				VolumeContext: map[string]string{
+					"sharedMount": "true",
+				},
+			},
+			setupFake: func() *clientset.FakeClientset { return clientset.NewFakeClientset() },
+			expectErr: status.Errorf(codes.Internal, "no pv found for volumeID: %q", testVolumeID),
+		},
+		{
+			name: "sharedMount true - claimRef nil - should return error",
+			req: &csi.ControllerPublishVolumeRequest{
+				VolumeId:         testVolumeID,
+				NodeId:           testNodeID,
+				VolumeCapability: testVolumeCapability,
+				VolumeContext: map[string]string{
+					"sharedMount": "true",
+				},
+			},
+			setupFake: func() *clientset.FakeClientset {
+				fc := clientset.NewFakeClientset()
+				fc.CreatePV(clientset.FakePVConfig{Name: testPV, VolumeHandle: testVolumeID, ClaimRef: nil})
+				return fc
+			},
+			expectErr: status.Errorf(codes.Internal, "pv %q is not bound to any pvc", testPV),
+		},
+		{
+			name: "sharedMount true - claimRef namespace empty - should return error",
+			req: &csi.ControllerPublishVolumeRequest{
+				VolumeId:         testVolumeID,
+				NodeId:           testNodeID,
+				VolumeCapability: testVolumeCapability,
+				VolumeContext: map[string]string{
+					"sharedMount": "true",
+				},
+			},
+			setupFake: func() *clientset.FakeClientset {
+				fc := clientset.NewFakeClientset()
+				fc.CreatePV(clientset.FakePVConfig{Name: testPV, VolumeHandle: testVolumeID, ClaimRef: &corev1.ObjectReference{
+					Name:      testPVC,
+					Namespace: "",
+				}})
+				return fc
+			},
+			expectErr: status.Error(codes.Internal, fmt.Sprintf("pv claimRef namespace and name can't be empty, namespace: %q, name: %q", "", testPVC)),
+		},
+		{
+			name: "sharedMount true - claimRef name empty - should return error",
+			req: &csi.ControllerPublishVolumeRequest{
+				VolumeId:         testVolumeID,
+				NodeId:           testNodeID,
+				VolumeCapability: testVolumeCapability,
+				VolumeContext: map[string]string{
+					"sharedMount": "true",
+				},
+			},
+			setupFake: func() *clientset.FakeClientset {
+				fc := clientset.NewFakeClientset()
+				fc.CreatePV(clientset.FakePVConfig{Name: testPV, VolumeHandle: testVolumeID, ClaimRef: &corev1.ObjectReference{
+					Name:      "",
+					Namespace: testNamespace,
+				}})
+				return fc
+			},
+			expectErr: status.Error(codes.Internal, fmt.Sprintf("pv claimRef namespace and name can't be empty, namespace: %q, name: %q", testNamespace, "")),
 		},
 		{
 			name: "sharedMount false - should return success",
@@ -235,12 +324,14 @@ func TestControllerPublishVolume(t *testing.T) {
 					"sharedMount": "false",
 				},
 			},
+			setupFake: func() *clientset.FakeClientset { return clientset.NewFakeClientset() },
 			expectErr: nil,
 		},
 	}
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
-			s := initTestController(t)
+			clientset := test.setupFake()
+			s := initTestController(t, clientset)
 			_, err := s.ControllerPublishVolume(context.Background(), test.req)
 			if !errors.Is(err, test.expectErr) {
 				t.Errorf("Expected error: %v, got: %v", test.expectErr, err)

--- a/pkg/csi_driver/gcs_fuse_driver_test.go
+++ b/pkg/csi_driver/gcs_fuse_driver_test.go
@@ -29,7 +29,7 @@ import (
 	mount "k8s.io/mount-utils"
 )
 
-func initTestDriver(t *testing.T, fm *mount.FakeMounter) *GCSDriver {
+func initTestDriver(t *testing.T, fm *mount.FakeMounter, clientset clientset.Interface) *GCSDriver {
 	t.Helper()
 	config := &GCSDriverConfig{
 		Name:                  "test-driver",
@@ -41,7 +41,7 @@ func initTestDriver(t *testing.T, fm *mount.FakeMounter) *GCSDriver {
 		TokenManager:          auth.NewFakeTokenManager(),
 		Mounter:               fm,
 		NetworkManager:        &fakeNetworkManager{},
-		K8sClients:            clientset.NewFakeClientset(),
+		K8sClients:            clientset,
 		MetricsManager:        metrics.NewFakeMetricsManager(),
 		FeatureOptions:        &GCSDriverFeatureOptions{FeatureGCSFuseProfiles: &FeatureGCSFuseProfiles{}},
 	}
@@ -88,7 +88,7 @@ func initTestDriverWithCustomNodeServer(t *testing.T, fm *mount.FakeMounter, cli
 
 func TestDriverValidateVolumeCapability(t *testing.T) {
 	t.Parallel()
-	driver := initTestDriver(t, nil)
+	driver := initTestDriver(t, nil, clientset.NewFakeClientset())
 
 	cases := []struct {
 		name       string
@@ -224,7 +224,7 @@ func TestDriverValidateVolumeCapability(t *testing.T) {
 
 func TestDriverValidateVolumeCapabilities(t *testing.T) {
 	t.Parallel()
-	driver := initTestDriver(t, nil)
+	driver := initTestDriver(t, nil, clientset.NewFakeClientset())
 
 	cases := []struct {
 		name         string

--- a/pkg/csi_driver/identity_test.go
+++ b/pkg/csi_driver/identity_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/clientset"
 	"golang.org/x/net/context"
 )
 
@@ -32,7 +33,7 @@ const (
 func initTestIdentityServer(t *testing.T) csi.IdentityServer {
 	t.Helper()
 
-	return newIdentityServer(initTestDriver(t, nil))
+	return newIdentityServer(initTestDriver(t, nil, clientset.NewFakeClientset()))
 }
 
 func TestGetPluginInfo(t *testing.T) {

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -58,7 +58,7 @@ type nodeServerTestEnv struct {
 func initTestNodeServer(t *testing.T) *nodeServerTestEnv {
 	t.Helper()
 	mounter := mount.NewFakeMounter([]mount.MountPoint{})
-	driver := initTestDriver(t, mounter)
+	driver := initTestDriver(t, mounter, clientset.NewFakeClientset())
 	s, _ := driver.config.StorageServiceManager.SetupService(context.TODO(), nil, "")
 	if _, err := s.CreateBucket(context.Background(), &storage.ServiceBucket{Name: testVolumeID}); err != nil {
 		t.Fatalf("failed to create the fake bucket: %v", err)
@@ -519,7 +519,7 @@ func TestNodePublishVolumeEnableAutoGoMemLimit(t *testing.T) {
 			}
 			fakeMounter := mount.NewFakeMounter([]mount.MountPoint{})
 
-			driver := initTestDriver(t, fakeMounter)
+			driver := initTestDriver(t, fakeMounter, clientset.NewFakeClientset())
 			s, _ := driver.config.StorageServiceManager.SetupService(context.TODO(), nil, "")
 			if _, err := s.CreateBucket(context.Background(), &storage.ServiceBucket{Name: testVolumeID}); err != nil {
 				t.Fatalf("failed to create the fake bucket: %v", err)
@@ -808,7 +808,7 @@ func TestNodePublishVolumeEnableGCSFuseKernelParams(t *testing.T) {
 			}
 			fakeMounter := mount.NewFakeMounter([]mount.MountPoint{})
 
-			driver := initTestDriver(t, fakeMounter)
+			driver := initTestDriver(t, fakeMounter, clientset.NewFakeClientset())
 			s, _ := driver.config.StorageServiceManager.SetupService(context.TODO(), nil, "")
 			if _, err := s.CreateBucket(context.Background(), &storage.ServiceBucket{Name: testVolumeID}); err != nil {
 				t.Fatalf("failed to create the fake bucket: %v", err)
@@ -1212,7 +1212,7 @@ func TestNodePublishVolumeStorageEndpointInternal(t *testing.T) {
 			}
 			fakeMounter := mount.NewFakeMounter([]mount.MountPoint{})
 
-			driver := initTestDriver(t, fakeMounter)
+			driver := initTestDriver(t, fakeMounter, clientset.NewFakeClientset())
 			s, _ := driver.config.StorageServiceManager.SetupService(context.TODO(), nil, "")
 			if _, err := s.CreateBucket(context.Background(), &storage.ServiceBucket{Name: testVolumeID}); err != nil {
 				t.Fatalf("failed to create the fake bucket: %v", err)

--- a/pkg/csi_driver/shared_mount.go
+++ b/pkg/csi_driver/shared_mount.go
@@ -17,7 +17,27 @@ limitations under the License.
 
 package driver
 
-import "github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util"
+import (
+	"crypto/sha1"
+	"fmt"
+	"io"
+
+	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/clientset"
+	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	mounterPodNamePrefix = "gcsfusecsi-mount"
+)
+
+// mounterPodConfig holds the configuration parameters required to define and manage a mounter pod.
+type mounterPodConfig struct {
+	podName       string // The name to assign to the mounter pod.
+	nodeID        string // The specific node ID where the pod should be scheduled.
+	namespace     string // The Kubernetes namespace in which to create the pod.
+	priorityClass string // The name of the PriorityClass to apply to the pod.
+}
 
 // sharedMount checks if the VolumeContext enables the shared node mount feature
 // by checking the sharedMount: true volumeAttribute.
@@ -26,4 +46,33 @@ func sharedMount(vc map[string]string) bool {
 		return true
 	}
 	return false
+}
+
+// createMounterPodName returns a unique name for the mounter pod. The name is composed by
+// the node and volume IDs, evaluated on a SHA1 hash for length shortening.
+func createMounterPodName(nodeID, volumeID string) string {
+	str := fmt.Sprintf("%s_%s", nodeID, volumeID)
+	h := sha1.New()
+	// Write the string to the hash
+	io.WriteString(h, str)
+	// Convert the byte slice to a hexadecimal string
+	sha1Hash := fmt.Sprintf("%x", h.Sum(nil))
+	return fmt.Sprintf("%s-%s", mounterPodNamePrefix, sha1Hash)
+}
+
+// pvFromVolumeID finds the PersistentVolume in the cluster that corresponds to the given CSI volumeID.
+func pvFromVolumeID(clientset clientset.Interface, volumeID string) (*corev1.PersistentVolume, error) {
+	if clientset == nil {
+		return nil, fmt.Errorf("clientset is nil")
+	}
+	pvs, err := clientset.ListPV()
+	if err != nil {
+		return nil, err
+	}
+	for _, pv := range pvs {
+		if pv != nil && pv.Spec.CSI != nil && pv.Spec.CSI.VolumeHandle == volumeID {
+			return pv, nil
+		}
+	}
+	return nil, fmt.Errorf("no pv found for volumeID: %q", volumeID)
 }

--- a/pkg/csi_driver/shared_mount_test.go
+++ b/pkg/csi_driver/shared_mount_test.go
@@ -17,7 +17,16 @@ limitations under the License.
 
 package driver
 
-import "testing"
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/clientset"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
 
 func TestSharedMount(t *testing.T) {
 	testCases := []struct {
@@ -47,6 +56,130 @@ func TestSharedMount(t *testing.T) {
 			result := sharedMount(vc)
 			if result != tc.expected {
 				t.Errorf("Expected %v, but got %v", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestCreateMounterPodName(t *testing.T) {
+	testCases := []struct {
+		name     string
+		nodeID   string
+		volumeID string
+		expected string
+	}{
+		{
+			name:     "Basic test - should generate name correctly",
+			nodeID:   testNodeID,
+			volumeID: testVolumeID,
+			expected: fmt.Sprintf("%s-f4d1ad31ce3ffcfcada13d5fe95e0f8ddc801bf7", mounterPodNamePrefix),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := createMounterPodName(tc.nodeID, tc.volumeID)
+			// Verify that the generated name matches the expected name
+			if actual != tc.expected {
+				t.Errorf("Expected pod name %q, but got %q", tc.expected, actual)
+			}
+			// Verify that the generated name contains the prefix and the hash
+			if len(actual) <= len(mounterPodNamePrefix) || actual[:len(mounterPodNamePrefix)] != mounterPodNamePrefix {
+				t.Errorf("Expected pod name to start with %q, but got %q", mounterPodNamePrefix, actual)
+			}
+			if len(actual) != len(mounterPodNamePrefix+"-")+40 { // SHA1 hash is 40 characters long
+				t.Errorf("Expected pod name to have a 40-character SHA1 hash, but got %q", actual)
+			}
+		})
+	}
+}
+
+func TestPVFromVolumeID(t *testing.T) {
+	// Helper to create the expected *corev1.PersistentVolume object for comparison
+	makeExpectedPV := func(name, volumeHandle string) *corev1.PersistentVolume {
+		return &corev1.PersistentVolume{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Labels: map[string]string{}},
+			Spec: corev1.PersistentVolumeSpec{
+				PersistentVolumeSource: corev1.PersistentVolumeSource{
+					CSI: &corev1.CSIPersistentVolumeSource{
+						VolumeHandle: volumeHandle,
+					},
+				},
+			},
+		}
+	}
+
+	testCases := []struct {
+		name      string
+		volumeID  string
+		setupFake func() *clientset.FakeClientset
+		wantPV    *corev1.PersistentVolume
+		wantErr   bool
+	}{
+		{
+			name:     "PV found - should return it",
+			volumeID: "csi-vol-001",
+			setupFake: func() *clientset.FakeClientset {
+				fc := clientset.NewFakeClientset()
+				fc.CreatePV(clientset.FakePVConfig{Name: "pv1", VolumeHandle: "csi-vol-000"})
+				fc.CreatePV(clientset.FakePVConfig{Name: "pv2", VolumeHandle: "csi-vol-001"})
+				fc.CreatePV(clientset.FakePVConfig{Name: "pv3", VolumeHandle: "csi-vol-002"})
+				return fc
+			},
+			wantPV:  makeExpectedPV("pv2", "csi-vol-001"),
+			wantErr: false,
+		},
+		{
+			name:     "PV not found - should return error",
+			volumeID: "csi-vol-999",
+			setupFake: func() *clientset.FakeClientset {
+				fc := clientset.NewFakeClientset()
+				fc.CreatePV(clientset.FakePVConfig{Name: "pv1", VolumeHandle: "csi-vol-000"})
+				fc.CreatePV(clientset.FakePVConfig{Name: "pv2", VolumeHandle: "csi-vol-001"})
+				return fc
+			},
+			wantErr: true,
+		},
+		{
+			name:     "ListPV returns error - should return error",
+			volumeID: "csi-vol-001",
+			setupFake: func() *clientset.FakeClientset {
+				fc := clientset.NewFakeClientset()
+				fc.ListPVErr = errors.New("failed to list PVs from apiserver")
+				return fc
+			},
+			wantErr: true,
+		},
+		{
+			name:     "Empty PV list - should return error",
+			volumeID: "csi-vol-001",
+			setupFake: func() *clientset.FakeClientset {
+				fc := clientset.NewFakeClientset()
+				// No PVs created
+				return fc
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeCS := tc.setupFake()
+
+			gotPV, err := pvFromVolumeID(fakeCS, tc.volumeID)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("pvFromVolumeID(%q) succeeded unexpectedly, want error", tc.volumeID)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("pvFromVolumeID(%q) returned an unexpected error: %v", tc.volumeID, err)
+			}
+
+			if diff := cmp.Diff(tc.wantPV, gotPV); diff != "" {
+				t.Errorf("pvFromVolumeID(%q) returned unexpected diff (-want +got):\n%s", tc.volumeID, diff)
 			}
 		})
 	}

--- a/pkg/csi_driver/utils_test.go
+++ b/pkg/csi_driver/utils_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/clientset"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util"
 	"google.golang.org/grpc/codes"
 )
@@ -919,7 +920,7 @@ func TestRemoveDisallowedMountOptions(t *testing.T) {
 
 func TestGenerateDisallowedFlagsMap(t *testing.T) {
 	t.Parallel()
-	driver := initTestDriver(t, nil)
+	driver := initTestDriver(t, nil, clientset.NewFakeClientset())
 	driver.config.FeatureOptions = &GCSDriverFeatureOptions{
 		FeatureGCSFuseProfiles: &FeatureGCSFuseProfiles{
 			EnableGcsfuseProfilesInternal: false,


### PR DESCRIPTION
generation logic.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Implement mounter pod name generation and mounter pod namespace generation logic.

The mounter pod name is obtained by applying a SHA1 hash on the "nodeID_volumeID" string.
The mounter pod namespace is obtained by listing all of the PVs and finding the one that matches the volumeID. Then, obtaining the PVC namespace by looking at the pv's claimRef field, which is expected to be populated by the pv controller after the pod has alraedy been scheduled.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```