### PR TITLE
feat(webhook): support custom executable credentials and additional volume mounts

### DIFF
--- a/pkg/webhook/mutatingwebhook.go
+++ b/pkg/webhook/mutatingwebhook.go
@@ -149,12 +149,22 @@ func (si *SidecarInjector) Handle(ctx context.Context, req admission.Request) ad
 		if err != nil {
 			return admission.Errored(http.StatusBadRequest, err)
 		}
+		mountPath := filepath.Dir(credentialConfig.CredentialSource.File)
+
+		credentialVolumeMounts := []corev1.VolumeMount{
+			{Name: SidecarContainerWICredentialConfigMapVolumeName, MountPath: SidecarContainerWICredentialConfigMapVolumeMountPath},
+		}
+		var envVars []corev1.EnvVar
+		if credentialConfig.CredentialSource.Executable == nil {
+			credentialVolumeMounts = append(credentialVolumeMounts, corev1.VolumeMount{Name: SidecarContainerWITokenVolumeName, MountPath: mountPath})
+		} else {
+			envVars = append(envVars, corev1.EnvVar{Name: "GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES", Value: "1"})
+		}
+
 		sidecarCredentialConfig = &SidecarContainerCredentialConfiguration{
 			GacEnv: &corev1.EnvVar{Name: "GOOGLE_APPLICATION_CREDENTIALS", Value: fmt.Sprintf("%s/%s", SidecarContainerWICredentialConfigMapVolumeMountPath, filename)},
-			CredentialVolumeMounts: []corev1.VolumeMount{
-				{Name: SidecarContainerWITokenVolumeName, MountPath: filepath.Dir(credentialConfig.CredentialSource.File)},
-				{Name: SidecarContainerWICredentialConfigMapVolumeName, MountPath: SidecarContainerWICredentialConfigMapVolumeMountPath},
-			},
+			CredentialVolumeMounts: credentialVolumeMounts,
+			EnvVars:                envVars,
 		}
 		klog.Infof("Injected GCP workload identity credential configuration configMap %s in namespace %s", configMapName, pod.Namespace)
 	}
@@ -417,23 +427,25 @@ func appendWorkloadCredentialConfigurationVolumes(client kubernetes.Interface, p
 	}
 	klog.Infof("Parsed the workload identity credential configuration configMap %s in namespace %s %+v", configMapName, pod.Namespace, credConfig)
 
-	pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
-		Name: SidecarContainerWITokenVolumeName,
-		VolumeSource: corev1.VolumeSource{
-			Projected: &corev1.ProjectedVolumeSource{
-				Sources: []corev1.VolumeProjection{
-					{
-						ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
-							Audience:          fmt.Sprintf("https:%s", credConfig.Audience), // Add the "https:" prefix to the audience.
-							ExpirationSeconds: &tokenExpirationSeconds,
-							Path:              filepath.Base(credConfig.CredentialSource.File),
+	if credConfig.CredentialSource.Executable == nil {
+		pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
+			Name: SidecarContainerWITokenVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				Projected: &corev1.ProjectedVolumeSource{
+					Sources: []corev1.VolumeProjection{
+						{
+							ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+								Audience:          fmt.Sprintf("https:%s", credConfig.Audience), // Add the "https:" prefix to the audience.
+								ExpirationSeconds: &tokenExpirationSeconds,
+								Path:              filepath.Base(credConfig.CredentialSource.File),
+							},
 						},
 					},
+					DefaultMode: &defaultMode,
 				},
-				DefaultMode: &defaultMode,
 			},
-		},
-	})
+		})
+	}
 
 	// Secondly try to add workload identity credential configuration configMap as volume.
 	if !checkConfigMapVolumeExists(pod) {
@@ -467,7 +479,10 @@ func checkConfigMapVolumeExists(pod *corev1.Pod) bool {
 type CredentialConfig struct {
 	Audience         string `json:"audience"`
 	CredentialSource struct {
-		File string `json:"file"`
+		File       string `json:"file,omitempty"`
+		Executable *struct {
+			Command string `json:"command"`
+		} `json:"executable,omitempty"`
 	} `json:"credential_source"`
 }
 

--- a/pkg/webhook/mutatingwebhook.go
+++ b/pkg/webhook/mutatingwebhook.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"path/filepath"
 	"slices"
+	"strings"
 
 	"cloud.google.com/go/compute/metadata"
 	putil "github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/profiles/util"
@@ -56,6 +57,9 @@ const (
 	metadataPrefetchMemoryRequestAnnotation          = "gke-gcsfuse/metadata-prefetch-memory-request"
 	GCPWorkloadIdentityCredentialConfigMapAnnotation = "gke-gcsfuse/workload-identity-credential-configmap"
 	NumaPinningAnnotation                            = "gke-gcsfuse/enable-numa-pinning"
+	// AdditionalVolumeMountsAnnotation is used to specify additional volumes to mount into the GCS Fuse sidecar.
+	// The expected format is a comma-separated list of volumeName:mountPath (e.g., "vol1:/path1,vol2:/path2").
+	AdditionalVolumeMountsAnnotation                 = "gke-gcsfuse/additional-volume-mounts"
 )
 
 var (
@@ -167,6 +171,32 @@ func (si *SidecarInjector) Handle(ctx context.Context, req admission.Request) ad
 			EnvVars:                envVars,
 		}
 		klog.Infof("Injected GCP workload identity credential configuration configMap %s in namespace %s", configMapName, pod.Namespace)
+	}
+
+	if additionalMounts, ok := pod.Annotations[AdditionalVolumeMountsAnnotation]; ok && additionalMounts != "" {
+		if sidecarCredentialConfig == nil {
+			sidecarCredentialConfig = &SidecarContainerCredentialConfiguration{}
+		}
+		mounts := strings.Split(additionalMounts, ",")
+		for _, mount := range mounts {
+			parts := strings.Split(mount, ":")
+			if len(parts) == 2 {
+				volName := parts[0]
+				mountPath := parts[1]
+
+				if !volumeExists(pod.Spec.Volumes, volName) {
+					klog.Warningf("Volume %q specified in %s not found in pod spec", volName, AdditionalVolumeMountsAnnotation)
+				}
+
+				sidecarCredentialConfig.CredentialVolumeMounts = append(sidecarCredentialConfig.CredentialVolumeMounts, corev1.VolumeMount{
+					Name:      volName,
+					MountPath: mountPath,
+					ReadOnly:  true,
+				})
+			} else {
+				klog.Warningf("Invalid format for %s: %s", AdditionalVolumeMountsAnnotation, mount)
+			}
+		}
 	}
 
 	// Inject Fuse Side Car container.

--- a/pkg/webhook/mutatingwebhook.go
+++ b/pkg/webhook/mutatingwebhook.go
@@ -140,18 +140,19 @@ func (si *SidecarInjector) Handle(ctx context.Context, req admission.Request) ad
 	var sidecarCredentialConfig *SidecarContainerCredentialConfiguration
 	// Inject GCP workload identity credential config configmap and token.
 	if configMapName, ok := pod.Annotations[GCPWorkloadIdentityCredentialConfigMapAnnotation]; ok && configMapName != "" && si.K8SClient != nil {
-		// Validate that OIDC authentication is not used with hostNetwork pods
-		if pod.Spec.HostNetwork {
-			return admission.Errored(http.StatusBadRequest,
-				fmt.Errorf("OIDC authentication (annotation %q) is not supported for pods with hostNetwork=true. "+
-					"HostNetwork pods use a different authentication mechanism (Google Workload Identity). "+
-					"Please either remove hostNetwork or use standard Workload Identity authentication. ",
-					GCPWorkloadIdentityCredentialConfigMapAnnotation))
-		}
-
 		filename, credentialConfig, err := appendWorkloadCredentialConfigurationVolumes(si.K8SClient, pod, configMapName)
 		if err != nil {
 			return admission.Errored(http.StatusBadRequest, err)
+		}
+
+		// Validate that OIDC authentication (file-based) is not used with hostNetwork pods.
+		// Executable-sourced credentials are supported since they do not rely on projected SA token volumes.
+		if pod.Spec.HostNetwork && credentialConfig.CredentialSource.Executable == nil {
+			return admission.Errored(http.StatusBadRequest,
+				fmt.Errorf("OIDC authentication (file-based, annotation %q) is not supported for pods with hostNetwork=true. "+
+					"HostNetwork pods use a different authentication mechanism (Google Workload Identity). "+
+					"Please either remove hostNetwork or use standard Workload Identity authentication. ",
+					GCPWorkloadIdentityCredentialConfigMapAnnotation))
 		}
 		mountPath := filepath.Dir(credentialConfig.CredentialSource.File)
 

--- a/pkg/webhook/mutatingwebhook.go
+++ b/pkg/webhook/mutatingwebhook.go
@@ -470,7 +470,7 @@ func appendWorkloadCredentialConfigurationVolumes(client kubernetes.Interface, p
 	}
 	klog.Infof("Parsed the workload identity credential configuration configMap %s in namespace %s %+v", configMapName, pod.Namespace, credConfig)
 
-	if credConfig.CredentialSource.Executable == nil {
+	if credConfig.CredentialSource.Executable == nil && !volumeExists(pod.Spec.Volumes, SidecarContainerWITokenVolumeName) {
 		pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
 			Name: SidecarContainerWITokenVolumeName,
 			VolumeSource: corev1.VolumeSource{

--- a/pkg/webhook/mutatingwebhook.go
+++ b/pkg/webhook/mutatingwebhook.go
@@ -154,13 +154,12 @@ func (si *SidecarInjector) Handle(ctx context.Context, req admission.Request) ad
 					"Please either remove hostNetwork or use standard Workload Identity authentication. ",
 					GCPWorkloadIdentityCredentialConfigMapAnnotation))
 		}
-		mountPath := filepath.Dir(credentialConfig.CredentialSource.File)
-
 		credentialVolumeMounts := []corev1.VolumeMount{
 			{Name: SidecarContainerWICredentialConfigMapVolumeName, MountPath: SidecarContainerWICredentialConfigMapVolumeMountPath},
 		}
 		var envVars []corev1.EnvVar
 		if credentialConfig.CredentialSource.Executable == nil {
+			mountPath := filepath.Dir(credentialConfig.CredentialSource.File)
 			credentialVolumeMounts = append(credentialVolumeMounts, corev1.VolumeMount{Name: SidecarContainerWITokenVolumeName, MountPath: mountPath})
 		} else {
 			envVars = append(envVars, corev1.EnvVar{Name: "GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES", Value: "1"})
@@ -180,10 +179,23 @@ func (si *SidecarInjector) Handle(ctx context.Context, req admission.Request) ad
 		}
 		mounts := strings.Split(additionalMounts, ",")
 		for _, mount := range mounts {
+			mount = strings.TrimSpace(mount)
+			if mount == "" {
+				continue
+			}
 			parts := strings.Split(mount, ":")
 			if len(parts) == 2 {
-				volName := parts[0]
-				mountPath := parts[1]
+				volName := strings.TrimSpace(parts[0])
+				mountPath := strings.TrimSpace(parts[1])
+
+				if volName == "" || mountPath == "" {
+					klog.Warningf("Invalid empty volume name or mount path in %s: %s", AdditionalVolumeMountsAnnotation, mount)
+					continue
+				}
+
+				if !strings.HasPrefix(mountPath, "/") {
+					klog.Warningf("Mount path %q specified in %s is not an absolute path", mountPath, AdditionalVolumeMountsAnnotation)
+				}
 
 				if !volumeExists(pod.Spec.Volumes, volName) {
 					klog.Warningf("Volume %q specified in %s not found in pod spec", volName, AdditionalVolumeMountsAnnotation)

--- a/pkg/webhook/mutatingwebhook.go
+++ b/pkg/webhook/mutatingwebhook.go
@@ -59,7 +59,7 @@ const (
 	NumaPinningAnnotation                            = "gke-gcsfuse/enable-numa-pinning"
 	// AdditionalVolumeMountsAnnotation is used to specify additional volumes to mount into the GCS Fuse sidecar.
 	// The expected format is a comma-separated list of volumeName:mountPath (e.g., "vol1:/path1,vol2:/path2").
-	AdditionalVolumeMountsAnnotation                 = "gke-gcsfuse/additional-volume-mounts"
+	AdditionalVolumeMountsAnnotation = "gke-gcsfuse/additional-volume-mounts"
 )
 
 var (
@@ -166,7 +166,7 @@ func (si *SidecarInjector) Handle(ctx context.Context, req admission.Request) ad
 		}
 
 		sidecarCredentialConfig = &SidecarContainerCredentialConfiguration{
-			GacEnv: &corev1.EnvVar{Name: "GOOGLE_APPLICATION_CREDENTIALS", Value: fmt.Sprintf("%s/%s", SidecarContainerWICredentialConfigMapVolumeMountPath, filename)},
+			GacEnv:                 &corev1.EnvVar{Name: "GOOGLE_APPLICATION_CREDENTIALS", Value: fmt.Sprintf("%s/%s", SidecarContainerWICredentialConfigMapVolumeMountPath, filename)},
 			CredentialVolumeMounts: credentialVolumeMounts,
 			EnvVars:                envVars,
 		}

--- a/pkg/webhook/mutatingwebhook.go
+++ b/pkg/webhook/mutatingwebhook.go
@@ -60,6 +60,8 @@ const (
 	// AdditionalVolumeMountsAnnotation is used to specify additional volumes to mount into the GCS Fuse sidecar.
 	// The expected format is a comma-separated list of volumeName:mountPath (e.g., "vol1:/path1,vol2:/path2").
 	AdditionalVolumeMountsAnnotation = "gke-gcsfuse/additional-volume-mounts"
+
+	GoogleExternalAccountAllowExecutablesEnvVar = "GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES"
 )
 
 var (
@@ -162,7 +164,7 @@ func (si *SidecarInjector) Handle(ctx context.Context, req admission.Request) ad
 			mountPath := filepath.Dir(credentialConfig.CredentialSource.File)
 			credentialVolumeMounts = append(credentialVolumeMounts, corev1.VolumeMount{Name: SidecarContainerWITokenVolumeName, MountPath: mountPath})
 		} else {
-			envVars = append(envVars, corev1.EnvVar{Name: "GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES", Value: "1"})
+			envVars = append(envVars, corev1.EnvVar{Name: GoogleExternalAccountAllowExecutablesEnvVar, Value: "1"})
 		}
 
 		sidecarCredentialConfig = &SidecarContainerCredentialConfiguration{
@@ -183,32 +185,30 @@ func (si *SidecarInjector) Handle(ctx context.Context, req admission.Request) ad
 			if mount == "" {
 				continue
 			}
-			parts := strings.Split(mount, ":")
-			if len(parts) == 2 {
-				volName := strings.TrimSpace(parts[0])
-				mountPath := strings.TrimSpace(parts[1])
-
-				if volName == "" || mountPath == "" {
-					klog.Warningf("Invalid empty volume name or mount path in %s: %s", AdditionalVolumeMountsAnnotation, mount)
-					continue
-				}
-
-				if !strings.HasPrefix(mountPath, "/") {
-					klog.Warningf("Mount path %q specified in %s is not an absolute path", mountPath, AdditionalVolumeMountsAnnotation)
-				}
-
-				if !volumeExists(pod.Spec.Volumes, volName) {
-					klog.Warningf("Volume %q specified in %s not found in pod spec", volName, AdditionalVolumeMountsAnnotation)
-				}
-
-				sidecarCredentialConfig.CredentialVolumeMounts = append(sidecarCredentialConfig.CredentialVolumeMounts, corev1.VolumeMount{
-					Name:      volName,
-					MountPath: mountPath,
-					ReadOnly:  true,
-				})
-			} else {
-				klog.Warningf("Invalid format for %s: %s", AdditionalVolumeMountsAnnotation, mount)
+			volName, mountPath, found := strings.Cut(mount, ":")
+			if !found {
+				return admission.Errored(http.StatusBadRequest, fmt.Errorf("invalid format for %s: %q, expected \"volume-name:mount-path\"", AdditionalVolumeMountsAnnotation, mount))
 			}
+			volName = strings.TrimSpace(volName)
+			mountPath = strings.TrimSpace(mountPath)
+
+			if volName == "" || mountPath == "" {
+				return admission.Errored(http.StatusBadRequest, fmt.Errorf("invalid empty volume name or mount path in %s: %q", AdditionalVolumeMountsAnnotation, mount))
+			}
+
+			if !strings.HasPrefix(mountPath, "/") {
+				return admission.Errored(http.StatusBadRequest, fmt.Errorf("mount path %q specified in %s is not an absolute path", mountPath, AdditionalVolumeMountsAnnotation))
+			}
+
+			if !volumeExists(pod.Spec.Volumes, volName) {
+				return admission.Errored(http.StatusBadRequest, fmt.Errorf("volume %q specified in %s not found in pod spec", volName, AdditionalVolumeMountsAnnotation))
+			}
+
+			sidecarCredentialConfig.CredentialVolumeMounts = append(sidecarCredentialConfig.CredentialVolumeMounts, corev1.VolumeMount{
+				Name:      volName,
+				MountPath: mountPath,
+				ReadOnly:  true,
+			})
 		}
 	}
 

--- a/pkg/webhook/mutatingwebhook_test.go
+++ b/pkg/webhook/mutatingwebhook_test.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -593,6 +594,21 @@ func TestValidateMutatingWebhookResponse(t *testing.T) {
 			operation:    admissionv1.Create,
 			inputPod:     validInputPodWithWorkloadIdentity(""),
 			wantResponse: wantResponse(t, false, false, true),
+			nodes:        nativeSupportNodes(),
+		},
+		{
+			name:         "workload identity with additional volume mounts injection successful test.",
+			operation:    admissionv1.Create,
+			inputPod: func() *corev1.Pod {
+				pod := validInputPodWithWorkloadIdentity("test-credentials")
+				pod.ObjectMeta.Annotations[AdditionalVolumeMountsAnnotation] = "binary-volume:/scripts,meta-certs-vol:/etc/meta/certs"
+				pod.Spec.Volumes = append(pod.Spec.Volumes,
+					corev1.Volume{Name: "binary-volume", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+					corev1.Volume{Name: "meta-certs-vol", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+				)
+				return pod
+			}(),
+			wantResponse: wantAdditionalVolumeMountsResponse(t, "test-credentials", "binary-volume:/scripts,meta-certs-vol:/etc/meta/certs"),
 			nodes:        nativeSupportNodes(),
 		},
 	}
@@ -1624,6 +1640,87 @@ func modifySpecWithWorkloadIdentity(newPod corev1.Pod, configMapName string) *co
 	}
 
 	// Add native sidecar container
+	newPod.Spec.InitContainers = append([]corev1.Container{GetNativeSidecarContainerSpec(config, sidecarCredentialConfig)}, newPod.Spec.InitContainers...)
+	newPod.Spec.Volumes = append(GetSidecarContainerVolumeSpec(newPod.Spec.Volumes...), newPod.Spec.Volumes...)
+
+	return &newPod
+}
+
+func wantAdditionalVolumeMountsResponse(t *testing.T, configMapName string, additionalMounts string) admission.Response {
+	t.Helper()
+	originalPod := validInputPodWithWorkloadIdentity(configMapName)
+	originalPod.Annotations[AdditionalVolumeMountsAnnotation] = additionalMounts
+	originalPod.Spec.Volumes = append(originalPod.Spec.Volumes,
+		corev1.Volume{Name: "binary-volume", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+		corev1.Volume{Name: "meta-certs-vol", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+	)
+
+	newPod := *modifySpecWithAdditionalVolumeMounts(*originalPod, configMapName, additionalMounts)
+	return generatePatch(t, originalPod, &newPod)
+}
+
+func modifySpecWithAdditionalVolumeMounts(newPod corev1.Pod, configMapName string, additionalMounts string) *corev1.Pod {
+	config := FakeConfig()
+
+	var sidecarCredentialConfig *SidecarContainerCredentialConfiguration
+	if configMapName != "" {
+		sidecarCredentialConfig = &SidecarContainerCredentialConfiguration{
+			GacEnv: &corev1.EnvVar{
+				Name:  "GOOGLE_APPLICATION_CREDENTIALS",
+				Value: fmt.Sprintf("%s/%s", SidecarContainerWICredentialConfigMapVolumeMountPath, "credential-configuration.json"),
+			},
+			CredentialVolumeMounts: []corev1.VolumeMount{
+				{Name: SidecarContainerWITokenVolumeName, MountPath: "/var/run/service-account"},
+				{Name: SidecarContainerWICredentialConfigMapVolumeName, MountPath: SidecarContainerWICredentialConfigMapVolumeMountPath},
+			},
+		}
+
+		newPod.Spec.Volumes = append(newPod.Spec.Volumes,
+			corev1.Volume{
+				Name: SidecarContainerWITokenVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					Projected: &corev1.ProjectedVolumeSource{
+						Sources: []corev1.VolumeProjection{
+							{
+								ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+									Audience:          "https://iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/test-pool/providers/test-provider",
+									ExpirationSeconds: &tokenExpirationSeconds,
+									Path:              "token",
+								},
+							},
+						},
+						DefaultMode: &defaultMode,
+					},
+				},
+			},
+			corev1.Volume{
+				Name: SidecarContainerWICredentialConfigMapVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: configMapName,
+						},
+						DefaultMode: &defaultMode,
+					},
+				},
+			},
+		)
+
+		if additionalMounts != "" {
+			mounts := strings.Split(additionalMounts, ",")
+			for _, mount := range mounts {
+				parts := strings.Split(mount, ":")
+				if len(parts) == 2 {
+					sidecarCredentialConfig.CredentialVolumeMounts = append(sidecarCredentialConfig.CredentialVolumeMounts, corev1.VolumeMount{
+						Name:      parts[0],
+						MountPath: parts[1],
+						ReadOnly:  true,
+					})
+				}
+			}
+		}
+	}
+
 	newPod.Spec.InitContainers = append([]corev1.Container{GetNativeSidecarContainerSpec(config, sidecarCredentialConfig)}, newPod.Spec.InitContainers...)
 	newPod.Spec.Volumes = append(GetSidecarContainerVolumeSpec(newPod.Spec.Volumes...), newPod.Spec.Volumes...)
 

--- a/pkg/webhook/mutatingwebhook_test.go
+++ b/pkg/webhook/mutatingwebhook_test.go
@@ -622,6 +622,21 @@ func TestValidateMutatingWebhookResponse(t *testing.T) {
 			wantResponse: wantAdditionalVolumeMountsResponseWithMissingVolume(t, "test-credentials", "valid-but-missing-vol:/scripts"),
 			nodes:        nativeSupportNodes(),
 		},
+		{
+			name:      "workload identity with additional volume mounts containing whitespace and relative path injection test.",
+			operation: admissionv1.Create,
+			inputPod: func() *corev1.Pod {
+				pod := validInputPodWithWorkloadIdentity("test-credentials")
+				pod.ObjectMeta.Annotations[AdditionalVolumeMountsAnnotation] = "  binary-volume : /scripts , meta-certs-vol : relative/path  "
+				pod.Spec.Volumes = append(pod.Spec.Volumes,
+					corev1.Volume{Name: "binary-volume", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+					corev1.Volume{Name: "meta-certs-vol", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+				)
+				return pod
+			}(),
+			wantResponse: wantAdditionalVolumeMountsResponse(t, "test-credentials", "binary-volume:/scripts,meta-certs-vol:relative/path"),
+			nodes:        nativeSupportNodes(),
+		},
 
 		{
 			name:         "executable workload identity injection successful test.",

--- a/pkg/webhook/mutatingwebhook_test.go
+++ b/pkg/webhook/mutatingwebhook_test.go
@@ -611,6 +611,18 @@ func TestValidateMutatingWebhookResponse(t *testing.T) {
 			wantResponse: wantAdditionalVolumeMountsResponse(t, "test-credentials", "binary-volume:/scripts,meta-certs-vol:/etc/meta/certs"),
 			nodes:        nativeSupportNodes(),
 		},
+		{
+			name:      "workload identity with invalid format and missing additional volume mounts injection test.",
+			operation: admissionv1.Create,
+			inputPod: func() *corev1.Pod {
+				pod := validInputPodWithWorkloadIdentity("test-credentials")
+				pod.ObjectMeta.Annotations[AdditionalVolumeMountsAnnotation] = "valid-but-missing-vol:/scripts,invalid-format"
+				return pod
+			}(),
+			wantResponse: wantAdditionalVolumeMountsResponseWithMissingVolume(t, "test-credentials", "valid-but-missing-vol:/scripts"),
+			nodes:        nativeSupportNodes(),
+		},
+
 	}
 
 	for _, tc := range testCases {
@@ -1654,6 +1666,15 @@ func wantAdditionalVolumeMountsResponse(t *testing.T, configMapName string, addi
 		corev1.Volume{Name: "binary-volume", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
 		corev1.Volume{Name: "meta-certs-vol", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
 	)
+
+	newPod := *modifySpecWithAdditionalVolumeMounts(*originalPod, configMapName, additionalMounts)
+	return generatePatch(t, originalPod, &newPod)
+}
+
+func wantAdditionalVolumeMountsResponseWithMissingVolume(t *testing.T, configMapName string, additionalMounts string) admission.Response {
+	t.Helper()
+	originalPod := validInputPodWithWorkloadIdentity(configMapName)
+	originalPod.Annotations[AdditionalVolumeMountsAnnotation] = additionalMounts
 
 	newPod := *modifySpecWithAdditionalVolumeMounts(*originalPod, configMapName, additionalMounts)
 	return generatePatch(t, originalPod, &newPod)

--- a/pkg/webhook/mutatingwebhook_test.go
+++ b/pkg/webhook/mutatingwebhook_test.go
@@ -612,29 +612,82 @@ func TestValidateMutatingWebhookResponse(t *testing.T) {
 			nodes:        nativeSupportNodes(),
 		},
 		{
-			name:      "workload identity with invalid format and missing additional volume mounts injection test.",
+			name:      "workload identity with additional volume mounts complex formatting successful test.",
 			operation: admissionv1.Create,
 			inputPod: func() *corev1.Pod {
 				pod := validInputPodWithWorkloadIdentity("test-credentials")
-				pod.ObjectMeta.Annotations[AdditionalVolumeMountsAnnotation] = "valid-but-missing-vol:/scripts,invalid-format"
-				return pod
-			}(),
-			wantResponse: wantAdditionalVolumeMountsResponseWithMissingVolume(t, "test-credentials", "valid-but-missing-vol:/scripts"),
-			nodes:        nativeSupportNodes(),
-		},
-		{
-			name:      "workload identity with additional volume mounts containing whitespace and relative path injection test.",
-			operation: admissionv1.Create,
-			inputPod: func() *corev1.Pod {
-				pod := validInputPodWithWorkloadIdentity("test-credentials")
-				pod.ObjectMeta.Annotations[AdditionalVolumeMountsAnnotation] = "  binary-volume : /scripts , meta-certs-vol : relative/path  "
+				pod.ObjectMeta.Annotations[AdditionalVolumeMountsAnnotation] = " , binary-volume : /scripts:extra , , meta-certs-vol : /etc/meta/certs , "
 				pod.Spec.Volumes = append(pod.Spec.Volumes,
 					corev1.Volume{Name: "binary-volume", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
 					corev1.Volume{Name: "meta-certs-vol", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
 				)
 				return pod
 			}(),
-			wantResponse: wantAdditionalVolumeMountsResponse(t, "test-credentials", "binary-volume:/scripts,meta-certs-vol:relative/path"),
+			wantResponse: wantAdditionalVolumeMountsResponse(t, "test-credentials", "binary-volume:/scripts:extra,meta-certs-vol:/etc/meta/certs"),
+			nodes:        nativeSupportNodes(),
+		},
+		{
+			name:      "workload identity with additional volume mounts missing volume failure test.",
+			operation: admissionv1.Create,
+			inputPod: func() *corev1.Pod {
+				pod := validInputPodWithWorkloadIdentity("test-credentials")
+				pod.ObjectMeta.Annotations[AdditionalVolumeMountsAnnotation] = "missing-vol:/scripts"
+				return pod
+			}(),
+			wantResponse: admission.Errored(http.StatusBadRequest, fmt.Errorf("volume %q specified in %s not found in pod spec", "missing-vol", AdditionalVolumeMountsAnnotation)),
+			nodes:        nativeSupportNodes(),
+		},
+		{
+			name:      "workload identity with additional volume mounts relative path failure test.",
+			operation: admissionv1.Create,
+			inputPod: func() *corev1.Pod {
+				pod := validInputPodWithWorkloadIdentity("test-credentials")
+				pod.ObjectMeta.Annotations[AdditionalVolumeMountsAnnotation] = "binary-volume:relative/path"
+				pod.Spec.Volumes = append(pod.Spec.Volumes,
+					corev1.Volume{Name: "binary-volume", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+				)
+				return pod
+			}(),
+			wantResponse: admission.Errored(http.StatusBadRequest, fmt.Errorf("mount path %q specified in %s is not an absolute path", "relative/path", AdditionalVolumeMountsAnnotation)),
+			nodes:        nativeSupportNodes(),
+		},
+		{
+			name:      "workload identity with additional volume mounts no colons failure test.",
+			operation: admissionv1.Create,
+			inputPod: func() *corev1.Pod {
+				pod := validInputPodWithWorkloadIdentity("test-credentials")
+				pod.ObjectMeta.Annotations[AdditionalVolumeMountsAnnotation] = "binary-volume-no-colons"
+				pod.Spec.Volumes = append(pod.Spec.Volumes,
+					corev1.Volume{Name: "binary-volume", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+				)
+				return pod
+			}(),
+			wantResponse: admission.Errored(http.StatusBadRequest, fmt.Errorf("invalid format for %s: %q, expected \"volume-name:mount-path\"", AdditionalVolumeMountsAnnotation, "binary-volume-no-colons")),
+			nodes:        nativeSupportNodes(),
+		},
+		{
+			name:      "workload identity with additional volume mounts empty volume name failure test.",
+			operation: admissionv1.Create,
+			inputPod: func() *corev1.Pod {
+				pod := validInputPodWithWorkloadIdentity("test-credentials")
+				pod.ObjectMeta.Annotations[AdditionalVolumeMountsAnnotation] = ":/scripts"
+				return pod
+			}(),
+			wantResponse: admission.Errored(http.StatusBadRequest, fmt.Errorf("invalid empty volume name or mount path in %s: %q", AdditionalVolumeMountsAnnotation, ":/scripts")),
+			nodes:        nativeSupportNodes(),
+		},
+		{
+			name:      "workload identity with additional volume mounts empty mount path failure test.",
+			operation: admissionv1.Create,
+			inputPod: func() *corev1.Pod {
+				pod := validInputPodWithWorkloadIdentity("test-credentials")
+				pod.ObjectMeta.Annotations[AdditionalVolumeMountsAnnotation] = "binary-volume:"
+				pod.Spec.Volumes = append(pod.Spec.Volumes,
+					corev1.Volume{Name: "binary-volume", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+				)
+				return pod
+			}(),
+			wantResponse: admission.Errored(http.StatusBadRequest, fmt.Errorf("invalid empty volume name or mount path in %s: %q", AdditionalVolumeMountsAnnotation, "binary-volume:")),
 			nodes:        nativeSupportNodes(),
 		},
 
@@ -1704,15 +1757,6 @@ func wantAdditionalVolumeMountsResponse(t *testing.T, configMapName string, addi
 	return generatePatch(t, originalPod, &newPod)
 }
 
-func wantAdditionalVolumeMountsResponseWithMissingVolume(t *testing.T, configMapName string, additionalMounts string) admission.Response {
-	t.Helper()
-	originalPod := validInputPodWithWorkloadIdentity(configMapName)
-	originalPod.Annotations[AdditionalVolumeMountsAnnotation] = additionalMounts
-
-	newPod := *modifySpecWithAdditionalVolumeMounts(*originalPod, configMapName, additionalMounts)
-	return generatePatch(t, originalPod, &newPod)
-}
-
 func modifySpecWithAdditionalVolumeMounts(newPod corev1.Pod, configMapName string, additionalMounts string) *corev1.Pod {
 	config := FakeConfig()
 
@@ -1763,11 +1807,17 @@ func modifySpecWithAdditionalVolumeMounts(newPod corev1.Pod, configMapName strin
 		if additionalMounts != "" {
 			mounts := strings.Split(additionalMounts, ",")
 			for _, mount := range mounts {
-				parts := strings.Split(mount, ":")
-				if len(parts) == 2 {
+				mount = strings.TrimSpace(mount)
+				if mount == "" {
+					continue
+				}
+				volName, mountPath, found := strings.Cut(mount, ":")
+				if found {
+					volName = strings.TrimSpace(volName)
+					mountPath = strings.TrimSpace(mountPath)
 					sidecarCredentialConfig.CredentialVolumeMounts = append(sidecarCredentialConfig.CredentialVolumeMounts, corev1.VolumeMount{
-						Name:      parts[0],
-						MountPath: parts[1],
+						Name:      volName,
+						MountPath: mountPath,
 						ReadOnly:  true,
 					})
 				}

--- a/pkg/webhook/mutatingwebhook_test.go
+++ b/pkg/webhook/mutatingwebhook_test.go
@@ -623,6 +623,13 @@ func TestValidateMutatingWebhookResponse(t *testing.T) {
 			nodes:        nativeSupportNodes(),
 		},
 
+		{
+			name:         "executable workload identity injection successful test.",
+			operation:    admissionv1.Create,
+			inputPod:     validInputPodWithWorkloadIdentity("executable-credentials"),
+			wantResponse: wantExecutableWorkloadIdentityResponse(t, "executable-credentials"),
+			nodes:        nativeSupportNodes(),
+		},
 	}
 
 	for _, tc := range testCases {
@@ -643,18 +650,29 @@ func TestValidateMutatingWebhookResponse(t *testing.T) {
 			// Create workload identity ConfigMap if the test uses it
 			if tc.inputPod != nil && tc.inputPod.Annotations != nil {
 				if configMapName, ok := tc.inputPod.Annotations[GCPWorkloadIdentityCredentialConfigMapAnnotation]; ok && configMapName != "" {
+					configJson := `{
+								"audience": "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/test-pool/providers/test-provider",
+								"credential_source": {
+									"file": "/var/run/service-account/token"
+								}
+							}`
+					if configMapName == "executable-credentials" {
+						configJson = `{
+								"audience": "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/test-pool/providers/test-provider",
+								"credential_source": {
+									"executable": {
+										"command": "/scripts/fetch-token"
+									}
+								}
+							}`
+					}
 					configMap := &corev1.ConfigMap{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      configMapName,
 							Namespace: testNamespace,
 						},
 						Data: map[string]string{
-							"credential-configuration.json": `{
-								"audience": "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/test-pool/providers/test-provider",
-								"credential_source": {
-									"file": "/var/run/service-account/token"
-								}
-							}`,
+							"credential-configuration.json": configJson,
 						},
 					}
 					_, err := fakeClient.CoreV1().ConfigMaps(testNamespace).Create(context.Background(), configMap, metav1.CreateOptions{})
@@ -1970,4 +1988,53 @@ func stringContains(s, substr string) bool {
 		}
 	}
 	return false
+}
+
+func wantExecutableWorkloadIdentityResponse(t *testing.T, configMapName string) admission.Response {
+	t.Helper()
+	originalPod := validInputPodWithWorkloadIdentity(configMapName)
+	newPod := *modifySpecWithExecutableWorkloadIdentity(*originalPod, configMapName)
+	return generatePatch(t, originalPod, &newPod)
+}
+
+func modifySpecWithExecutableWorkloadIdentity(newPod corev1.Pod, configMapName string) *corev1.Pod {
+	config := FakeConfig()
+
+	var sidecarCredentialConfig *SidecarContainerCredentialConfiguration
+	if configMapName != "" {
+		sidecarCredentialConfig = &SidecarContainerCredentialConfiguration{
+			GacEnv: &corev1.EnvVar{
+				Name:  "GOOGLE_APPLICATION_CREDENTIALS",
+				Value: fmt.Sprintf("%s/%s", SidecarContainerWICredentialConfigMapVolumeMountPath, "credential-configuration.json"),
+			},
+			CredentialVolumeMounts: []corev1.VolumeMount{
+				{Name: SidecarContainerWICredentialConfigMapVolumeName, MountPath: SidecarContainerWICredentialConfigMapVolumeMountPath},
+			},
+			EnvVars: []corev1.EnvVar{
+				{
+					Name:  "GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES",
+					Value: "1",
+				},
+			},
+		}
+
+		newPod.Spec.Volumes = append(newPod.Spec.Volumes,
+			corev1.Volume{
+				Name: SidecarContainerWICredentialConfigMapVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: configMapName,
+						},
+						DefaultMode: &defaultMode,
+					},
+				},
+			},
+		)
+	}
+
+	newPod.Spec.InitContainers = append([]corev1.Container{GetNativeSidecarContainerSpec(config, sidecarCredentialConfig)}, newPod.Spec.InitContainers...)
+	newPod.Spec.Volumes = append(GetSidecarContainerVolumeSpec(newPod.Spec.Volumes...), newPod.Spec.Volumes...)
+
+	return &newPod
 }

--- a/pkg/webhook/mutatingwebhook_test.go
+++ b/pkg/webhook/mutatingwebhook_test.go
@@ -1874,6 +1874,26 @@ func TestOIDCAuthenticationWithHostNetwork(t *testing.T) {
 			},
 			expectError: false, // Empty annotation value should be ignored
 		},
+		{
+			name: "allow pod with hostNetwork=true and executable credential configuration",
+			inputPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: testNamespace,
+					Annotations: map[string]string{
+						GcsFuseVolumeEnableAnnotation:                    "true",
+						GCPWorkloadIdentityCredentialConfigMapAnnotation: "executable-credentials",
+					},
+				},
+				Spec: corev1.PodSpec{
+					HostNetwork:                   true,
+					Containers:                    []corev1.Container{{Name: "app-container"}},
+					Volumes:                       []corev1.Volume{},
+					TerminationGracePeriodSeconds: ptr.To[int64](60),
+				},
+			},
+			expectError: false, // Executable credentials should be ALLOWED on hostNetwork pods
+		},
 	}
 
 	for _, tc := range testCases {
@@ -1881,18 +1901,29 @@ func TestOIDCAuthenticationWithHostNetwork(t *testing.T) {
 			// Create fake clientset with necessary ConfigMap for OIDC tests
 			fakeClient := fake.NewSimpleClientset()
 			if tc.inputPod.Annotations[GCPWorkloadIdentityCredentialConfigMapAnnotation] != "" {
+				configJson := `{
+							"audience": "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/test-pool/providers/test-provider",
+							"credential_source": {
+								"file": "/var/run/service-account/token"
+							}
+						}`
+				if tc.inputPod.Annotations[GCPWorkloadIdentityCredentialConfigMapAnnotation] == "executable-credentials" {
+					configJson = `{
+							"audience": "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/test-pool/providers/test-provider",
+							"credential_source": {
+								"executable": {
+									"command": "/scripts/fetch-token"
+								}
+							}
+						}`
+				}
 				configMap := &corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      tc.inputPod.Annotations[GCPWorkloadIdentityCredentialConfigMapAnnotation],
 						Namespace: testNamespace,
 					},
 					Data: map[string]string{
-						"credential-configuration.json": `{
-							"audience": "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/test-pool/providers/test-provider",
-							"credential_source": {
-								"file": "/var/run/service-account/token"
-							}
-						}`,
+						"credential-configuration.json": configJson,
 					},
 				}
 				_, err := fakeClient.CoreV1().ConfigMaps(testNamespace).Create(context.Background(), configMap, metav1.CreateOptions{})

--- a/pkg/webhook/mutatingwebhook_test.go
+++ b/pkg/webhook/mutatingwebhook_test.go
@@ -597,8 +597,8 @@ func TestValidateMutatingWebhookResponse(t *testing.T) {
 			nodes:        nativeSupportNodes(),
 		},
 		{
-			name:         "workload identity with additional volume mounts injection successful test.",
-			operation:    admissionv1.Create,
+			name:      "workload identity with additional volume mounts injection successful test.",
+			operation: admissionv1.Create,
 			inputPod: func() *corev1.Pod {
 				pod := validInputPodWithWorkloadIdentity("test-credentials")
 				pod.ObjectMeta.Annotations[AdditionalVolumeMountsAnnotation] = "binary-volume:/scripts,meta-certs-vol:/etc/meta/certs"

--- a/pkg/webhook/oidc_test.go
+++ b/pkg/webhook/oidc_test.go
@@ -64,7 +64,10 @@ func TestParseCredentialConfigurationConfigMap(t *testing.T) {
 			expectedCredConfig: &CredentialConfig{
 				Audience: "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/test-pool/providers/test-provider",
 				CredentialSource: struct {
-					File string `json:"file"`
+					File       string `json:"file,omitempty"`
+					Executable *struct {
+						Command string `json:"command"`
+					} `json:"executable,omitempty"`
 				}{
 					File: "/var/run/service-account/token",
 				},
@@ -485,11 +488,12 @@ func TestSidecarContainerCredentialConfiguration(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
-		name           string
-		credConfig     *SidecarContainerCredentialConfiguration
-		config         *Config
-		expectedEnvVar *corev1.EnvVar
-		expectedMounts []corev1.VolumeMount
+		name            string
+		credConfig      *SidecarContainerCredentialConfiguration
+		config          *Config
+		expectedEnvVar  *corev1.EnvVar
+		expectedEnvVars []corev1.EnvVar
+		expectedMounts  []corev1.VolumeMount
 	}{
 		{
 			name: "valid credential configuration",
@@ -620,6 +624,33 @@ func TestSidecarContainerCredentialConfiguration(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "credential configuration with generic env vars",
+			credConfig: &SidecarContainerCredentialConfiguration{
+				GacEnv: &corev1.EnvVar{
+					Name:  "GOOGLE_APPLICATION_CREDENTIALS",
+					Value: "/etc/workload-identity/credential-configuration.json",
+				},
+				EnvVars: []corev1.EnvVar{
+					{
+						Name:  "GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES",
+						Value: "1",
+					},
+				},
+			},
+			config: FakeConfig(),
+			expectedEnvVar: &corev1.EnvVar{
+				Name:  "GOOGLE_APPLICATION_CREDENTIALS",
+				Value: "/etc/workload-identity/credential-configuration.json",
+			},
+			expectedEnvVars: []corev1.EnvVar{
+				{
+					Name:  "GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES",
+					Value: "1",
+				},
+			},
+			expectedMounts: nil,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -647,6 +678,17 @@ func TestSidecarContainerCredentialConfiguration(t *testing.T) {
 				} else if diff := cmp.Diff(tc.expectedEnvVar, foundGacEnv); diff != "" {
 					t.Errorf("GOOGLE_APPLICATION_CREDENTIALS env var mismatch (-want +got):\n%s", diff)
 				}
+			}
+
+			// Check generic environment variables
+			var foundEnvVars []corev1.EnvVar
+			for _, env := range container.Env {
+				if env.Name == "GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES" {
+					foundEnvVars = append(foundEnvVars, env)
+				}
+			}
+			if diff := cmp.Diff(tc.expectedEnvVars, foundEnvVars); diff != "" {
+				t.Errorf("generic env vars mismatch (-want +got):\n%s", diff)
 			}
 
 			// Check volume mounts - find credential-related mounts

--- a/pkg/webhook/oidc_test.go
+++ b/pkg/webhook/oidc_test.go
@@ -74,6 +74,45 @@ func TestParseCredentialConfigurationConfigMap(t *testing.T) {
 			},
 		},
 		{
+			name:          "valid credential configuration with executable",
+			configMapName: "executable-credentials",
+			configMapsInCluster: []*corev1.ConfigMap{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "executable-credentials",
+						Namespace: "default",
+					},
+					Data: map[string]string{
+						"credential-configuration.json": `{
+							"audience": "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/test-pool/providers/test-provider",
+							"credential_source": {
+								"executable": {
+									"command": "/scripts/fetch-token"
+								}
+							}
+						}`,
+					},
+				},
+			},
+			expectError:      false,
+			expectedFilename: "credential-configuration.json",
+			expectedCredConfig: &CredentialConfig{
+				Audience: "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/test-pool/providers/test-provider",
+				CredentialSource: struct {
+					File       string `json:"file,omitempty"`
+					Executable *struct {
+						Command string `json:"command"`
+					} `json:"executable,omitempty"`
+				}{
+					Executable: &struct {
+						Command string `json:"command"`
+					}{
+						Command: "/scripts/fetch-token",
+					},
+				},
+			},
+		},
+		{
 			name:                "configmap not found",
 			configMapName:       "missing-credentials",
 			configMapsInCluster: []*corev1.ConfigMap{},
@@ -423,6 +462,52 @@ func TestAppendWorkloadCredentialConfigurationVolumes(t *testing.T) {
 						ConfigMap: &corev1.ConfigMapVolumeSource{
 							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "root-level-credentials",
+							},
+							DefaultMode: &defaultMode,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:          "successful volume injection for executable credential configuration",
+			configMapName: "executable-credentials",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{},
+				},
+			},
+			configMapsInCluster: []*corev1.ConfigMap{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "executable-credentials",
+						Namespace: "default",
+					},
+					Data: map[string]string{
+						"credential-configuration.json": `{
+							"audience": "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/test-pool/providers/test-provider",
+							"credential_source": {
+								"executable": {
+									"command": "/scripts/fetch-token"
+								}
+							}
+						}`,
+					},
+				},
+			},
+			expectError:      false,
+			expectedFilename: "credential-configuration.json",
+			expectedVolumes: []corev1.Volume{
+				{
+					Name: SidecarContainerWICredentialConfigMapVolumeName,
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "executable-credentials",
 							},
 							DefaultMode: &defaultMode,
 						},

--- a/pkg/webhook/sidecar_spec.go
+++ b/pkg/webhook/sidecar_spec.go
@@ -118,6 +118,7 @@ var (
 type SidecarContainerCredentialConfiguration struct {
 	GacEnv                 *corev1.EnvVar       // This is the environment variable for GOOGLE_APPLICATION_CREDENTIALS that will be injected into the sidecar container.
 	CredentialVolumeMounts []corev1.VolumeMount // These are the volume mounts for the credential files that will be injected into the sidecar container.
+	EnvVars                []corev1.EnvVar      // These are generic environment variables that will be injected into the sidecar container.
 }
 
 func GetNativeSidecarContainerSpec(c *Config, credentialConfig *SidecarContainerCredentialConfiguration) corev1.Container {
@@ -159,6 +160,10 @@ func GetSidecarContainerSpec(c *Config, credentialConfig *SidecarContainerCreden
 			container.Env = append(container.Env, *credentialConfig.GacEnv)
 		}
 
+		// Inject generic environment variables.
+		if len(credentialConfig.EnvVars) > 0 {
+			container.Env = append(container.Env, credentialConfig.EnvVars...)
+		}
 		// Inject the volume mounts for the credential files.
 		if len(credentialConfig.CredentialVolumeMounts) > 0 {
 			container.VolumeMounts = append(container.VolumeMounts, credentialConfig.CredentialVolumeMounts...)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:
This PR introduces webhook enhancements to support custom identity providers and secure proxy integrations. It enables external authentication mechanisms (AIP-4117) and gives users fine-grained control over how volumes and binaries are mounted and ordered in the GCS Fuse sidecar.
Specifically, this PR introduces and validates two key features:
1. **Executable-Sourced Credentials**:
   - Extends the `gke-gcsfuse/workload-identity-credential-configmap` annotation flow to support `executable`-sourced credentials.
   - Injects `GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES="1"` and custom environment variables into the GCS Fuse sidecar.
   - Bypasses the Projected Service Account Token volume injection since authentication is handled dynamically by the user-provided executable.
   - **HostNetwork Support**: Refined the webhook's validation check to allow `hostNetwork: true` pods to use the `executable`-sourced OIDC flow (since it does not query the local metadata server and avoids network interception conflicts), while maintaining the protective block on standard `file`-based Workload Identity.
2. **Additional Volume Mounts (`gke-gcsfuse/additional-volume-mounts`)**:
   - Allows users to mount custom volumes (such as statically linked token copier binaries and mTLS client certificates) directly into the distroless GCS Fuse sidecar container.
   - Robustly handles validation warnings for missing volumes and ignores invalid formatting.
### Verification & Test Coverage:
- Added `TestParseCredentialConfigurationConfigMap` and `TestAppendWorkloadCredentialConfigurationVolumes` unit tests in `pkg/webhook/oidc_test.go` for executable credential parsing.
- Added complete Mutating Webhook integration tests in `pkg/webhook/mutatingwebhook_test.go` covering:
  - Formatting edge cases and missing volumes for `gke-gcsfuse/additional-volume-mounts`.
  - Seamless injection of executable workload identity credentials.
  - Bypassing hostNetwork checks for executable credentials on `hostNetwork: true` pods.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # b/495760030

**Special notes for your reviewer**:
Please verify the deferred `hostNetwork` check logic in `pkg/webhook/mutatingwebhook.go` around lines 144-158. It now correctly parses the ConfigMap first to distinguish between file-based (blocked on hostNetwork) and executable-based (allowed on hostNetwork) configurations.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
feat(webhook): introduced support for executable-sourced credentials (AIP-4117) in GCS Fuse sidecar injection.
feat(webhook): added the `gke-gcsfuse/additional-volume-mounts` annotation to mount custom volumes and certificates into the sidecar.
fix(webhook): allowed executable-sourced credentials on hostNetwork pods.
```