### PR TITLE
fix inconsistent informer set up for flaky unit test

### DIFF
--- a/pkg/webhook/injection_test.go
+++ b/pkg/webhook/injection_test.go
@@ -1939,7 +1939,6 @@ func TestInjectMetadataPrefetchSidecarWithSC(t *testing.T) {
 			si.ScLister = informer.Storage().V1().StorageClasses().Lister()
 			si.PvLister = informer.Core().V1().PersistentVolumes().Lister()
 			si.PvcLister = informer.Core().V1().PersistentVolumeClaims().Lister()
-			informer.Start(ctx.Done())
 			_, err := fakeClient.StorageV1().StorageClasses().Create(context.TODO(), tc.sc, metav1.CreateOptions{})
 
 			if err != nil {
@@ -1971,6 +1970,7 @@ func TestInjectMetadataPrefetchSidecarWithSC(t *testing.T) {
 				t.Fatalf("failed to setup test PVC: %v", err)
 			}
 
+			informer.Start(ctx.Done())
 			informer.WaitForCacheSync(ctx.Done())
 
 			err = si.injectSidecarContainer(MetadataPrefetchSidecarName, tc.pod, *tc.nativeSidecar, nil)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR fixes a race condition in TestInjectMetadataPrefetchSidecarWithSC which occassionally caused flakes with the following error:
```failed to determine if my-volume is a GcsFuseCSI backed volume: persistentvolumeclaim "my-pvc1" not found``` 
This causes the webhook to not inject the metadata prefetch sidecar and thus cause a diff between expected pod spec and actual.

The reason is that informer.Start(ctx.Done()) was called before creating the mock objects (StorageClass, PersistentVolume, and PersistentVolumeClaim) in the fakeClient. Since informer.WaitForCacheSync guarantees that the initial LIST request has synced to the cache and does not wait for subsequent WATCH events ([this is how we add pvcs](https://github.com/chrisThePattyEater/gcs-fuse-csi-driver/blob/42be85abf36e8f0d0b67927c5b95a4d9bdbc6c53/pkg/webhook/injection_test.go#L1959)), the test would occasionally execute before the informer cache had processed the newl resources, resulting in an empty cache.

This PR moves the informer.Start(ctx.Done()) and informer.WaitForCacheSync(ctx.Done()) after all of the mock objects have been created in the fakeClient. This makes WaitForCacheSync properly block the test until the cache is fully populated and ready to use.

This also moves the test to be inline with the way other tests use informers, example https://github.com/chrisThePattyEater/gcs-fuse-csi-driver/blob/42be85abf36e8f0d0b67927c5b95a4d9bdbc6c53/pkg/webhook/client_test.go#L196
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```