### PR TITLE
Implement ControllerPublishVolume mounter pod creation logic.

### DIFF
--- a/pkg/cloud_provider/clientset/fake.go
+++ b/pkg/cloud_provider/clientset/fake.go
@@ -26,7 +26,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 type FakeNodeConfig struct {
@@ -38,6 +40,7 @@ type FakeNodeConfig struct {
 type FakePodConfig struct {
 	HostNetworkEnabled bool
 	SidecarLimits      corev1.ResourceList
+	DeletionTimestamp  *metav1.Time
 }
 
 type FakePVConfig struct {
@@ -62,6 +65,7 @@ type FakeSCConfig struct {
 }
 
 type FakeClientset struct {
+	Client    kubernetes.Interface
 	fakePod   *corev1.Pod
 	fakeNode  *corev1.Node
 	fakePVs   map[string]*corev1.PersistentVolume
@@ -70,8 +74,10 @@ type FakeClientset struct {
 	ListPVErr error
 }
 
-func NewFakeClientset() *FakeClientset {
+func NewFakeClientset(objects ...runtime.Object) *FakeClientset {
+	fakeK8sClient := fake.NewSimpleClientset(objects...)
 	fakeClientSet := &FakeClientset{
+		Client:   fakeK8sClient,
 		fakePVs:  make(map[string]*corev1.PersistentVolume),
 		fakePVCs: make(map[string]*corev1.PersistentVolumeClaim),
 		fakeSCs:  make(map[string]*storagev1.StorageClass),
@@ -87,7 +93,7 @@ func NewFakeClientset() *FakeClientset {
 }
 
 func (c *FakeClientset) K8sClient() kubernetes.Interface {
-	return nil
+	return c.Client
 }
 
 func (c *FakeClientset) ConfigurePodLister(_ context.Context, _ string) {}
@@ -133,6 +139,10 @@ func (c *FakeClientset) CreatePod(podConfig FakePodConfig) {
 
 	if podConfig.HostNetworkEnabled {
 		c.fakePod.Spec.HostNetwork = true
+	}
+
+	if podConfig.DeletionTimestamp != nil {
+		c.fakePod.DeletionTimestamp = podConfig.DeletionTimestamp
 	}
 }
 

--- a/pkg/csi_driver/controller.go
+++ b/pkg/csi_driver/controller.go
@@ -171,17 +171,25 @@ func (s *controllerServer) ControllerPublishVolume(ctx context.Context, req *csi
 	if pvcNamespace == "" || pvcName == "" {
 		return nil, status.Errorf(codes.Internal, "pv claimRef namespace and name can't be empty, namespace: %q, name: %q", pvcNamespace, pvcName)
 	}
-	mounterPodNamespace := pvcNamespace
+	podNamespace := pvcNamespace
 
 	// Prepare mounter pod config.
 	podName := createMounterPodName(nodeID, volumeID)
-	_ = &mounterPodConfig{
+	podConfig := &mounterPodConfig{
 		podName:   podName,
-		namespace: mounterPodNamespace,
+		namespace: podNamespace,
 		nodeID:    nodeID,
+		// TODO(urielguzman): Replace with the actual mounter pod image.
+		image: "k8s.gcr.io/pause",
+	}
+
+	if err := createMounterPod(clientset, ctx, podConfig); err != nil {
+		// TODO(urielguzman): Wait for mounter pod to be scheduled before succeeding.
+		return nil, err
 	}
 
 	// TODO(urielguzman): implement ControllerPublishVolume when sharedMount: true.
+	klog.Infof("ControllerPublishVolume succeeded for mounter pod %s/%s. Node: %q, volume %q", podConfig.namespace, podConfig.podName, nodeID, volumeID)
 	return &csi.ControllerPublishVolumeResponse{}, nil
 }
 

--- a/pkg/csi_driver/controller_test.go
+++ b/pkg/csi_driver/controller_test.go
@@ -18,18 +18,21 @@ limitations under the License.
 package driver
 
 import (
+	"context"
 	"errors"
-	"fmt"
 	"reflect"
 	"testing"
 
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/clientset"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 const (
@@ -38,6 +41,8 @@ const (
 	testPV        = "test-pv"
 	testPVC       = "test-pvc"
 	testNamespace = "test-namespace"
+	testPod       = "test-pod"
+	testImage     = "k8s.gcr.io/pause"
 )
 
 func initTestController(t *testing.T, clientset clientset.Interface) csi.ControllerServer {
@@ -174,11 +179,31 @@ func TestDeleteVolume(t *testing.T) {
 
 func TestControllerPublishVolume(t *testing.T) {
 	t.Parallel()
+	timeNow := metav1.Now()
+
+	// Helper to create a mounter pod for initial state
+	makeMounterPod := func(config *mounterPodConfig, deletionTimestamp *metav1.Time) *corev1.Pod {
+		p := createMounterPodSpec(config)
+		p.ObjectMeta.DeletionTimestamp = deletionTimestamp
+		p.ResourceVersion = "1"
+		return p
+	}
+
+	defaultMounterPodConfig := &mounterPodConfig{
+		podName:   createMounterPodName(testNodeID, testVolumeID),
+		namespace: testNamespace,
+		nodeID:    testNodeID,
+		image:     testImage,
+	}
+
 	cases := []struct {
-		name      string
-		req       *csi.ControllerPublishVolumeRequest
-		setupFake func() *clientset.FakeClientset
-		expectErr error
+		name          string
+		req           *csi.ControllerPublishVolumeRequest
+		setupFake     func() *clientset.FakeClientset
+		podGetErr     error
+		podCreateErr  error
+		expectErr     bool
+		expectErrCode codes.Code
 	}{
 		{
 			name: "empty volume ID - should return error",
@@ -186,10 +211,10 @@ func TestControllerPublishVolume(t *testing.T) {
 				VolumeId:         "",
 				NodeId:           testNodeID,
 				VolumeCapability: testVolumeCapability,
-				VolumeContext:    map[string]string{},
 			},
-			setupFake: func() *clientset.FakeClientset { return clientset.NewFakeClientset() },
-			expectErr: status.Error(codes.InvalidArgument, "ControllerPublishVolume Volume ID must be provided"),
+			setupFake:     func() *clientset.FakeClientset { return clientset.NewFakeClientset() },
+			expectErr:     true,
+			expectErrCode: codes.InvalidArgument,
 		},
 		{
 			name: "empty node ID - should return error",
@@ -197,10 +222,10 @@ func TestControllerPublishVolume(t *testing.T) {
 				VolumeId:         testVolumeID,
 				NodeId:           "",
 				VolumeCapability: testVolumeCapability,
-				VolumeContext:    map[string]string{},
 			},
-			setupFake: func() *clientset.FakeClientset { return clientset.NewFakeClientset() },
-			expectErr: status.Error(codes.InvalidArgument, "ControllerPublishVolume Node ID must be provided"),
+			setupFake:     func() *clientset.FakeClientset { return clientset.NewFakeClientset() },
+			expectErr:     true,
+			expectErrCode: codes.InvalidArgument,
 		},
 		{
 			name: "empty volume capabilities - should return error",
@@ -208,10 +233,10 @@ func TestControllerPublishVolume(t *testing.T) {
 				VolumeId:         testVolumeID,
 				NodeId:           testNodeID,
 				VolumeCapability: nil,
-				VolumeContext:    map[string]string{},
 			},
-			setupFake: func() *clientset.FakeClientset { return clientset.NewFakeClientset() },
-			expectErr: status.Error(codes.InvalidArgument, "volume capability must be provided"),
+			setupFake:     func() *clientset.FakeClientset { return clientset.NewFakeClientset() },
+			expectErr:     true,
+			expectErrCode: codes.InvalidArgument,
 		},
 		{
 			name: "missing sharedMount - should return success",
@@ -222,27 +247,20 @@ func TestControllerPublishVolume(t *testing.T) {
 				VolumeContext:    map[string]string{},
 			},
 			setupFake: func() *clientset.FakeClientset { return clientset.NewFakeClientset() },
-			expectErr: nil,
+			expectErr: false,
 		},
 		{
-			name: "sharedMount true - should return success",
+			name: "sharedMount false - should return success",
 			req: &csi.ControllerPublishVolumeRequest{
 				VolumeId:         testVolumeID,
 				NodeId:           testNodeID,
 				VolumeCapability: testVolumeCapability,
 				VolumeContext: map[string]string{
-					"sharedMount": "true",
+					"sharedMount": "false",
 				},
 			},
-			setupFake: func() *clientset.FakeClientset {
-				fc := clientset.NewFakeClientset()
-				fc.CreatePV(clientset.FakePVConfig{Name: testPV, VolumeHandle: testVolumeID, ClaimRef: &corev1.ObjectReference{
-					Name:      "test-pvc",
-					Namespace: "test-namespace",
-				}})
-				return fc
-			},
-			expectErr: nil,
+			setupFake: func() *clientset.FakeClientset { return clientset.NewFakeClientset() },
+			expectErr: false,
 		},
 		{
 			name: "sharedMount true - no pv found - should return error",
@@ -254,8 +272,9 @@ func TestControllerPublishVolume(t *testing.T) {
 					"sharedMount": "true",
 				},
 			},
-			setupFake: func() *clientset.FakeClientset { return clientset.NewFakeClientset() },
-			expectErr: status.Errorf(codes.Internal, "no pv found for volumeID: %q", testVolumeID),
+			setupFake:     func() *clientset.FakeClientset { return clientset.NewFakeClientset() },
+			expectErr:     true,
+			expectErrCode: codes.Internal,
 		},
 		{
 			name: "sharedMount true - claimRef nil - should return error",
@@ -272,10 +291,11 @@ func TestControllerPublishVolume(t *testing.T) {
 				fc.CreatePV(clientset.FakePVConfig{Name: testPV, VolumeHandle: testVolumeID, ClaimRef: nil})
 				return fc
 			},
-			expectErr: status.Errorf(codes.Internal, "pv %q is not bound to any pvc", testPV),
+			expectErr:     true,
+			expectErrCode: codes.Internal,
 		},
 		{
-			name: "sharedMount true - claimRef namespace empty - should return error",
+			name: "sharedMount true - mounter pod created successfully",
 			req: &csi.ControllerPublishVolumeRequest{
 				VolumeId:         testVolumeID,
 				NodeId:           testNodeID,
@@ -288,14 +308,57 @@ func TestControllerPublishVolume(t *testing.T) {
 				fc := clientset.NewFakeClientset()
 				fc.CreatePV(clientset.FakePVConfig{Name: testPV, VolumeHandle: testVolumeID, ClaimRef: &corev1.ObjectReference{
 					Name:      testPVC,
-					Namespace: "",
+					Namespace: testNamespace,
 				}})
 				return fc
 			},
-			expectErr: status.Error(codes.Internal, fmt.Sprintf("pv claimRef namespace and name can't be empty, namespace: %q, name: %q", "", testPVC)),
+			expectErr: false,
 		},
 		{
-			name: "sharedMount true - claimRef name empty - should return error",
+			name: "sharedMount true - mounter pod already exists",
+			req: &csi.ControllerPublishVolumeRequest{
+				VolumeId:         testVolumeID,
+				NodeId:           testNodeID,
+				VolumeCapability: testVolumeCapability,
+				VolumeContext: map[string]string{
+					"sharedMount": "true",
+				},
+			},
+			setupFake: func() *clientset.FakeClientset {
+				existingPod := makeMounterPod(defaultMounterPodConfig, nil)
+				fc := clientset.NewFakeClientset(existingPod)
+				fc.CreatePV(clientset.FakePVConfig{Name: testPV, VolumeHandle: testVolumeID, ClaimRef: &corev1.ObjectReference{
+					Name:      testPVC,
+					Namespace: testNamespace,
+				}})
+				return fc
+			},
+			expectErr: false,
+		},
+		{
+			name: "sharedMount true - mounter pod being deleted",
+			req: &csi.ControllerPublishVolumeRequest{
+				VolumeId:         testVolumeID,
+				NodeId:           testNodeID,
+				VolumeCapability: testVolumeCapability,
+				VolumeContext: map[string]string{
+					"sharedMount": "true",
+				},
+			},
+			setupFake: func() *clientset.FakeClientset {
+				existingPod := makeMounterPod(defaultMounterPodConfig, &timeNow)
+				fc := clientset.NewFakeClientset(existingPod)
+				fc.CreatePV(clientset.FakePVConfig{Name: testPV, VolumeHandle: testVolumeID, ClaimRef: &corev1.ObjectReference{
+					Name:      testPVC,
+					Namespace: testNamespace,
+				}})
+				return fc
+			},
+			expectErr:     true,
+			expectErrCode: codes.Aborted,
+		},
+		{
+			name: "sharedMount true - mounter pod get error",
 			req: &csi.ControllerPublishVolumeRequest{
 				VolumeId:         testVolumeID,
 				NodeId:           testNodeID,
@@ -307,34 +370,75 @@ func TestControllerPublishVolume(t *testing.T) {
 			setupFake: func() *clientset.FakeClientset {
 				fc := clientset.NewFakeClientset()
 				fc.CreatePV(clientset.FakePVConfig{Name: testPV, VolumeHandle: testVolumeID, ClaimRef: &corev1.ObjectReference{
-					Name:      "",
+					Name:      testPVC,
 					Namespace: testNamespace,
 				}})
 				return fc
 			},
-			expectErr: status.Error(codes.Internal, fmt.Sprintf("pv claimRef namespace and name can't be empty, namespace: %q, name: %q", testNamespace, "")),
+			podGetErr:     errors.New("simulated get error"),
+			expectErr:     true,
+			expectErrCode: codes.Internal,
 		},
 		{
-			name: "sharedMount false - should return success",
+			name: "sharedMount true - mounter pod create error",
 			req: &csi.ControllerPublishVolumeRequest{
 				VolumeId:         testVolumeID,
 				NodeId:           testNodeID,
 				VolumeCapability: testVolumeCapability,
 				VolumeContext: map[string]string{
-					"sharedMount": "false",
+					"sharedMount": "true",
 				},
 			},
-			setupFake: func() *clientset.FakeClientset { return clientset.NewFakeClientset() },
-			expectErr: nil,
+			setupFake: func() *clientset.FakeClientset {
+				fc := clientset.NewFakeClientset()
+				fc.CreatePV(clientset.FakePVConfig{Name: testPV, VolumeHandle: testVolumeID, ClaimRef: &corev1.ObjectReference{
+					Name:      testPVC,
+					Namespace: testNamespace,
+				}})
+				return fc
+			},
+			podCreateErr:  errors.New("simulated create error"),
+			expectErr:     true,
+			expectErrCode: codes.Internal,
 		},
 	}
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
 			clientset := test.setupFake()
 			s := initTestController(t, clientset)
+
+			fakeK8sClient := clientset.K8sClient().(*fake.Clientset)
+
+			if test.podGetErr != nil {
+				fakeK8sClient.PrependReactor("get", "pods", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, nil, test.podGetErr
+				})
+			}
+			if test.podCreateErr != nil {
+				fakeK8sClient.Fake.PrependReactor("create", "pods", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, nil, test.podCreateErr
+				})
+			}
+
 			_, err := s.ControllerPublishVolume(context.Background(), test.req)
-			if !errors.Is(err, test.expectErr) {
-				t.Errorf("Expected error: %v, got: %v", test.expectErr, err)
+
+			if test.expectErr {
+				if err == nil {
+					t.Fatalf("Expected error code %v, got nil", test.expectErrCode)
+				}
+				st, ok := status.FromError(err)
+				if !ok {
+					// If not a status error, check if any error was expected
+					if test.expectErrCode != codes.Unknown {
+						t.Fatalf("Expected status error with code %v, got non-status error: %v", test.expectErrCode, err)
+					}
+				} else if st.Code() != test.expectErrCode {
+					t.Errorf("Expected error code %v, got %v (error: %v)", test.expectErrCode, st.Code(), err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Expected no error, got: %v", err)
+				}
 			}
 		})
 	}

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -934,7 +934,7 @@ func TestNodePublishVolumeRespectEnableSidecarBucketAccessCheck(t *testing.T) {
 			}
 			fakeMounter := mount.NewFakeMounter([]mount.MountPoint{})
 
-			driver := initTestDriver(t, fakeMounter)
+			driver := initTestDriver(t, fakeMounter, clientset.NewFakeClientset())
 			s, _ := driver.config.StorageServiceManager.SetupService(context.TODO(), nil, "")
 			if _, err := s.CreateBucket(context.Background(), &storage.ServiceBucket{Name: testVolumeID}); err != nil {
 				t.Fatalf("failed to create the fake bucket: %v", err)

--- a/pkg/csi_driver/shared_mount.go
+++ b/pkg/csi_driver/shared_mount.go
@@ -22,21 +22,31 @@ import (
 	"fmt"
 	"io"
 
+	"context"
+
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/clientset"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 )
 
 const (
-	mounterPodNamePrefix = "gcsfusecsi-mount"
+	mounterPodNamePrefix    = "gcsfusecsi-mount"
+	mounterPodPriorityClass = "gcsfusecsi-mount-priority"
+	mounterPodMountDir      = "mount-dir"
 )
 
 // mounterPodConfig holds the configuration parameters required to define and manage a mounter pod.
 type mounterPodConfig struct {
-	podName       string // The name to assign to the mounter pod.
-	nodeID        string // The specific node ID where the pod should be scheduled.
-	namespace     string // The Kubernetes namespace in which to create the pod.
-	priorityClass string // The name of the PriorityClass to apply to the pod.
+	podName   string // The name to assign to the mounter pod.
+	nodeID    string // The specific node ID where the pod should be scheduled.
+	namespace string // The Kubernetes namespace in which to create the pod.
+	image     string // The image for the mounter pod binary.
 }
 
 // sharedMount checks if the VolumeContext enables the shared node mount feature
@@ -75,4 +85,112 @@ func pvFromVolumeID(clientset clientset.Interface, volumeID string) (*corev1.Per
 		}
 	}
 	return nil, fmt.Errorf("no pv found for volumeID: %q", volumeID)
+}
+
+// createMounterPod handles the creation of the mounter pod using the Kubernetes API client.
+func createMounterPod(clientset clientset.Interface, ctx context.Context, config *mounterPodConfig) error {
+	if clientset == nil || clientset.K8sClient() == nil {
+		return status.Error(codes.Internal, "kubernetes client is uninitialized")
+	}
+	if config == nil {
+		return status.Error(codes.Internal, "mounter pod config cannot be nil")
+	}
+	// Check if the mounter pod already exists, but was marked for deletion.
+	// This requires calling the API server directly to retrieve the most up-to-date pod status.
+	pod, err := clientset.K8sClient().CoreV1().Pods(config.namespace).Get(ctx, config.podName, metav1.GetOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		return status.Errorf(codes.Internal, "failed to get mounter pod %s/%s: %v", config.namespace, config.podName, err)
+	}
+	// GET always returns a pointer to the pod, even if the pod doesn't exist.
+	// Therefore, we cannot rely on a nil pointer to determine the pod's existence.
+	if errors.IsNotFound(err) {
+		podSpec := createMounterPodSpec(config)
+		if _, err = clientset.K8sClient().CoreV1().Pods(config.namespace).Create(ctx, podSpec, metav1.CreateOptions{}); err != nil {
+			if errors.IsAlreadyExists(err) {
+				klog.Infof("Mounter pod %s/%s already exists.", config.namespace, config.podName)
+				return nil
+			}
+			return status.Errorf(codes.Internal, "failed to create mounter pod %s/%s: %v", config.namespace, config.podName, err)
+		}
+		return nil
+	}
+	// If the mounter pod is marked for deletion, prevent ControllerPublishVolume from succeeding.
+	if pod == nil {
+		return status.Errorf(codes.Internal, "mounter pod %s/%s was found but returned as nil", config.namespace, config.podName)
+	}
+	if pod.ObjectMeta.DeletionTimestamp != nil {
+		return status.Errorf(
+			codes.Aborted,
+			"Mounter pod %s/%s is marked for deletion. Waiting for pod deletion to complete.",
+			config.namespace, config.podName,
+		)
+	}
+	klog.Infof("Mounter pod %s/%s already exists.", config.namespace, config.podName)
+	return nil
+}
+
+// createMounterPodSpec returns the pod spec for the mounter pod.
+func createMounterPodSpec(config *mounterPodConfig) *corev1.Pod {
+	spec := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      config.podName,
+			Namespace: config.namespace,
+		},
+		Spec: corev1.PodSpec{
+			NodeSelector: map[string]string{
+				// Use NodeSelector rather than NodeName in the mounter pod spec,
+				// since NodeName will bypass kube-scheduler.
+				"kubernetes.io/hostname": config.nodeID,
+				"kubernetes.io/os":       "linux",
+			},
+			PriorityClassName: mounterPodPriorityClass,
+			Containers: []corev1.Container{
+				{
+					Name:            mounterPodNamePrefix,
+					Image:           config.image,
+					ImagePullPolicy: corev1.PullAlways,
+					SecurityContext: &corev1.SecurityContext{
+						Privileged: ptr.To(true),
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:             mounterPodMountDir,
+							MountPath:        util.KubeletDir,
+							MountPropagation: ptr.To(corev1.MountPropagationBidirectional),
+						},
+						{
+							Name:      util.SidecarContainerTmpVolumeName,
+							MountPath: util.SidecarContainerTmpVolumePath,
+						},
+					},
+				},
+			},
+			Volumes: []corev1.Volume{
+				{
+					Name: mounterPodMountDir,
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: util.KubeletDir,
+							Type: ptr.To(corev1.HostPathDirectoryOrCreate),
+						},
+					},
+				},
+				{
+					Name: util.SidecarContainerTmpVolumeName,
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
+					},
+				},
+			},
+			Tolerations: []corev1.Toleration{
+				{
+					//  https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+					//  See "special case". This will tolerate everything. Mounter pod should
+					//  be possible to be scheduled on all nodes where the workloads are scheduled.
+					Operator: corev1.TolerationOpExists,
+				},
+			},
+		},
+	}
+	return spec
 }

--- a/pkg/csi_driver/shared_mount_test.go
+++ b/pkg/csi_driver/shared_mount_test.go
@@ -18,14 +18,22 @@ limitations under the License.
 package driver
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/clientset"
+	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+	"k8s.io/utils/ptr"
 )
 
 func TestSharedMount(t *testing.T) {
@@ -180,6 +188,211 @@ func TestPVFromVolumeID(t *testing.T) {
 
 			if diff := cmp.Diff(tc.wantPV, gotPV); diff != "" {
 				t.Errorf("pvFromVolumeID(%q) returned unexpected diff (-want +got):\n%s", tc.volumeID, diff)
+			}
+		})
+	}
+}
+
+func TestCreateMounterPodSpec(t *testing.T) {
+	tests := []struct {
+		name   string
+		config *mounterPodConfig
+		want   *corev1.Pod
+	}{
+		{
+			name: "basic config - should succeed",
+			config: &mounterPodConfig{
+				podName:   "my-mounter-pod",
+				namespace: "my-namespace",
+				nodeID:    "node-123",
+				image:     "gcr.io/my-project/my-image:v1.0.0",
+			},
+			want: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-mounter-pod",
+					Namespace: "my-namespace",
+				},
+				Spec: corev1.PodSpec{
+					NodeSelector: map[string]string{
+						"kubernetes.io/hostname": "node-123",
+						"kubernetes.io/os":       "linux",
+					},
+					PriorityClassName: mounterPodPriorityClass,
+					Containers: []corev1.Container{
+						{
+							Name:            mounterPodNamePrefix,
+							Image:           "gcr.io/my-project/my-image:v1.0.0",
+							ImagePullPolicy: corev1.PullAlways,
+							SecurityContext: &corev1.SecurityContext{
+								Privileged: ptr.To(true),
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:             mounterPodMountDir,
+									MountPath:        util.KubeletDir,
+									MountPropagation: ptr.To(corev1.MountPropagationBidirectional),
+								},
+								{
+									Name:      util.SidecarContainerTmpVolumeName,
+									MountPath: util.SidecarContainerTmpVolumePath,
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: mounterPodMountDir,
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: util.KubeletDir,
+									Type: ptr.To(corev1.HostPathDirectoryOrCreate),
+								},
+							},
+						},
+						{
+							Name: util.SidecarContainerTmpVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
+							},
+						},
+					},
+					Tolerations: []corev1.Toleration{
+						{
+							Operator: corev1.TolerationOpExists,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := createMounterPodSpec(tc.config)
+
+			// Compare the got and want Pod specs using cmp.Diff
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("createMounterPodSpec(%v) returned an unexpected diff (-want +got):\n%s", tc.config, diff)
+			}
+		})
+	}
+}
+
+func TestCreateMounterPod(t *testing.T) {
+	ctx := context.Background()
+
+	baseConfig := &mounterPodConfig{
+		namespace: testNamespace,
+		podName:   testPod,
+		nodeID:    testNodeID,
+		image:     testImage,
+	}
+
+	timeNow := metav1.Now()
+
+	makePod := func(deletionTimestamp *metav1.Time) *corev1.Pod {
+		p := createMounterPodSpec(baseConfig)
+		p.ObjectMeta.DeletionTimestamp = deletionTimestamp
+		p.ResourceVersion = "1" // Needed for some fake client operations
+		return p
+	}
+
+	tests := []struct {
+		name         string
+		initialState []runtime.Object
+		getErr       error
+		createErr    error
+		wantErr      bool
+		wantCode     codes.Code
+		wantCreates  int
+	}{
+		{
+			name:         "pod does not exist - create pod successfully",
+			initialState: []runtime.Object{},
+			wantErr:      false,
+			wantCreates:  1,
+		},
+		{
+			name: "pod exists - no-op success",
+			initialState: []runtime.Object{
+				makePod(nil),
+			},
+			wantErr:     false,
+			wantCreates: 0,
+		},
+		{
+			name: "pod exists with deletion timestamp - return error",
+			initialState: []runtime.Object{
+				makePod(&timeNow),
+			},
+			wantErr:     true,
+			wantCode:    codes.Aborted,
+			wantCreates: 0,
+		},
+		{
+			name:        "pod get fails with non-NotFound error - return error",
+			getErr:      errors.New("simulated internal error"),
+			wantErr:     true,
+			wantCreates: 0,
+		},
+		{
+			name:        "pod create fails with error - return error",
+			createErr:   errors.New("simulated create failed"),
+			wantErr:     true,
+			wantCreates: 1, // Create was attempted
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// NewFakeClientset now initializes the standard fake client
+			testClientset := clientset.NewFakeClientset(tc.initialState...)
+			fakeK8sClient := testClientset.K8sClient().(*fake.Clientset)
+
+			// Inject errors using reactors on the standard fake client
+			if tc.getErr != nil {
+				fakeK8sClient.PrependReactor("get", "pods", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, nil, tc.getErr
+				})
+			}
+			if tc.createErr != nil {
+				fakeK8sClient.PrependReactor("create", "pods", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, nil, tc.createErr
+				})
+			}
+
+			err := createMounterPod(testClientset, ctx, baseConfig)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("createMounterPod(%v) succeeded unexpectedly, want error", baseConfig)
+				}
+				if tc.wantCode != codes.OK {
+					st, ok := status.FromError(err)
+					if !ok {
+						t.Fatalf("createMounterPod(%v) returned non-status error %v, want status error with code %v", baseConfig, err, tc.wantCode)
+					}
+					if st.Code() != tc.wantCode {
+						t.Errorf("createMounterPod(%v) returned error code %v, want %v (error: %v)", baseConfig, st.Code(), tc.wantCode, err)
+					}
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("createMounterPod(%v) failed unexpectedly: %v", baseConfig, err)
+				}
+			}
+
+			// Verify create calls on the standard fake client
+			actions := fakeK8sClient.Actions()
+			gotCreates := 0
+			for _, action := range actions {
+				if action.Matches("create", "pods") {
+					gotCreates++
+				}
+			}
+
+			if gotCreates != tc.wantCreates {
+				t.Errorf("createMounterPod(%v) made %d create calls, want %d", baseConfig, gotCreates, tc.wantCreates)
 			}
 		})
 	}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -59,6 +59,7 @@ const (
 	EnableCloudProfilerForSidecarConst  = "enable-cloud-profiler-for-sidecar"
 	EnableCloudProfilerConst            = "enable-cloud-profiler"
 	SidecarContainerTmpVolumeName       = "gke-gcsfuse-tmp"
+	SidecarContainerTmpVolumePath       = "/gke-gcsfuse-tmp"
 	SidecarBucketAccessCheckErrorPrefix = "sidecar bucket access check error"
 	StorageServiceErrorStr              = "failed to setup storage service"
 	GCSFuseCsiDriverName                = "gcsfuse.csi.storage.gke.io"
@@ -70,6 +71,7 @@ const (
 	AutoGoMemLimitRatioConst            = "auto-gomemlimit-ratio"
 	GoMemLimitCgroupPercentage          = 0.95
 	StorageEndpointInternal             = "storage-endpoint-internal"
+	KubeletDir                          = "/var/lib/kubelet"
 )
 
 var (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**: This PR introduces new logic into ControllerPublishVolume to create the mounter pod. It introduces a function `createMounterPod`, which succeeds if the mounter pod already exists, or creates it. It also intrdocues the function `createMounterPodSpec` to generate the spec based on the provided `mounterPodConfig`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```