### PR TITLE
Fix ClusterName env var for failing prow tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,14 +56,14 @@ ifeq ($(SELF_MANAGED_K8S), true)
 else
 # GKE-Specific Logic (Default)
     export WI_NODE_LABEL_CHECK ?= true
-    # assume that a GKE cluster identifier follows the format gke_{project-name}_{location}_{cluster-name}
-    export PROJECT ?= $(shell kubectl config current-context | cut -d '_' -f 2)
-    export CLUSTER_LOCATION ?= $(shell kubectl config current-context | cut -d '_' -f 3)
-    export CLUSTER_NAME ?= $(shell kubectl config current-context | cut -d '_' -f 4)
-    # Use jq to extract CA Bundle specifically for the current GKE context
-    CA_BUNDLE ?= $(shell kubectl config view --raw -o json | jq '.clusters[]' | jq "select(.name == \"$(shell kubectl config current-context)\")" | jq '.cluster."certificate-authority-data"' | head -n 1)
     # Auto-discover Identity Provider from the cluster
     IDENTITY_PROVIDER ?= $(shell kubectl get --raw /.well-known/openid-configuration | jq -r .issuer)
+    # assume that a GKE cluster identifier follows the format gke_{project-name}_{location}_{cluster-name}
+    export PROJECT ?= $(shell ctx=$$(kubectl config current-context); echo "$$ctx" | grep -q '^gke_' && echo "$$ctx" | cut -d '_' -f 2 || echo "$(IDENTITY_PROVIDER)" | awk -F/ '{print $$6}')
+    export CLUSTER_LOCATION ?= $(shell ctx=$$(kubectl config current-context); echo "$$ctx" | grep -q '^gke_' && echo "$$ctx" | cut -d '_' -f 3 || echo "$(IDENTITY_PROVIDER)" | awk -F/ '{print $$8}')
+    export CLUSTER_NAME ?= $(shell ctx=$$(kubectl config current-context); echo "$$ctx" | grep -q '^gke_' && echo "$$ctx" | cut -d '_' -f 4 || echo "$(IDENTITY_PROVIDER)" | awk -F/ '{print $$10}')
+    # Use jq to extract CA Bundle specifically for the current GKE context
+    CA_BUNDLE ?= $(shell kubectl config view --raw -o json | jq '.clusters[]' | jq "select(.name == \"$(shell kubectl config current-context)\")" | jq '.cluster."certificate-authority-data"' | head -n 1)
     # Derive Identity Pool from Project ID
     IDENTITY_POOL ?= ${PROJECT}.svc.id.goog
 endif
@@ -95,6 +95,7 @@ $(info PROJECT is ${PROJECT})
 $(info CLUSTER_LOCATION is ${CLUSTER_LOCATION})
 $(info CLUSTER_NAME is ${CLUSTER_NAME})
 $(info UNIVERSE_DOMAIN is ${UNIVERSE_DOMAIN})
+$(info IDENTITY_PROVIDER is ${IDENTITY_PROVIDER})
 $(info OVERLAY is ${OVERLAY})
 $(info STAGINGVERSION is ${STAGINGVERSION})
 $(info DRIVER_IMAGE is ${DRIVER_IMAGE})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Recently we have had a lot of test failures in our prow because there was a set of tests added that rely on CLUSTER_NAME env var it seems that the prow tests used to run these do not have access to this field are return nil. This issue is likely due to the difference in kube contexts between local runs and the prow env. To resolve the failing tests this pr implements a more robust parsing logic which fallsback to parsing the IDENTITY_PROVIDER value which is available both in prow and locally. The idenity provider format is "https://container.googleapis.com/v1/projects/prow-gob-internal-boskos-371/locations/us-central1/clusters/gcsfuseca8e". 

This change has been tested locally without the falback logic to verify that the parsing occurs as expected
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```