### PR TITLE
Automated cherry pick of #1416: Feat/proper sidecar override dedup

### DIFF
--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -195,7 +195,7 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 		}
 		klog.V(6).Infof("NodePublishVolume populating identity provider %q in mount options", identityProvider)
 		args.fuseMountOptions = joinMountOptions(args.fuseMountOptions, []string{util.OptInHnw + "=true", util.TokenServerIdentityProviderConst + "=" + identityProvider})
-	} else if enableSidecarBucketAccessCheckForSidecarVersion {
+	} else if enableSidecarBucketAccessCheckForSidecarVersion && !userExplicitlyEnabled {
 		//Enable sidecar bucket access check only for Workload Identity workloads. This feature consumes additional quota for Host Network pods as we do not have token caching.
 		args.fuseMountOptions = joinMountOptions(args.fuseMountOptions, []string{util.EnableSidecarBucketAccessCheckConst + "=true"})
 	}

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -181,11 +181,11 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 		}
 	}
 
-sidecarCheckVal := getInternalMountOptionValue(args.fuseMountOptions, util.EnableSidecarBucketAccessCheckConst)
-userExplicitlyEnabled := sidecarCheckVal == util.TrueStr
-userExplicitlyDisabled := sidecarCheckVal == util.FalseStr
-enableSidecarBucketAccessCheckForSidecarVersion := s.driver.isSidecarVersionSupportedForGivenFeature(gcsFuseSidecarImage, SidecarBucketAccessCheckMinVersion) &&
-	(userExplicitlyEnabled || (s.driver.config.EnableSidecarBucketAccessCheck && !userExplicitlyDisabled))
+	sidecarCheckVal := getInternalMountOptionValue(args.fuseMountOptions, util.EnableSidecarBucketAccessCheckConst)
+	userExplicitlyEnabled := sidecarCheckVal == util.TrueStr
+	userExplicitlyDisabled := sidecarCheckVal == util.FalseStr
+	enableSidecarBucketAccessCheckForSidecarVersion := s.driver.isSidecarVersionSupportedForGivenFeature(gcsFuseSidecarImage, SidecarBucketAccessCheckMinVersion) &&
+		(userExplicitlyEnabled || (s.driver.config.EnableSidecarBucketAccessCheck && !userExplicitlyDisabled))
 	identityProvider := ""
 	if s.shouldPopulateIdentityProvider(pod, args.optInHostnetworkKSA, args.userSpecifiedIdentityProvider != "") {
 		if args.userSpecifiedIdentityProvider != "" {
@@ -197,7 +197,7 @@ enableSidecarBucketAccessCheckForSidecarVersion := s.driver.isSidecarVersionSupp
 		args.fuseMountOptions = joinMountOptions(args.fuseMountOptions, []string{util.OptInHnw + "=true", util.TokenServerIdentityProviderConst + "=" + identityProvider})
 	} else if enableSidecarBucketAccessCheckForSidecarVersion {
 		//Enable sidecar bucket access check only for Workload Identity workloads. This feature consumes additional quota for Host Network pods as we do not have token caching.
-	args.fuseMountOptions = joinMountOptions(args.fuseMountOptions, []string{util.EnableSidecarBucketAccessCheckConst + "=true"})
+		args.fuseMountOptions = joinMountOptions(args.fuseMountOptions, []string{util.EnableSidecarBucketAccessCheckConst + "=true"})
 	}
 
 	if enableSidecarBucketAccessCheckForSidecarVersion {

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -181,10 +181,11 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 		}
 	}
 
-	userExplicitlyEnabled := hasMountOption(args.fuseMountOptions, util.EnableSidecarBucketAccessCheckConst) && getMountOptionValue(args.fuseMountOptions, util.EnableSidecarBucketAccessCheckConst) == util.TrueStr
-	userExplicitlyDisabled := hasMountOption(args.fuseMountOptions, util.EnableSidecarBucketAccessCheckConst) && getMountOptionValue(args.fuseMountOptions, util.EnableSidecarBucketAccessCheckConst) == util.FalseStr
-	enableSidecarBucketAccessCheckForSidecarVersion := s.driver.isSidecarVersionSupportedForGivenFeature(gcsFuseSidecarImage, SidecarBucketAccessCheckMinVersion) &&
-		(userExplicitlyEnabled || (s.driver.config.EnableSidecarBucketAccessCheck && !userExplicitlyDisabled))
+sidecarCheckVal := getMountOptionValue(args.fuseMountOptions, util.EnableSidecarBucketAccessCheckConst)
+userExplicitlyEnabled := sidecarCheckVal == util.TrueStr
+userExplicitlyDisabled := sidecarCheckVal == util.FalseStr
+enableSidecarBucketAccessCheckForSidecarVersion := s.driver.isSidecarVersionSupportedForGivenFeature(gcsFuseSidecarImage, SidecarBucketAccessCheckMinVersion) &&
+	(userExplicitlyEnabled || (s.driver.config.EnableSidecarBucketAccessCheck && !userExplicitlyDisabled))
 	identityProvider := ""
 	if s.shouldPopulateIdentityProvider(pod, args.optInHostnetworkKSA, args.userSpecifiedIdentityProvider != "") {
 		if args.userSpecifiedIdentityProvider != "" {

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -181,7 +181,10 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 		}
 	}
 
-	enableSidecarBucketAccessCheckForSidecarVersion := s.driver.config.EnableSidecarBucketAccessCheck && s.driver.isSidecarVersionSupportedForGivenFeature(gcsFuseSidecarImage, SidecarBucketAccessCheckMinVersion)
+	userExplicitlyEnabled := hasMountOption(args.fuseMountOptions, util.EnableSidecarBucketAccessCheckConst) && getMountOptionValue(args.fuseMountOptions, util.EnableSidecarBucketAccessCheckConst) == util.TrueStr
+	userExplicitlyDisabled := hasMountOption(args.fuseMountOptions, util.EnableSidecarBucketAccessCheckConst) && getMountOptionValue(args.fuseMountOptions, util.EnableSidecarBucketAccessCheckConst) == util.FalseStr
+	enableSidecarBucketAccessCheckForSidecarVersion := s.driver.isSidecarVersionSupportedForGivenFeature(gcsFuseSidecarImage, SidecarBucketAccessCheckMinVersion) &&
+		(userExplicitlyEnabled || (s.driver.config.EnableSidecarBucketAccessCheck && !userExplicitlyDisabled))
 	identityProvider := ""
 	if s.shouldPopulateIdentityProvider(pod, args.optInHostnetworkKSA, args.userSpecifiedIdentityProvider != "") {
 		if args.userSpecifiedIdentityProvider != "" {
@@ -193,7 +196,7 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 		args.fuseMountOptions = joinMountOptions(args.fuseMountOptions, []string{util.OptInHnw + "=true", util.TokenServerIdentityProviderConst + "=" + identityProvider})
 	} else if enableSidecarBucketAccessCheckForSidecarVersion {
 		//Enable sidecar bucket access check only for Workload Identity workloads. This feature consumes additional quota for Host Network pods as we do not have token caching.
-		args.fuseMountOptions = joinMountOptions(args.fuseMountOptions, []string{util.EnableSidecarBucketAccessCheckConst + "=" + strconv.FormatBool(s.driver.config.EnableSidecarBucketAccessCheck)})
+		args.fuseMountOptions = joinMountOptions(args.fuseMountOptions, []string{util.EnableSidecarBucketAccessCheckConst + "=" + strconv.FormatBool(enableSidecarBucketAccessCheckForSidecarVersion)})
 	}
 
 	if enableSidecarBucketAccessCheckForSidecarVersion {

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -197,7 +197,7 @@ enableSidecarBucketAccessCheckForSidecarVersion := s.driver.isSidecarVersionSupp
 		args.fuseMountOptions = joinMountOptions(args.fuseMountOptions, []string{util.OptInHnw + "=true", util.TokenServerIdentityProviderConst + "=" + identityProvider})
 	} else if enableSidecarBucketAccessCheckForSidecarVersion {
 		//Enable sidecar bucket access check only for Workload Identity workloads. This feature consumes additional quota for Host Network pods as we do not have token caching.
-		args.fuseMountOptions = joinMountOptions(args.fuseMountOptions, []string{util.EnableSidecarBucketAccessCheckConst + "=" + strconv.FormatBool(enableSidecarBucketAccessCheckForSidecarVersion)})
+	args.fuseMountOptions = joinMountOptions(args.fuseMountOptions, []string{util.EnableSidecarBucketAccessCheckConst + "=true"})
 	}
 
 	if enableSidecarBucketAccessCheckForSidecarVersion {

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -181,7 +181,7 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 		}
 	}
 
-sidecarCheckVal := getMountOptionValue(args.fuseMountOptions, util.EnableSidecarBucketAccessCheckConst)
+sidecarCheckVal := getInternalMountOptionValue(args.fuseMountOptions, util.EnableSidecarBucketAccessCheckConst)
 userExplicitlyEnabled := sidecarCheckVal == util.TrueStr
 userExplicitlyDisabled := sidecarCheckVal == util.FalseStr
 enableSidecarBucketAccessCheckForSidecarVersion := s.driver.isSidecarVersionSupportedForGivenFeature(gcsFuseSidecarImage, SidecarBucketAccessCheckMinVersion) &&

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -833,6 +833,131 @@ func TestNodePublishVolumeEnableGCSFuseKernelParams(t *testing.T) {
 	}
 }
 
+func TestNodePublishVolumeRespectEnableSidecarBucketAccessCheck(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name                           string
+		enableSidecarBucketAccessCheck bool
+		userMountOptions               string
+		assumeGoodSidecarVersion       bool
+		expectedOptions                []string
+		unexpectedOptions              []string
+	}{
+		{
+			name:                           "sidecar check enabled globally, user does not specify option, sidecar check should be enabled",
+			enableSidecarBucketAccessCheck: true,
+			userMountOptions:               "",
+			assumeGoodSidecarVersion:       true,
+			expectedOptions:                []string{"enable-sidecar-bucket-access-check=true"},
+		},
+		{
+			name:                           "sidecar check enabled globally, user specifies false, sidecar check should be disabled",
+			enableSidecarBucketAccessCheck: true,
+			userMountOptions:               "enable-sidecar-bucket-access-check=false",
+			assumeGoodSidecarVersion:       true,
+			expectedOptions:                []string{"enable-sidecar-bucket-access-check=false"},
+			unexpectedOptions:              []string{"enable-sidecar-bucket-access-check=true"},
+		},
+		{
+			name:                           "sidecar check enabled globally, user specifies true, sidecar check should be enabled",
+			enableSidecarBucketAccessCheck: true,
+			userMountOptions:               "enable-sidecar-bucket-access-check=true",
+			assumeGoodSidecarVersion:       true,
+			expectedOptions:                []string{"enable-sidecar-bucket-access-check=true"},
+		},
+		{
+			name:                           "sidecar check disabled globally, user does not specify option, sidecar check should be disabled (absent)",
+			enableSidecarBucketAccessCheck: false,
+			userMountOptions:               "",
+			assumeGoodSidecarVersion:       true,
+			unexpectedOptions:              []string{"enable-sidecar-bucket-access-check=true", "enable-sidecar-bucket-access-check=false"},
+		},
+		{
+			name:                           "sidecar check disabled globally, user specifies true, sidecar check should be enabled",
+			enableSidecarBucketAccessCheck: false,
+			userMountOptions:               "enable-sidecar-bucket-access-check=true",
+			assumeGoodSidecarVersion:       true,
+			expectedOptions:                []string{"enable-sidecar-bucket-access-check=true"},
+		},
+		{
+			name:                           "sidecar check disabled globally, user specifies false, sidecar check should be disabled",
+			enableSidecarBucketAccessCheck: false,
+			userMountOptions:               "enable-sidecar-bucket-access-check=false",
+			assumeGoodSidecarVersion:       true,
+			expectedOptions:                []string{"enable-sidecar-bucket-access-check=false"},
+			unexpectedOptions:              []string{"enable-sidecar-bucket-access-check=true"},
+		},
+		{
+			name:                           "sidecar check enabled globally, unsupported sidecar version, user does not specify, sidecar check should be absent",
+			enableSidecarBucketAccessCheck: true,
+			userMountOptions:               "",
+			assumeGoodSidecarVersion:       false,
+			unexpectedOptions:              []string{"enable-sidecar-bucket-access-check=true", "enable-sidecar-bucket-access-check=false"},
+		},
+		{
+			name:                           "sidecar check enabled globally, unsupported sidecar version, user specifies true, sidecar check should be enabled",
+			enableSidecarBucketAccessCheck: true,
+			userMountOptions:               "enable-sidecar-bucket-access-check=true",
+			assumeGoodSidecarVersion:       false,
+			expectedOptions:                []string{"enable-sidecar-bucket-access-check=true"},
+		},
+		{
+			name:                           "sidecar check enabled globally, unsupported sidecar version, user specifies false, sidecar check should be disabled",
+			enableSidecarBucketAccessCheck: true,
+			userMountOptions:               "enable-sidecar-bucket-access-check=false",
+			assumeGoodSidecarVersion:       false,
+			expectedOptions:                []string{"enable-sidecar-bucket-access-check=false"},
+			unexpectedOptions:              []string{"enable-sidecar-bucket-access-check=true"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			testTargetPath, cleanup := setupMountTarget(t)
+			defer cleanup()
+
+			volumeContext := map[string]string{
+				VolumeContextKeyPodName:            "test-pod",
+				VolumeContextKeyPodNamespace:       "test-ns",
+				VolumeContextKeyServiceAccountName: "test-sa",
+			}
+			if tc.userMountOptions != "" {
+				volumeContext[VolumeContextKeyMountOptions] = tc.userMountOptions
+			}
+
+			req := &csi.NodePublishVolumeRequest{
+				VolumeId:         testVolumeID,
+				TargetPath:       testTargetPath,
+				VolumeCapability: testVolumeCapability,
+				VolumeContext:    volumeContext,
+			}
+			fakeMounter := mount.NewFakeMounter([]mount.MountPoint{})
+
+			driver := initTestDriver(t, fakeMounter)
+			s, _ := driver.config.StorageServiceManager.SetupService(context.TODO(), nil, "")
+			if _, err := s.CreateBucket(context.Background(), &storage.ServiceBucket{Name: testVolumeID}); err != nil {
+				t.Fatalf("failed to create the fake bucket: %v", err)
+			}
+			driver.config.EnableSidecarBucketAccessCheck = tc.enableSidecarBucketAccessCheck
+			driver.config.AssumeGoodSidecarVersion = tc.assumeGoodSidecarVersion
+			ns := newNodeServer(driver, fakeMounter)
+
+			_, err := ns.NodePublishVolume(context.TODO(), req)
+			if err != nil {
+				t.Fatalf("failed to publish volume: %v", err)
+			}
+			validateMountPoint(t, fakeMounter, &mount.MountPoint{
+				Device: testVolumeID,
+				Path:   testTargetPath,
+				Type:   "fuse",
+				Opts:   tc.expectedOptions,
+			},
+				tc.unexpectedOptions)
+		})
+	}
+}
+
 type volumeTestCase struct {
 	name                         string
 	totalEphemeralVolumeCount    int

--- a/pkg/csi_driver/utils.go
+++ b/pkg/csi_driver/utils.go
@@ -779,16 +779,6 @@ func transformKeysToSet(inputMap map[string]string) map[string]struct{} {
 	return outputSet
 }
 
-func hasInternalMountOption(options []string, key string) bool {
-	for _, o := range options {
-		k, _, _ := strings.Cut(o, "=")
-		if k == key {
-			return true
-		}
-	}
-	return false
-}
-
 func getInternalMountOptionValue(options []string, key string) string {
 	for i := len(options) - 1; i >= 0; i-- {
 		k, v, found := strings.Cut(options[i], "=")

--- a/pkg/csi_driver/utils.go
+++ b/pkg/csi_driver/utils.go
@@ -182,10 +182,9 @@ func logGRPC(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, h
 // joinMountOptions joins mount options eliminating duplicates.
 func joinMountOptions(existingOptions []string, newOptions []string) []string {
 	overwritableOptions := map[string]string{
-		"gid":                                    "",
-		"file-mode":                              "",
-		"dir-mode":                               "",
-		util.EnableSidecarBucketAccessCheckConst: "",
+		"gid":       "",
+		"file-mode": "",
+		"dir-mode":  "",
 	}
 
 	ignorableOptions := map[string]bool{

--- a/pkg/csi_driver/utils.go
+++ b/pkg/csi_driver/utils.go
@@ -779,7 +779,7 @@ func transformKeysToSet(inputMap map[string]string) map[string]struct{} {
 	return outputSet
 }
 
-func hasMountOption(options []string, key string) bool {
+func hasInternalMountOption(options []string, key string) bool {
 	for _, o := range options {
 		k, _, _ := strings.Cut(o, "=")
 		if k == key {
@@ -789,7 +789,7 @@ func hasMountOption(options []string, key string) bool {
 	return false
 }
 
-func getMountOptionValue(options []string, key string) string {
+func getInternalMountOptionValue(options []string, key string) string {
 	for i := len(options) - 1; i >= 0; i-- {
 		k, v, found := strings.Cut(options[i], "=")
 		if k == key {

--- a/pkg/csi_driver/utils.go
+++ b/pkg/csi_driver/utils.go
@@ -182,9 +182,10 @@ func logGRPC(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, h
 // joinMountOptions joins mount options eliminating duplicates.
 func joinMountOptions(existingOptions []string, newOptions []string) []string {
 	overwritableOptions := map[string]string{
-		"gid":       "",
-		"file-mode": "",
-		"dir-mode":  "",
+		"gid":                                    "",
+		"file-mode":                              "",
+		"dir-mode":                               "",
+		util.EnableSidecarBucketAccessCheckConst: "",
 	}
 
 	ignorableOptions := map[string]bool{
@@ -776,4 +777,27 @@ func transformKeysToSet(inputMap map[string]string) map[string]struct{} {
 		outputSet[key] = struct{}{}
 	}
 	return outputSet
+}
+
+func hasMountOption(options []string, key string) bool {
+	for _, o := range options {
+		k, _, _ := strings.Cut(o, "=")
+		if k == key {
+			return true
+		}
+	}
+	return false
+}
+
+func getMountOptionValue(options []string, key string) string {
+	for i := len(options) - 1; i >= 0; i-- {
+		k, v, found := strings.Cut(options[i], "=")
+		if k == key {
+			if found {
+				return v
+			}
+			return ""
+		}
+	}
+	return ""
 }

--- a/pkg/csi_driver/utils_test.go
+++ b/pkg/csi_driver/utils_test.go
@@ -1150,7 +1150,7 @@ func TestOverrideStorageEndpointInternal(t *testing.T) {
 	}
 }
 
-func TestHasMountOption(t *testing.T) {
+func TestHasInternalMountOption(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {
 		name     string
@@ -1192,15 +1192,15 @@ func TestHasMountOption(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := hasMountOption(tc.options, tc.key)
+			got := hasInternalMountOption(tc.options, tc.key)
 			if got != tc.expected {
-				t.Errorf("hasMountOption(%v, %q) = %v; want %v", tc.options, tc.key, got, tc.expected)
+				t.Errorf("hasInternalMountOption(%v, %q) = %v; want %v", tc.options, tc.key, got, tc.expected)
 			}
 		})
 	}
 }
 
-func TestGetMountOptionValue(t *testing.T) {
+func TestGetInternalMountOptionValue(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {
 		name     string
@@ -1242,9 +1242,9 @@ func TestGetMountOptionValue(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := getMountOptionValue(tc.options, tc.key)
+			got := getInternalMountOptionValue(tc.options, tc.key)
 			if got != tc.expected {
-				t.Errorf("getMountOptionValue(%v, %q) = %q; want %q", tc.options, tc.key, got, tc.expected)
+				t.Errorf("getInternalMountOptionValue(%v, %q) = %q; want %q", tc.options, tc.key, got, tc.expected)
 			}
 		})
 	}

--- a/pkg/csi_driver/utils_test.go
+++ b/pkg/csi_driver/utils_test.go
@@ -163,12 +163,6 @@ func TestJoinMountOptions(t *testing.T) {
 			newOptions:      []string{"experimental-local-socket-address=144.2.2.0"},
 			expectedOptions: []string{"experimental-local-socket-address=128.0.0.1"},
 		},
-		{
-			name:            "should overwrite enable-sidecar-bucket-access-check",
-			existingOptions: []string{"o=noexec", "enable-sidecar-bucket-access-check=true"},
-			newOptions:      []string{"enable-sidecar-bucket-access-check=false"},
-			expectedOptions: []string{"o=noexec", "enable-sidecar-bucket-access-check=false"},
-		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/csi_driver/utils_test.go
+++ b/pkg/csi_driver/utils_test.go
@@ -163,6 +163,12 @@ func TestJoinMountOptions(t *testing.T) {
 			newOptions:      []string{"experimental-local-socket-address=144.2.2.0"},
 			expectedOptions: []string{"experimental-local-socket-address=128.0.0.1"},
 		},
+		{
+			name:            "should overwrite enable-sidecar-bucket-access-check",
+			existingOptions: []string{"o=noexec", "enable-sidecar-bucket-access-check=true"},
+			newOptions:      []string{"enable-sidecar-bucket-access-check=false"},
+			expectedOptions: []string{"o=noexec", "enable-sidecar-bucket-access-check=false"},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -1139,6 +1145,106 @@ func TestOverrideStorageEndpointInternal(t *testing.T) {
 
 			if diff := cmp.Diff(output, tc.expectedOptions); diff != "" {
 				t.Errorf("unexpected options slice (-got, +want)\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestHasMountOption(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name     string
+		options  []string
+		key      string
+		expected bool
+	}{
+		{
+			name:     "key exists with value",
+			options:  []string{"o=noexec", "enable-sidecar-bucket-access-check=true", "rw"},
+			key:      "enable-sidecar-bucket-access-check",
+			expected: true,
+		},
+		{
+			name:     "key exists without value",
+			options:  []string{"o=noexec", "enable-sidecar-bucket-access-check", "rw"},
+			key:      "enable-sidecar-bucket-access-check",
+			expected: true,
+		},
+		{
+			name:     "key does not exist",
+			options:  []string{"o=noexec", "rw"},
+			key:      "enable-sidecar-bucket-access-check",
+			expected: false,
+		},
+		{
+			name:     "empty options list",
+			options:  []string{},
+			key:      "enable-sidecar-bucket-access-check",
+			expected: false,
+		},
+		{
+			name:     "key is prefix of another option",
+			options:  []string{"enable-sidecar-bucket-access-check-suffix=true"},
+			key:      "enable-sidecar-bucket-access-check",
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := hasMountOption(tc.options, tc.key)
+			if got != tc.expected {
+				t.Errorf("hasMountOption(%v, %q) = %v; want %v", tc.options, tc.key, got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestGetMountOptionValue(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name     string
+		options  []string
+		key      string
+		expected string
+	}{
+		{
+			name:     "key exists with value",
+			options:  []string{"o=noexec", "enable-sidecar-bucket-access-check=true", "rw"},
+			key:      "enable-sidecar-bucket-access-check",
+			expected: "true",
+		},
+		{
+			name:     "key exists without value",
+			options:  []string{"o=noexec", "enable-sidecar-bucket-access-check", "rw"},
+			key:      "enable-sidecar-bucket-access-check",
+			expected: "",
+		},
+		{
+			name:     "key does not exist",
+			options:  []string{"o=noexec", "rw"},
+			key:      "enable-sidecar-bucket-access-check",
+			expected: "",
+		},
+		{
+			name:     "empty options list",
+			options:  []string{},
+			key:      "enable-sidecar-bucket-access-check",
+			expected: "",
+		},
+		{
+			name:     "multiple occurrences - returns last one",
+			options:  []string{"enable-sidecar-bucket-access-check=true", "enable-sidecar-bucket-access-check=false"},
+			key:      "enable-sidecar-bucket-access-check",
+			expected: "false",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := getMountOptionValue(tc.options, tc.key)
+			if got != tc.expected {
+				t.Errorf("getMountOptionValue(%v, %q) = %q; want %q", tc.options, tc.key, got, tc.expected)
 			}
 		})
 	}

--- a/pkg/csi_driver/utils_test.go
+++ b/pkg/csi_driver/utils_test.go
@@ -1150,56 +1150,6 @@ func TestOverrideStorageEndpointInternal(t *testing.T) {
 	}
 }
 
-func TestHasInternalMountOption(t *testing.T) {
-	t.Parallel()
-	testCases := []struct {
-		name     string
-		options  []string
-		key      string
-		expected bool
-	}{
-		{
-			name:     "key exists with value",
-			options:  []string{"o=noexec", "enable-sidecar-bucket-access-check=true", "rw"},
-			key:      "enable-sidecar-bucket-access-check",
-			expected: true,
-		},
-		{
-			name:     "key exists without value",
-			options:  []string{"o=noexec", "enable-sidecar-bucket-access-check", "rw"},
-			key:      "enable-sidecar-bucket-access-check",
-			expected: true,
-		},
-		{
-			name:     "key does not exist",
-			options:  []string{"o=noexec", "rw"},
-			key:      "enable-sidecar-bucket-access-check",
-			expected: false,
-		},
-		{
-			name:     "empty options list",
-			options:  []string{},
-			key:      "enable-sidecar-bucket-access-check",
-			expected: false,
-		},
-		{
-			name:     "key is prefix of another option",
-			options:  []string{"enable-sidecar-bucket-access-check-suffix=true"},
-			key:      "enable-sidecar-bucket-access-check",
-			expected: false,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			got := hasInternalMountOption(tc.options, tc.key)
-			if got != tc.expected {
-				t.Errorf("hasInternalMountOption(%v, %q) = %v; want %v", tc.options, tc.key, got, tc.expected)
-			}
-		})
-	}
-}
-
 func TestGetInternalMountOptionValue(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {

--- a/pkg/webhook/injection_test.go
+++ b/pkg/webhook/injection_test.go
@@ -1939,7 +1939,6 @@ func TestInjectMetadataPrefetchSidecarWithSC(t *testing.T) {
 			si.ScLister = informer.Storage().V1().StorageClasses().Lister()
 			si.PvLister = informer.Core().V1().PersistentVolumes().Lister()
 			si.PvcLister = informer.Core().V1().PersistentVolumeClaims().Lister()
-			informer.Start(ctx.Done())
 			_, err := fakeClient.StorageV1().StorageClasses().Create(context.TODO(), tc.sc, metav1.CreateOptions{})
 
 			if err != nil {
@@ -1971,6 +1970,7 @@ func TestInjectMetadataPrefetchSidecarWithSC(t *testing.T) {
 				t.Fatalf("failed to setup test PVC: %v", err)
 			}
 
+			informer.Start(ctx.Done())
 			informer.WaitForCacheSync(ctx.Done())
 
 			err = si.injectSidecarContainer(MetadataPrefetchSidecarName, tc.pod, *tc.nativeSidecar, nil)


### PR DESCRIPTION
Cherry pick of #1416 on release-1.23.

#1416: Feat/proper sidecar override dedup

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Added support to respect and deduplicate user-provided `enable-sidecar-bucket-access-check` mount options, allowing per-volume overrides of the global sidecar bucket access check setting.
```