### PR TITLE
Implement ControllerPublishVolume wait for mounter pod to be scheduled

### DIFF
--- a/cmd/csi_driver/main.go
+++ b/cmd/csi_driver/main.go
@@ -252,6 +252,7 @@ func main() {
 			klog.Fatalf("NodeID cannot be empty for node service")
 		}
 
+		// TODO(urielguzman): Configure pod lister in the controller for shared node mount.
 		clientset.ConfigurePodLister(ctx, *nodeID)
 		clientset.ConfigureNodeLister(ctx, *nodeID)
 		// Both PVs & PVCs are needed to check count of GCSFuseVolumes

--- a/pkg/cloud_provider/clientset/fake.go
+++ b/pkg/cloud_provider/clientset/fake.go
@@ -41,6 +41,8 @@ type FakePodConfig struct {
 	HostNetworkEnabled bool
 	SidecarLimits      corev1.ResourceList
 	DeletionTimestamp  *metav1.Time
+	PodStatus          *corev1.PodStatus
+	NodeName           string
 }
 
 type FakePVConfig struct {
@@ -72,6 +74,7 @@ type FakeClientset struct {
 	fakePVCs  map[string]*corev1.PersistentVolumeClaim
 	fakeSCs   map[string]*storagev1.StorageClass
 	ListPVErr error
+	GetPodErr error
 }
 
 func NewFakeClientset(objects ...runtime.Object) *FakeClientset {
@@ -143,6 +146,14 @@ func (c *FakeClientset) CreatePod(podConfig FakePodConfig) {
 
 	if podConfig.DeletionTimestamp != nil {
 		c.fakePod.DeletionTimestamp = podConfig.DeletionTimestamp
+	}
+
+	if podConfig.PodStatus != nil {
+		c.fakePod.Status = *podConfig.PodStatus
+	}
+
+	if podConfig.NodeName != "" {
+		c.fakePod.Spec.NodeName = podConfig.NodeName
 	}
 }
 
@@ -219,6 +230,9 @@ func (c *FakeClientset) AddPodVolumes(volumes []corev1.Volume) {
 }
 
 func (c *FakeClientset) GetPod(namespace, name string) (*corev1.Pod, error) {
+	if c.GetPodErr != nil {
+		return nil, c.GetPodErr
+	}
 	c.fakePod.ObjectMeta.Name = name
 	c.fakePod.ObjectMeta.Namespace = namespace
 

--- a/pkg/csi_driver/controller.go
+++ b/pkg/csi_driver/controller.go
@@ -184,7 +184,14 @@ func (s *controllerServer) ControllerPublishVolume(ctx context.Context, req *csi
 	}
 
 	if err := createMounterPod(clientset, ctx, podConfig); err != nil {
-		// TODO(urielguzman): Wait for mounter pod to be scheduled before succeeding.
+		return nil, err
+	}
+
+	// Wait until the mounter pod is scheduled to a node.
+	// This ensures that the mounter pod can be scheduled even if there are resource constraints on the node,
+	// such as needing to wait for a regular pod to be evicted first.
+	// Without this check, NodeStageVolume could return an internal error because the mounter pod is not yet scheduled.
+	if err := waitForMounterPodScheduled(clientset, ctx, podNamespace, podName, nodeID); err != nil {
 		return nil, err
 	}
 

--- a/pkg/csi_driver/controller_test.go
+++ b/pkg/csi_driver/controller_test.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"reflect"
 	"testing"
+	"time"
 
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/clientset"
@@ -178,7 +179,10 @@ func TestDeleteVolume(t *testing.T) {
 }
 
 func TestControllerPublishVolume(t *testing.T) {
-	t.Parallel()
+	oldInterval := mounterPodPollInterval
+	mounterPodPollInterval = 10 * time.Millisecond
+	defer func() { mounterPodPollInterval = oldInterval }()
+
 	timeNow := metav1.Now()
 
 	// Helper to create a mounter pod for initial state
@@ -327,6 +331,17 @@ func TestControllerPublishVolume(t *testing.T) {
 			setupFake: func() *clientset.FakeClientset {
 				existingPod := makeMounterPod(defaultMounterPodConfig, nil)
 				fc := clientset.NewFakeClientset(existingPod)
+				fc.CreatePod(clientset.FakePodConfig{
+					NodeName: testNodeID,
+					PodStatus: &corev1.PodStatus{
+						Conditions: []corev1.PodCondition{
+							{
+								Type:   corev1.PodScheduled,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				})
 				fc.CreatePV(clientset.FakePVConfig{Name: testPV, VolumeHandle: testVolumeID, ClaimRef: &corev1.ObjectReference{
 					Name:      testPVC,
 					Namespace: testNamespace,
@@ -404,10 +419,10 @@ func TestControllerPublishVolume(t *testing.T) {
 	}
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
-			clientset := test.setupFake()
-			s := initTestController(t, clientset)
+			fc := test.setupFake()
+			s := initTestController(t, fc)
 
-			fakeK8sClient := clientset.K8sClient().(*fake.Clientset)
+			fakeK8sClient := fc.K8sClient().(*fake.Clientset)
 
 			if test.podGetErr != nil {
 				fakeK8sClient.PrependReactor("get", "pods", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
@@ -418,9 +433,31 @@ func TestControllerPublishVolume(t *testing.T) {
 				fakeK8sClient.Fake.PrependReactor("create", "pods", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
 					return true, nil, test.podCreateErr
 				})
+			} else {
+				fakeK8sClient.Fake.PrependReactor("create", "pods", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+					createAction := action.(k8stesting.CreateAction)
+					pod := createAction.GetObject().(*corev1.Pod)
+					pod.Spec.NodeName = testNodeID
+					pod.Status.Conditions = []corev1.PodCondition{
+						{
+							Type:   corev1.PodScheduled,
+							Status: corev1.ConditionTrue,
+						},
+					}
+
+					// Update the fakePod in clientset so GetPod returns it!
+					fc.CreatePod(clientset.FakePodConfig{
+						NodeName:  testNodeID,
+						PodStatus: &pod.Status,
+					})
+
+					return false, nil, nil
+				})
 			}
 
-			_, err := s.ControllerPublishVolume(context.Background(), test.req)
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+			_, err := s.ControllerPublishVolume(ctx, test.req)
 
 			if test.expectErr {
 				if err == nil {

--- a/pkg/csi_driver/shared_mount.go
+++ b/pkg/csi_driver/shared_mount.go
@@ -21,6 +21,7 @@ import (
 	"crypto/sha1"
 	"fmt"
 	"io"
+	"time"
 
 	"context"
 
@@ -39,6 +40,10 @@ const (
 	mounterPodNamePrefix    = "gcsfusecsi-mount"
 	mounterPodPriorityClass = "gcsfusecsi-mount-priority"
 	mounterPodMountDir      = "mount-dir"
+)
+
+var (
+	mounterPodPollInterval = 1 * time.Second
 )
 
 // mounterPodConfig holds the configuration parameters required to define and manage a mounter pod.
@@ -193,4 +198,57 @@ func createMounterPodSpec(config *mounterPodConfig) *corev1.Pod {
 		},
 	}
 	return spec
+}
+
+// waitForMounterPodScheduled wait for mounter pod to be scheduled.
+func waitForMounterPodScheduled(clientset clientset.Interface, ctx context.Context, namespace, podName, nodeID string) error {
+	if clientset == nil {
+		return status.Error(codes.Internal, "kubernetes client is uninitialized")
+	}
+
+	checkIfScheduled := func() (bool, error) {
+		pod, err := clientset.GetPod(namespace, podName)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, status.Errorf(codes.Internal, "failed to get mounter pod %s/%s: %v", namespace, podName, err)
+		}
+		if pod != nil && pod.Spec.NodeName != "" {
+			if pod.Spec.NodeName != nodeID {
+				return false, status.Errorf(codes.Internal, "mounter pod %s/%s expected to be scheduled to node %q, instead, was scheduled to node %q", namespace, podName, nodeID, pod.Spec.NodeName)
+			}
+			for _, condition := range pod.Status.Conditions {
+				if condition.Type == corev1.PodScheduled && condition.Status == corev1.ConditionTrue {
+					klog.Infof("Mounter pod %s/%s has been scheduled to node %s", namespace, podName, pod.Spec.NodeName)
+					return true, nil
+				}
+			}
+		}
+		return false, nil
+	}
+
+	// Check immediately to avoid waiting if the pod is already scheduled.
+	if scheduled, err := checkIfScheduled(); err != nil || scheduled {
+		return err
+	}
+
+	klog.Infof("Waiting for mounter pod %s/%s to be scheduled. Polling every %v", namespace, podName, mounterPodPollInterval)
+
+	ticker := time.NewTicker(mounterPodPollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			if scheduled, err := checkIfScheduled(); err != nil || scheduled {
+				return err
+			}
+		case <-ctx.Done():
+			code := codes.DeadlineExceeded
+			if ctx.Err() == context.Canceled {
+				code = codes.Canceled
+			}
+			return status.Errorf(code, "timeout waiting for mounter pod %s/%s to be scheduled to node %q: %v", namespace, podName, nodeID, ctx.Err())
+		}
+	}
 }

--- a/pkg/csi_driver/shared_mount_test.go
+++ b/pkg/csi_driver/shared_mount_test.go
@@ -21,7 +21,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/clientset"
@@ -29,6 +33,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
@@ -394,6 +399,181 @@ func TestCreateMounterPod(t *testing.T) {
 			if gotCreates != tc.wantCreates {
 				t.Errorf("createMounterPod(%v) made %d create calls, want %d", baseConfig, gotCreates, tc.wantCreates)
 			}
+		})
+	}
+}
+func TestWaitForMounterPodScheduled(t *testing.T) {
+	// Do not enable t.Parallel to avoid global data races.
+	oldInterval := mounterPodPollInterval
+	mounterPodPollInterval = 10 * time.Millisecond
+	defer func() { mounterPodPollInterval = oldInterval }()
+
+	testMounterPodName := createMounterPodName(testNodeID, testVolumeID)
+	// Fast timeout to improve test speed.
+	testContextTimeout := 200 * time.Millisecond
+	cases := []struct {
+		name       string
+		expectErr  error
+		podStatus  *corev1.PodStatus
+		nodeName   string
+		getPodErr  error
+		initialPod *clientset.FakePodConfig
+		patchPod   *clientset.FakePodConfig
+		nodeID     string
+	}{
+		{
+			name:      "scheduled to node - should return success",
+			expectErr: nil,
+			initialPod: &clientset.FakePodConfig{
+				PodStatus: &corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					Conditions: []corev1.PodCondition{
+						{
+							Type:   corev1.PodScheduled,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+				NodeName: testNodeID,
+			},
+			nodeID: testNodeID,
+		},
+		{
+			name:      "scheduled to wrong node - should return internal error",
+			expectErr: status.Errorf(codes.Internal, "mounter pod %s/%s expected to be scheduled to node %q, instead, was scheduled to node %q", testNamespace, testMounterPodName, testNodeID, "other-node"),
+			initialPod: &clientset.FakePodConfig{
+				PodStatus: &corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					Conditions: []corev1.PodCondition{
+						{
+							Type:   corev1.PodScheduled,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+				NodeName: "other-node",
+			},
+			nodeID: testNodeID,
+		},
+		{
+			name:      "scheduled to node with a delay - should return success",
+			expectErr: nil,
+			initialPod: &clientset.FakePodConfig{
+				NodeName: testNodeID,
+			},
+			patchPod: &clientset.FakePodConfig{
+				PodStatus: &corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					Conditions: []corev1.PodCondition{
+						{
+							Type:   corev1.PodScheduled,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+				NodeName: testNodeID,
+			},
+			nodeID: testNodeID,
+		},
+		{
+			name: "scheduled but nodeName missing - should return error",
+			expectErr: status.Errorf(codes.DeadlineExceeded,
+				"timeout waiting for mounter pod %s/%s to be scheduled to node %q: context deadline exceeded",
+				testNamespace, testMounterPodName, testNodeID,
+			),
+			initialPod: &clientset.FakePodConfig{
+				PodStatus: &corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					Conditions: []corev1.PodCondition{
+						{
+							Type:   corev1.PodScheduled,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			},
+			nodeID: testNodeID,
+		},
+		{
+			name: "not scheduled but has nodeName - should return error",
+			expectErr: status.Errorf(codes.DeadlineExceeded,
+				"timeout waiting for mounter pod %s/%s to be scheduled to node %q: context deadline exceeded",
+				testNamespace, testMounterPodName, testNodeID,
+			),
+			initialPod: &clientset.FakePodConfig{
+				PodStatus: &corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					Conditions: []corev1.PodCondition{
+						{
+							Type:   corev1.PodScheduled,
+							Status: corev1.ConditionFalse,
+						},
+					},
+				},
+				NodeName: testNodeID,
+			},
+			nodeID: testNodeID,
+		},
+		{
+			name:      "time out waiting for scheduled - should return DeadlineExceeded error",
+			podStatus: &corev1.PodStatus{},
+			expectErr: status.Errorf(codes.DeadlineExceeded,
+				"timeout waiting for mounter pod %s/%s to be scheduled to node %q: context deadline exceeded",
+				testNamespace, testMounterPodName, testNodeID,
+			),
+			nodeID: testNodeID,
+		},
+		{
+			name:      "pod get internal error - should return Internal error",
+			podStatus: &corev1.PodStatus{},
+			getPodErr: status.Errorf(codes.Internal, "failed to get pod"),
+			expectErr: status.Errorf(codes.Internal, "failed to get mounter pod %s/%s: %v", testNamespace, testMounterPodName, status.Errorf(codes.Internal, "failed to get pod")),
+			nodeID:    testNodeID,
+		},
+		{
+			name:      "pod not found - should time out and return DeadlineExceeded error",
+			podStatus: &corev1.PodStatus{},
+			getPodErr: k8serrors.NewNotFound(schema.GroupResource{}, "pod not found"),
+			expectErr: status.Errorf(codes.DeadlineExceeded,
+				"timeout waiting for mounter pod %s/%s to be scheduled to node %q: context deadline exceeded",
+				testNamespace, testMounterPodName, testNodeID,
+			),
+			nodeID: testNodeID,
+		},
+	}
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), testContextTimeout)
+			defer cancel()
+			clientset := clientset.NewFakeClientset()
+
+			if test.initialPod != nil {
+				clientset.CreatePod(*test.initialPod)
+			}
+
+			if test.getPodErr != nil {
+				clientset.GetPodErr = test.getPodErr
+			}
+
+			// Asynchronously wait for the pod so we can patch it while it polls.
+			var wg sync.WaitGroup
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				err := waitForMounterPodScheduled(clientset, ctx, testNamespace, testMounterPodName, test.nodeID)
+				if !errors.Is(err, test.expectErr) {
+					t.Errorf("Expected error: %v, got: %v", test.expectErr, err)
+				}
+			}()
+
+			if test.patchPod != nil {
+				time.Sleep(15 * time.Millisecond)
+				// CreatePod replaces the pod when it already exists, so it
+				// acts like a patch.
+				clientset.CreatePod(*test.patchPod)
+			}
+
+			wg.Wait()
 		})
 	}
 }


### PR DESCRIPTION
logic.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Implement ControllerPublishVolume logic so that we wait for the mounter pod until it is scheduled. Otherwise, return DeadlineExceeded error if it times out, or Internal if the errors are from the API server.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```