### PR TITLE
override CLUSTER_NAME env var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,12 @@ else
     IDENTITY_PROVIDER ?= $(shell kubectl get --raw /.well-known/openid-configuration | jq -r .issuer)
     export PROJECT ?= $(shell echo "$(IDENTITY_PROVIDER)" | awk -F/ '{print $$6}')
     export CLUSTER_LOCATION ?= $(shell echo "$(IDENTITY_PROVIDER)" | awk -F/ '{print $$8}')
-    export CLUSTER_NAME ?= $(shell echo "$(IDENTITY_PROVIDER)" | awk -F/ '{print $$10}')
+
+    # To override the default empty string in prow and support overriding it via environment variables or command-line arguments we conditionally use :=.
+    ifeq ($(CLUSTER_NAME),)
+        CLUSTER_NAME := $(shell echo "$(IDENTITY_PROVIDER)" | awk -F/ '{print $$10}')
+    endif
+    export CLUSTER_NAME
     # Use jq to extract CA Bundle specifically for the current GKE context
     CA_BUNDLE ?= $(shell kubectl config view --raw -o json | jq '.clusters[]' | jq "select(.name == \"$(shell kubectl config current-context)\")" | jq '.cluster."certificate-authority-data"' | head -n 1)
     # Derive Identity Pool from Project ID


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

 /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
?= sets values if the var does not already have a value, this includes empty vals. In our prow tests CLUSTER_NAME is already set by the env to be an empty string which prevents the CLUSTER_NAME env var from being set. This pr sets it using := instead of ?= to correctly set the value and unblock failing e2e tests.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```