### PR TITLE
make CLUSTER_NAME available to e2e nodes

### DIFF
--- a/test/e2e/utils/handler.go
+++ b/test/e2e/utils/handler.go
@@ -154,15 +154,6 @@ func Handle(testParams *TestParameters) error {
 		testParams.ProjectID = newProject
 		testParams.ImageRegistry = fmt.Sprintf("gcr.io/%s/gcs-fuse-csi-driver", strings.TrimSpace(newProject))
 
-		// Set env variables for OIDC auth prow tests. For local tests, these
-		// env variables are set in the Makefile from kubectl config current-context.
-		if err = os.Setenv(ClusterNameEnvVar, testParams.GkeClusterName); err != nil {
-			klog.Fatalf(`env variable %q could not be set: %v`, ClusterNameEnvVar, err)
-		}
-		if err = os.Setenv(ClusterLocationEnvVar, testParams.GkeClusterRegion); err != nil {
-			klog.Fatalf(`env variable %q could not be set: %v`, ClusterLocationEnvVar, err)
-		}
-
 		// 4. After the test, tear down the cluster, and switch back to the old project.
 		defer func() {
 			if err := setEnvProject(oldProject); err != nil {
@@ -174,6 +165,15 @@ func Handle(testParams *TestParameters) error {
 		testParams.GkeClusterName = "gcsfuse" + string(uuid.NewUUID())[0:4]
 		if err := clusterUpGKE(testParams); err != nil {
 			return fmt.Errorf("failed to cluster up: %w", err)
+		}
+
+		// Set env variables for OIDC auth prow tests. For local tests, these
+		// env variables are set in the Makefile from kubectl config current-context.
+		if err = os.Setenv(ClusterNameEnvVar, testParams.GkeClusterName); err != nil {
+			klog.Fatalf(`env variable %q could not be set: %v`, ClusterNameEnvVar, err)
+		}
+		if err = os.Setenv(ClusterLocationEnvVar, testParams.GkeClusterRegion); err != nil {
+			klog.Fatalf(`env variable %q could not be set: %v`, ClusterLocationEnvVar, err)
 		}
 
 		// 4. After the test, tear down the cluster, and switch back to the old project.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
makes CLUSTER_NAME env var available to the machines where test suites run instead of just the prow cluster which creates our test cluster. We do this by setting the env var after cluster name is generated
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```