### PR TITLE
Implement shared node mount support in the mutating webhook

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -30,8 +30,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
-	storagelisters "k8s.io/client-go/listers/storage/v1"
 	"k8s.io/client-go/rest"
+
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -58,6 +58,7 @@ var (
 	metadataSidecarImage                    = flag.String("metadata-sidecar-image", "", "The metadata prefetch sidecar container image.")
 	injectSAVol                             = flag.Bool("should-inject-sa-vol", false, "Inject projected service account volume when true")
 	enableGcsfuseProfiles                   = flag.Bool("enable-gcsfuse-profiles", false, "Enable gcsfuse profiles when true")
+	enableSharedNodeMount                   = flag.Bool("enable-shared-node-mount", false, "Enable shared node mount feature when true")
 	enableAutoGoMemLimit                    = flag.Bool("enable-auto-gomemlimit", false, "Automatically set GOMEMLIMIT to a percentage of the container's cgroup memory limit.")
 	autoGoMemLimitRatio                     = flag.Float64("auto-gomemlimit-ratio", util.GoMemLimitCgroupPercentage, "The ratio of the container's cgroup memory limit to set as GOMEMLIMIT when enable-auto-gomemlimit is enabled.")
 	metadataMemoryRequest                   = flag.String("metadata-sidecar-memory-request", "10Mi", "Flag to use default value for gcsfuse memory prefetch sidecar container memory request.")
@@ -106,6 +107,9 @@ func main() {
 	fuseSideCarConfig.EnableGcsfuseProfiles = *enableGcsfuseProfiles
 	klog.Infof("Webhook should enable gcsfuse profiles: %t", fuseSideCarConfig.EnableGcsfuseProfiles)
 
+	fuseSideCarConfig.EnableSharedNodeMount = *enableSharedNodeMount
+	klog.Infof("Webhook should enable shared node mount: %t", fuseSideCarConfig.EnableSharedNodeMount)
+
 	metadataPrefetchSideCarConfig := wh.LoadConfig(*metadataSidecarImage, *imagePullPolicy, *metadataPrefetchCPURequest, *metadataPrefetchCPULimit, *metadataMemoryRequest, *metadataMemoryLimit, *metadataPrefetchEphemeralStorageRequest, *metadataPrefetchEphemeralStorageLimit)
 	metadataPrefetchSideCarConfig.EnableGcsfuseProfiles = *enableGcsfuseProfiles
 
@@ -140,10 +144,8 @@ func main() {
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
 	pvcLister := informerFactory.Core().V1().PersistentVolumeClaims().Lister()
 	pvLister := informerFactory.Core().V1().PersistentVolumes().Lister()
-	var scLister storagelisters.StorageClassLister
-	if *enableGcsfuseProfiles {
-		scLister = informerFactory.Storage().V1().StorageClasses().Lister()
-	}
+	scLister := informerFactory.Storage().V1().StorageClasses().Lister()
+	podTemplateLister := informerFactory.Core().V1().PodTemplates().Lister()
 
 	informerFactory.Start(context.Done())
 	informerFactory.WaitForCacheSync(context.Done())
@@ -185,6 +187,7 @@ func main() {
 			PvLister:               pvLister,
 			PvcLister:              pvcLister,
 			ScLister:               scLister,
+			PodTemplateLister:      podTemplateLister,
 			ServerVersion:          serverVersion,
 			K8SClient:              client,
 		},

--- a/deploy/base/webhook/webhook_setup.yaml
+++ b/deploy/base/webhook/webhook_setup.yaml
@@ -34,7 +34,7 @@ metadata:
   name: gcs-fuse-csi-webhook-role
 rules:
   - apiGroups: [""]
-    resources: ["nodes", "persistentvolumes", "persistentvolumeclaims", "configmaps"]
+    resources: ["nodes", "persistentvolumes", "persistentvolumeclaims", "configmaps", "podtemplates"]
     verbs: ["get","list","watch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["storageclasses"]

--- a/deploy/overlays/shared-mount/enable_shared_node_mount_patch.json
+++ b/deploy/overlays/shared-mount/enable_shared_node_mount_patch.json
@@ -1,0 +1,7 @@
+[
+  {
+    "op": "add",
+    "path": "/spec/template/spec/containers/0/args/-",
+    "value": "--enable-shared-node-mount=true"
+  }
+]

--- a/deploy/overlays/shared-mount/kustomization.yaml
+++ b/deploy/overlays/shared-mount/kustomization.yaml
@@ -67,4 +67,10 @@ patches:
     kind: DaemonSet
     name: gcsfusecsi-node
     version: v1
+- path: enable_shared_node_mount_patch.json
+  target:
+    group: apps
+    kind: Deployment
+    name: gcs-fuse-csi-driver-webhook
+    version: v1
 

--- a/pkg/webhook/client.go
+++ b/pkg/webhook/client.go
@@ -94,3 +94,13 @@ func (si *SidecarInjector) GetVolumesStorageClass(volume *corev1.PersistentVolum
 	}
 	return sc, nil
 }
+
+// GetPodTemplate retrieves the referenced PodTemplate object from the informer cache.
+func (si *SidecarInjector) GetPodTemplate(namespace, name string) (*corev1.PodTemplate, error) {
+	podTemplate, err := si.PodTemplateLister.PodTemplates(namespace).Get(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return podTemplate, nil
+}

--- a/pkg/webhook/client_test.go
+++ b/pkg/webhook/client_test.go
@@ -516,3 +516,108 @@ func TestGetVolumesStorageClass(t *testing.T) {
 		}
 	}
 }
+
+func TestGetPodTemplate(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		testName         string
+		ptName           string
+		ptNamespace      string
+		ptsInK8s         []corev1.PodTemplate
+		expectedResponse *corev1.PodTemplate
+		expectedError    error
+	}{
+		{
+			testName:         "pod template not in k8s",
+			ptName:           "pt-5678",
+			ptNamespace:      metav1.NamespaceAll,
+			ptsInK8s:         []corev1.PodTemplate{},
+			expectedResponse: nil,
+			expectedError:    errors.New(`podtemplate "pt-5678" not found`),
+		},
+		{
+			testName:    "pod template in k8s on different namespace",
+			ptName:      "pt-12345",
+			ptNamespace: metav1.NamespaceSystem,
+			ptsInK8s: []corev1.PodTemplate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pt-13",
+						Namespace: metav1.NamespaceDefault,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pt-12345",
+						Namespace: metav1.NamespaceDefault,
+					},
+				},
+			},
+			expectedResponse: nil,
+			expectedError:    errors.New(`podtemplate "pt-12345" not found`),
+		},
+		{
+			testName:    "pod template in k8s",
+			ptName:      "pt-12345",
+			ptNamespace: metav1.NamespaceDefault,
+			ptsInK8s: []corev1.PodTemplate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pt-13",
+						Namespace: metav1.NamespaceDefault,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pt-12345",
+						Namespace: metav1.NamespaceDefault,
+					},
+				},
+			},
+			expectedResponse: &corev1.PodTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pt-12345",
+					Namespace: metav1.NamespaceDefault,
+				},
+			},
+			expectedError: nil,
+		},
+	}
+
+	for _, testcase := range testcases {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		fakeClient := fake.NewSimpleClientset()
+		for _, ptInK8s := range testcase.ptsInK8s {
+			pt := ptInK8s
+			_, err := fakeClient.CoreV1().PodTemplates(pt.Namespace).Create(context.TODO(), &pt, metav1.CreateOptions{})
+			if err != nil {
+				t.Fatalf("failed to setup test: %v", err)
+			}
+		}
+
+		csiGroupClient := SidecarInjector{}
+		const resyncDuration = 0 * time.Second
+
+		informer := informers.NewSharedInformerFactory(fakeClient, resyncDuration)
+		csiGroupClient.PodTemplateLister = informer.Core().V1().PodTemplates().Lister()
+
+		informer.Start(ctx.Done())
+		informer.WaitForCacheSync(ctx.Done())
+
+		response, err := csiGroupClient.GetPodTemplate(testcase.ptNamespace, testcase.ptName)
+		if err != nil && testcase.expectedError != nil {
+			if err.Error() != testcase.expectedError.Error() {
+				t.Error("for test: ", testcase.testName, ", want error: ", testcase.expectedError.Error(), " but got: ", err.Error())
+			}
+		} else if err != nil || testcase.expectedError != nil {
+			t.Error("for test: ", testcase.testName, ", want error: ", testcase.expectedError, " but got: ", err)
+		}
+
+		if !reflect.DeepEqual(response, testcase.expectedResponse) {
+			t.Error("for test: ", testcase.testName, ", want response: ", testcase.expectedResponse, " but got: ", response)
+		}
+	}
+}

--- a/pkg/webhook/config.go
+++ b/pkg/webhook/config.go
@@ -31,6 +31,7 @@ import (
 type Config struct {
 	ShouldInjectSAVolume  bool   `json:"-"`
 	EnableGcsfuseProfiles bool   `json:"-"`
+	EnableSharedNodeMount bool   `json:"-"`
 	PodHostNetworkSetting bool   `json:"-"`
 	EnableNumaPinning     bool   `json:"enable-numa-pinning,omitempty"`
 	ContainerImage        string `json:"-"`

--- a/pkg/webhook/mutatingwebhook.go
+++ b/pkg/webhook/mutatingwebhook.go
@@ -73,13 +73,14 @@ type SidecarInjector struct {
 	PvcLister              listersv1.PersistentVolumeClaimLister
 	PvLister               listersv1.PersistentVolumeLister
 	ScLister               listerstoragev1.StorageClassLister
+	PodTemplateLister      listersv1.PodTemplateLister
 	ServerVersion          *version.Version
 	K8SClient              kubernetes.Interface
 }
 
 // Handle injects a gcsfuse sidecar container and a emptyDir to incoming qualified pods.
 func (si *SidecarInjector) Handle(ctx context.Context, req admission.Request) admission.Response {
-	if req.Kind.Kind == "PersistentVolume" && si.Config.EnableGcsfuseProfiles { // Currently only handling pvs for gcsfuse profiles
+	if req.Kind.Kind == "PersistentVolume" {
 		pv := &corev1.PersistentVolume{}
 		if err := si.Decoder.Decode(req, pv); err != nil {
 			klog.Errorf("Could not decode PersistentVolume object: %v", err)
@@ -87,10 +88,33 @@ func (si *SidecarInjector) Handle(ctx context.Context, req admission.Request) ad
 		}
 		klog.Infof("Mutating webhook is handling PersistentVolume: %s", pv.Name)
 
-		if err := si.validatePersistentVolumeForGCSFuseProfiles(pv); err != nil {
-			klog.Errorf("PersistentVolume validation failed: %v", err)
-			return admission.Errored(http.StatusBadRequest, err)
+		if pv.Spec.CSI == nil || pv.Spec.CSI.Driver != util.GCSFuseCsiDriverName {
+			// Not a gcsfuse CSI driver volume, skip validation/mutation
+			return admission.Allowed(fmt.Sprintf("No mutation Required on PersistentVolume: %s", pv.Name))
 		}
+
+		if si.Config.EnableGcsfuseProfiles {
+			if err := si.validatePersistentVolumeForGCSFuseProfiles(pv); err != nil {
+				klog.Errorf("PersistentVolume validation failed: %v", err)
+				return admission.Errored(http.StatusBadRequest, err)
+			}
+		}
+
+		// Patch the label to PV if it uses shared node mount.
+		if si.Config.EnableSharedNodeMount && pv.Spec.CSI.VolumeAttributes != nil && pv.Spec.CSI.VolumeAttributes[SharedMountVolumeAttribute] == util.TrueStr {
+			if pv.Labels == nil {
+				pv.Labels = make(map[string]string)
+			}
+			if pv.Labels[SharedMountLabel] != util.TrueStr {
+				pv.Labels[SharedMountLabel] = util.TrueStr
+				marshaledPV, err := json.Marshal(pv)
+				if err != nil {
+					return admission.Errored(http.StatusInternalServerError, fmt.Errorf("failed to marshal pv: %w", err))
+				}
+				return admission.PatchResponseFromRaw(req.Object.Raw, marshaledPV)
+			}
+		}
+
 		return admission.Allowed(fmt.Sprintf("No mutation Required on PersistentVolume: %s", pv.Name))
 	}
 
@@ -105,6 +129,91 @@ func (si *SidecarInjector) Handle(ctx context.Context, req admission.Request) ad
 
 	if req.Operation != admissionv1.Create {
 		return admission.Allowed(fmt.Sprintf("No injection required for operation %v.", req.Operation))
+	}
+
+	// Classify Pod volumes to check if they are GCSFuse volumes and if they use shared node mount.
+	var hasSharedNodeMount bool
+	var hasStandardMount bool
+	var cacheCreatedByUser bool
+
+	for _, volume := range pod.Spec.Volumes {
+		isGcsfuse, _, volumeAttributes, pv, err := si.isGcsFuseCSIVolume(volume, pod.Namespace)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				klog.Warningf("PVC does not exist, skipping volume %q: %v", volume.Name, err)
+				continue
+			}
+			klog.Errorf("Failed to check if volume %q is GCSFuse volume: %v", volume.Name, err)
+			return admission.Errored(http.StatusInternalServerError, err)
+		}
+		if !isGcsfuse {
+			continue
+		}
+
+		isSharedNodeMount := si.Config.EnableSharedNodeMount && pv != nil && volumeAttributes != nil && volumeAttributes[SharedMountVolumeAttribute] == util.TrueStr
+
+		if isSharedNodeMount {
+			hasSharedNodeMount = true
+			if volume.PersistentVolumeClaim != nil {
+				pvc, err := si.GetPVC(pod.Namespace, volume.PersistentVolumeClaim.ClaimName)
+				if err != nil {
+					return admission.Errored(http.StatusBadRequest, fmt.Errorf("failed to get PVC %q: %w", volume.PersistentVolumeClaim.ClaimName, err))
+				}
+
+				podTemplate, err := si.getMounterPodTemplate(pod.Namespace, pvc)
+				if err != nil {
+					if apierrors.IsNotFound(err) {
+						klog.Warningf("Skip volume %q verification because the referenced PodTemplate was not found: %v", volume.Name, err)
+						continue
+					}
+					klog.Errorf("failed to get mounter PodTemplate for PVC %q: %v", pvc.Name, err)
+					return admission.Errored(http.StatusInternalServerError, err)
+				}
+				if podTemplate == nil {
+					return admission.Errored(http.StatusBadRequest, fmt.Errorf("volume %q uses shared node mount but its PVC %q is missing a referenced PodTemplate annotation %q", volume.Name, pvc.Name, MounterPodTemplateAnnotation))
+				}
+
+				if volumeExists(podTemplate.Template.Spec.Volumes, SidecarContainerCacheVolumeName) {
+					cacheCreatedByUser = true
+				}
+
+				// Validate that Pod fsGroup matches the requirements of the referenced PVC PodTemplate.
+				if err := si.validateFSGroup(pod, podTemplate); err != nil {
+					klog.Errorf("fsGroup validation failed: %v", err)
+					return admission.Errored(http.StatusBadRequest, err)
+				}
+			}
+		} else {
+			hasStandardMount = true
+		}
+	}
+
+	// Prevent mixing shared node mount and standard mount GCSFuse volumes in the same Pod.
+	if hasSharedNodeMount && hasStandardMount {
+		return admission.Errored(http.StatusBadRequest, fmt.Errorf("mixing shared node mount and non-shared node mount GCSFuse volumes in the same Pod is not allowed"))
+	}
+
+	// Handle Pod mutation and validations for shared node mount mode.
+	if hasSharedNodeMount {
+		// Inject profiles label and scheduling gate if storage profiles are enabled and match.
+		if si.Config.EnableGcsfuseProfiles {
+			profilesEnabled, err := si.IsGCSFuseProfilesEnabled(pod)
+			if err != nil {
+				return admission.Errored(http.StatusBadRequest, err)
+			}
+			if profilesEnabled {
+				if err := ModifyPodSpecForGCSFuseProfiles(pod, cacheCreatedByUser, true); err != nil {
+					return admission.Errored(http.StatusBadRequest, err)
+				}
+				marshaledPod, err := json.Marshal(pod)
+				if err != nil {
+					return admission.Errored(http.StatusBadRequest, fmt.Errorf("failed to marshal pod: %w", err))
+				}
+				return admission.PatchResponseFromRaw(req.Object.Raw, marshaledPod)
+			}
+		}
+
+		return admission.Allowed("No sidecar injection required for shared node mount mode.")
 	}
 
 	enableGcsfuseVolumes, ok := pod.Annotations[GcsFuseVolumeEnableAnnotation]
@@ -177,7 +286,7 @@ func (si *SidecarInjector) Handle(ctx context.Context, req admission.Request) ad
 		pod.Spec.Volumes = append(pod.Spec.Volumes, GetSATokenVolume(audience))
 	}
 
-	cacheCreatedByUser := volumeExists(pod.Spec.Volumes, SidecarContainerCacheVolumeName)
+	cacheCreatedByUser = volumeExists(pod.Spec.Volumes, SidecarContainerCacheVolumeName)
 	pod.Spec.Volumes = append(GetSidecarContainerVolumeSpec(pod.Spec.Volumes...), pod.Spec.Volumes...)
 
 	// Inject metadata prefetch sidecar.
@@ -198,7 +307,7 @@ func (si *SidecarInjector) Handle(ctx context.Context, req admission.Request) ad
 		}
 		klog.Infof("Pod %q has at least one volume using gcsfuse profiles", pod.Name)
 		if profilesEnabled {
-			err = ModifyPodSpecForGCSFuseProfiles(pod, cacheCreatedByUser)
+			err = ModifyPodSpecForGCSFuseProfiles(pod, cacheCreatedByUser, false)
 			if err != nil {
 				return admission.Errored(http.StatusBadRequest, err)
 			}
@@ -251,7 +360,7 @@ func audienceForInjectedSATokenVolume(projectID string, pod *corev1.Pod) string 
 }
 
 // Modifies the pod spec to add gcsfuse profile related features. This includes adding a label, scheduling gate, and placeholder file cache volumes
-func ModifyPodSpecForGCSFuseProfiles(pod *corev1.Pod, cacheCreatedByUser bool) error {
+func ModifyPodSpecForGCSFuseProfiles(pod *corev1.Pod, cacheCreatedByUser bool, isSharedMount bool) error {
 	// Always apply the gcsfuse profile label when gcsfuse profiles are enabled for pod informer's Kubernetes API efficient filtering
 	if pod.Labels == nil {
 		pod.Labels = make(map[string]string)
@@ -278,6 +387,10 @@ func ModifyPodSpecForGCSFuseProfiles(pod *corev1.Pod, cacheCreatedByUser bool) e
 		pod.Spec.SchedulingGates = append(pod.Spec.SchedulingGates, profilesGate)
 	} else {
 		klog.Warningf("Pod %s/%s already has the %s scheduling gate, skipping injection of gcsfuse profiles scheduling gate.", pod.Namespace, pod.Name, BucketScanPendingSchedulingGate)
+	}
+
+	if isSharedMount {
+		return nil
 	}
 
 	// Inject placeholder file cache volumes
@@ -502,4 +615,47 @@ func parseCredentialConfigurationConfigMap(client kubernetes.Interface, pod *cor
 	}
 
 	return filename, &credConfig, nil
+}
+
+// getMounterPodTemplate retrieves the referenced mounter PodTemplate for a PVC if the annotation is present.
+func (si *SidecarInjector) getMounterPodTemplate(namespace string, pvc *corev1.PersistentVolumeClaim) (*corev1.PodTemplate, error) {
+	if pvc.Annotations == nil {
+		return nil, nil
+	}
+	templateName, ok := pvc.Annotations[MounterPodTemplateAnnotation]
+	if !ok || templateName == "" {
+		return nil, nil
+	}
+
+	podTemplate, err := si.GetPodTemplate(namespace, templateName)
+	if err != nil {
+		return nil, err
+	}
+	return podTemplate, nil
+}
+
+// validateFSGroup checks if the Pod's fsGroup matches the one specified in the volume's referenced mounter PodTemplate.
+func (si *SidecarInjector) validateFSGroup(pod *corev1.Pod, podTemplate *corev1.PodTemplate) error {
+	templateName := podTemplate.Name
+	templateHasFSGroup := podTemplate.Template.Spec.SecurityContext != nil && podTemplate.Template.Spec.SecurityContext.FSGroup != nil
+	podHasFSGroup := pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.FSGroup != nil
+
+	// Enforce strict matching between Pod and PodTemplate fsGroup settings to prevent shared mount permission conflicts.
+	if templateHasFSGroup {
+		expectedFSGroup := *podTemplate.Template.Spec.SecurityContext.FSGroup
+		if !podHasFSGroup {
+			return fmt.Errorf("Pod fsGroup is not set, but volume's PodTemplate %q requires fsGroup %d", templateName, expectedFSGroup)
+		}
+		actualFSGroup := *pod.Spec.SecurityContext.FSGroup
+		if actualFSGroup != expectedFSGroup {
+			return fmt.Errorf("Pod fsGroup %d does not match the one specified in volume's PodTemplate %q (%d)", actualFSGroup, templateName, expectedFSGroup)
+		}
+		return nil
+	}
+
+	if podHasFSGroup {
+		return fmt.Errorf("Pod has fsGroup set, but volume's PodTemplate %q does not specify one (not allowed for shared node mount)", templateName)
+	}
+
+	return nil
 }

--- a/pkg/webhook/mutatingwebhook_test.go
+++ b/pkg/webhook/mutatingwebhook_test.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -35,6 +36,7 @@ import (
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -1202,6 +1204,7 @@ func TestModifyPodSpecForGCSFuseProfiles(t *testing.T) {
 		inputPod           *corev1.Pod
 		wantPod            *corev1.Pod
 		cacheCreatedByUser bool
+		isSharedMount      bool
 		expectErr          bool
 	}{
 		{
@@ -1530,6 +1533,64 @@ func TestModifyPodSpecForGCSFuseProfiles(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "pod with shared node mount, should inject profile label and scheduling gate but not sidecar cache",
+			inputPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "shared-mount-pod",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "app-container"},
+					},
+				},
+			},
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "shared-mount-pod",
+					Labels: map[string]string{
+						GcsfuseProfilesManagedLabel: "true",
+					},
+				},
+				Spec: corev1.PodSpec{
+					SchedulingGates: []corev1.PodSchedulingGate{expectedGate},
+					Containers: []corev1.Container{
+						{Name: "app-container"},
+					},
+				},
+			},
+			isSharedMount: true,
+		},
+		{
+			name: "pod with shared node mount and user provided cache volume, should inject profile label, scheduling gate, and cache created by user label",
+			inputPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "shared-mount-pod-user-provided-cache",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "app-container"},
+					},
+				},
+			},
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "shared-mount-pod-user-provided-cache",
+					Labels: map[string]string{
+						GcsfuseProfilesManagedLabel:    "true",
+						GcsfuseCacheCreatedByUserLabel: "true",
+					},
+				},
+				Spec: corev1.PodSpec{
+					SchedulingGates: []corev1.PodSchedulingGate{expectedGate},
+					Containers: []corev1.Container{
+						{Name: "app-container"},
+					},
+				},
+			},
+			cacheCreatedByUser: true,
+			isSharedMount:      true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -1539,7 +1600,7 @@ func TestModifyPodSpecForGCSFuseProfiles(t *testing.T) {
 
 			// The function doesn't actually use the client or context,
 			// so we can pass in nil or empty values.
-			err := ModifyPodSpecForGCSFuseProfiles(podToModify, tc.cacheCreatedByUser)
+			err := ModifyPodSpecForGCSFuseProfiles(podToModify, tc.cacheCreatedByUser, tc.isSharedMount)
 			if err != nil || tc.expectErr {
 				if !tc.expectErr {
 					t.Fatalf("ModifyPodSpecForGcsfuseProfiles() returned an unexpected error: %v", err)
@@ -1800,6 +1861,7 @@ func TestOIDCAuthenticationWithHostNetwork(t *testing.T) {
 				MetadataPrefetchConfig: FakePrefetchConfig(),
 				Decoder:                admission.NewDecoder(runtime.NewScheme()),
 				NodeLister:             nodeInformer.Lister(),
+				PodTemplateLister:      informerFactory.Core().V1().PodTemplates().Lister(),
 			}
 
 			// Marshal the pod to create admission request
@@ -1826,7 +1888,7 @@ func TestOIDCAuthenticationWithHostNetwork(t *testing.T) {
 				if resp.Allowed {
 					t.Errorf("Expected request to be denied, but it was allowed")
 				}
-				if tc.expectedErrorSubstr != "" && !stringContains(resp.Result.Message, tc.expectedErrorSubstr) {
+				if tc.expectedErrorSubstr != "" && !strings.Contains(resp.Result.Message, tc.expectedErrorSubstr) {
 					t.Errorf("Expected error message to contain %q, but got: %q", tc.expectedErrorSubstr, resp.Result.Message)
 				}
 				if resp.Result.Code != http.StatusBadRequest {
@@ -1841,15 +1903,402 @@ func TestOIDCAuthenticationWithHostNetwork(t *testing.T) {
 	}
 }
 
-// Helper function to check if a string contains a substring
-func stringContains(s, substr string) bool {
-	if len(substr) == 0 {
-		return true
+func TestSharedNodeMountWebhook(t *testing.T) {
+	t.Parallel()
+
+	sharedPV := &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "shared-pv",
+		},
+		Spec: corev1.PersistentVolumeSpec{
+			PersistentVolumeSource: corev1.PersistentVolumeSource{
+				CSI: &corev1.CSIPersistentVolumeSource{
+					Driver: util.GCSFuseCsiDriverName,
+					VolumeAttributes: map[string]string{
+						"sharedMount": "true",
+					},
+				},
+			},
+		},
 	}
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
+
+	sharedPVWithLabel := sharedPV.DeepCopy()
+	sharedPVWithLabel.Labels = map[string]string{
+		SharedMountLabel: "true",
 	}
-	return false
+
+	sharedPVC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "shared-pvc",
+			Namespace: "default",
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			VolumeName: "shared-pv",
+		},
+	}
+
+	sharedProfileSC := &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "shared-profile-sc",
+			Labels: map[string]string{
+				putil.LabelProfile: "true",
+			},
+		},
+		Provisioner: util.GCSFuseCsiDriverName,
+		Parameters: map[string]string{
+			"sharedMount": "true",
+		},
+	}
+
+	sharedPVCWithProfile := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "shared-pvc",
+			Namespace: "default",
+			Annotations: map[string]string{
+				MounterPodTemplateAnnotation: "mounter-template",
+			},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: ptr.To("shared-profile-sc"),
+			VolumeName:       "shared-pv",
+		},
+	}
+
+	podTemplateWithUserProvidedCache := &corev1.PodTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mounter-template-user-provided-cache",
+			Namespace: "default",
+		},
+		Template: corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				Volumes: []corev1.Volume{
+					{
+						Name: SidecarContainerCacheVolumeName,
+					},
+				},
+			},
+		},
+	}
+
+	sharedPVCWithProfileAndUserProvidedCache := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "shared-pvc",
+			Namespace: "default",
+			Annotations: map[string]string{
+				MounterPodTemplateAnnotation: "mounter-template-user-provided-cache",
+			},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: ptr.To("shared-profile-sc"),
+			VolumeName:       "shared-pv",
+		},
+	}
+
+	sharedPVCWithAnnotation := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "shared-pvc",
+			Namespace: "default",
+			Annotations: map[string]string{
+				MounterPodTemplateAnnotation: "mounter-template",
+			},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			VolumeName: "shared-pv",
+		},
+	}
+
+	podTemplate := &corev1.PodTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mounter-template",
+			Namespace: "default",
+		},
+		Template: corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{
+					FSGroup: ptr.To[int64](2001),
+				},
+			},
+		},
+	}
+
+	mixedPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mixed-pod",
+			Namespace: "default",
+		},
+		Spec: corev1.PodSpec{
+			Volumes: []corev1.Volume{
+				{
+					Name: "shared-vol",
+					VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+							ClaimName: "shared-pvc",
+						},
+					},
+				},
+				{
+					Name: "standard-vol",
+					VolumeSource: corev1.VolumeSource{
+						CSI: &corev1.CSIVolumeSource{
+							Driver: util.GCSFuseCsiDriverName,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	sharedOnlyPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "shared-only-pod",
+			Namespace: "default",
+			Annotations: map[string]string{
+				GcsFuseVolumeEnableAnnotation: "true",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Volumes: []corev1.Volume{
+				{
+					Name: "shared-vol",
+					VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+							ClaimName: "shared-pvc",
+						},
+					},
+				},
+			},
+			Containers: []corev1.Container{
+				{
+					Name: "app-container",
+				},
+			},
+		},
+	}
+
+	sharedOnlyPodWithProfileMutated := sharedOnlyPod.DeepCopy()
+	sharedOnlyPodWithProfileMutated.Labels = map[string]string{
+		GcsfuseProfilesManagedLabel: "true",
+	}
+	sharedOnlyPodWithProfileMutated.Spec.SchedulingGates = []corev1.PodSchedulingGate{
+		{Name: BucketScanPendingSchedulingGate},
+	}
+
+	sharedOnlyPodWithProfileAndUserProvidedCacheMutated := sharedOnlyPod.DeepCopy()
+	sharedOnlyPodWithProfileAndUserProvidedCacheMutated.Labels = map[string]string{
+		GcsfuseProfilesManagedLabel:    "true",
+		GcsfuseCacheCreatedByUserLabel: "true",
+	}
+	sharedOnlyPodWithProfileAndUserProvidedCacheMutated.Spec.SchedulingGates = []corev1.PodSchedulingGate{
+		{Name: BucketScanPendingSchedulingGate},
+	}
+
+	workloadPodMismatchFSGroup := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "workload-pod",
+			Namespace: "default",
+		},
+		Spec: corev1.PodSpec{
+			SecurityContext: &corev1.PodSecurityContext{
+				FSGroup: ptr.To[int64](1001), // fsGroup (1001) does not match the volume's PodTemplate fsGroup (2001)
+			},
+			Volumes: []corev1.Volume{
+				{
+					Name: "shared-vol",
+					VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+							ClaimName: "shared-pvc",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	workloadPodMatchFSGroup := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "workload-pod",
+			Namespace: "default",
+		},
+		Spec: corev1.PodSpec{
+			SecurityContext: &corev1.PodSecurityContext{
+				FSGroup: ptr.To[int64](2001), // fsGroup (2001) matches the volume's PodTemplate fsGroup (2001)
+			},
+			Volumes: []corev1.Volume{
+				{
+					Name: "shared-vol",
+					VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+							ClaimName: "shared-pvc",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	workloadPodNoFSGroup := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "workload-pod",
+			Namespace: "default",
+		},
+		Spec: corev1.PodSpec{
+			Volumes: []corev1.Volume{
+				{
+					Name: "shared-vol",
+					VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+							ClaimName: "shared-pvc",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	podTemplateNoFSGroup := &corev1.PodTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mounter-template",
+			Namespace: "default",
+		},
+		Template: corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{},
+		},
+	}
+
+	testCases := []struct {
+		name           string
+		objects        []runtime.Object
+		requestObj     runtime.Object
+		requestKind    string
+		wantResponse   admission.Response
+		enableProfiles bool
+	}{
+		{
+			name:         "PersistentVolume using shared node mount is labeled with the shared-mount label.",
+			objects:      []runtime.Object{sharedPV},
+			requestObj:   sharedPV,
+			requestKind:  "PersistentVolume",
+			wantResponse: admission.PatchResponseFromRaw(serialize(t, sharedPV), serialize(t, sharedPVWithLabel)),
+		},
+		{
+			name:         "Pod mixing standard and shared node mount GCSFuse volumes is rejected.",
+			objects:      []runtime.Object{sharedPV, sharedPVCWithAnnotation, podTemplateNoFSGroup},
+			requestObj:   mixedPod,
+			requestKind:  "Pod",
+			wantResponse: admission.Errored(http.StatusBadRequest, fmt.Errorf("mixing shared node mount and non-shared node mount GCSFuse volumes in the same Pod is not allowed")),
+		},
+		{
+			name:         "Pod using only shared node mount GCSFuse volumes bypasses sidecar injection.",
+			objects:      []runtime.Object{sharedPV, sharedPVCWithAnnotation, podTemplateNoFSGroup},
+			requestObj:   sharedOnlyPod,
+			requestKind:  "Pod",
+			wantResponse: admission.Allowed("No sidecar injection required for shared node mount mode."),
+		},
+		{
+			name:         "Pod using shared node mount is rejected if PVC is missing PodTemplate annotation.",
+			objects:      []runtime.Object{sharedPV, sharedPVC},
+			requestObj:   sharedOnlyPod,
+			requestKind:  "Pod",
+			wantResponse: admission.Errored(http.StatusBadRequest, fmt.Errorf("volume %q uses shared node mount but its PVC %q is missing a referenced PodTemplate annotation %q", "shared-vol", "shared-pvc", MounterPodTemplateAnnotation)),
+		},
+		{
+			name:         "Pod is rejected if its fsGroup does not match the volume's PodTemplate fsGroup.",
+			objects:      []runtime.Object{sharedPV, sharedPVCWithAnnotation, podTemplate},
+			requestObj:   workloadPodMismatchFSGroup,
+			requestKind:  "Pod",
+			wantResponse: admission.Errored(http.StatusBadRequest, fmt.Errorf("Pod fsGroup 1001 does not match the one specified in volume's PodTemplate %q (2001)", "mounter-template")),
+		},
+		{
+			name:         "Pod is allowed if its fsGroup matches the volume's PodTemplate fsGroup.",
+			objects:      []runtime.Object{sharedPV, sharedPVCWithAnnotation, podTemplate},
+			requestObj:   workloadPodMatchFSGroup,
+			requestKind:  "Pod",
+			wantResponse: admission.Allowed("No sidecar injection required for shared node mount mode."),
+		},
+		{
+			name:         "Pod is rejected if its fsGroup is not set but the volume's PodTemplate requires one.",
+			objects:      []runtime.Object{sharedPV, sharedPVCWithAnnotation, podTemplate},
+			requestObj:   workloadPodNoFSGroup,
+			requestKind:  "Pod",
+			wantResponse: admission.Errored(http.StatusBadRequest, fmt.Errorf("Pod fsGroup is not set, but volume's PodTemplate %q requires fsGroup %d", "mounter-template", 2001)),
+		},
+		{
+			name:         "Pod is rejected if its fsGroup is set but the volume's PodTemplate does not specify one.",
+			objects:      []runtime.Object{sharedPV, sharedPVCWithAnnotation, podTemplateNoFSGroup},
+			requestObj:   workloadPodMatchFSGroup,
+			requestKind:  "Pod",
+			wantResponse: admission.Errored(http.StatusBadRequest, fmt.Errorf("Pod has fsGroup set, but volume's PodTemplate %q does not specify one (not allowed for shared node mount)", "mounter-template")),
+		},
+		{
+			name:         "Pod is allowed if neither the Pod nor the volume's PodTemplate specify an fsGroup.",
+			objects:      []runtime.Object{sharedPV, sharedPVCWithAnnotation, podTemplateNoFSGroup},
+			requestObj:   workloadPodNoFSGroup,
+			requestKind:  "Pod",
+			wantResponse: admission.Allowed("No sidecar injection required for shared node mount mode."),
+		},
+		{
+			name:           "Pod using shared node mount with Profiles enabled is mutated with profile label and scheduling gate.",
+			objects:        []runtime.Object{sharedProfileSC, sharedPVCWithProfile, sharedPV, podTemplateNoFSGroup},
+			requestObj:     sharedOnlyPod,
+			requestKind:    "Pod",
+			wantResponse:   admission.PatchResponseFromRaw(serialize(t, sharedOnlyPod), serialize(t, sharedOnlyPodWithProfileMutated)),
+			enableProfiles: true,
+		},
+		{
+			name:           "Pod using shared node mount with Profiles enabled and user provided cache volume in PodTemplate is mutated with profile label, scheduling gate, and cache-created-by-user label.",
+			objects:        []runtime.Object{sharedProfileSC, sharedPVCWithProfileAndUserProvidedCache, sharedPV, podTemplateWithUserProvidedCache},
+			requestObj:     sharedOnlyPod,
+			requestKind:    "Pod",
+			wantResponse:   admission.PatchResponseFromRaw(serialize(t, sharedOnlyPod), serialize(t, sharedOnlyPodWithProfileAndUserProvidedCacheMutated)),
+			enableProfiles: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			fakeClient := fake.NewSimpleClientset(tc.objects...)
+			informerFactory := informers.NewSharedInformerFactory(fakeClient, 0)
+			si := SidecarInjector{
+				Decoder:                admission.NewDecoder(runtime.NewScheme()),
+				Config:                 FakeConfig(),
+				MetadataPrefetchConfig: FakePrefetchConfig(),
+				K8SClient:              fakeClient,
+				PvLister:               informerFactory.Core().V1().PersistentVolumes().Lister(),
+				PvcLister:              informerFactory.Core().V1().PersistentVolumeClaims().Lister(),
+				ScLister:               informerFactory.Storage().V1().StorageClasses().Lister(),
+				PodTemplateLister:      informerFactory.Core().V1().PodTemplates().Lister(),
+			}
+			if tc.enableProfiles {
+				si.Config.EnableGcsfuseProfiles = true
+			}
+			si.Config.EnableSharedNodeMount = true
+
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+			informerFactory.Start(stopCh)
+			informerFactory.WaitForCacheSync(stopCh)
+
+			req := admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
+					Kind: metav1.GroupVersionKind{
+						Group:   "",
+						Version: "v1",
+						Kind:    tc.requestKind,
+					},
+					Object: runtime.RawExtension{
+						Raw: serialize(t, tc.requestObj),
+					},
+				},
+			}
+
+			gotResponse := si.Handle(context.Background(), req)
+
+			if err := compareResponses(tc.wantResponse, gotResponse); err != nil {
+				t.Errorf("for test case %q: %v", tc.name, err)
+			}
+		})
+	}
 }

--- a/pkg/webhook/sidecar_spec.go
+++ b/pkg/webhook/sidecar_spec.go
@@ -43,6 +43,11 @@ const (
 
 	// Webhook relevant volume attributes.
 	gcsFuseMetadataPrefetchOnMountVolumeAttribute = "gcsfuseMetadataPrefetchOnMount"
+	SharedMountVolumeAttribute                    = "sharedMount"
+
+	// Webhook relevant labels and annotations.
+	SharedMountLabel             = "gke-gcsfuse/shared-mount"
+	MounterPodTemplateAnnotation = "gke-gcsfuse/mounter-pod-template"
 
 	// gcsfuse profiles constants
 	GcsfuseProfilesManagedLabel                           = "gke-gcsfuse/profile-managed"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

/kind feature

**What this PR does / why we need it**:

This PR implements shared node mount support in the mutating webhook of the GCS FUSE CSI Driver. 
Specifically, the webhook is updated to:

1. **Label PVs**: Automatically labels `PersistentVolume` objects using shared node mount with `gcsfuse.csi.storage.gke.io/shared-mount=true`.
2. **Control Sidecar Injection**: Bypasses sidecar injection for Pods using shared node mount volumes, and rejects Pods that mix using shared node mount and non-shared node mount GCSFuse volumes.
3. **Validate fsGroup**: Enforces that the Pod's `fsGroup` matches the one specified in the volume's `PodTemplate` for shared node mount volumes.
4. **Mutate for Profiles**: Injects GCSFuse profiles managed label and scheduling gate to the Pod spec when profiles are enabled for shared mount.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
Tested e2e tests on non managed driver, using 10 n2-standard-4 nodes on GKE 1.36
```
Summarizing 9 Failures:
    [FAIL] E2E Test Suite [Driver: gcsfuse.csi.storage.gke.io] [Testpattern: CSI Ephemeral-volume (default fs)] workload-identity-federation [It] should successfully authenticate multiple pods using same federation configuration
    /usr/local/google/home/yaozile/oss/gcs-fuse-csi-driver/test/e2e/specs/specs.go:325
    [FAIL] E2E Test Suite [Driver: gcsfuse.csi.storage.gke.io] [Testpattern: CSI Ephemeral-volume (default fs)] workload-identity-federation [It] should isolate workload identity federation access for Kubernetes service accounts with the same name across different namespaces
    /usr/local/google/home/yaozile/oss/gcs-fuse-csi-driver/test/e2e/specs/specs.go:325
    [FAIL] E2E Test Suite [Driver: gcsfuse.csi.storage.gke.io] [Testpattern: CSI Ephemeral-volume (default fs)] workload-identity-federation [It] should fail write operations when WI principal has read-only storage role
    /usr/local/google/home/yaozile/oss/gcs-fuse-csi-driver/test/e2e/specs/specs.go:325
    [FAIL] E2E Test Suite [Driver: gcsfuse.csi.storage.gke.io] [Testpattern: CSI Ephemeral-volume (default fs)] workload-identity-federation [It] should fail GCS access when WI principal has no storage role
    /usr/local/google/home/yaozile/oss/gcs-fuse-csi-driver/test/e2e/specs/specs.go:382
    [FAIL] E2E Test Suite [Driver: gcsfuse.csi.storage.gke.io] [Testpattern: CSI Ephemeral-volume (default fs)] workload-identity-federation [It] should fail GCS access when WI principal role is on a different bucket
    /usr/local/google/home/yaozile/oss/gcs-fuse-csi-driver/test/e2e/specs/specs.go:382
    [FAIL] E2E Test Suite [Driver: gcsfuse.csi.storage.gke.io] [Testpattern: CSI Ephemeral-volume (default fs)] workload-identity-federation [It] should successfully mount when pod KSA has WIF bucket access but node SA does not
    /usr/local/google/home/yaozile/oss/gcs-fuse-csi-driver/test/e2e/specs/specs.go:325
    [FAIL] E2E Test Suite [Driver: gcsfuse.csi.storage.gke.io] [Testpattern: CSI Ephemeral-volume (default fs)] workload-identity-federation [It] should fail GCS access after workload identity federation principal permissions are removed while pod is running
    /usr/local/google/home/yaozile/oss/gcs-fuse-csi-driver/test/e2e/specs/specs.go:325
    [FAIL] E2E Test Suite [Driver: gcsfuse.csi.storage.gke.io] [Testpattern: CSI Ephemeral-volume (default fs)] workload-identity-federation [It] should enforce different GCS bucket permissions for different Kubernetes service accounts
    /usr/local/google/home/yaozile/oss/gcs-fuse-csi-driver/test/e2e/specs/specs.go:325
    [FAIL] E2E Test Suite [Driver: gcsfuse.csi.storage.gke.io] [Testpattern: CSI Ephemeral-volume (default fs)] workload-identity-federation [It] should re-authenticate successfully after pod restart using federation
    /usr/local/google/home/yaozile/oss/gcs-fuse-csi-driver/test/e2e/specs/specs.go:325

  Ran 468 of 596 Specs in 7132.322 seconds
  FAIL! -- 459 Passed | 9 Failed | 0 Pending | 128 Skipped


  Ginkgo ran 1 suite in 1h59m5.624547168s

  Test Suite Failed
```
All the test are passed except the workload identity test cases, those will be fixed in another PR

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
