### PR TITLE
[Shared Mount] Verify Mounter Pod exists during NodeStageVolume

### DIFF
--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -671,11 +671,76 @@ func (s *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolu
 		return &csi.NodeStageVolumeResponse{}, nil
 	}
 
+	publishContext := req.GetPublishContext()
+	if publishContext == nil {
+		return nil, status.Error(codes.InvalidArgument, "publishContext must be provided")
+	}
+
+	podName, ok := publishContext[PublishContextKeyMounterPodName]
+	if !ok {
+		return nil, status.Error(codes.InvalidArgument, "publishContext must contain mounter pod name")
+	}
+	if podName == "" {
+		return nil, status.Error(codes.InvalidArgument, "mounter pod name in publishContext cannot be empty")
+	}
+
+	podNamespace, ok := publishContext[PublishContextKeyMounterPodNamespace]
+	if !ok {
+		return nil, status.Error(codes.InvalidArgument, "publishContext must contain mounter pod namespace")
+	}
+	if podNamespace == "" {
+		return nil, status.Error(codes.InvalidArgument, "mounter pod namespace in publishContext cannot be empty")
+	}
+
 	// Acquire a lock on the staging path.
 	if acquired := s.volumeLocks.TryAcquire(stagingPath); !acquired {
 		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, stagingPath)
 	}
 	defer s.volumeLocks.Release(stagingPath)
 
+	resp, err := s.executeNodeStageVolume(ctx, req)
+
+	if err != nil {
+		klog.Errorf("NodeStageVolume failed on staging path %q for volume %q: %v)", stagingPath, volumeID, err)
+	}
+
+	return resp, err
+}
+
+func (s *nodeServer) executeNodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
+	clientset := s.driver.config.K8sClients
+	stagingPath := req.GetStagingTargetPath()
+
+	// Validate staging path and mounter pod information from the request.
+	publishContext := req.GetPublishContext()
+	podName := publishContext[PublishContextKeyMounterPodName]
+	podNamespace := publishContext[PublishContextKeyMounterPodNamespace]
+
+	klog.Infof("Executing NodeStageVolume. Mounter pod: %s/%s, node: %q, volume: %q, staging path: %q", podNamespace, podName, s.driver.config.NodeID, req.GetVolumeId(), stagingPath)
+
+	// Verify mounter pod exists.
+	pod, err := clientset.GetPod(podNamespace, podName)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, status.Errorf(codes.FailedPrecondition, "mounter pod %s/%s expected to exist but was not found", podNamespace, podName)
+		}
+		return nil, status.Errorf(codes.Internal, "failed to get mounter pod %s/%s: %v", podNamespace, podName, err)
+	}
+	if pod == nil {
+		return nil, status.Errorf(codes.Internal, "mounter pod %s/%s can't be nil", podNamespace, podName)
+	}
+
+	// Make the staging path.
+	klog.Infof("NodeStageVolume attempting mkdir for staging path %q", stagingPath)
+	if err := os.MkdirAll(stagingPath, 0750); err != nil {
+		return nil, status.Errorf(codes.Internal, "mkdir failed for path %q: %v", stagingPath, err)
+	}
+
+	// TODO(FUECHR) Add empty dir creation flow.
+	// TODO(FUECHR) Wait for mounter pod running flow.
+	// TODO(FUECHR) Add start gcsfuse flow.
+	klog.Infof("Mounter pod %s/%s is running and staging path %s is mounted", podNamespace, podName, stagingPath)
+
+	klog.Infof("NodeStageVolume succeeded on staging path %q for volume %q", stagingPath, req.GetVolumeId())
 	return &csi.NodeStageVolumeResponse{}, nil
 }

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -650,14 +650,14 @@ func (s *nodeServer) countGcsFuseVolumes(pod *corev1.Pod) (int, error) {
 func (s *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
 	// Validate arguments.
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "Request cannot be nil")
+		return nil, status.Error(codes.InvalidArgument, "NodeStageVolume Request cannot be nil")
 	}
 	volumeID := req.GetVolumeId()
 	if len(volumeID) == 0 {
-		return nil, status.Error(codes.InvalidArgument, "Volume ID must be provided")
+		return nil, status.Error(codes.InvalidArgument, "NodeStageVolume Volume ID must be provided")
 	}
 	if req.GetVolumeCapability() == nil {
-		return nil, status.Error(codes.InvalidArgument, "Volume capability must be provided")
+		return nil, status.Error(codes.InvalidArgument, "NodeStageVolume Volume capability must be provided")
 	}
 	if err := s.driver.validateVolumeCapabilities([]*csi.VolumeCapability{req.GetVolumeCapability()}); err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -37,6 +37,9 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	mount "k8s.io/mount-utils"
 )
 
@@ -58,7 +61,23 @@ type nodeServerTestEnv struct {
 func initTestNodeServer(t *testing.T) *nodeServerTestEnv {
 	t.Helper()
 	mounter := mount.NewFakeMounter([]mount.MountPoint{})
-	driver := initTestDriver(t, mounter, clientset.NewFakeClientset())
+	podName := createMounterPodName("test-node", testVolumeID)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: "test-ns",
+		},
+	}
+	fakeClient := clientset.NewFakeClientset(pod)
+	fakeClient.CreatePV(clientset.FakePVConfig{
+		Name:         "test-pv",
+		VolumeHandle: testVolumeID,
+		ClaimRef: &corev1.ObjectReference{
+			Namespace: "test-ns",
+			Name:      "test-pvc",
+		},
+	})
+	driver := initTestDriver(t, mounter, fakeClient)
 	s, _ := driver.config.StorageServiceManager.SetupService(context.TODO(), nil, "")
 	if _, err := s.CreateBucket(context.Background(), &storage.ServiceBucket{Name: testVolumeID}); err != nil {
 		t.Fatalf("failed to create the fake bucket: %v", err)
@@ -201,6 +220,126 @@ func TestNodePublishVolume(t *testing.T) {
 				t.Errorf("got error %q, expected error %q", err, test.expectErr)
 			}
 			validateMountPoint(t, testEnv.fm, test.expectedMount, nil)
+		})
+	}
+}
+
+func TestExecuteNodeStageVolume(t *testing.T) {
+	t.Parallel()
+
+	stagingPath, cleanup := setupMountTarget(t)
+	defer cleanup()
+
+	nodeID := "test-node" // default from initTestDriver
+	volID := testVolumeID
+	podNamespace := "test-ns"
+	podName := createMounterPodName(nodeID, volID)
+
+	cases := []struct {
+		name      string
+		req       *csi.NodeStageVolumeRequest
+		mounts    []mount.MountPoint
+		podExists bool
+		expectErr error
+	}{
+		{
+			name: "mounter pod does not exist - should return FailedPrecondition error",
+			req: &csi.NodeStageVolumeRequest{
+				VolumeId:          volID,
+				StagingTargetPath: stagingPath,
+				PublishContext: map[string]string{
+					PublishContextKeyMounterPodNamespace: podNamespace,
+					PublishContextKeyMounterPodName:      podName,
+				},
+			},
+			podExists: false,
+			expectErr: status.Errorf(codes.FailedPrecondition, "mounter pod %s/%s expected to exist but was not found", podNamespace, podName),
+		},
+		{
+			name: "mounter pod exists, not mounted - should return success",
+			req: &csi.NodeStageVolumeRequest{
+				VolumeId:          volID,
+				StagingTargetPath: stagingPath,
+				PublishContext: map[string]string{
+					PublishContextKeyMounterPodNamespace: podNamespace,
+					PublishContextKeyMounterPodName:      podName,
+				},
+			},
+			podExists: true,
+			expectErr: nil,
+		},
+		{
+			name: "mounter pod exists, already mounted - should return success",
+			req: &csi.NodeStageVolumeRequest{
+				VolumeId:          volID,
+				StagingTargetPath: stagingPath,
+				PublishContext: map[string]string{
+					PublishContextKeyMounterPodNamespace: podNamespace,
+					PublishContextKeyMounterPodName:      podName,
+				},
+			},
+			mounts: []mount.MountPoint{
+				{Path: stagingPath},
+			},
+			podExists: true,
+			expectErr: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var fakeClientSet *clientset.FakeClientset
+			if tc.podExists {
+				pod := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      podName,
+						Namespace: podNamespace,
+					},
+				}
+				fakeClientSet = clientset.NewFakeClientset(pod)
+			} else {
+				fakeClientSet = clientset.NewFakeClientset()
+				fakeClientSet.GetPodErr = apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, podName)
+			}
+
+			testEnv := initTestNodeServerWithCustomClientset(t, fakeClientSet, false)
+			if tc.mounts != nil {
+				testEnv.fm.MountPoints = tc.mounts
+			}
+
+			ns, ok := testEnv.ns.(*nodeServer)
+			if !ok {
+				t.Fatalf("Failed to cast NodeServer to *nodeServer")
+			}
+
+			// Ensure the directory doesn't exist prior to the test to verify mkdir
+			if err := os.RemoveAll(tc.req.StagingTargetPath); err != nil {
+				t.Fatalf("failed to remove staging target path: %v", err)
+			}
+
+			_, err := ns.executeNodeStageVolume(context.TODO(), tc.req)
+			if tc.expectErr == nil && err != nil {
+				t.Errorf("got error %q, expected error nil", err)
+			}
+			if tc.expectErr != nil {
+				if err == nil {
+					t.Errorf("got error nil, expected error %q", tc.expectErr)
+				} else if !errors.Is(err, tc.expectErr) && err.Error() != tc.expectErr.Error() {
+					t.Errorf("got error %q, expected error %q", err, tc.expectErr)
+				}
+			}
+
+			if tc.expectErr == nil {
+				if info, err := os.Stat(tc.req.StagingTargetPath); err != nil {
+					if os.IsNotExist(err) {
+						t.Errorf("expected staging target path %q to be created, but it was not", tc.req.StagingTargetPath)
+					} else {
+						t.Errorf("failed to stat staging target path: %v", err)
+					}
+				} else if !info.IsDir() {
+					t.Errorf("expected staging target path %q to be a directory", tc.req.StagingTargetPath)
+				}
+			}
 		})
 	}
 }
@@ -637,6 +776,9 @@ func TestNodeUnpublishVolume(t *testing.T) {
 func TestNodeStageVolume(t *testing.T) {
 	t.Parallel()
 
+	stagingPath, cleanup := setupMountTarget(t)
+	defer cleanup()
+
 	cases := []struct {
 		name      string
 		req       *csi.NodeStageVolumeRequest
@@ -650,7 +792,7 @@ func TestNodeStageVolume(t *testing.T) {
 		{
 			name: "empty volume id",
 			req: &csi.NodeStageVolumeRequest{
-				StagingTargetPath: "/test/staging/path",
+				StagingTargetPath: stagingPath,
 				VolumeCapability:  testVolumeCapability,
 			},
 			expectErr: status.Error(codes.InvalidArgument, "NodeStageVolume Volume ID must be provided"),
@@ -659,7 +801,7 @@ func TestNodeStageVolume(t *testing.T) {
 			name: "missing volume capability",
 			req: &csi.NodeStageVolumeRequest{
 				VolumeId:          testVolumeID,
-				StagingTargetPath: "/test/staging/path",
+				StagingTargetPath: stagingPath,
 			},
 			expectErr: status.Error(codes.InvalidArgument, "NodeStageVolume Volume capability must be provided"),
 		},
@@ -667,7 +809,7 @@ func TestNodeStageVolume(t *testing.T) {
 			name: "invalid volume capability",
 			req: &csi.NodeStageVolumeRequest{
 				VolumeId:          testVolumeID,
-				StagingTargetPath: "/test/staging/path",
+				StagingTargetPath: stagingPath,
 				VolumeCapability: &csi.VolumeCapability{
 					AccessType: &csi.VolumeCapability_Mount{
 						Mount: &csi.VolumeCapability_MountVolume{},
@@ -691,7 +833,7 @@ func TestNodeStageVolume(t *testing.T) {
 			name: "valid request with sharedMount false",
 			req: &csi.NodeStageVolumeRequest{
 				VolumeId:          testVolumeID,
-				StagingTargetPath: "/test/staging/path",
+				StagingTargetPath: stagingPath,
 				VolumeCapability:  testVolumeCapability,
 				VolumeContext: map[string]string{
 					VolumeContextSharedNodeMount: "false",
@@ -699,13 +841,89 @@ func TestNodeStageVolume(t *testing.T) {
 			},
 		},
 		{
-			name: "valid request with sharedMount true",
+			name: "nil publish context - should return InvalidArgument error",
 			req: &csi.NodeStageVolumeRequest{
 				VolumeId:          testVolumeID,
-				StagingTargetPath: "/test/staging/path",
+				StagingTargetPath: stagingPath,
 				VolumeCapability:  testVolumeCapability,
 				VolumeContext: map[string]string{
 					VolumeContextSharedNodeMount: "true",
+				},
+				PublishContext: nil,
+			},
+			expectErr: status.Error(codes.InvalidArgument, "publishContext must be provided"),
+		},
+		{
+			name: "missing pod name in publish context - should return InvalidArgument error",
+			req: &csi.NodeStageVolumeRequest{
+				VolumeId:          testVolumeID,
+				StagingTargetPath: stagingPath,
+				VolumeCapability:  testVolumeCapability,
+				VolumeContext: map[string]string{
+					VolumeContextSharedNodeMount: "true",
+				},
+				PublishContext: map[string]string{},
+			},
+			expectErr: status.Error(codes.InvalidArgument, "publishContext must contain mounter pod name"),
+		},
+		{
+			name: "empty pod name in publish context - should return InvalidArgument error",
+			req: &csi.NodeStageVolumeRequest{
+				VolumeId:          testVolumeID,
+				StagingTargetPath: stagingPath,
+				VolumeCapability:  testVolumeCapability,
+				VolumeContext: map[string]string{
+					VolumeContextSharedNodeMount: "true",
+				},
+				PublishContext: map[string]string{
+					PublishContextKeyMounterPodName: "",
+				},
+			},
+			expectErr: status.Error(codes.InvalidArgument, "mounter pod name in publishContext cannot be empty"),
+		},
+		{
+			name: "missing pod namespace in publish context - should return InvalidArgument error",
+			req: &csi.NodeStageVolumeRequest{
+				VolumeId:          testVolumeID,
+				StagingTargetPath: stagingPath,
+				VolumeCapability:  testVolumeCapability,
+				VolumeContext: map[string]string{
+					VolumeContextSharedNodeMount: "true",
+				},
+				PublishContext: map[string]string{
+					PublishContextKeyMounterPodName: createMounterPodName("test-node", testVolumeID),
+				},
+			},
+			expectErr: status.Error(codes.InvalidArgument, "publishContext must contain mounter pod namespace"),
+		},
+		{
+			name: "empty pod namespace in publish context - should return InvalidArgument error",
+			req: &csi.NodeStageVolumeRequest{
+				VolumeId:          testVolumeID,
+				StagingTargetPath: stagingPath,
+				VolumeCapability:  testVolumeCapability,
+				VolumeContext: map[string]string{
+					VolumeContextSharedNodeMount: "true",
+				},
+				PublishContext: map[string]string{
+					PublishContextKeyMounterPodName:      createMounterPodName("test-node", testVolumeID),
+					PublishContextKeyMounterPodNamespace: "",
+				},
+			},
+			expectErr: status.Error(codes.InvalidArgument, "mounter pod namespace in publishContext cannot be empty"),
+		},
+		{
+			name: "valid request with sharedMount true",
+			req: &csi.NodeStageVolumeRequest{
+				VolumeId:          testVolumeID,
+				StagingTargetPath: stagingPath,
+				VolumeCapability:  testVolumeCapability,
+				VolumeContext: map[string]string{
+					VolumeContextSharedNodeMount: "true",
+				},
+				PublishContext: map[string]string{
+					PublishContextKeyMounterPodName:      createMounterPodName("test-node", testVolumeID),
+					PublishContextKeyMounterPodNamespace: "test-ns",
 				},
 			},
 		},

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -645,7 +645,7 @@ func TestNodeStageVolume(t *testing.T) {
 		{
 			name:      "empty request",
 			req:       nil,
-			expectErr: status.Error(codes.InvalidArgument, "Request cannot be nil"),
+			expectErr: status.Error(codes.InvalidArgument, "NodeStageVolume Request cannot be nil"),
 		},
 		{
 			name: "empty volume id",
@@ -653,7 +653,7 @@ func TestNodeStageVolume(t *testing.T) {
 				StagingTargetPath: "/test/staging/path",
 				VolumeCapability:  testVolumeCapability,
 			},
-			expectErr: status.Error(codes.InvalidArgument, "Volume ID must be provided"),
+			expectErr: status.Error(codes.InvalidArgument, "NodeStageVolume Volume ID must be provided"),
 		},
 		{
 			name: "missing volume capability",
@@ -661,7 +661,7 @@ func TestNodeStageVolume(t *testing.T) {
 				VolumeId:          testVolumeID,
 				StagingTargetPath: "/test/staging/path",
 			},
-			expectErr: status.Error(codes.InvalidArgument, "Volume capability must be provided"),
+			expectErr: status.Error(codes.InvalidArgument, "NodeStageVolume Volume capability must be provided"),
 		},
 		{
 			name: "invalid volume capability",

--- a/pkg/csi_driver/utils.go
+++ b/pkg/csi_driver/utils.go
@@ -92,6 +92,8 @@ const (
 	FlagFileForDefaultingPath              = "flags-for-defaulting"
 	GCSFuseProfileFlag                     = "profile"
 	LocalSocketAddressArg                  = "experimental-local-socket-address"
+	PublishContextKeyMounterPodName        = "mounter-pod-name"
+	PublishContextKeyMounterPodNamespace   = "mounter-pod-namespace"
 )
 
 var (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:
This is the second pr for nodestage volume it creates the skeleton NSV Execution by retrieving the mounter pod (fails if it doesn't exist), checking if the staging path is already mounted (succeeding if it is), and finally creating the staging path.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```