### PR TITLE
Automated cherry pick of #1371: cleanup gcsfuse errofile before next NPV attempt

### DIFF
--- a/cmd/sidecar_mounter/main.go
+++ b/cmd/sidecar_mounter/main.go
@@ -117,6 +117,11 @@ func main() {
 					klog.Fatalf("Failed to fetch identity pool and identity provider details required for bucket access check, got error %v", err)
 				}
 			}
+			// Clean up any errors raised until this point due to transient metadata and storage service creation issues.
+			if err := mc.ErrWriter.Clean(); err != nil {
+				klog.Warningf("failed to cleanup error file: %v", err)
+			}
+
 			if err := mounter.Mount(ctx, mc); err != nil {
 				mc.ErrWriter.WriteMsg(fmt.Sprintf("failed to mount bucket %q for volume %q: %v\n", mc.BucketName, mc.VolumeName, err))
 			}

--- a/pkg/csi_mounter/csi_mounter.go
+++ b/pkg/csi_mounter/csi_mounter.go
@@ -153,9 +153,9 @@ func (m *Mounter) Mount(source string, target string, fstype string, options []s
 		klog.Errorf("failed to get emptyDir path: %v", err)
 	}
 
-	err = util.CheckAndDeleteStaleFile(emptyDirBasePath, "/error")
+	err = util.CheckAndDeleteStaleFile(emptyDirBasePath, util.ErrorFileName)
 	if err != nil {
-		klog.Errorf("failed to check and delete stale /error file: %v", err)
+		klog.Errorf("failed to check and delete stale %s file: %v", util.ErrorFileName, err)
 	}
 
 	err = util.CheckAndDeleteStaleFile(emptyDirBasePath, util.GCSFuseKernelParamsFileName)

--- a/pkg/sidecar_mounter/logger.go
+++ b/pkg/sidecar_mounter/logger.go
@@ -28,6 +28,7 @@ import (
 type stderrWriterInterface interface {
 	io.Writer
 	WriteMsg(errMsg string)
+	Clean() error
 }
 
 type stderrWriter struct {
@@ -36,6 +37,22 @@ type stderrWriter struct {
 
 func NewErrorWriter(errorFile string) stderrWriterInterface {
 	return &stderrWriter{errorFile: errorFile}
+}
+
+func (w *stderrWriter) Clean() error {
+	if w.errorFile != "" {
+		err := os.Remove(w.errorFile)
+		if os.IsNotExist(err) {
+			// File does not exist.
+			klog.V(4).Infof("File '%s' not found. No action needed.", w.errorFile)
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("failed to clean up error file %q: %w", w.errorFile, err)
+		}
+		klog.V(4).Infof("Cleaned up error file %q", w.errorFile)
+	}
+	return nil
 }
 
 // Write writes the error message to a given local file.

--- a/pkg/sidecar_mounter/sidecar_mounter.go
+++ b/pkg/sidecar_mounter/sidecar_mounter.go
@@ -104,6 +104,12 @@ func (m *Mounter) Mount(ctx context.Context, mc *MountConfig) error {
 		}
 	}
 
+	// Clear the GCS Fuse error file after the sidecar bucket access check completes and just before the GCS Fuse mount starts.
+	// This ensures the NodePublish volume will always fail if the error persists until the GCS Fuse mount actually starts.
+	if err := mc.ErrWriter.Clean(); err != nil {
+		klog.Warningf("failed to cleanup error file: %v", err)
+	}
+
 	klog.Infof("start to mount bucket %q for volume %q", mc.BucketName, mc.VolumeName)
 
 	if err := os.MkdirAll(mc.BufferDir+TempDir, os.ModePerm); err != nil {

--- a/pkg/sidecar_mounter/sidecar_mounter_config.go
+++ b/pkg/sidecar_mounter/sidecar_mounter_config.go
@@ -125,8 +125,12 @@ func NewMountConfig(sp string, flagMapFromDriver map[string]string) *MountConfig
 		CacheDir:            filepath.Join(webhook.SidecarContainerCacheVolumeMountPath, ".volumes", volumeName),
 		TempDir:             tempDir,
 		ConfigFile:          filepath.Join(webhook.SidecarContainerTmpVolumeMountPath, ".volumes", volumeName, "config.yaml"),
-		ErrWriter:           NewErrorWriter(filepath.Join(tempDir, "error")),
+		ErrWriter:           NewErrorWriter(filepath.Join(tempDir, util.ErrorFileName)),
 		AutoGoMemLimitRatio: util.GoMemLimitCgroupPercentage,
+	}
+
+	if err := mc.ErrWriter.Clean(); err != nil {
+		klog.Warningf("failed to cleanup stale error file: %v", err)
 	}
 
 	klog.Infof("connecting to socket %q", sp)

--- a/pkg/sidecar_mounter/sidecar_mounter_config.go
+++ b/pkg/sidecar_mounter/sidecar_mounter_config.go
@@ -129,10 +129,6 @@ func NewMountConfig(sp string, flagMapFromDriver map[string]string) *MountConfig
 		AutoGoMemLimitRatio: util.GoMemLimitCgroupPercentage,
 	}
 
-	if err := mc.ErrWriter.Clean(); err != nil {
-		klog.Warningf("failed to cleanup stale error file: %v", err)
-	}
-
 	klog.Infof("connecting to socket %q", sp)
 	c, err := net.Dial("unix", sp)
 	if err != nil {

--- a/pkg/sidecar_mounter/sidecar_mounter_config_test.go
+++ b/pkg/sidecar_mounter/sidecar_mounter_config_test.go
@@ -573,17 +573,25 @@ func TestMountErrorFileCleanup(t *testing.T) {
 		t.Fatalf("failed to write error file: %v", err)
 	}
 
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	defer w.Close()
+
 	mc := &MountConfig{
-		BucketName: "test-bucket",
-		VolumeName: "test-volume",
-		TempDir:    tempDir,
-		BufferDir:  filepath.Join(tempDir, "buffer"),
-		CacheDir:   filepath.Join(tempDir, "cache"),
-		ErrWriter:  NewErrorWriter(filepath.Join(tempDir, util.ErrorFileName)),
+		BucketName:     "test-bucket",
+		VolumeName:     "test-volume",
+		TempDir:        tempDir,
+		BufferDir:      filepath.Join(tempDir, "buffer"),
+		CacheDir:       filepath.Join(tempDir, "cache"),
+		ErrWriter:      NewErrorWriter(errFilePath),
+		FileDescriptor: int(r.Fd()),
 	}
 
-	mounter := New("invalid-gcsfuse-path")
+	mounter := New("true")
 	_ = mounter.Mount(context.Background(), mc)
+	mounter.WaitGroup.Wait()
 
 	if _, err := os.Stat(errFilePath); !os.IsNotExist(err) {
 		t.Fatalf("expected error file to be deleted, but it still exists (or another error occurred: %v)", err)

--- a/pkg/sidecar_mounter/sidecar_mounter_config_test.go
+++ b/pkg/sidecar_mounter/sidecar_mounter_config_test.go
@@ -18,6 +18,7 @@ limitations under the License.
 package sidecarmounter
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -555,6 +556,37 @@ func TestPrepareMountArgs(t *testing.T) {
 				t.Errorf("Got storage endpoint %s, but expected %s", tc.mc.StorageEndpoint, tc.expectedStorageEndpoint)
 			}
 		})
+	}
+}
+
+func TestMountErrorFileCleanup(t *testing.T) {
+	t.Parallel()
+
+	tempDir, err := os.MkdirTemp("", "sidecar-mounter-test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	errFilePath := filepath.Join(tempDir, util.ErrorFileName)
+	if err := os.WriteFile(errFilePath, []byte("fake error"), 0644); err != nil {
+		t.Fatalf("failed to write error file: %v", err)
+	}
+
+	mc := &MountConfig{
+		BucketName: "test-bucket",
+		VolumeName: "test-volume",
+		TempDir:    tempDir,
+		BufferDir:  filepath.Join(tempDir, "buffer"),
+		CacheDir:   filepath.Join(tempDir, "cache"),
+		ErrWriter:  NewErrorWriter(filepath.Join(tempDir, util.ErrorFileName)),
+	}
+
+	mounter := New("invalid-gcsfuse-path")
+	_ = mounter.Mount(context.Background(), mc)
+
+	if _, err := os.Stat(errFilePath); !os.IsNotExist(err) {
+		t.Fatalf("expected error file to be deleted, but it still exists (or another error occurred: %v)", err)
 	}
 }
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -53,6 +53,7 @@ const (
 	FileCacheMediumConst                = "file-cache-medium"
 	EnableGCSFuseKernelParams           = "enable-gcsfuse-kernel-params"
 	GCSFuseKernelParamsFileName         = "kernel-params.json"
+	ErrorFileName                       = "error"
 	MediumRAM                           = "ram"
 	MediumLSSD                          = "lssd"
 	OptInHnw                            = "hnw-ksa"

--- a/test/e2e/testsuites/failed_mount.go
+++ b/test/e2e/testsuites/failed_mount.go
@@ -316,12 +316,22 @@ func (t *gcsFuseCSIFailedMountTestSuite) DefineTests(driver storageframework.Tes
 		init(configPrefix...)
 		defer cleanup()
 
-		// The test driver uses config.Prefix to pass the bucket names back to the test suite.
-		bucketName := l.config.Prefix
+		var bucketName string
+		if l.volumeResource.Pv != nil {
+			bucketName = l.volumeResource.Pv.Spec.CSI.VolumeHandle
+		} else {
+			bucketName = l.volumeResource.VolSource.CSI.VolumeAttributes["bucketName"]
+		}
+
+		volumeFolder := volumeName
+		if l.volumeResource.Pv != nil {
+			volumeFolder = l.volumeResource.Pv.Name
+		}
 
 		ginkgo.By("Configuring the pod")
 		tPod := specs.NewTestPod(f.ClientSet, f.Namespace)
 		tPod.SetupVolume(l.volumeResource, volumeName, mountPath, false)
+		tPod.SetupTmpVolumeMount("/gcsfuse-tmp")
 
 		ginkgo.By("Deploying a Kubernetes service account without access to the GCS bucket")
 		saName := "sa-without-access"
@@ -334,15 +344,13 @@ func (t *gcsFuseCSIFailedMountTestSuite) DefineTests(driver storageframework.Tes
 		defer tPod.Cleanup(ctx)
 
 		ginkgo.By("Checking that the pod has failed mount error PermissionDenied")
-		if enableSidecarBucketAccessCheck {
-			if slices.Contains(configPrefix, specs.SkipCSIBucketAccessCheckPrefix) {
-				tPod.WaitForFailedContainerError(ctx, "Error: failed to reserve container name")
-				tPod.WaitForLog(ctx, webhook.GcsFuseSidecarName, "does not have storage.objects.list access to the Google Cloud Storage bucket")
-				return
-			}
+		if enableSidecarBucketAccessCheck && slices.Contains(configPrefix, specs.SkipCSIBucketAccessCheckPrefix) {
+			tPod.WaitForFailedContainerError(ctx, "Error: failed to reserve container name")
+			tPod.WaitForLog(ctx, webhook.GcsFuseSidecarName, "does not have storage.objects.list access to the Google Cloud Storage bucket")
+		} else {
+			tPod.WaitForFailedMountError(ctx, codes.PermissionDenied.String())
+			tPod.WaitForFailedMountError(ctx, "does not have storage.objects.list access to the Google Cloud Storage bucket.")
 		}
-		tPod.WaitForFailedMountError(ctx, codes.PermissionDenied.String())
-		tPod.WaitForFailedMountError(ctx, "does not have storage.objects.list access to the Google Cloud Storage bucket.")
 
 		ginkgo.By("Setting up SA IAM policy")
 		setupIAMPolicy(bucketName, f.Namespace.Name, saName)
@@ -353,6 +361,9 @@ func (t *gcsFuseCSIFailedMountTestSuite) DefineTests(driver storageframework.Tes
 		ginkgo.By("Checking that the pod command exits with no error")
 		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("mount | grep %v | grep rw,", mountPath))
 		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("echo 'hello world' > %v/data && grep 'hello world' %v/data", mountPath, mountPath))
+
+		ginkgo.By("Checking that the error file is deleted")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("test ! -f /gcsfuse-tmp/.volumes/%v/error", volumeFolder))
 
 		ginkgo.By("Removing SA IAM policy")
 		removeIAMPolicy(bucketName, f.Namespace.Name, saName)
@@ -370,7 +381,7 @@ func (t *gcsFuseCSIFailedMountTestSuite) DefineTests(driver storageframework.Tes
 		if !enableSidecarBucketAccessCheck {
 			// We are skipping this test combination because this configuration disables bucket access checks in both the node driver and the sidecar.
 			// This prevents the system from recovering from any permission issues
-			e2eskipper.Skipf("skip permission change test for sidecar bcuekt access check not enabled and skip-csi-bucket-access-check set")
+			e2eskipper.Skipf("skip permission change test for sidecar bucket access check not enabled and skip-csi-bucket-access-check set")
 		}
 		testCasePermissionChanges(specs.SkipCSIBucketAccessCheckPrefix)
 	})


### PR DESCRIPTION
Cherry pick of #1371 on release-1.23.

#1371: cleanup gcsfuse errofile before next NPV attempt

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Removes excessive logging caused by transient Node Publish Volume failures.
```