### PR TITLE
[Shared Mount] NSV Check if staging path is already mounted

### DIFF
--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -730,6 +730,16 @@ func (s *nodeServer) executeNodeStageVolume(ctx context.Context, req *csi.NodeSt
 		return nil, status.Errorf(codes.Internal, "mounter pod %s/%s can't be nil", podNamespace, podName)
 	}
 
+	// Check if the staging path is already mounted.
+	mounted, err := s.isDirMounted(stagingPath)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to check if path %q is already mounted: %v", stagingPath, err)
+	}
+	if mounted {
+		klog.Infof("NodeStageVolume succeeded on staging path %q for volume %q, mount already exists.", stagingPath, req.GetVolumeId())
+		return &csi.NodeStageVolumeResponse{}, nil
+	}
+
 	// Make the staging path.
 	klog.Infof("NodeStageVolume attempting mkdir for staging path %q", stagingPath)
 	if err := os.MkdirAll(stagingPath, 0750); err != nil {

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -256,7 +256,7 @@ func TestExecuteNodeStageVolume(t *testing.T) {
 			expectErr: status.Errorf(codes.FailedPrecondition, "mounter pod %s/%s expected to exist but was not found", podNamespace, podName),
 		},
 		{
-			name: "mounter pod exists, not mounted - should return success",
+			name: "mounter pod exists, not already mounted - should return success",
 			req: &csi.NodeStageVolumeRequest{
 				VolumeId:          volID,
 				StagingTargetPath: stagingPath,
@@ -312,8 +312,11 @@ func TestExecuteNodeStageVolume(t *testing.T) {
 				t.Fatalf("Failed to cast NodeServer to *nodeServer")
 			}
 
-			// Ensure the directory doesn't exist prior to the test to verify mkdir
-			if err := os.RemoveAll(tc.req.StagingTargetPath); err != nil {
+			// Clear the staging path so we can check whether os.MkdirAll was called.
+			// Note: isDirMounted relies on a FakeMounter which simply reads the test case's
+			// mounts array. It doesn't check the physical file system. This allows us to
+			// delete the physical directory here without affecting the mount check.
+			if err := os.RemoveAll(stagingPath); err != nil && !os.IsNotExist(err) {
 				t.Fatalf("failed to remove staging target path: %v", err)
 			}
 
@@ -329,15 +332,18 @@ func TestExecuteNodeStageVolume(t *testing.T) {
 				}
 			}
 
-			if tc.expectErr == nil {
-				if info, err := os.Stat(tc.req.StagingTargetPath); err != nil {
-					if os.IsNotExist(err) {
-						t.Errorf("expected staging target path %q to be created, but it was not", tc.req.StagingTargetPath)
-					} else {
-						t.Errorf("failed to stat staging target path: %v", err)
-					}
-				} else if !info.IsDir() {
-					t.Errorf("expected staging target path %q to be a directory", tc.req.StagingTargetPath)
+			// Check if staging path was recreated
+			dirExists := false
+			if _, statErr := os.Stat(stagingPath); statErr == nil {
+				dirExists = true
+			}
+			isAlreadyMounted := len(tc.mounts) > 0
+			if tc.expectErr == nil && tc.podExists {
+				if isAlreadyMounted && dirExists {
+					t.Errorf("expected MkdirAll to not be called (mount already exists), but directory was created")
+				}
+				if !isAlreadyMounted && !dirExists {
+					t.Errorf("expected MkdirAll to be called, but directory was not created")
 				}
 			}
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:
Continues NSV implementation by adding check for whether the stagin path has already been mounted. Returning early if it has since there is no need to continue trying to mount.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```