### PR TITLE
Fix webhook by not setting cache-created-by-user label on pod for sha…

### DIFF
--- a/pkg/webhook/mutatingwebhook.go
+++ b/pkg/webhook/mutatingwebhook.go
@@ -140,7 +140,6 @@ func (si *SidecarInjector) Handle(ctx context.Context, req admission.Request) ad
 	// Classify Pod volumes to check if they are GCSFuse volumes and if they use shared node mount.
 	var hasSharedNodeMount bool
 	var hasStandardMount bool
-	var cacheCreatedByUser bool
 
 	for _, volume := range pod.Spec.Volumes {
 		isGcsfuse, _, volumeAttributes, pv, err := si.isGcsFuseCSIVolume(volume, pod.Namespace)
@@ -179,10 +178,6 @@ func (si *SidecarInjector) Handle(ctx context.Context, req admission.Request) ad
 					return admission.Errored(http.StatusBadRequest, fmt.Errorf("volume %q uses shared node mount but its PVC %q is missing a referenced PodTemplate annotation %q", volume.Name, pvc.Name, MounterPodTemplateAnnotation))
 				}
 
-				if volumeExists(podTemplate.Template.Spec.Volumes, SidecarContainerCacheVolumeName) {
-					cacheCreatedByUser = true
-				}
-
 				// Validate that Pod fsGroup matches the requirements of the referenced PVC PodTemplate.
 				if err := si.validateFSGroup(pod, podTemplate); err != nil {
 					klog.Errorf("fsGroup validation failed: %v", err)
@@ -208,7 +203,7 @@ func (si *SidecarInjector) Handle(ctx context.Context, req admission.Request) ad
 				return admission.Errored(http.StatusBadRequest, err)
 			}
 			if profilesEnabled {
-				if err := ModifyPodSpecForGCSFuseProfiles(pod, cacheCreatedByUser, true); err != nil {
+				if err := ModifyPodSpecForGCSFuseProfiles(pod, false, true); err != nil {
 					return admission.Errored(http.StatusBadRequest, err)
 				}
 				marshaledPod, err := json.Marshal(pod)
@@ -339,7 +334,7 @@ func (si *SidecarInjector) Handle(ctx context.Context, req admission.Request) ad
 		pod.Spec.Volumes = append(pod.Spec.Volumes, GetSATokenVolume(audience))
 	}
 
-	cacheCreatedByUser = volumeExists(pod.Spec.Volumes, SidecarContainerCacheVolumeName)
+	cacheCreatedByUser := volumeExists(pod.Spec.Volumes, SidecarContainerCacheVolumeName)
 	pod.Spec.Volumes = append(GetSidecarContainerVolumeSpec(pod.Spec.Volumes...), pod.Spec.Volumes...)
 
 	// Inject metadata prefetch sidecar.

--- a/pkg/webhook/mutatingwebhook_test.go
+++ b/pkg/webhook/mutatingwebhook_test.go
@@ -2195,36 +2195,6 @@ func TestSharedNodeMountWebhook(t *testing.T) {
 		},
 	}
 
-	podTemplateWithUserProvidedCache := &corev1.PodTemplate{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "mounter-template-user-provided-cache",
-			Namespace: "default",
-		},
-		Template: corev1.PodTemplateSpec{
-			Spec: corev1.PodSpec{
-				Volumes: []corev1.Volume{
-					{
-						Name: SidecarContainerCacheVolumeName,
-					},
-				},
-			},
-		},
-	}
-
-	sharedPVCWithProfileAndUserProvidedCache := &corev1.PersistentVolumeClaim{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "shared-pvc",
-			Namespace: "default",
-			Annotations: map[string]string{
-				MounterPodTemplateAnnotation: "mounter-template-user-provided-cache",
-			},
-		},
-		Spec: corev1.PersistentVolumeClaimSpec{
-			StorageClassName: ptr.To("shared-profile-sc"),
-			VolumeName:       "shared-pv",
-		},
-	}
-
 	sharedPVCWithAnnotation := &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "shared-pvc",
@@ -2311,15 +2281,6 @@ func TestSharedNodeMountWebhook(t *testing.T) {
 		GcsfuseProfilesManagedLabel: "true",
 	}
 	sharedOnlyPodWithProfileMutated.Spec.SchedulingGates = []corev1.PodSchedulingGate{
-		{Name: BucketScanPendingSchedulingGate},
-	}
-
-	sharedOnlyPodWithProfileAndUserProvidedCacheMutated := sharedOnlyPod.DeepCopy()
-	sharedOnlyPodWithProfileAndUserProvidedCacheMutated.Labels = map[string]string{
-		GcsfuseProfilesManagedLabel:    "true",
-		GcsfuseCacheCreatedByUserLabel: "true",
-	}
-	sharedOnlyPodWithProfileAndUserProvidedCacheMutated.Spec.SchedulingGates = []corev1.PodSchedulingGate{
 		{Name: BucketScanPendingSchedulingGate},
 	}
 
@@ -2473,14 +2434,6 @@ func TestSharedNodeMountWebhook(t *testing.T) {
 			requestObj:     sharedOnlyPod,
 			requestKind:    "Pod",
 			wantResponse:   admission.PatchResponseFromRaw(serialize(t, sharedOnlyPod), serialize(t, sharedOnlyPodWithProfileMutated)),
-			enableProfiles: true,
-		},
-		{
-			name:           "Pod using shared node mount with Profiles enabled and user provided cache volume in PodTemplate is mutated with profile label, scheduling gate, and cache-created-by-user label.",
-			objects:        []runtime.Object{sharedProfileSC, sharedPVCWithProfileAndUserProvidedCache, sharedPV, podTemplateWithUserProvidedCache},
-			requestObj:     sharedOnlyPod,
-			requestKind:    "Pod",
-			wantResponse:   admission.PatchResponseFromRaw(serialize(t, sharedOnlyPod), serialize(t, sharedOnlyPodWithProfileAndUserProvidedCacheMutated)),
 			enableProfiles: true,
 		},
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
For shared node mounts, GCSFuse cache configurations are managed at the Mounter Pod level (one per volume) rather than the user Pod level. Setting the Pod-level `gke-gcsfuse/cache-created-by-user` label on the user Pod incorrectly disables automatic cache recommendations for all other shared node mount volumes on the same Pod even those volume didn't specify custom cache.

This PR stops the mutating webhook from setting this label on the user Pod for shared node mounts. We also clean up the redundant unit test and test variables associated with it. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
None.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
