### PR TITLE
add a new test for error file cleanup check

### DIFF
--- a/test/e2e/testsuites/failed_mount.go
+++ b/test/e2e/testsuites/failed_mount.go
@@ -82,6 +82,11 @@ func (t *gcsFuseCSIFailedMountTestSuite) DefineTests(driver storageframework.Tes
 	// check from being enabled.
 	enableSidecarBucketAccessCheck = enableSidecarBucketAccessCheck && supportsNativeSidecar
 
+	testErrorLogCleanUp, err := strconv.ParseBool(os.Getenv(utils.TestWithErrorFileCleanUpEnvVar))
+	if err != nil {
+		klog.Fatalf(`env variable "%t" could not be converted to boolean`, testErrorLogCleanUp)
+	}
+
 	saVolInjectEnvVar := os.Getenv(utils.TestWithSAVolumeInjectionEnvVar)
 	supportSAVolInjection, err := strconv.ParseBool(saVolInjectEnvVar)
 	if err != nil {
@@ -323,15 +328,9 @@ func (t *gcsFuseCSIFailedMountTestSuite) DefineTests(driver storageframework.Tes
 			bucketName = l.volumeResource.VolSource.CSI.VolumeAttributes["bucketName"]
 		}
 
-		volumeFolder := volumeName
-		if l.volumeResource.Pv != nil {
-			volumeFolder = l.volumeResource.Pv.Name
-		}
-
 		ginkgo.By("Configuring the pod")
 		tPod := specs.NewTestPod(f.ClientSet, f.Namespace)
 		tPod.SetupVolume(l.volumeResource, volumeName, mountPath, false)
-		tPod.SetupTmpVolumeMount("/gcsfuse-tmp")
 
 		ginkgo.By("Deploying a Kubernetes service account without access to the GCS bucket")
 		saName := "sa-without-access"
@@ -361,9 +360,6 @@ func (t *gcsFuseCSIFailedMountTestSuite) DefineTests(driver storageframework.Tes
 		ginkgo.By("Checking that the pod command exits with no error")
 		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("mount | grep %v | grep rw,", mountPath))
 		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("echo 'hello world' > %v/data && grep 'hello world' %v/data", mountPath, mountPath))
-
-		ginkgo.By("Checking that the error file is deleted")
-		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("test ! -f /gcsfuse-tmp/.volumes/%v/error", volumeFolder))
 
 		ginkgo.By("Removing SA IAM policy")
 		removeIAMPolicy(bucketName, f.Namespace.Name, saName)
@@ -520,5 +516,73 @@ func (t *gcsFuseCSIFailedMountTestSuite) DefineTests(driver storageframework.Tes
 
 		ginkgo.By("Checking that the pod is in Unschedulable status")
 		tPod.WaitForUnschedulable(ctx)
+	})
+
+	testCaseErrorFileCleanUp := func(configPrefix ...string) {
+		init(configPrefix...)
+		defer cleanup()
+
+		var bucketName string
+		if l.volumeResource.Pv != nil {
+			bucketName = l.volumeResource.Pv.Spec.CSI.VolumeHandle
+		} else {
+			bucketName = l.volumeResource.VolSource.CSI.VolumeAttributes["bucketName"]
+		}
+
+		volumeFolder := volumeName
+		if l.volumeResource.Pv != nil {
+			volumeFolder = l.volumeResource.Pv.Name
+		}
+
+		ginkgo.By("Configuring the pod")
+		tPod := specs.NewTestPod(f.ClientSet, f.Namespace)
+		tPod.SetupVolume(l.volumeResource, volumeName, mountPath, false)
+		tPod.SetupTmpVolumeMount("/gcsfuse-tmp")
+
+		ginkgo.By("Deploying a Kubernetes service account without access to the GCS bucket")
+		saName := "sa-without-access"
+		testK8sSA := utils.NewTestKubernetesServiceAccount(f.ClientSet, f.Namespace, saName, "")
+		testK8sSA.Create(ctx)
+		tPod.SetServiceAccount(saName)
+
+		ginkgo.By("Deploying the pod")
+		tPod.Create(ctx)
+		defer tPod.Cleanup(ctx)
+
+		ginkgo.By("Checking that the pod has failed mount error PermissionDenied")
+		if enableSidecarBucketAccessCheck && slices.Contains(configPrefix, specs.SkipCSIBucketAccessCheckPrefix) {
+			tPod.WaitForFailedContainerError(ctx, "Error: failed to reserve container name")
+			tPod.WaitForLog(ctx, webhook.GcsFuseSidecarName, "does not have storage.objects.list access to the Google Cloud Storage bucket")
+		} else {
+			tPod.WaitForFailedMountError(ctx, codes.PermissionDenied.String())
+			tPod.WaitForFailedMountError(ctx, "does not have storage.objects.list access to the Google Cloud Storage bucket.")
+		}
+
+		ginkgo.By("Setting up SA IAM policy")
+		setupIAMPolicy(bucketName, f.Namespace.Name, saName)
+
+		ginkgo.By("Checking that the pod is running")
+		tPod.WaitForRunning(ctx)
+
+		ginkgo.By("Checking that the pod command exits with no error")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("mount | grep %v | grep rw,", mountPath))
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("echo 'hello world' > %v/data && grep 'hello world' %v/data", mountPath, mountPath))
+
+		ginkgo.By("Checking that the error file is deleted")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("test ! -f /gcsfuse-tmp/.volumes/%v/error", volumeFolder))
+	}
+
+	// Only test the error file cleanup when node bucket access check is skipped, since otherwise it will fail in node and the sidecar will not create the error file.
+	ginkgo.It("[skip-csi-bucket-access-check] should clean up error file", func() {
+		if !enableSidecarBucketAccessCheck {
+			// We are skipping this test combination because this configuration disables bucket access checks in both the node driver and the sidecar.
+			// This prevents the system from recovering from any permission issues
+			e2eskipper.Skipf("skip permission change test for sidecar bucket access check not enabled and skip-csi-bucket-access-check set")
+		}
+		if !testErrorLogCleanUp {
+			// We are skipping this test combination because the driver version does not support error file cleanup, which is required for this test case.
+			e2eskipper.Skipf("skip error file cleanup test for driver versions that do not support this feature")
+		}
+		testCaseErrorFileCleanUp(specs.SkipCSIBucketAccessCheckPrefix)
 	})
 }

--- a/test/e2e/testsuites/failed_mount.go
+++ b/test/e2e/testsuites/failed_mount.go
@@ -70,11 +70,11 @@ func (t *gcsFuseCSIFailedMountTestSuite) DefineTests(driver storageframework.Tes
 	nativeSidecarEnvVar := os.Getenv(utils.TestWithNativeSidecarEnvVar)
 	supportsNativeSidecar, err := strconv.ParseBool(nativeSidecarEnvVar)
 	if err != nil {
-		klog.Fatalf(`env variable "%s" could not be converted to boolean`, nativeSidecarEnvVar)
+		klog.Fatalf(`env variable "%s" could not be converted to boolean`, utils.TestWithNativeSidecarEnvVar)
 	}
 	enableSidecarBucketAccessCheck, err := strconv.ParseBool(os.Getenv(utils.TestWithSidecarBucketAccessCheckEnvVar))
 	if err != nil {
-		klog.Fatalf(`env variable "%t" could not be converted to boolean`, enableSidecarBucketAccessCheck)
+		klog.Fatalf(`env variable "%s" could not be converted to boolean`, utils.TestWithSidecarBucketAccessCheckEnvVar)
 	}
 	// In 1.28 (non native sidecar), when the sidecar is injected as a main
 	// container, the gcsFuseSidecarContainerImage always returns "". This
@@ -84,13 +84,13 @@ func (t *gcsFuseCSIFailedMountTestSuite) DefineTests(driver storageframework.Tes
 
 	testErrorLogCleanUp, err := strconv.ParseBool(os.Getenv(utils.TestWithErrorFileCleanUpEnvVar))
 	if err != nil {
-		klog.Fatalf(`env variable "%t" could not be converted to boolean`, testErrorLogCleanUp)
+		klog.Fatalf(`env variable "%s" could not be converted to boolean`, utils.TestWithErrorFileCleanUpEnvVar)
 	}
 
 	saVolInjectEnvVar := os.Getenv(utils.TestWithSAVolumeInjectionEnvVar)
 	supportSAVolInjection, err := strconv.ParseBool(saVolInjectEnvVar)
 	if err != nil {
-		klog.Fatalf(`env variable "%s" could not be converted to boolean`, saVolInjectEnvVar)
+		klog.Fatalf(`env variable "%s" could not be converted to boolean`, utils.TestWithSAVolumeInjectionEnvVar)
 	}
 
 	type local struct {

--- a/test/e2e/utils/cluster.go
+++ b/test/e2e/utils/cluster.go
@@ -41,6 +41,7 @@ var (
 	sidecarBucketAccessCheckMinimumVersion      = version.MustParseGeneric("1.34.1")
 	gcsfuseProfilesMinimumVersion               = version.MustParseGeneric("1.35.1")
 	cloudProfilerMinimumVersion                 = version.MustParseGeneric("1.36.1")
+	errorFileCleanUpMinimumVersion              = version.MustParseGeneric("1.99.99") // Update once the driver is released with the error file cleanup feature
 )
 
 // gcloudCommand constructs an exec.Cmd for a gcloud command,

--- a/test/e2e/utils/handler.go
+++ b/test/e2e/utils/handler.go
@@ -93,6 +93,7 @@ const (
 	TestWithNativeSidecarEnvVar            = "TEST_WITH_NATIVE_SIDECAR"
 	TestWithSAVolumeInjectionEnvVar        = "TEST_WITH_SA_VOL_INJECTION"
 	TestWithSidecarBucketAccessCheckEnvVar = "TEST_WITH_SIDECAR_BUCKET_ACCESS_CHECK"
+	TestWithErrorFileCleanUpEnvVar         = "TEST_WITH_ERROR_FILE_CLEAN_UP"
 	ClusterNameEnvVar                      = "CLUSTER_NAME"
 	ClusterLocationEnvVar                  = "CLUSTER_LOCATION"
 	ProjectEnvVar                          = "PROJECT"
@@ -271,6 +272,16 @@ func Handle(testParams *TestParameters) error {
 
 	if err = os.Setenv(TestWithSidecarBucketAccessCheckEnvVar, strconv.FormatBool(supportSidecarBucketAccessCheck && testParams.EnableSidecarBucketAccessCheck)); err != nil {
 		klog.Fatalf(`env variable "%s" could not be set: %v`, TestWithSidecarBucketAccessCheckEnvVar, err)
+	}
+
+	supportErrorFileCleanUpMinVersionSatisfied, err := ClusterAtLeastMinVersion(testParams.GkeClusterVersion, "" /*CSI version depends on the master version only*/, errorFileCleanUpMinimumVersion)
+	if err != nil {
+		klog.Fatalf(`managed driver version for error file cleanup support could not be determined: %v`, err)
+	}
+	supportErrorFileCleanUp := !testParams.UseGKEManagedDriver || (testParams.UseGKEManagedDriver && supportErrorFileCleanUpMinVersionSatisfied)
+
+	if err = os.Setenv(TestWithErrorFileCleanUpEnvVar, strconv.FormatBool(supportErrorFileCleanUp)); err != nil {
+		klog.Fatalf(`env variable "%s" could not be set: %v`, TestWithErrorFileCleanUpEnvVar, err)
 	}
 
 	supportsMachineTypeAutoConfig, err := ClusterAtLeastMinVersion(testParams.GkeClusterVersion, testParams.GkeNodeVersion, supportsMachineTypeAutoConfigMinimumVersion)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation

 /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
#1371 updated a test case in failedMount testsuite that is causing failures on managed testgrid as the test case specific change is not yet released in the managed driver. This PR creates a new test case for the new logic change for error file clean up and reverts the existing test to it's original intent
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
* Managed driver: 1.35 GKE version
```
make e2e-test E2E_TEST_USE_GKE_MANAGED_DRIVER=true E2E_TEST_FOCUS="failedMount.*"

// Skips the test as expected
 S [SKIPPED] [0.468 seconds]
  E2E Test Suite [Driver: gcsfuse.csi.storage.gke.io] [Testpattern: CSI Ephemeral-volume (default fs)] failedMount [It] [skip-csi-bucket-access-check] should clean up error file

S [SKIPPED] [0.967 seconds]
  E2E Test Suite [Driver: gcsfuse.csi.storage.gke.io] [Testpattern: Pre-provisioned PV (default fs)] failedMount [It] [skip-csi-bucket-access-check] should clean up error file

  [ReportAfterSuite] PASSED [0.050 seconds]
  [ReportAfterSuite] Autogenerated ReportAfterSuite for --junit-report
  autogenerated by Ginkgo
  ------------------------------

  Ran 35 of 499 Specs in 205.684 seconds
  SUCCESS! -- 35 Passed | 0 Failed | 0 Pending | 464 Skipped
```
* Unmanaged driver:
New test
```
 make e2e-test E2E_TEST_USE_GKE_MANAGED_DRIVER=false    STAGINGVERSION=$STAGINGVERSION  REGISTRY=$REGISTRY E2E_TEST_FOCUS="should.clean.up.error.file.*"

  • [176.585 seconds]
  E2E Test Suite [Driver: gcsfuse.csi.storage.gke.io] [Testpattern: CSI Ephemeral-volume (default fs)] failedMount [skip-csi-bucket-access-check] should clean up error file
  • [193.874 seconds]
  E2E Test Suite [Driver: gcsfuse.csi.storage.gke.io] [Testpattern: Pre-provisioned PV (default fs)] failedMount [skip-csi-bucket-access-check] should clean up error file
  ------------------------------
  [ReportAfterSuite] PASSED [0.051 seconds]
  [ReportAfterSuite] Autogenerated ReportAfterSuite for --junit-report
  autogenerated by Ginkgo
  ------------------------------

  Ran 2 of 595 Specs in 193.975 seconds
  SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 593 Skipped
```

Old service account permission changes test
```
make e2e-test E2E_TEST_USE_GKE_MANAGED_DRIVER=false    STAGINGVERSION=$STAGINGVERSION  REGISTRY=$REGISTRY E2E_TEST_FOCUS="respond.to.service*"


  Will run 4 of 595 specs
 • [173.598 seconds]
  E2E Test Suite [Driver: gcsfuse.csi.storage.gke.io] [Testpattern: CSI Ephemeral-volume (default fs)] failedMount should respond to service account permission changes

 E2E Test Suite [Driver: gcsfuse.csi.storage.gke.io] [Testpattern: Pre-provisioned PV (default fs)] failedMount should respond to service account permission changes

• [345.119 seconds]
  E2E Test Suite [Driver: gcsfuse.csi.storage.gke.io] [Testpattern: CSI Ephemeral-volume (default fs)] failedMount [skip-csi-bucket-access-check] should respond to service account permission changes

 • [357.351 seconds]
  E2E Test Suite [Driver: gcsfuse.csi.storage.gke.io] [Testpattern: Pre-provisioned PV (default fs)] failedMount [skip-csi-bucket-access-check] should respond to service account permission changes

 [ReportAfterSuite] PASSED [0.048 seconds]
  [ReportAfterSuite] Autogenerated ReportAfterSuite for --junit-report
  autogenerated by Ginkgo
  ------------------------------

  Ran 4 of 595 Specs in 357.599 seconds
  SUCCESS! -- 4 Passed | 0 Failed | 0 Pending | 591 Skipped


  Ginkgo ran 1 suite in 6m6.812085994s
  Test Suite Passed

```
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```