### PR TITLE
[Shared Mount] NSV - Prepare Empty Dir for staging path

### DIFF
--- a/pkg/csi_driver/controller_test.go
+++ b/pkg/csi_driver/controller_test.go
@@ -43,6 +43,7 @@ const (
 	testPVC       = "test-pvc"
 	testNamespace = "test-namespace"
 	testPod       = "test-pod"
+	testPodUID    = "test-pod-uid"
 	testImage     = "k8s.gcr.io/pause"
 )
 

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -662,10 +662,15 @@ func (s *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolu
 	if err := s.driver.validateVolumeCapabilities([]*csi.VolumeCapability{req.GetVolumeCapability()}); err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
+	// Validate the staging path.
 	stagingPath := req.GetStagingTargetPath()
 	if len(stagingPath) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "NodeStageVolume Staging Target Path must be provided")
 	}
+	if matched := util.StagingPathRegexp.FindStringSubmatch(stagingPath); len(matched) < 2 {
+		return nil, status.Errorf(codes.InvalidArgument, "NodeStageVolume Staging Target Path %v does not contain volume information", stagingPath)
+	}
+
 	// Skip NodeStageVolume for sidecar mounted volumes.
 	if !sharedMount(req.GetVolumeContext()) {
 		return &csi.NodeStageVolumeResponse{}, nil
@@ -743,11 +748,16 @@ func (s *nodeServer) executeNodeStageVolume(ctx context.Context, req *csi.NodeSt
 	// Make the staging path.
 	klog.Infof("NodeStageVolume attempting mkdir for staging path %q", stagingPath)
 	if err := os.MkdirAll(stagingPath, 0750); err != nil {
-		return nil, status.Errorf(codes.Internal, "mkdir failed for path %q: %v", stagingPath, err)
+		return nil, status.Errorf(codes.Internal, "mkdir failed for staging path %q: %v", stagingPath, err)
 	}
 
-	// TODO(FUECHR) Add empty dir creation flow.
-	// TODO(FUECHR) Wait for mounter pod running flow.
+	// Create mounter pod's emptyDir in the tmp volume.
+	emptyDirPath := util.MounterPodEmptyDirPath(stagingPath, string(pod.UID))
+	klog.Infof("NodeStageVolume attempting mkdir for emptyDir path %q", emptyDirPath)
+	if err := os.MkdirAll(emptyDirPath, 0750); err != nil {
+		return nil, status.Errorf(codes.Internal, "mkdir failed for emptyDir path %q: %v", emptyDirPath, err)
+	}
+	// TODO(FUECHR) Wait for the mounter pod to be ready.
 	// TODO(FUECHR) Add start gcsfuse flow.
 	klog.Infof("Mounter pod %s/%s is running and staging path %s is mounted", podNamespace, podName, stagingPath)
 

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -40,8 +40,11 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog/v2"
 	mount "k8s.io/mount-utils"
 )
+
+const testStagingPathStr = "/var/lib/kubelet/plugins/kubernetes.io/csi/gcsfuse.csi.storage.gke.io/test-volume-id/globalmount"
 
 var testVolumeCapability = &csi.VolumeCapability{
 	AccessType: &csi.VolumeCapability_Mount{
@@ -123,6 +126,20 @@ func setupMountTarget(t *testing.T) (string, func()) {
 		t.Fatalf("failed to setup target path: %v", err)
 	}
 	return testTargetPath, func() { defer os.RemoveAll(base) }
+}
+
+func setupTestDir(t *testing.T, path string) (string, func()) {
+	// Create a temporary directory for the test
+	tempDir := t.TempDir()
+	// Append the full path
+	fullPath := filepath.Join(tempDir, path)
+	// Create the directory path (including any parent directories)
+	err := os.MkdirAll(fullPath, 0755)
+	if err != nil {
+		t.Fatalf("failed to create path: %v", err)
+	}
+	klog.Infof("Created test path %q", fullPath)
+	return fullPath, func() { defer os.RemoveAll(tempDir) }
 }
 
 func TestNodePublishVolume(t *testing.T) {
@@ -227,7 +244,8 @@ func TestNodePublishVolume(t *testing.T) {
 func TestExecuteNodeStageVolume(t *testing.T) {
 	t.Parallel()
 
-	stagingPath, cleanup := setupMountTarget(t)
+	// Setup the staging path for the test.
+	stagingPath, cleanup := setupTestDir(t, testStagingPathStr)
 	defer cleanup()
 
 	nodeID := "test-node" // default from initTestDriver
@@ -297,6 +315,10 @@ func TestExecuteNodeStageVolume(t *testing.T) {
 					},
 				}
 				fakeClientSet = clientset.NewFakeClientset(pod)
+
+				// fakeClientset always overrides the pod uid to nil, so we need to set it manually.
+				pod, _ = fakeClientSet.GetPod(podNamespace, podName)
+				pod.UID = testPodUID
 			} else {
 				fakeClientSet = clientset.NewFakeClientset()
 				fakeClientSet.GetPodErr = apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, podName)
@@ -312,38 +334,26 @@ func TestExecuteNodeStageVolume(t *testing.T) {
 				t.Fatalf("Failed to cast NodeServer to *nodeServer")
 			}
 
-			// Clear the staging path so we can check whether os.MkdirAll was called.
-			// Note: isDirMounted relies on a FakeMounter which simply reads the test case's
-			// mounts array. It doesn't check the physical file system. This allows us to
-			// delete the physical directory here without affecting the mount check.
-			if err := os.RemoveAll(stagingPath); err != nil && !os.IsNotExist(err) {
-				t.Fatalf("failed to remove staging target path: %v", err)
-			}
-
 			_, err := ns.executeNodeStageVolume(context.TODO(), tc.req)
-			if tc.expectErr == nil && err != nil {
-				t.Errorf("got error %q, expected error nil", err)
+			if tc.expectErr == nil {
+				if err != nil {
+					t.Errorf("got error %q, expected error nil", err)
+				}
+				if tc.podExists {
+					if _, err := os.Stat(stagingPath); os.IsNotExist(err) {
+						t.Errorf("expected stagingPath %q to be created, but it was not", stagingPath)
+					}
+					expectedEmptyDirPath := util.MounterPodEmptyDirPath(stagingPath, testPodUID)
+					if _, err := os.Stat(expectedEmptyDirPath); os.IsNotExist(err) {
+						t.Errorf("expected emptyDirPath %q to be created, but it was not", expectedEmptyDirPath)
+					}
+				}
 			}
 			if tc.expectErr != nil {
 				if err == nil {
 					t.Errorf("got error nil, expected error %q", tc.expectErr)
 				} else if !errors.Is(err, tc.expectErr) && err.Error() != tc.expectErr.Error() {
 					t.Errorf("got error %q, expected error %q", err, tc.expectErr)
-				}
-			}
-
-			// Check if staging path was recreated
-			dirExists := false
-			if _, statErr := os.Stat(stagingPath); statErr == nil {
-				dirExists = true
-			}
-			isAlreadyMounted := len(tc.mounts) > 0
-			if tc.expectErr == nil && tc.podExists {
-				if isAlreadyMounted && dirExists {
-					t.Errorf("expected MkdirAll to not be called (mount already exists), but directory was created")
-				}
-				if !isAlreadyMounted && !dirExists {
-					t.Errorf("expected MkdirAll to be called, but directory was not created")
 				}
 			}
 		})
@@ -782,7 +792,8 @@ func TestNodeUnpublishVolume(t *testing.T) {
 func TestNodeStageVolume(t *testing.T) {
 	t.Parallel()
 
-	stagingPath, cleanup := setupMountTarget(t)
+	// Setup the staging path for the test.
+	stagingPath, cleanup := setupTestDir(t, testStagingPathStr)
 	defer cleanup()
 
 	cases := []struct {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -76,10 +76,13 @@ const (
 )
 
 var (
-	volumeIDRegEx            = regexp.MustCompile(`:.*$`)
-	targetPathRegexp         = regexp.MustCompile(`/var/lib/kubelet/pods/(.*)/volumes/kubernetes\.io~csi/(.*)/mount`)
-	emptyReplacementRegexp   = regexp.MustCompile(`kubernetes\.io~csi/(.*)/mount`)
-	gkeIdentityProviderRegex = regexp.MustCompile(
+	volumeIDRegEx          = regexp.MustCompile(`:.*$`)
+	targetPathRegexp       = regexp.MustCompile(`/var/lib/kubelet/pods/(.*)/volumes/kubernetes\.io~csi/(.*)/mount`)
+	emptyReplacementRegexp = regexp.MustCompile(`kubernetes\.io~csi/(.*)/mount`)
+	StagingPathRegexp      = regexp.MustCompile(`/var/lib/kubelet/plugins/kubernetes\.io/csi/gcsfuse\.csi\.storage\.gke\.io/(.*)/globalmount`)
+	// Used to allow tests to create directories in test root dirs since they do not have permissions to create directories in /var/lib/kubelet
+	stagingPathEmptyReplacementRegexp = regexp.MustCompile(`plugins/kubernetes\.io/csi/gcsfuse\.csi\.storage\.gke\.io/(.*)/globalmount`)
+	gkeIdentityProviderRegex          = regexp.MustCompile(
 		`^https://(?:[a-z0-9-]+-)?container(?:\.sandbox)?\.googleapis\.com/v1/projects/[^/]+/locations/[^/]+/clusters/[^/]+$`,
 	)
 )
@@ -180,6 +183,11 @@ func ParsePodIDVolumeFromTargetpath(targetPath string) (string, string, error) {
 	volume := matched[2]
 
 	return podID, volume, nil
+}
+
+// MounterPodEmptyDirPath constructs the path for the empty directory of a given pod.
+func MounterPodEmptyDirPath(stagingPath string, podUID string) string {
+	return stagingPathEmptyReplacementRegexp.ReplaceAllString(stagingPath, fmt.Sprintf("pods/%s/volumes/kubernetes.io~empty-dir/%v", podUID, SidecarContainerTmpVolumeName))
 }
 
 func PrepareEmptyDir(targetPath string, createEmptyDir bool) (string, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:
This PR adds logic to create an empty dir for the mounter pod in its tmp volume. Additionally we now verify that the volume details are passed in the staging path during NSV validation. Unit tests verify that the empty dir was created if expected and not created if the staging path was already mounted.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```