### PR TITLE
Validate serviceAccountName in mutating webhook for shared node mount

### DIFF
--- a/pkg/webhook/mutatingwebhook.go
+++ b/pkg/webhook/mutatingwebhook.go
@@ -188,6 +188,12 @@ func (si *SidecarInjector) Handle(ctx context.Context, req admission.Request) ad
 					klog.Errorf("fsGroup validation failed: %v", err)
 					return admission.Errored(http.StatusBadRequest, err)
 				}
+
+				// Validate that Pod serviceAccountName matches the requirements of the referenced PVC PodTemplate.
+				if err := si.validateServiceAccountName(pod, podTemplate); err != nil {
+					klog.Errorf("serviceAccountName validation failed: %v", err)
+					return admission.Errored(http.StatusBadRequest, err)
+				}
 			}
 		} else {
 			hasStandardMount = true
@@ -713,6 +719,24 @@ func (si *SidecarInjector) validateFSGroup(pod *corev1.Pod, podTemplate *corev1.
 
 	if podHasFSGroup {
 		return fmt.Errorf("Pod has fsGroup set, but volume's PodTemplate %q does not specify one (not allowed for shared node mount)", templateName)
+	}
+
+	return nil
+}
+
+// validateServiceAccountName checks if the Pod's serviceAccountName matches the one specified in the volume's referenced mounter PodTemplate.
+func (si *SidecarInjector) validateServiceAccountName(pod *corev1.Pod, podTemplate *corev1.PodTemplate) error {
+	templateSA := podTemplate.Template.Spec.ServiceAccountName
+	if templateSA == "" {
+		templateSA = "default"
+	}
+	podSA := pod.Spec.ServiceAccountName
+	if podSA == "" {
+		podSA = "default"
+	}
+
+	if templateSA != podSA {
+		return fmt.Errorf("Pod serviceAccountName %q does not match the one specified in volume's PodTemplate %q (%q)", podSA, podTemplate.Name, templateSA)
 	}
 
 	return nil

--- a/pkg/webhook/mutatingwebhook_test.go
+++ b/pkg/webhook/mutatingwebhook_test.go
@@ -2396,6 +2396,67 @@ func TestSharedNodeMountWebhook(t *testing.T) {
 		},
 	}
 
+	podMismatchSA := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "workload-pod-mismatch-sa", Namespace: "default"},
+		Spec: corev1.PodSpec{
+			ServiceAccountName: "wrong-sa",
+			Volumes: []corev1.Volume{
+				{Name: "shared-vol", VolumeSource: corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "shared-pvc"}}},
+			},
+		},
+	}
+
+	podMatchSA := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "workload-pod-match-sa", Namespace: "default"},
+		Spec: corev1.PodSpec{
+			ServiceAccountName: "mounter-sa",
+			Volumes: []corev1.Volume{
+				{Name: "shared-vol", VolumeSource: corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "shared-pvc"}}},
+			},
+		},
+	}
+
+	podMissingSA := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "workload-pod-missing-sa", Namespace: "default"},
+		Spec: corev1.PodSpec{
+			ServiceAccountName: "",
+			Volumes: []corev1.Volume{
+				{Name: "shared-vol", VolumeSource: corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "shared-pvc"}}},
+			},
+		},
+	}
+
+	podDefaultSA := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "workload-pod-default-sa", Namespace: "default"},
+		Spec: corev1.PodSpec{
+			ServiceAccountName: "default",
+			Volumes: []corev1.Volume{
+				{Name: "shared-vol", VolumeSource: corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "shared-pvc"}}},
+			},
+		},
+	}
+
+	templateWithSA := &corev1.PodTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "mounter-template", Namespace: "default"},
+		Template: corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{ServiceAccountName: "mounter-sa"},
+		},
+	}
+
+	templateDefaultSA := &corev1.PodTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "mounter-template", Namespace: "default"},
+		Template: corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{ServiceAccountName: "default"},
+		},
+	}
+
+	templateMissingSA := &corev1.PodTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "mounter-template", Namespace: "default"},
+		Template: corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{ServiceAccountName: ""},
+		},
+	}
+
 	testCases := []struct {
 		name           string
 		objects        []runtime.Object
@@ -2464,6 +2525,48 @@ func TestSharedNodeMountWebhook(t *testing.T) {
 			name:         "Pod is allowed if neither the Pod nor the volume's PodTemplate specify an fsGroup.",
 			objects:      []runtime.Object{sharedPV, sharedPVCWithAnnotation, podTemplateNoFSGroup},
 			requestObj:   workloadPodNoFSGroup,
+			requestKind:  "Pod",
+			wantResponse: admission.Allowed("No sidecar injection required for shared node mount mode."),
+		},
+		{
+			name:         "Pod is rejected if its serviceAccountName does not match the volume's PodTemplate serviceAccountName.",
+			objects:      []runtime.Object{sharedPV, sharedPVCWithAnnotation, templateWithSA},
+			requestObj:   podMismatchSA,
+			requestKind:  "Pod",
+			wantResponse: admission.Errored(http.StatusBadRequest, fmt.Errorf("Pod serviceAccountName %q does not match the one specified in volume's PodTemplate %q (%q)", "wrong-sa", "mounter-template", "mounter-sa")),
+		},
+		{
+			name:         "Pod is allowed if its serviceAccountName matches the volume's PodTemplate serviceAccountName.",
+			objects:      []runtime.Object{sharedPV, sharedPVCWithAnnotation, templateWithSA},
+			requestObj:   podMatchSA,
+			requestKind:  "Pod",
+			wantResponse: admission.Allowed("No sidecar injection required for shared node mount mode."),
+		},
+		{
+			name:         "Pod is allowed if both the Pod and the volume's PodTemplate leave serviceAccountName blank.",
+			objects:      []runtime.Object{sharedPV, sharedPVCWithAnnotation, templateMissingSA},
+			requestObj:   podMissingSA,
+			requestKind:  "Pod",
+			wantResponse: admission.Allowed("No sidecar injection required for shared node mount mode."),
+		},
+		{
+			name:         "Pod is allowed if Pod specifies default and the volume's PodTemplate leaves serviceAccountName blank.",
+			objects:      []runtime.Object{sharedPV, sharedPVCWithAnnotation, templateMissingSA},
+			requestObj:   podDefaultSA,
+			requestKind:  "Pod",
+			wantResponse: admission.Allowed("No sidecar injection required for shared node mount mode."),
+		},
+		{
+			name:         "Pod is allowed if Pod leaves serviceAccountName blank and the volume's PodTemplate specifies default.",
+			objects:      []runtime.Object{sharedPV, sharedPVCWithAnnotation, templateDefaultSA},
+			requestObj:   podMissingSA,
+			requestKind:  "Pod",
+			wantResponse: admission.Allowed("No sidecar injection required for shared node mount mode."),
+		},
+		{
+			name:         "Pod is allowed if both Pod and the volume's PodTemplate specify default serviceAccountName.",
+			objects:      []runtime.Object{sharedPV, sharedPVCWithAnnotation, templateDefaultSA},
+			requestObj:   podDefaultSA,
 			requestKind:  "Pod",
 			wantResponse: admission.Allowed("No sidecar injection required for shared node mount mode."),
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
**What type of PR is this?**
/kind feature
**What this PR does / why we need it**:
This PR implements `serviceAccountName` validation in webhook when using the shared node mount feature. 
It ensures that user Pods are using exactly the same KSA as the mounter Pod (defined in the referenced `PodTemplate`) by doing:
- Pod creation is rejected if its `serviceAccountName` does not match the referenced `PodTemplate`'s `serviceAccountName`.
- Handles multi-volume Pods: all referenced PodTemplates must match the Pod's SA.
- Treats empty/missing `serviceAccountName` values in both the Pod and `PodTemplate` as `"default"` to accommodate default Kubernetes behavior.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```