### PR TITLE
Implement ControllerPublishVolume PodTemplate logic

### DIFF
--- a/deploy/base/controller/controller_setup.yaml
+++ b/deploy/base/controller/controller_setup.yaml
@@ -130,6 +130,10 @@ rules:
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get", "list", "watch"]
+# Required to get PodTemplates when using shared node mount feature.
+  - apiGroups: [""]
+    resources: ["podtemplates"]
+    verbs: ["get", "list", "watch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/cloud_provider/clientset/clientset.go
+++ b/pkg/cloud_provider/clientset/clientset.go
@@ -47,11 +47,13 @@ type Interface interface {
 	ConfigurePVLister(ctx context.Context)
 	ConfigurePVCLister(ctx context.Context)
 	ConfigureSCLister(ctx context.Context)
+	ConfigurePodTemplateLister(ctx context.Context)
 	GetPod(namespace, name string) (*corev1.Pod, error)
 	GetNode(name string) (*corev1.Node, error)
 	GetPV(name string) (*corev1.PersistentVolume, error)
 	GetPVC(namespace string, name string) (*corev1.PersistentVolumeClaim, error)
 	GetSC(name string) (*storagev1.StorageClass, error)
+	GetPodTemplate(namespace, name string) (*corev1.PodTemplate, error)
 	ListPV() ([]*corev1.PersistentVolume, error)
 	CreateServiceAccountToken(ctx context.Context, namespace, name string, tokenRequest *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error)
 	GetGCPServiceAccountName(ctx context.Context, namespace, name string) (string, error)
@@ -69,6 +71,7 @@ type Clientset struct {
 	pvLister                  listersv1.PersistentVolumeLister
 	pvcLister                 listersv1.PersistentVolumeClaimLister
 	scLister                  storagelisters.StorageClassLister
+	podTemplateLister         listersv1.PodTemplateLister
 	informerResyncDurationSec int
 }
 
@@ -249,6 +252,36 @@ func (c *Clientset) ConfigureSCLister(ctx context.Context) {
 	c.scLister = scLister
 }
 
+func (c *Clientset) ConfigurePodTemplateLister(ctx context.Context) {
+	trim := func(obj any) (any, error) {
+		podTemplateObj, ok := obj.(*corev1.PodTemplate)
+		if !ok || podTemplateObj == nil {
+			return obj, nil
+		}
+		return &corev1.PodTemplate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      podTemplateObj.ObjectMeta.Name,
+				Namespace: podTemplateObj.Namespace,
+			},
+			Template: corev1.PodTemplateSpec{
+				Spec: podTemplateObj.Template.Spec,
+			},
+		}, nil
+	}
+
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(
+		c.k8sClients,
+		time.Duration(c.informerResyncDurationSec)*time.Second,
+		informers.WithTransform(trim),
+	)
+	podTemplateLister := informerFactory.Core().V1().PodTemplates().Lister()
+
+	informerFactory.Start(ctx.Done())
+	informerFactory.WaitForCacheSync(ctx.Done())
+
+	c.podTemplateLister = podTemplateLister
+}
+
 func New(kubeconfigPath string, informerResyncDurationSec int) (Interface, error) {
 	var err error
 	var rc *rest.Config
@@ -392,6 +425,14 @@ func (c *Clientset) GetSC(name string) (*storagev1.StorageClass, error) {
 	}
 
 	return c.scLister.Get(name)
+}
+
+func (c *Clientset) GetPodTemplate(namespace, name string) (*corev1.PodTemplate, error) {
+	if c.podTemplateLister == nil {
+		return nil, errors.New("pod template informer is not ready")
+	}
+
+	return c.podTemplateLister.PodTemplates(namespace).Get(name)
 }
 
 func (c *Clientset) CreateServiceAccountToken(ctx context.Context, namespace, name string, tokenRequest *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error) {

--- a/pkg/cloud_provider/clientset/fake.go
+++ b/pkg/cloud_provider/clientset/fake.go
@@ -55,9 +55,10 @@ type FakePVConfig struct {
 }
 
 type FakePVCConfig struct {
-	Name       string
-	VolumeName string
-	Namespace  string
+	Name        string
+	VolumeName  string
+	Namespace   string
+	Annotations map[string]string
 }
 
 type FakeSCConfig struct {
@@ -66,24 +67,32 @@ type FakeSCConfig struct {
 	MountOptions []string
 }
 
+type FakePodTemplateConfig struct {
+	Name      string
+	Namespace string
+}
+
 type FakeClientset struct {
-	Client    kubernetes.Interface
-	fakePod   *corev1.Pod
-	fakeNode  *corev1.Node
-	fakePVs   map[string]*corev1.PersistentVolume
-	fakePVCs  map[string]*corev1.PersistentVolumeClaim
-	fakeSCs   map[string]*storagev1.StorageClass
-	ListPVErr error
-	GetPodErr error
+	Client            kubernetes.Interface
+	fakePod           *corev1.Pod
+	fakeNode          *corev1.Node
+	fakePVs           map[string]*corev1.PersistentVolume
+	fakePVCs          map[string]*corev1.PersistentVolumeClaim
+	fakeSCs           map[string]*storagev1.StorageClass
+	fakePodTemplates  map[string]*corev1.PodTemplate
+	ListPVErr         error
+	GetPodErr         error
+	GetPodTemplateErr error
 }
 
 func NewFakeClientset(objects ...runtime.Object) *FakeClientset {
 	fakeK8sClient := fake.NewSimpleClientset(objects...)
 	fakeClientSet := &FakeClientset{
-		Client:   fakeK8sClient,
-		fakePVs:  make(map[string]*corev1.PersistentVolume),
-		fakePVCs: make(map[string]*corev1.PersistentVolumeClaim),
-		fakeSCs:  make(map[string]*storagev1.StorageClass),
+		Client:           fakeK8sClient,
+		fakePVs:          make(map[string]*corev1.PersistentVolume),
+		fakePVCs:         make(map[string]*corev1.PersistentVolumeClaim),
+		fakeSCs:          make(map[string]*storagev1.StorageClass),
+		fakePodTemplates: make(map[string]*corev1.PodTemplate),
 	}
 	// Default setting for most unit tests is pod doesn't use host network & workload identity is enabled on the node
 	fakeClientSet.CreatePod(FakePodConfig{HostNetworkEnabled: false})
@@ -91,6 +100,7 @@ func NewFakeClientset(objects ...runtime.Object) *FakeClientset {
 	fakeClientSet.CreatePV(FakePVConfig{})
 	fakeClientSet.CreatePVC(FakePVCConfig{})
 	fakeClientSet.CreateSC(FakeSCConfig{})
+	fakeClientSet.CreatePodTemplate(FakePodTemplateConfig{})
 
 	return fakeClientSet
 }
@@ -108,6 +118,8 @@ func (c *FakeClientset) ConfigurePVLister(_ context.Context) {}
 func (c *FakeClientset) ConfigurePVCLister(_ context.Context) {}
 
 func (c *FakeClientset) ConfigureSCLister(_ context.Context) {}
+
+func (c *FakeClientset) ConfigurePodTemplateLister(_ context.Context) {}
 
 func (c *FakeClientset) CreatePod(podConfig FakePodConfig) {
 	config := webhook.FakeConfig()
@@ -198,8 +210,9 @@ func (c *FakeClientset) CreatePV(pvConfig FakePVConfig) {
 func (c *FakeClientset) CreatePVC(pvcConfig FakePVCConfig) {
 	pvc := &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   pvcConfig.Name,
-			Labels: map[string]string{},
+			Name:        pvcConfig.Name,
+			Labels:      map[string]string{},
+			Annotations: pvcConfig.Annotations,
 		},
 	}
 
@@ -221,6 +234,17 @@ func (c *FakeClientset) CreateSC(scConfig FakeSCConfig) {
 	sc.Parameters = scConfig.Parameters
 	sc.Labels = scConfig.Labels
 	c.fakeSCs[sc.Name] = sc
+}
+
+func (c *FakeClientset) CreatePodTemplate(podTemplateConfig FakePodTemplateConfig) {
+	podTemplate := &corev1.PodTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podTemplateConfig.Name,
+			Namespace: podTemplateConfig.Namespace,
+		},
+	}
+
+	c.fakePodTemplates[podTemplate.Name] = podTemplate
 }
 
 func (c *FakeClientset) AddPodVolumes(volumes []corev1.Volume) {
@@ -278,6 +302,17 @@ func (c *FakeClientset) GetSC(name string) (*storagev1.StorageClass, error) {
 	}
 
 	return c.fakeSCs[""], nil
+}
+
+func (c *FakeClientset) GetPodTemplate(namespace, name string) (*corev1.PodTemplate, error) {
+	if c.GetPodTemplateErr != nil {
+		return nil, c.GetPodTemplateErr
+	}
+	if podTemplate, ok := c.fakePodTemplates[name]; ok {
+		return podTemplate, nil
+	}
+
+	return c.fakePodTemplates[""], nil
 }
 
 func (c *FakeClientset) CreateServiceAccountToken(_ context.Context, _, _ string, _ *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error) {

--- a/pkg/csi_driver/controller.go
+++ b/pkg/csi_driver/controller.go
@@ -28,6 +28,7 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/klog/v2"
 )
 
@@ -160,6 +161,9 @@ func (s *controllerServer) ControllerPublishVolume(ctx context.Context, req *csi
 	clientset := s.driver.config.K8sClients
 	pv, err := pvFromVolumeID(clientset, volumeID)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, status.Error(codes.NotFound, err.Error())
+		}
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 	if pv.Spec.ClaimRef == nil {
@@ -173,12 +177,29 @@ func (s *controllerServer) ControllerPublishVolume(ctx context.Context, req *csi
 	}
 	podNamespace := pvcNamespace
 
+	// Find the PodTemplate from the PVC to allow mounter pod config overrides.
+	pvc, err := clientset.GetPVC(pvcNamespace, pvcName)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, status.Error(codes.NotFound, err.Error())
+		}
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	podTemplate, err := mounterPodTemplate(clientset, pvc)
+	if err != nil {
+		return nil, err
+	}
+	if podTemplate == nil {
+		return nil, status.Error(codes.Internal, "pod template can't be nil")
+	}
+
 	// Prepare mounter pod config.
 	podName := createMounterPodName(nodeID, volumeID)
 	podConfig := &mounterPodConfig{
-		podName:   podName,
-		namespace: podNamespace,
-		nodeID:    nodeID,
+		podName:            podName,
+		namespace:          podNamespace,
+		serviceAccountName: podTemplate.Template.Spec.ServiceAccountName,
+		nodeID:             nodeID,
 		// TODO(urielguzman): Replace with the actual mounter pod image.
 		image: "k8s.gcr.io/pause",
 	}

--- a/pkg/csi_driver/controller_test.go
+++ b/pkg/csi_driver/controller_test.go
@@ -30,20 +30,23 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
 )
 
 const (
-	testVolumeID  = "test-volume-id"
-	testNodeID    = "test-node-id"
-	testPV        = "test-pv"
-	testPVC       = "test-pvc"
-	testNamespace = "test-namespace"
-	testPod       = "test-pod"
-	testImage     = "k8s.gcr.io/pause"
+	testVolumeID           = "test-volume-id"
+	testNodeID             = "test-node-id"
+	testPV                 = "test-pv"
+	testPVC                = "test-pvc"
+	testMounterPodTemplate = "test-mounter-pod-template"
+	testNamespace          = "test-namespace"
+	testPod                = "test-pod"
+	testImage              = "k8s.gcr.io/pause"
 )
 
 func initTestController(t *testing.T, clientset clientset.Interface) csi.ControllerServer {
@@ -54,6 +57,55 @@ func initTestController(t *testing.T, clientset clientset.Interface) csi.Control
 		t.Fatalf("newControllerServer failed: %v", err)
 	}
 	return cs
+}
+
+type fakeClientsetConfig struct {
+	existingObjects []runtime.Object
+	pvConfig        *clientset.FakePVConfig
+	pvcConfig       *clientset.FakePVCConfig
+	ptConfig        *clientset.FakePodTemplateConfig
+	podConfig       *clientset.FakePodConfig
+}
+
+func setupFakeBase(cfg fakeClientsetConfig) *clientset.FakeClientset {
+	fc := clientset.NewFakeClientset(cfg.existingObjects...)
+	if cfg.pvConfig != nil {
+		fc.CreatePV(*cfg.pvConfig)
+	}
+	if cfg.pvcConfig != nil {
+		fc.CreatePVC(*cfg.pvcConfig)
+	}
+	if cfg.ptConfig != nil {
+		fc.CreatePodTemplate(*cfg.ptConfig)
+	}
+	if cfg.podConfig != nil {
+		fc.CreatePod(*cfg.podConfig)
+	}
+	return fc
+}
+
+func getDefaultFakeClientsetConfig() fakeClientsetConfig {
+	return fakeClientsetConfig{
+		pvConfig: &clientset.FakePVConfig{
+			Name:         testPV,
+			VolumeHandle: testVolumeID,
+			ClaimRef: &corev1.ObjectReference{
+				Name:      testPVC,
+				Namespace: testNamespace,
+			},
+		},
+		pvcConfig: &clientset.FakePVCConfig{
+			Name:      testPVC,
+			Namespace: testNamespace,
+			Annotations: map[string]string{
+				"gke-gcsfuse/mounter-pod-template": testMounterPodTemplate,
+			},
+		},
+		ptConfig: &clientset.FakePodTemplateConfig{
+			Name:      testMounterPodTemplate,
+			Namespace: testNamespace,
+		},
+	}
 }
 
 func TestCreateVolume(t *testing.T) {
@@ -201,13 +253,14 @@ func TestControllerPublishVolume(t *testing.T) {
 	}
 
 	cases := []struct {
-		name          string
-		req           *csi.ControllerPublishVolumeRequest
-		setupFake     func() *clientset.FakeClientset
-		podGetErr     error
-		podCreateErr  error
-		expectErr     bool
-		expectErrCode codes.Code
+		name              string
+		req               *csi.ControllerPublishVolumeRequest
+		setupFake         func() *clientset.FakeClientset
+		podGetErr         error
+		podCreateErr      error
+		expectErr         bool
+		expectErrCode     codes.Code
+		podTemplateGetErr error
 	}{
 		{
 			name: "empty volume ID - should return error",
@@ -291,9 +344,11 @@ func TestControllerPublishVolume(t *testing.T) {
 				},
 			},
 			setupFake: func() *clientset.FakeClientset {
-				fc := clientset.NewFakeClientset()
-				fc.CreatePV(clientset.FakePVConfig{Name: testPV, VolumeHandle: testVolumeID, ClaimRef: nil})
-				return fc
+				cfg := getDefaultFakeClientsetConfig()
+				cfg.pvConfig.ClaimRef = nil
+				cfg.pvcConfig = nil
+				cfg.ptConfig = nil
+				return setupFakeBase(cfg)
 			},
 			expectErr:     true,
 			expectErrCode: codes.Internal,
@@ -309,17 +364,68 @@ func TestControllerPublishVolume(t *testing.T) {
 				},
 			},
 			setupFake: func() *clientset.FakeClientset {
-				fc := clientset.NewFakeClientset()
-				fc.CreatePV(clientset.FakePVConfig{Name: testPV, VolumeHandle: testVolumeID, ClaimRef: &corev1.ObjectReference{
-					Name:      testPVC,
-					Namespace: testNamespace,
-				}})
-				return fc
+				return setupFakeBase(getDefaultFakeClientsetConfig())
 			},
 			expectErr: false,
 		},
 		{
-			name: "sharedMount true - mounter pod already exists",
+			name: "sharedMount true - missing mounter pod template annotation - should return error",
+			req: &csi.ControllerPublishVolumeRequest{
+				VolumeId:         testVolumeID,
+				NodeId:           testNodeID,
+				VolumeCapability: testVolumeCapability,
+				VolumeContext: map[string]string{
+					"sharedMount": "true",
+				},
+			},
+			setupFake: func() *clientset.FakeClientset {
+				cfg := getDefaultFakeClientsetConfig()
+				cfg.pvcConfig.Annotations = nil
+				return setupFakeBase(cfg)
+			},
+			expectErr:     true,
+			expectErrCode: codes.InvalidArgument,
+		},
+		{
+			name: "sharedMount true - pod template doesn't exist - should return error",
+			req: &csi.ControllerPublishVolumeRequest{
+				VolumeId:         testVolumeID,
+				NodeId:           testNodeID,
+				VolumeCapability: testVolumeCapability,
+				VolumeContext: map[string]string{
+					"sharedMount": "true",
+				},
+			},
+			setupFake: func() *clientset.FakeClientset {
+				cfg := getDefaultFakeClientsetConfig()
+				cfg.pvcConfig.Annotations["gke-gcsfuse/mounter-pod-template"] = "non-existent-template"
+				return setupFakeBase(cfg)
+			},
+			expectErr:         true,
+			expectErrCode:     codes.NotFound,
+			podTemplateGetErr: apierrors.NewNotFound(schema.GroupResource{}, "pod template not found"),
+		},
+		{
+			name: "sharedMount true - pod template get internal error - should return error",
+			req: &csi.ControllerPublishVolumeRequest{
+				VolumeId:         testVolumeID,
+				NodeId:           testNodeID,
+				VolumeCapability: testVolumeCapability,
+				VolumeContext: map[string]string{
+					"sharedMount": "true",
+				},
+			},
+			setupFake: func() *clientset.FakeClientset {
+				cfg := getDefaultFakeClientsetConfig()
+				cfg.pvcConfig.Annotations["gke-gcsfuse/mounter-pod-template"] = "non-existent-template"
+				return setupFakeBase(cfg)
+			},
+			expectErr:         true,
+			expectErrCode:     codes.Internal,
+			podTemplateGetErr: apierrors.NewInternalError(errors.New("internal error")),
+		},
+		{
+			name: "sharedMount true - mounter pod already exists - should return success",
 			req: &csi.ControllerPublishVolumeRequest{
 				VolumeId:         testVolumeID,
 				NodeId:           testNodeID,
@@ -330,8 +436,9 @@ func TestControllerPublishVolume(t *testing.T) {
 			},
 			setupFake: func() *clientset.FakeClientset {
 				existingPod := makeMounterPod(defaultMounterPodConfig, nil)
-				fc := clientset.NewFakeClientset(existingPod)
-				fc.CreatePod(clientset.FakePodConfig{
+				cfg := getDefaultFakeClientsetConfig()
+				cfg.existingObjects = []runtime.Object{existingPod}
+				cfg.podConfig = &clientset.FakePodConfig{
 					NodeName: testNodeID,
 					PodStatus: &corev1.PodStatus{
 						Conditions: []corev1.PodCondition{
@@ -341,17 +448,13 @@ func TestControllerPublishVolume(t *testing.T) {
 							},
 						},
 					},
-				})
-				fc.CreatePV(clientset.FakePVConfig{Name: testPV, VolumeHandle: testVolumeID, ClaimRef: &corev1.ObjectReference{
-					Name:      testPVC,
-					Namespace: testNamespace,
-				}})
-				return fc
+				}
+				return setupFakeBase(cfg)
 			},
 			expectErr: false,
 		},
 		{
-			name: "sharedMount true - mounter pod being deleted",
+			name: "sharedMount true - mounter pod being deleted - should return error",
 			req: &csi.ControllerPublishVolumeRequest{
 				VolumeId:         testVolumeID,
 				NodeId:           testNodeID,
@@ -362,18 +465,15 @@ func TestControllerPublishVolume(t *testing.T) {
 			},
 			setupFake: func() *clientset.FakeClientset {
 				existingPod := makeMounterPod(defaultMounterPodConfig, &timeNow)
-				fc := clientset.NewFakeClientset(existingPod)
-				fc.CreatePV(clientset.FakePVConfig{Name: testPV, VolumeHandle: testVolumeID, ClaimRef: &corev1.ObjectReference{
-					Name:      testPVC,
-					Namespace: testNamespace,
-				}})
-				return fc
+				cfg := getDefaultFakeClientsetConfig()
+				cfg.existingObjects = []runtime.Object{existingPod}
+				return setupFakeBase(cfg)
 			},
 			expectErr:     true,
 			expectErrCode: codes.Aborted,
 		},
 		{
-			name: "sharedMount true - mounter pod get error",
+			name: "sharedMount true - mounter pod get error - should return error",
 			req: &csi.ControllerPublishVolumeRequest{
 				VolumeId:         testVolumeID,
 				NodeId:           testNodeID,
@@ -383,19 +483,14 @@ func TestControllerPublishVolume(t *testing.T) {
 				},
 			},
 			setupFake: func() *clientset.FakeClientset {
-				fc := clientset.NewFakeClientset()
-				fc.CreatePV(clientset.FakePVConfig{Name: testPV, VolumeHandle: testVolumeID, ClaimRef: &corev1.ObjectReference{
-					Name:      testPVC,
-					Namespace: testNamespace,
-				}})
-				return fc
+				return setupFakeBase(getDefaultFakeClientsetConfig())
 			},
 			podGetErr:     errors.New("simulated get error"),
 			expectErr:     true,
 			expectErrCode: codes.Internal,
 		},
 		{
-			name: "sharedMount true - mounter pod create error",
+			name: "sharedMount true - mounter pod create error - should return error",
 			req: &csi.ControllerPublishVolumeRequest{
 				VolumeId:         testVolumeID,
 				NodeId:           testNodeID,
@@ -405,12 +500,7 @@ func TestControllerPublishVolume(t *testing.T) {
 				},
 			},
 			setupFake: func() *clientset.FakeClientset {
-				fc := clientset.NewFakeClientset()
-				fc.CreatePV(clientset.FakePVConfig{Name: testPV, VolumeHandle: testVolumeID, ClaimRef: &corev1.ObjectReference{
-					Name:      testPVC,
-					Namespace: testNamespace,
-				}})
-				return fc
+				return setupFakeBase(getDefaultFakeClientsetConfig())
 			},
 			podCreateErr:  errors.New("simulated create error"),
 			expectErr:     true,
@@ -453,6 +543,10 @@ func TestControllerPublishVolume(t *testing.T) {
 
 					return false, nil, nil
 				})
+			}
+
+			if test.podTemplateGetErr != nil {
+				fc.GetPodTemplateErr = test.podTemplateGetErr
 			}
 
 			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)

--- a/pkg/csi_driver/shared_mount.go
+++ b/pkg/csi_driver/shared_mount.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/clientset"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util"
+	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/webhook"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
@@ -48,10 +49,11 @@ var (
 
 // mounterPodConfig holds the configuration parameters required to define and manage a mounter pod.
 type mounterPodConfig struct {
-	podName   string // The name to assign to the mounter pod.
-	nodeID    string // The specific node ID where the pod should be scheduled.
-	namespace string // The Kubernetes namespace in which to create the pod.
-	image     string // The image for the mounter pod binary.
+	podName            string // The name to assign to the mounter pod.
+	nodeID             string // The specific node ID where the pod should be scheduled.
+	namespace          string // The Kubernetes namespace in which to create the pod.
+	image              string // The image for the mounter pod binary.
+	serviceAccountName string // The KSA name for the mounter pod.
 }
 
 // sharedMount checks if the VolumeContext enables the shared node mount feature
@@ -197,6 +199,9 @@ func createMounterPodSpec(config *mounterPodConfig) *corev1.Pod {
 			},
 		},
 	}
+	if config.serviceAccountName != "" {
+		spec.Spec.ServiceAccountName = config.serviceAccountName
+	}
 	return spec
 }
 
@@ -251,4 +256,27 @@ func waitForMounterPodScheduled(clientset clientset.Interface, ctx context.Conte
 			return status.Errorf(code, "timeout waiting for mounter pod %s/%s to be scheduled to node %q: %v", namespace, podName, nodeID, ctx.Err())
 		}
 	}
+}
+
+// mounterPodTemplate retrieves the referenced mounter PodTemplate for a PVC if the annotation is present.
+func mounterPodTemplate(clientset clientset.Interface, pvc *corev1.PersistentVolumeClaim) (*corev1.PodTemplate, error) {
+	if pvc == nil {
+		return nil, status.Errorf(codes.InvalidArgument, "pvc cannot be nil")
+	}
+	if pvc.Annotations == nil {
+		return nil, status.Errorf(codes.InvalidArgument, "mounter pod template annotation must be provided")
+	}
+	templateName, ok := pvc.Annotations[webhook.MounterPodTemplateAnnotation]
+	if !ok || templateName == "" {
+		return nil, status.Errorf(codes.InvalidArgument, "mounter pod template annotation must be provided")
+	}
+
+	podTemplate, err := clientset.GetPodTemplate(pvc.Namespace, templateName)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, status.Error(codes.NotFound, err.Error())
+		}
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	return podTemplate, nil
 }

--- a/pkg/csi_driver/shared_mount_test.go
+++ b/pkg/csi_driver/shared_mount_test.go
@@ -207,10 +207,11 @@ func TestCreateMounterPodSpec(t *testing.T) {
 		{
 			name: "basic config - should succeed",
 			config: &mounterPodConfig{
-				podName:   "my-mounter-pod",
-				namespace: "my-namespace",
-				nodeID:    "node-123",
-				image:     "gcr.io/my-project/my-image:v1.0.0",
+				podName:            "my-mounter-pod",
+				namespace:          "my-namespace",
+				serviceAccountName: "my-ksa",
+				nodeID:             "node-123",
+				image:              "gcr.io/my-project/my-image:v1.0.0",
 			},
 			want: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
@@ -222,7 +223,8 @@ func TestCreateMounterPodSpec(t *testing.T) {
 						"kubernetes.io/hostname": "node-123",
 						"kubernetes.io/os":       "linux",
 					},
-					PriorityClassName: mounterPodPriorityClass,
+					ServiceAccountName: "my-ksa",
+					PriorityClassName:  mounterPodPriorityClass,
 					Containers: []corev1.Container{
 						{
 							Name:            mounterPodNamePrefix,
@@ -574,6 +576,128 @@ func TestWaitForMounterPodScheduled(t *testing.T) {
 			}
 
 			wg.Wait()
+		})
+	}
+}
+
+func TestMounterPodTemplate(t *testing.T) {
+	namespace := "test-ns"
+	templateName := "my-pod-template"
+
+	existingPodTemplate := clientset.FakePodTemplateConfig{
+		Name: templateName,
+	}
+
+	testCases := []struct {
+		name              string
+		pvc               *corev1.PersistentVolumeClaim
+		initialObjects    []clientset.FakePodTemplateConfig
+		wantPodTemplate   *corev1.PodTemplate
+		wantErr           bool
+		getPodTemplateErr error
+	}{
+		{
+			name: "pvc nil annotation - should return error",
+			pvc: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pvc-no-anno",
+					Namespace: namespace,
+				},
+			},
+			wantPodTemplate: nil,
+			wantErr:         true,
+		},
+		{
+			name: "pvc unrelated annotation - should return error",
+			pvc: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pvc-other-anno",
+					Namespace: namespace,
+					Annotations: map[string]string{
+						"another.annotation/foo": "bar",
+					},
+				},
+			},
+			wantPodTemplate: nil,
+			wantErr:         true,
+		},
+		{
+			name: "pvc empty annotation - should return error",
+			pvc: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pvc-empty-anno",
+					Namespace: namespace,
+					Annotations: map[string]string{
+						"gke-gcsfuse/mounter-pod-template": "",
+					},
+				},
+			},
+			wantPodTemplate: nil,
+			wantErr:         true,
+		},
+		{
+			name: "pod template not found - should return error",
+			pvc: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pvc-pt-notfound",
+					Namespace: namespace,
+					Annotations: map[string]string{
+						"gke-gcsfuse/mounter-pod-template": "non-existent-template",
+					},
+				},
+			},
+			initialObjects:    []clientset.FakePodTemplateConfig{existingPodTemplate}, // Seed with a different one
+			wantPodTemplate:   nil,
+			wantErr:           true,
+			getPodTemplateErr: errors.New("pod template not found"),
+		},
+		{
+			name: "pod template found - should return pod template",
+			pvc: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pvc-pt-found",
+					Namespace: namespace,
+					Annotations: map[string]string{
+						"gke-gcsfuse/mounter-pod-template": templateName,
+					},
+				},
+			},
+			initialObjects: []clientset.FakePodTemplateConfig{existingPodTemplate},
+			wantPodTemplate: &corev1.PodTemplate{ObjectMeta: metav1.ObjectMeta{
+				Name: templateName,
+			}},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Initialize the fake clientset with any predefined objects
+			fakeClientset := clientset.NewFakeClientset()
+
+			if tc.getPodTemplateErr != nil {
+				fakeClientset.GetPodTemplateErr = tc.getPodTemplateErr
+			}
+
+			for _, podTemplate := range tc.initialObjects {
+				fakeClientset.CreatePodTemplate(podTemplate)
+			}
+
+			gotPodTemplate, err := mounterPodTemplate(fakeClientset, tc.pvc)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("mounterPodTemplate(%v): expected an error but got none", tc.pvc.Name)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("mounterPodTemplate(%v): unexpected error: %v", tc.pvc.Name, err)
+				}
+			}
+
+			if diff := cmp.Diff(tc.wantPodTemplate, gotPodTemplate); diff != "" {
+				t.Errorf("mounterPodTemplate(%v): returned diff (-want +got):\n%s", tc.pvc.Name, diff)
+			}
 		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Implement the logic for ControllerPublishVolume so that it can find the PodTemplate from the PVC, and then allow the mounter pod to be overridden with supported values from there. In this PR, we start simply with `serviceAccountName`. More will be added later.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```