### PR TITLE
Implement ControllerUnpublishVolume

### DIFF
--- a/pkg/cloud_provider/clientset/clientset.go
+++ b/pkg/cloud_provider/clientset/clientset.go
@@ -54,7 +54,8 @@ type Interface interface {
 	GetPVC(namespace string, name string) (*corev1.PersistentVolumeClaim, error)
 	GetSC(name string) (*storagev1.StorageClass, error)
 	GetPodTemplate(namespace, name string) (*corev1.PodTemplate, error)
-	ListPV() ([]*corev1.PersistentVolume, error)
+	ListPVs() ([]*corev1.PersistentVolume, error)
+	ListPods() ([]*corev1.Pod, error)
 	CreateServiceAccountToken(ctx context.Context, namespace, name string, tokenRequest *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error)
 	GetGCPServiceAccountName(ctx context.Context, namespace, name string) (string, error)
 }
@@ -366,7 +367,9 @@ func (c *Clientset) ConfigurePodLister(ctx context.Context, nodeName string) {
 		c.k8sClients,
 		time.Duration(c.informerResyncDurationSec)*time.Second,
 		informers.WithTweakListOptions(func(options *metav1.ListOptions) {
-			options.FieldSelector = "spec.nodeName=" + nodeName
+			if nodeName != "" {
+				options.FieldSelector = "spec.nodeName=" + nodeName
+			}
 		}),
 		informers.WithTransform(trim),
 	)
@@ -402,13 +405,22 @@ func (c *Clientset) GetPV(name string) (*corev1.PersistentVolume, error) {
 	return c.pvLister.Get(name)
 }
 
-func (c *Clientset) ListPV() ([]*corev1.PersistentVolume, error) {
+func (c *Clientset) ListPVs() ([]*corev1.PersistentVolume, error) {
 	if c.pvLister == nil {
 		return nil, errors.New("pv informer is not ready")
 	}
 
-	// TODO(urielguzman): Optimize lister to only filter for a specific label.
+	// TODO(urielguzman): Add volumeHandle indexer to reduce O(N) -> O(1) for shared mount ControllerPublishVolume.
 	return c.pvLister.List(labels.Everything())
+}
+
+func (c *Clientset) ListPods() ([]*corev1.Pod, error) {
+	if c.podLister == nil {
+		return nil, errors.New("pod informer is not ready")
+	}
+
+	// TODO(urielguzman): Add podName indexer to reduce O(N) -> O(1) for shared node mount ControllerUnpublishVolume.
+	return c.podLister.List(labels.Everything())
 }
 
 func (c *Clientset) GetPVC(namespace, name string) (*corev1.PersistentVolumeClaim, error) {

--- a/pkg/cloud_provider/clientset/fake.go
+++ b/pkg/cloud_provider/clientset/fake.go
@@ -38,6 +38,8 @@ type FakeNodeConfig struct {
 }
 
 type FakePodConfig struct {
+	Name               string
+	Namespace          string
 	HostNetworkEnabled bool
 	SidecarLimits      corev1.ResourceList
 	DeletionTimestamp  *metav1.Time
@@ -79,8 +81,10 @@ type FakeClientset struct {
 	fakePVs           map[string]*corev1.PersistentVolume
 	fakePVCs          map[string]*corev1.PersistentVolumeClaim
 	fakeSCs           map[string]*storagev1.StorageClass
+	fakePods          []*corev1.Pod
 	fakePodTemplates  map[string]*corev1.PodTemplate
 	ListPVErr         error
+	ListPodErr        error
 	GetPodErr         error
 	GetPodTemplateErr error
 }
@@ -93,6 +97,7 @@ func NewFakeClientset(objects ...runtime.Object) *FakeClientset {
 		fakePVCs:         make(map[string]*corev1.PersistentVolumeClaim),
 		fakeSCs:          make(map[string]*storagev1.StorageClass),
 		fakePodTemplates: make(map[string]*corev1.PodTemplate),
+		fakePods:         []*corev1.Pod{},
 	}
 	// Default setting for most unit tests is pod doesn't use host network & workload identity is enabled on the node
 	fakeClientSet.CreatePod(FakePodConfig{HostNetworkEnabled: false})
@@ -131,8 +136,8 @@ func (c *FakeClientset) CreatePod(podConfig FakePodConfig) {
 
 	c.fakePod = &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "",
-			Namespace: "",
+			Name:      podConfig.Name,
+			Namespace: podConfig.Namespace,
 		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
@@ -167,6 +172,8 @@ func (c *FakeClientset) CreatePod(podConfig FakePodConfig) {
 	if podConfig.NodeName != "" {
 		c.fakePod.Spec.NodeName = podConfig.NodeName
 	}
+
+	c.fakePods = append(c.fakePods, c.fakePod)
 }
 
 func (c *FakeClientset) CreateNode(nodeConfig FakeNodeConfig) {
@@ -277,7 +284,7 @@ func (c *FakeClientset) GetPV(name string) (*corev1.PersistentVolume, error) {
 	return c.fakePVs[""], nil
 }
 
-func (c *FakeClientset) ListPV() ([]*corev1.PersistentVolume, error) {
+func (c *FakeClientset) ListPVs() ([]*corev1.PersistentVolume, error) {
 	if c.ListPVErr != nil {
 		return nil, c.ListPVErr
 	}
@@ -286,6 +293,13 @@ func (c *FakeClientset) ListPV() ([]*corev1.PersistentVolume, error) {
 		pvs = append(pvs, pv)
 	}
 	return pvs, nil
+}
+
+func (c *FakeClientset) ListPods() ([]*corev1.Pod, error) {
+	if c.ListPodErr != nil {
+		return nil, c.ListPodErr
+	}
+	return c.fakePods, nil
 }
 
 func (c *FakeClientset) GetPVC(namespace, name string) (*corev1.PersistentVolumeClaim, error) {

--- a/pkg/csi_driver/controller.go
+++ b/pkg/csi_driver/controller.go
@@ -18,6 +18,7 @@ limitations under the License.
 package driver
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -25,9 +26,9 @@ import (
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/storage"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/profiles"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/klog/v2"
 )
@@ -159,6 +160,9 @@ func (s *controllerServer) ControllerPublishVolume(ctx context.Context, req *csi
 	// Find the workload namespace where the mounter pod should be created by identifying the PVC
 	// bound to this volume's PV.
 	clientset := s.driver.config.K8sClients
+	// TODO(urielguzman): This implementation requires PVs from the informer's cache, which can
+	// unbounded. When manually testing the feature, we should add a volumeHandle indexer,
+	// so that the lookup can be O(1).
 	pv, err := pvFromVolumeID(clientset, volumeID)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -216,7 +220,6 @@ func (s *controllerServer) ControllerPublishVolume(ctx context.Context, req *csi
 		return nil, err
 	}
 
-	// TODO(urielguzman): implement ControllerPublishVolume when sharedMount: true.
 	klog.Infof("ControllerPublishVolume succeeded for mounter pod %s/%s. Node: %q, volume %q", podConfig.namespace, podConfig.podName, nodeID, volumeID)
 	return &csi.ControllerPublishVolumeResponse{
 		PublishContext: map[string]string{
@@ -229,7 +232,56 @@ func (s *controllerServer) ControllerPublishVolume(ctx context.Context, req *csi
 }
 
 // TODO(urielguzman): implement ControllerUnpublishVolume.
-func (s *controllerServer) ControllerUnpublishVolume(_ context.Context, _ *csi.ControllerUnpublishVolumeRequest) (*csi.ControllerUnpublishVolumeResponse, error) {
+func (s *controllerServer) ControllerUnpublishVolume(ctx context.Context, req *csi.ControllerUnpublishVolumeRequest) (*csi.ControllerUnpublishVolumeResponse, error) {
+	// Validate arguments.
+	volumeID := req.GetVolumeId()
+	if len(volumeID) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "ControllerUnpublishVolume Volume ID must be provided")
+	}
+	nodeID := req.NodeId
+	if len(nodeID) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "ControllerUnpublishVolume Node ID must be provided")
+	}
+
+	// Acquires the lock for the volume on that node only, because we need to support the ability
+	// to publish the same volume onto different nodes concurrently
+	lockingVolumeID := fmt.Sprintf("%s/%s", nodeID, volumeID)
+	if acquired := s.volumeLocks.TryAcquire(lockingVolumeID); !acquired {
+		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, lockingVolumeID)
+	}
+	defer s.volumeLocks.Release(lockingVolumeID)
+
+	// Delete the mounter pod, if it exists.
+	podName := createMounterPodName(nodeID, volumeID)
+	pods, err := s.driver.config.K8sClients.ListPods()
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to list pods: %v", err)
+	}
+	// TODO(urielguzman): This implementation requires listing pods from the informer's cache, which can
+	// be max 110 pods per node. When manually testing the feature, we should add a podName indexer,
+	// so that the lookup can be O(1).
+	mounterPods := make([]*corev1.Pod, 0, len(pods))
+	for _, pod := range pods {
+		if pod != nil && pod.Name == podName {
+			mounterPods = append(mounterPods, pod)
+		}
+	}
+	if len(mounterPods) == 0 {
+		klog.Infof("ControllerUnpublishVolume succeeded for volume %q on node %q", volumeID, nodeID)
+		return &csi.ControllerUnpublishVolumeResponse{}, nil
+	}
+	if len(mounterPods) > 1 {
+		// Each nodeID/volumeID pair should match exactly to 1 mounter pod. If there are more than 1 in that node,
+		// this signals an internal bug on how the mounter pods are being handled by the CSI Driver.
+		return nil, status.Errorf(codes.Internal, "expected 1 mounter pod for volume %q on node %q, found: %d", volumeID, nodeID, len(mounterPods))
+	}
+
+	podNamespace := mounterPods[0].Namespace
+	if err := deleteMounterPod(ctx, s.driver.config.K8sClients, podNamespace, podName); err != nil {
+		return nil, err
+	}
+
+	klog.Infof("ControllerUnpublishVolume succeeded for volume %q on node %q", volumeID, nodeID)
 	return &csi.ControllerUnpublishVolumeResponse{}, nil
 }
 

--- a/pkg/csi_driver/controller_test.go
+++ b/pkg/csi_driver/controller_test.go
@@ -253,15 +253,15 @@ func TestControllerPublishVolume(t *testing.T) {
 	}
 
 	cases := []struct {
-		name              string
-		req               *csi.ControllerPublishVolumeRequest
-		setupFake         func() *clientset.FakeClientset
-		podGetErr         error
-		podCreateErr      error
-		expectErr         bool
-		expectErrCode     codes.Code
-		podTemplateGetErr error
-        wantPublishContext map[string]string
+		name               string
+		req                *csi.ControllerPublishVolumeRequest
+		setupFake          func() *clientset.FakeClientset
+		podGetErr          error
+		podCreateErr       error
+		expectErr          bool
+		expectErrCode      codes.Code
+		podTemplateGetErr  error
+		wantPublishContext map[string]string
 	}{
 		{
 			name: "empty volume ID - should return error",
@@ -581,6 +581,185 @@ func TestControllerPublishVolume(t *testing.T) {
 				}
 				if !reflect.DeepEqual(test.wantPublishContext, resp.PublishContext) {
 					t.Errorf("Expected publish context: %v, got: %v", test.wantPublishContext, resp.PublishContext)
+				}
+			}
+		})
+	}
+}
+
+func TestControllerUnpublishVolume(t *testing.T) {
+	oldInterval := mounterPodPollInterval
+	mounterPodPollInterval = 10 * time.Millisecond
+	defer func() { mounterPodPollInterval = oldInterval }()
+
+	mounterPodName := createMounterPodName(testNodeID, testVolumeID)
+
+	testCases := []struct {
+		name string
+		req  *csi.ControllerUnpublishVolumeRequest
+
+		initialFCPods        []clientset.FakePodConfig
+		listPodErr           error
+		deleteReactionError  error // Injected error for the Delete call
+		getPodErrAfterDelete error // Error for clientset.GetPod to return after Delete is called
+
+		wantErr     bool
+		wantErrCode codes.Code
+	}{
+		{
+			name: "valid request - should delete pod successfully",
+			req: &csi.ControllerUnpublishVolumeRequest{
+				VolumeId: testVolumeID,
+				NodeId:   testNodeID,
+			},
+			initialFCPods: []clientset.FakePodConfig{
+				{
+					Name:      mounterPodName,
+					Namespace: testNamespace,
+				},
+			},
+			getPodErrAfterDelete: apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "pods"}, mounterPodName),
+			wantErr:              false,
+		},
+		{
+			name: "pod not found - should succeed",
+			req: &csi.ControllerUnpublishVolumeRequest{
+				VolumeId: testVolumeID,
+				NodeId:   testNodeID,
+			},
+			initialFCPods: nil, // No mounter pod
+			wantErr:       false,
+		},
+		{
+			name: "empty volume ID - should return error",
+			req: &csi.ControllerUnpublishVolumeRequest{
+				VolumeId: "",
+				NodeId:   testNodeID,
+			},
+			wantErr:     true,
+			wantErrCode: codes.InvalidArgument,
+		},
+		{
+			name: "empty node ID - should return error",
+			req: &csi.ControllerUnpublishVolumeRequest{
+				VolumeId: testVolumeID,
+				NodeId:   "",
+			},
+			wantErr:     true,
+			wantErrCode: codes.InvalidArgument,
+		},
+		{
+			name: "list pods fails - should return error",
+			req: &csi.ControllerUnpublishVolumeRequest{
+				VolumeId: testVolumeID,
+				NodeId:   testNodeID,
+			},
+			listPodErr:  errors.New("simulated ListPods error"),
+			wantErr:     true,
+			wantErrCode: codes.Internal,
+		},
+		{
+			name: "multiple mounter pods found - should return error",
+			req: &csi.ControllerUnpublishVolumeRequest{
+				VolumeId: testVolumeID,
+				NodeId:   testNodeID,
+			},
+			initialFCPods: []clientset.FakePodConfig{
+				{
+					Name:      mounterPodName,
+					Namespace: testNamespace,
+				},
+				{
+					Name:      mounterPodName,
+					Namespace: "another-namespace",
+				},
+			},
+			wantErr:     true,
+			wantErrCode: codes.Internal,
+		},
+		{
+			name: "deleteMounterPod fails with API error - should return error",
+			req: &csi.ControllerUnpublishVolumeRequest{
+				VolumeId: testVolumeID,
+				NodeId:   testNodeID,
+			},
+			initialFCPods: []clientset.FakePodConfig{
+				{
+					Name:      mounterPodName,
+					Namespace: testNamespace,
+				},
+			},
+			deleteReactionError: errors.New("simulated delete API error"),
+			wantErr:             true,
+			wantErrCode:         codes.Internal,
+		},
+		{
+			name: "deleteMounterPod times out (pod never deleted) - should return error",
+			req: &csi.ControllerUnpublishVolumeRequest{
+				VolumeId: testVolumeID,
+				NodeId:   testNodeID,
+			},
+			initialFCPods: []clientset.FakePodConfig{
+				{
+					Name:      mounterPodName,
+					Namespace: testNamespace,
+				},
+			},
+			getPodErrAfterDelete: nil, // GetPod continues to find the pod
+			wantErr:              true,
+			wantErrCode:          codes.DeadlineExceeded,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fc := clientset.NewFakeClientset()
+			fc.ListPodErr = tc.listPodErr
+			for _, pod := range tc.initialFCPods {
+				fc.CreatePod(pod)
+			}
+
+			s := initTestController(t, fc)
+
+			fakeK8sClient := fc.K8sClient().(*fake.Clientset)
+			deleteCalled := false
+			fakeK8sClient.PrependReactor("delete", "pods", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+				deleteCalled = true
+				if tc.deleteReactionError != nil {
+					return true, nil, tc.deleteReactionError
+				}
+				// Simulate effect on GetPod for the poller in deleteMounterPod
+				fc.GetPodErr = tc.getPodErrAfterDelete
+				return true, nil, nil
+			})
+
+			// Initial GetPodErr state for deleteMounterPod if delete is not called or fails early
+			if len(tc.initialFCPods) == 0 {
+				fc.GetPodErr = apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "pods"}, mounterPodName)
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+			defer cancel()
+			_, err := s.ControllerUnpublishVolume(ctx, tc.req)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("Expected error code %v, got nil", tc.wantErrCode)
+				}
+				st, ok := status.FromError(err)
+				if !ok {
+					t.Fatalf("Expected status error with code %v, got non-status error: %v", tc.wantErrCode, err)
+				}
+				if st.Code() != tc.wantErrCode {
+					t.Errorf("Expected error code %v, got %v (error: %v)", tc.wantErrCode, st.Code(), err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Expected no error, got: %v", err)
+				}
+				// Verify delete was called if a pod was expected to be found
+				if len(tc.initialFCPods) > 0 && !deleteCalled && tc.deleteReactionError == nil {
+					t.Errorf("Delete was not called on the mounter pod when it should have been")
 				}
 			}
 		})

--- a/pkg/csi_driver/shared_mount.go
+++ b/pkg/csi_driver/shared_mount.go
@@ -82,7 +82,7 @@ func pvFromVolumeID(clientset clientset.Interface, volumeID string) (*corev1.Per
 	if clientset == nil {
 		return nil, fmt.Errorf("clientset is nil")
 	}
-	pvs, err := clientset.ListPV()
+	pvs, err := clientset.ListPVs()
 	if err != nil {
 		return nil, err
 	}
@@ -279,4 +279,44 @@ func mounterPodTemplate(clientset clientset.Interface, pvc *corev1.PersistentVol
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 	return podTemplate, nil
+}
+
+// deleteMounterPod handles the deletion of the mounter pod, if it exists.
+// It will retry until it is deleted or return an error if the number of retries have exceeded the limit.
+// deleteMounterPod returns only after mounter pod has terminated and deleted from the API server.
+func deleteMounterPod(ctx context.Context, clientset clientset.Interface, podNamespace, podName string) error {
+	if clientset == nil || clientset.K8sClient() == nil {
+		return status.Error(codes.Internal, "kubernetes client is uninitialized")
+	}
+	if err := clientset.K8sClient().CoreV1().Pods(podNamespace).Delete(ctx, podName, metav1.DeleteOptions{}); err != nil {
+		if errors.IsNotFound(err) {
+			// If the pod is not found, it's not an error
+			klog.Infof("Mounter pod %s/%s was already deleted.", podNamespace, podName)
+			return nil
+		}
+		return status.Errorf(codes.Internal, "failed to delete pod %s/%s: %v", podNamespace, podName, err)
+	}
+	pollInterval := mounterPodPollInterval
+	klog.Infof("Waiting for mounter pod %s/%s deletion to complete. Polling every %s",
+		podNamespace, podName, pollInterval)
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			code := codes.DeadlineExceeded
+			if ctx.Err() == context.Canceled {
+				code = codes.Canceled
+			}
+			return status.Errorf(code, "timed out waiting for mounter pod %s/%s to be deleted", podNamespace, podName)
+		case <-ticker.C:
+			if _, err := clientset.GetPod(podNamespace, podName); err != nil {
+				if errors.IsNotFound(err) {
+					klog.Infof("Mounter pod %s/%s was successfully deleted.", podNamespace, podName)
+					return nil
+				}
+				return status.Errorf(codes.Internal, "failed to get pod %s/%s: %v", podNamespace, podName, err)
+			}
+		}
+	}
 }

--- a/pkg/csi_driver/shared_mount_test.go
+++ b/pkg/csi_driver/shared_mount_test.go
@@ -701,3 +701,142 @@ func TestMounterPodTemplate(t *testing.T) {
 		})
 	}
 }
+
+func TestDeleteMounterPod(t *testing.T) {
+	oldInterval := mounterPodPollInterval
+	mounterPodPollInterval = 10 * time.Millisecond
+	defer func() { mounterPodPollInterval = oldInterval }()
+
+	podName := "test-mounter-pod"
+	namespace := "test-namespace"
+
+	basePod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            podName,
+			Namespace:       namespace,
+			ResourceVersion: "1",
+		},
+	}
+
+	tests := []struct {
+		name                  string
+		initialObjects        []runtime.Object // Objects for the inner fake.Clientset
+		deleteReactionError   error            // Error returned by the Delete reactor
+		getPodShouldDisappear bool             // Whether custom GetPod should start returning NotFound after delete
+		getPodPersistentError error            // Persistent error for custom GetPod
+
+		wantErr      bool
+		wantCode     codes.Code
+		expectDelete bool // Whether a delete call is expected
+	}{
+		{
+			name:                  "pod exists - should be deleted successfully",
+			initialObjects:        []runtime.Object{basePod},
+			getPodShouldDisappear: true, // Simulate NotFound after delete call
+			expectDelete:          true,
+			wantErr:               false,
+		},
+		{
+			name:                  "pod does not exist - should return no-op success",
+			initialObjects:        []runtime.Object{},
+			deleteReactionError:   k8serrors.NewNotFound(schema.GroupResource{Group: "", Resource: "pods"}, podName),
+			getPodShouldDisappear: true, // GetPod should also reflect NotFound
+			expectDelete:          true, // Delete is still called
+			wantErr:               false,
+		},
+		{
+			name:                "delete fails with internal error - should return Internal error",
+			initialObjects:      []runtime.Object{basePod},
+			deleteReactionError: k8serrors.NewInternalError(errors.New("simulated delete error")),
+			expectDelete:        true,
+			wantErr:             true,
+			wantCode:            codes.Internal,
+		},
+		{
+			name:                  "pod never disappears (timeout) - should return DeadlineExceeded error",
+			initialObjects:        []runtime.Object{basePod},
+			getPodShouldDisappear: false, // GetPod continues to return the pod
+			expectDelete:          true,
+			wantErr:               true,
+			wantCode:              codes.DeadlineExceeded,
+		},
+		{
+			name:                  "getPod fails during poll with internal error - should return Internal error",
+			initialObjects:        []runtime.Object{basePod},
+			getPodPersistentError: k8serrors.NewInternalError(errors.New("simulated get error")),
+			expectDelete:          true,
+			wantErr:               true,
+			wantCode:              codes.Internal,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond) // Short timeout for testing
+			defer cancel()
+
+			testClientset := clientset.NewFakeClientset(tc.initialObjects...)
+			fakeK8sClient := testClientset.K8sClient().(*fake.Clientset)
+
+			deleteCalled := false
+			// Reactor for Delete
+			fakeK8sClient.PrependReactor("delete", "pods", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+				deleteCalled = true
+				if tc.deleteReactionError != nil {
+					return true, nil, tc.deleteReactionError
+				}
+
+				// Simulate the effect on the custom GetPod
+				if tc.getPodShouldDisappear {
+					testClientset.GetPodErr = k8serrors.NewNotFound(schema.GroupResource{Group: "", Resource: "pods"}, podName)
+				}
+				return true, nil, nil
+			})
+
+			// Configure initial state of custom GetPod
+			if tc.getPodPersistentError != nil {
+				testClientset.GetPodErr = tc.getPodPersistentError
+			} else {
+				found := false
+				for _, obj := range tc.initialObjects {
+					if pod, ok := obj.(*corev1.Pod); ok && pod.Name == podName && pod.Namespace == namespace {
+						found = true
+						break
+					}
+				}
+				if !found {
+					testClientset.GetPodErr = k8serrors.NewNotFound(schema.GroupResource{Group: "", Resource: "pods"}, podName)
+				} else {
+					testClientset.GetPodErr = nil // Pod exists
+				}
+			}
+
+			err := deleteMounterPod(ctx, testClientset, namespace, podName)
+
+			if deleteCalled != tc.expectDelete {
+				t.Errorf("Expected delete call: %v, got: %v", tc.expectDelete, deleteCalled)
+			}
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("deleteMounterPod() succeeded unexpectedly, want error")
+				}
+				st, ok := status.FromError(err)
+				if !ok {
+					// Handle non-status errors if wantCode is not set
+					if tc.wantCode == codes.OK {
+						return
+					}
+					t.Fatalf("deleteMounterPod() returned non-status error %v, want status error with code %v", err, tc.wantCode)
+				}
+				if st.Code() != tc.wantCode {
+					t.Errorf("deleteMounterPod() returned error code %v, want %v (error: %v)", st.Code(), tc.wantCode, err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("deleteMounterPod() failed unexpectedly: %v", err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**: This PR implements ControllerUnpublishVolume. If the mounter pod exists, it deletes it, otherwise, if it doesn't exist, or it was already deleted, ControllerUnpublishVolume is a no-op and returns success.

Currently, the call lists all of the pods in the node to find the mounter pod. Although the pods are already cached by the infomrer and the list should be relatively unexpensive (at most ~100 pods in a node), a future PR will optimize this to O(1) by adding a new informer indexer on the mounter pod name. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```