### PR TITLE
[Shared Mount] NSV - Wait for Mounter Pod GRPC Server

### DIFF
--- a/pkg/cloud_provider/clientset/fake.go
+++ b/pkg/cloud_provider/clientset/fake.go
@@ -27,6 +27,7 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 )
@@ -43,6 +44,7 @@ type FakePodConfig struct {
 	HostNetworkEnabled bool
 	SidecarLimits      corev1.ResourceList
 	DeletionTimestamp  *metav1.Time
+	UID                types.UID
 	PodStatus          *corev1.PodStatus
 	NodeName           string
 }
@@ -139,6 +141,7 @@ func (c *FakeClientset) CreatePod(podConfig FakePodConfig) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      podConfig.Name,
 			Namespace: podConfig.Namespace,
+			UID:       podConfig.UID,
 		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{

--- a/pkg/csi_driver/gcs_fuse_driver.go
+++ b/pkg/csi_driver/gcs_fuse_driver.go
@@ -21,12 +21,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
 
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/auth"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/clientset"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/storage"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/metrics"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/profiles"
+	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -75,6 +77,7 @@ type GCSDriverConfig struct {
 	FeatureOptions                 *GCSDriverFeatureOptions
 	AssumeGoodSidecarVersion       bool
 	UniverseDomain                 string
+	EmptyDirBasePath               func(podUID string) string
 }
 
 type GCSDriver struct {
@@ -103,6 +106,11 @@ func NewGCSDriver(config *GCSDriverConfig, recorder record.EventRecorder) (*GCSD
 	}
 	if !config.RunController && !config.RunNode {
 		return nil, errors.New("must run at least one controller or node service")
+	}
+	if config.EmptyDirBasePath == nil {
+		config.EmptyDirBasePath = func(podUID string) string {
+			return filepath.Join(util.KubeletDir, "pods", podUID, "volumes", "kubernetes.io~empty-dir", util.SidecarContainerTmpVolumeName)
+		}
 	}
 
 	driver := &GCSDriver{

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -726,8 +726,11 @@ func (s *nodeServer) executeNodeStageVolume(ctx context.Context, req *csi.NodeSt
 		return nil, status.Errorf(codes.Internal, "mkdir failed for path %q: %v", stagingPath, err)
 	}
 
-	// TODO(FUECHR) Add empty dir creation flow.
-	// TODO(FUECHR) Wait for mounter pod running flow.
+	// Wait for the mounter pod grpc server to be ready.
+	if err := waitForMounterServer(ctx, clientset, podNamespace, podName, string(pod.UID), s.driver.config.EmptyDirBasePath); err != nil {
+		return nil, err
+	}
+
 	// TODO(FUECHR) Add start gcsfuse flow.
 	klog.Infof("Mounter pod %s/%s is running and staging path %s is mounted", podNamespace, podName, stagingPath)
 

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -40,6 +40,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	mount "k8s.io/mount-utils"
 )
 
@@ -235,6 +236,20 @@ func TestExecuteNodeStageVolume(t *testing.T) {
 	podNamespace := "test-ns"
 	podName := createMounterPodName(nodeID, volID)
 
+	kubeletDir := t.TempDir()
+
+	// Create a temporary directory for mounter pod empty dir
+	mounterSocketDirValid := filepath.Join(kubeletDir, "pods", podName, "volumes", "kubernetes.io~empty-dir", util.SidecarContainerTmpVolumeName)
+	if err := os.MkdirAll(mounterSocketDirValid, 0755); err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	validSocketFile := filepath.Join(mounterSocketDirValid, mounterSocketFile)
+	if file, err := os.Create(validSocketFile); err != nil {
+		t.Fatalf("failed to create socket file: %v", err)
+	} else {
+		file.Close()
+	}
+
 	cases := []struct {
 		name      string
 		req       *csi.NodeStageVolumeRequest
@@ -290,13 +305,12 @@ func TestExecuteNodeStageVolume(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var fakeClientSet *clientset.FakeClientset
 			if tc.podExists {
-				pod := &corev1.Pod{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      podName,
-						Namespace: podNamespace,
-					},
-				}
-				fakeClientSet = clientset.NewFakeClientset(pod)
+				fakeClientSet = clientset.NewFakeClientset()
+				fakeClientSet.CreatePod(clientset.FakePodConfig{
+
+					UID:       types.UID(podName),
+					PodStatus: &corev1.PodStatus{Phase: corev1.PodRunning},
+				})
 			} else {
 				fakeClientSet = clientset.NewFakeClientset()
 				fakeClientSet.GetPodErr = apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, podName)
@@ -310,6 +324,9 @@ func TestExecuteNodeStageVolume(t *testing.T) {
 			ns, ok := testEnv.ns.(*nodeServer)
 			if !ok {
 				t.Fatalf("Failed to cast NodeServer to *nodeServer")
+			}
+			ns.driver.config.EmptyDirBasePath = func(uid string) string {
+				return filepath.Join(kubeletDir, "pods", uid, "volumes", "kubernetes.io~empty-dir", util.SidecarContainerTmpVolumeName)
 			}
 
 			// Clear the staging path so we can check whether os.MkdirAll was called.
@@ -784,6 +801,23 @@ func TestNodeStageVolume(t *testing.T) {
 
 	stagingPath, cleanup := setupMountTarget(t)
 	defer cleanup()
+	nodeID := "test-node" // default from initTestDriver
+	volID := testVolumeID
+	podName := createMounterPodName(nodeID, volID)
+
+	kubeletDir := t.TempDir()
+
+	// Create a temporary directory for mounter pod empty dir
+	mounterSocketDirValid := filepath.Join(kubeletDir, "pods", podName, "volumes", "kubernetes.io~empty-dir", util.SidecarContainerTmpVolumeName)
+	if err := os.MkdirAll(mounterSocketDirValid, 0755); err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	validSocketFile := filepath.Join(mounterSocketDirValid, mounterSocketFile)
+	if file, err := os.Create(validSocketFile); err != nil {
+		t.Fatalf("failed to create socket file: %v", err)
+	} else {
+		file.Close()
+	}
 
 	cases := []struct {
 		name      string
@@ -937,7 +971,21 @@ func TestNodeStageVolume(t *testing.T) {
 
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
-			testEnv := initTestNodeServer(t)
+			fakeClientset := clientset.NewFakeClientset()
+			fakeClientset.CreatePod(clientset.FakePodConfig{
+				UID:       types.UID(podName),
+				PodStatus: &corev1.PodStatus{Phase: corev1.PodRunning},
+			})
+
+			testEnv := initTestNodeServerWithCustomClientset(t, fakeClientset, false)
+			ns, ok := testEnv.ns.(*nodeServer)
+			if !ok {
+				t.Fatalf("Failed to cast NodeServer to *nodeServer")
+			}
+			ns.driver.config.EmptyDirBasePath = func(uid string) string {
+				return filepath.Join(kubeletDir, "pods", uid, "volumes", "kubernetes.io~empty-dir", util.SidecarContainerTmpVolumeName)
+			}
+
 			_, err := testEnv.ns.NodeStageVolume(context.TODO(), test.req)
 			if test.expectErr == nil && err != nil {
 				t.Errorf("got error %q, expected error nil", err)

--- a/pkg/csi_driver/shared_mount.go
+++ b/pkg/csi_driver/shared_mount.go
@@ -21,6 +21,8 @@ import (
 	"crypto/sha1"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"time"
 
 	"context"
@@ -42,6 +44,7 @@ const (
 	mounterPodNamePrefix    = "gcsfusecsi-mount"
 	mounterPodPriorityClass = "gcsfusecsi-mount-priority"
 	mounterPodMountDir      = "mount-dir"
+	mounterSocketFile       = "mounter.sock"
 )
 
 var (
@@ -376,5 +379,85 @@ func setResource(target *corev1.ResourceList, override corev1.ResourceList, reso
 		}
 	} else {
 		(*target)[resourceName] = val
+	}
+}
+
+// waitForMounterServer waits for the mounter pod's gRPC server to be ready.
+func waitForMounterServer(ctx context.Context, clientset clientset.Interface, mounterPodNamespace, mounterPodName, podUID string, emptyDirBasePath func(string) string) error {
+	if clientset == nil {
+		return status.Error(codes.Internal, "kubernetes client is uninitialized")
+	}
+	if emptyDirBasePath == nil {
+		return status.Error(codes.Internal, "emptyDirBasePath function is uninitialized")
+	}
+
+	// Construct the mounter socket file path.
+	mounterSocketFilePath := filepath.Join(emptyDirBasePath(podUID), mounterSocketFile)
+	var pod *corev1.Pod
+	var err error
+
+	checkIfReady := func() (bool, error) {
+		// Get the mounter pod status.
+		if pod, err = clientset.GetPod(mounterPodNamespace, mounterPodName); err != nil {
+			// Mounter Pod should exist by this point.
+			if errors.IsNotFound(err) {
+				return false, status.Errorf(codes.FailedPrecondition, "mounter pod %s/%s expected to exist but was not found", mounterPodNamespace, mounterPodName)
+			}
+			return false, status.Errorf(codes.Internal, "failed to get mounter pod %s/%s: %v", mounterPodNamespace, mounterPodName, err)
+		}
+
+		// If the pod is not pending or running, it's in an unexpected state.
+		if pod.Status.Phase != corev1.PodRunning && pod.Status.Phase != corev1.PodPending {
+			return false, status.Errorf(codes.Internal, "mounter pod %s/%s found with an unexpected status: %s", mounterPodNamespace, mounterPodName, pod.Status.Phase)
+		}
+
+		// If the pod is pending, retry.
+		if pod.Status.Phase == corev1.PodPending {
+			klog.Infof("Mounter pod %s/%s is still Pending. Retrying...", mounterPodNamespace, mounterPodName)
+			return false, nil
+		}
+
+		// Mounter pod is running, check if the socket file is available.
+		// TODO(FUECHR): Investigate symlink traversal vulnerabilities for os.Stat vs os.Lstat.
+		if _, err = os.Stat(mounterSocketFilePath); err == nil {
+			klog.Infof("Mounter pod %s/%s is running and socket file %q is available.", mounterPodNamespace, mounterPodName, mounterSocketFilePath)
+			return true, nil
+		}
+		if !os.IsNotExist(err) {
+			return false, status.Errorf(codes.Internal, "error checking socket file %q for mounter pod %s/%s: %v", mounterSocketFilePath, mounterPodNamespace, mounterPodName, err)
+		}
+		klog.Infof("Mounter pod %s/%s is running but socket file %q is not yet available. Retrying...", mounterPodNamespace, mounterPodName, mounterSocketFilePath)
+		return false, nil
+	}
+
+	// Check immediately to avoid waiting if the pod and socket are already ready.
+	if ready, err := checkIfReady(); err != nil || ready {
+		return err
+	}
+
+	klog.Infof("Waiting for mounter pod %s/%s to start running and the mounter pod socket file %q to become available. Polling every %s",
+		mounterPodNamespace, mounterPodName, mounterSocketFilePath, mounterPodPollInterval)
+
+	ticker := time.NewTicker(mounterPodPollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			if ready, err := checkIfReady(); err != nil || ready {
+				return err
+			}
+		case <-ctx.Done():
+			code := codes.DeadlineExceeded
+			if ctx.Err() == context.Canceled {
+				code = codes.Canceled
+			}
+			errMsg := fmt.Sprintf("timeout waiting for mounter pod %s/%s gRPC server to become available at %s: %v",
+				mounterPodNamespace, mounterPodName, mounterSocketFilePath, ctx.Err())
+			if pod != nil { // Catches the case where context is cancelled before GetPod is first called.
+				errMsg += fmt.Sprintf(", pod status: %+v", pod.Status)
+			}
+			return status.Error(code, errMsg)
+		}
 	}
 }

--- a/pkg/csi_driver/shared_mount_test.go
+++ b/pkg/csi_driver/shared_mount_test.go
@@ -21,6 +21,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -70,6 +72,120 @@ func TestSharedMount(t *testing.T) {
 			result := sharedMount(vc)
 			if result != tc.expected {
 				t.Errorf("Expected %v, but got %v", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestWaitForMounterServer(t *testing.T) {
+	// Do not enable t.Parallel to avoid global data races.
+	oldInterval := mounterPodPollInterval
+	mounterPodPollInterval = 10 * time.Millisecond
+	defer func() { mounterPodPollInterval = oldInterval }()
+
+	// Create a temporary directory for kubelet dir
+	tmpDir := t.TempDir()
+
+	mounterSocketDirValid := filepath.Join(tmpDir, "pods", testPod, "volumes", "kubernetes.io~empty-dir", util.SidecarContainerTmpVolumeName)
+	if err := os.MkdirAll(mounterSocketDirValid, 0755); err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+
+	validSocketFile := filepath.Join(mounterSocketDirValid, mounterSocketFile)
+	if file, err := os.Create(validSocketFile); err != nil {
+		t.Fatalf("failed to create socket file: %v", err)
+	} else {
+		file.Close()
+	}
+
+	podUIDWithoutSocket := "test-pod-uid-missing"
+	mounterSocketDirMissing := filepath.Join(tmpDir, "pods", podUIDWithoutSocket, "volumes", "kubernetes.io~empty-dir", util.SidecarContainerTmpVolumeName)
+	if err := os.MkdirAll(mounterSocketDirMissing, 0755); err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+
+	cases := []struct {
+		name         string
+		podStatus    *corev1.PodStatus
+		getPodErr    error
+		podUID       string
+		timeout      time.Duration
+		expectErr    bool
+		expectedCode codes.Code
+	}{
+		{
+			name:      "pod running and socket exists - should return success",
+			podStatus: &corev1.PodStatus{Phase: corev1.PodRunning},
+			podUID:    testPod,
+			timeout:   200 * time.Millisecond,
+			expectErr: false,
+		},
+		{
+			name:         "unexpected pod phase - should return failure",
+			podStatus:    &corev1.PodStatus{Phase: corev1.PodFailed},
+			podUID:       testPod,
+			timeout:      200 * time.Millisecond,
+			expectErr:    true,
+			expectedCode: codes.Internal,
+		},
+		{
+			name:         "pod get fails - should return failure",
+			getPodErr:    fmt.Errorf("simulated get pod error"),
+			podUID:       testPod,
+			timeout:      200 * time.Millisecond,
+			expectErr:    true,
+			expectedCode: codes.Internal,
+		},
+		{
+			name:         "context times out, pod pending - should return failure",
+			podStatus:    &corev1.PodStatus{Phase: corev1.PodPending},
+			podUID:       testPod,
+			timeout:      200 * time.Millisecond,
+			expectErr:    true,
+			expectedCode: codes.DeadlineExceeded,
+		},
+		{
+			name:         "context times out, pod running but socket missing - should return failure",
+			podStatus:    &corev1.PodStatus{Phase: corev1.PodRunning},
+			podUID:       podUIDWithoutSocket,
+			timeout:      200 * time.Millisecond,
+			expectErr:    true,
+			expectedCode: codes.DeadlineExceeded,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fc := clientset.NewFakeClientset()
+			if tc.podStatus != nil {
+				fc.CreatePod(clientset.FakePodConfig{PodStatus: tc.podStatus})
+			}
+			if tc.getPodErr != nil {
+				fc.GetPodErr = tc.getPodErr
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), tc.timeout)
+			defer cancel()
+
+			emptyDirBasePath := func(uid string) string {
+				return filepath.Join(tmpDir, "pods", uid, "volumes", "kubernetes.io~empty-dir", util.SidecarContainerTmpVolumeName)
+			}
+			err := waitForMounterServer(ctx, fc, testNamespace, testPod, tc.podUID, emptyDirBasePath)
+
+			if tc.expectErr {
+				if err == nil {
+					t.Fatalf("Expected error, but got nil")
+				}
+				st, ok := status.FromError(err)
+				if !ok {
+					t.Errorf("Expected grpc status error, bu got: %v", err)
+				} else if st.Code() != tc.expectedCode {
+					t.Errorf("Expected error code %v, but got %v (error: %v)", tc.expectedCode, st.Code(), err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("Expected no error, but got: %v", err)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

 /kind feature
> /kind flake

**What this PR does / why we need it**:
This feature continues the implementation of NSV by checking to see if the Mounter Pod GRPC Server is ready by checking the existence of the socket file over which it is hosted. We first check if the mounter pod is in a running state because if it is not then even though the socket file may exist it may be stale or the socket was created and then the mounter pod crashed.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```