### PR TITLE
Allow customer to override mounter pod resources.

### DIFF
--- a/pkg/cloud_provider/clientset/fake.go
+++ b/pkg/cloud_provider/clientset/fake.go
@@ -72,6 +72,7 @@ type FakeSCConfig struct {
 type FakePodTemplateConfig struct {
 	Name      string
 	Namespace string
+	Template  corev1.PodTemplateSpec
 }
 
 type FakeClientset struct {
@@ -249,6 +250,7 @@ func (c *FakeClientset) CreatePodTemplate(podTemplateConfig FakePodTemplateConfi
 			Name:      podTemplateConfig.Name,
 			Namespace: podTemplateConfig.Namespace,
 		},
+		Template: podTemplateConfig.Template,
 	}
 
 	c.fakePodTemplates[podTemplate.Name] = podTemplate

--- a/pkg/csi_driver/controller.go
+++ b/pkg/csi_driver/controller.go
@@ -197,12 +197,22 @@ func (s *controllerServer) ControllerPublishVolume(ctx context.Context, req *csi
 		return nil, status.Error(codes.Internal, "pod template can't be nil")
 	}
 
+	// Extract resources specifically from the container named "gcsfusecsi-mount".
+	var containerResources *corev1.ResourceRequirements
+	for i := range podTemplate.Template.Spec.Containers {
+		if podTemplate.Template.Spec.Containers[i].Name == mounterPodNamePrefix {
+			containerResources = &podTemplate.Template.Spec.Containers[i].Resources
+			break
+		}
+	}
+
 	// Prepare mounter pod config.
 	podName := createMounterPodName(nodeID, volumeID)
 	podConfig := &mounterPodConfig{
 		podName:            podName,
 		namespace:          podNamespace,
 		serviceAccountName: podTemplate.Template.Spec.ServiceAccountName,
+		resources:          containerResources,
 		nodeID:             nodeID,
 		// TODO(urielguzman): Replace with the actual mounter pod image.
 		image: "k8s.gcr.io/pause",

--- a/pkg/csi_driver/controller_test.go
+++ b/pkg/csi_driver/controller_test.go
@@ -31,6 +31,7 @@ import (
 	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -262,6 +263,7 @@ func TestControllerPublishVolume(t *testing.T) {
 		expectErrCode      codes.Code
 		podTemplateGetErr  error
 		wantPublishContext map[string]string
+		verifyCreatedPod   func(t *testing.T, pod *corev1.Pod)
 	}{
 		{
 			name: "empty volume ID - should return error",
@@ -372,6 +374,71 @@ func TestControllerPublishVolume(t *testing.T) {
 				PublishContextKeyMounterPodName:      createMounterPodName(testNodeID, testVolumeID),
 			},
 			expectErr: false,
+		},
+		{
+			name: "sharedMount true - mounter pod with resource overrides - should create pod with overridden resources",
+			req: &csi.ControllerPublishVolumeRequest{
+				VolumeId:         testVolumeID,
+				NodeId:           testNodeID,
+				VolumeCapability: testVolumeCapability,
+				VolumeContext: map[string]string{
+					"sharedMount": "true",
+				},
+			},
+			setupFake: func() *clientset.FakeClientset {
+				cfg := getDefaultFakeClientsetConfig()
+				// Modify the PodTemplate to include specific resources
+				cfg.ptConfig.Template = corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: mounterPodNamePrefix,
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("150m"),
+										corev1.ResourceMemory: resource.MustParse("128Mi"),
+									},
+									Limits: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("300m"),
+										corev1.ResourceMemory: resource.MustParse("256Mi"),
+									},
+								},
+							},
+						},
+					},
+				}
+				return setupFakeBase(cfg)
+			},
+			wantPublishContext: map[string]string{
+				PublishContextKeyMounterPodNamespace: testNamespace,
+				PublishContextKeyMounterPodName:      createMounterPodName(testNodeID, testVolumeID),
+			},
+			expectErr: false,
+			verifyCreatedPod: func(t *testing.T, pod *corev1.Pod) {
+				if len(pod.Spec.Containers) != 1 {
+					t.Fatalf("Expected 1 container in created pod, got %d", len(pod.Spec.Containers))
+				}
+				container := pod.Spec.Containers[0]
+				if container.Name != mounterPodNamePrefix {
+					t.Errorf("Expected container name %q, got %q", mounterPodNamePrefix, container.Name)
+				}
+
+				expectedResources := corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:              resource.MustParse("150m"),
+						corev1.ResourceMemory:           resource.MustParse("128Mi"),
+						corev1.ResourceEphemeralStorage: resource.MustParse("15Gi"), // Default
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("300m"),
+						corev1.ResourceMemory: resource.MustParse("256Mi"),
+					},
+				}
+
+				if !reflect.DeepEqual(container.Resources, expectedResources) {
+					t.Errorf("Mounter pod resources do not match expected overrides.\nGot: %+v\nWant: %+v", container.Resources, expectedResources)
+				}
+			},
 		},
 		{
 			name: "sharedMount true - missing mounter pod template annotation - should return error",
@@ -522,6 +589,7 @@ func TestControllerPublishVolume(t *testing.T) {
 			s := initTestController(t, fc)
 
 			fakeK8sClient := fc.K8sClient().(*fake.Clientset)
+			var createdPod *corev1.Pod
 
 			if test.podGetErr != nil {
 				fakeK8sClient.PrependReactor("get", "pods", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
@@ -536,6 +604,9 @@ func TestControllerPublishVolume(t *testing.T) {
 				fakeK8sClient.Fake.PrependReactor("create", "pods", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
 					createAction := action.(k8stesting.CreateAction)
 					pod := createAction.GetObject().(*corev1.Pod)
+					createdPod = pod.DeepCopy() // Capture the pod spec for verification
+
+					// Simulate successful creation and scheduling
 					pod.Spec.NodeName = testNodeID
 					pod.Status.Conditions = []corev1.PodCondition{
 						{
@@ -544,13 +615,14 @@ func TestControllerPublishVolume(t *testing.T) {
 						},
 					}
 
-					// Update the fakePod in clientset so GetPod returns it!
 					fc.CreatePod(clientset.FakePodConfig{
+						Name:      pod.Name,
+						Namespace: pod.Namespace,
 						NodeName:  testNodeID,
 						PodStatus: &pod.Status,
 					})
 
-					return false, nil, nil
+					return false, pod, nil // Return false to allow default fake client handling to store the object
 				})
 			}
 
@@ -568,7 +640,6 @@ func TestControllerPublishVolume(t *testing.T) {
 				}
 				st, ok := status.FromError(err)
 				if !ok {
-					// If not a status error, check if any error was expected
 					if test.expectErrCode != codes.Unknown {
 						t.Fatalf("Expected status error with code %v, got non-status error: %v", test.expectErrCode, err)
 					}
@@ -581,6 +652,12 @@ func TestControllerPublishVolume(t *testing.T) {
 				}
 				if !reflect.DeepEqual(test.wantPublishContext, resp.PublishContext) {
 					t.Errorf("Expected publish context: %v, got: %v", test.wantPublishContext, resp.PublishContext)
+				}
+				if test.verifyCreatedPod != nil {
+					if createdPod == nil {
+						t.Fatalf("Expected pod to be created, but it was not captured")
+					}
+					test.verifyCreatedPod(t, createdPod)
 				}
 			}
 		})

--- a/pkg/csi_driver/shared_mount.go
+++ b/pkg/csi_driver/shared_mount.go
@@ -32,6 +32,7 @@ import (
 	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
@@ -49,11 +50,12 @@ var (
 
 // mounterPodConfig holds the configuration parameters required to define and manage a mounter pod.
 type mounterPodConfig struct {
-	podName            string // The name to assign to the mounter pod.
-	nodeID             string // The specific node ID where the pod should be scheduled.
-	namespace          string // The Kubernetes namespace in which to create the pod.
-	image              string // The image for the mounter pod binary.
-	serviceAccountName string // The KSA name for the mounter pod.
+	podName            string                       // The name to assign to the mounter pod.
+	nodeID             string                       // The specific node ID where the pod should be scheduled.
+	namespace          string                       // The Kubernetes namespace in which to create the pod.
+	image              string                       // The image for the mounter pod binary.
+	serviceAccountName string                       // The KSA name for the mounter pod.
+	resources          *corev1.ResourceRequirements // The resource requirements for the mounter pod container.
 }
 
 // sharedMount checks if the VolumeContext enables the shared node mount feature
@@ -199,9 +201,13 @@ func createMounterPodSpec(config *mounterPodConfig) *corev1.Pod {
 			},
 		},
 	}
+
 	if config.serviceAccountName != "" {
 		spec.Spec.ServiceAccountName = config.serviceAccountName
 	}
+
+	spec.Spec.Containers[0].Resources = *mounterPodResources(config)
+
 	return spec
 }
 
@@ -318,5 +324,57 @@ func deleteMounterPod(ctx context.Context, clientset clientset.Interface, podNam
 				return status.Errorf(codes.Internal, "failed to get pod %s/%s: %v", podNamespace, podName, err)
 			}
 		}
+	}
+}
+
+func mounterPodResources(config *mounterPodConfig) *corev1.ResourceRequirements {
+	// Instantiate maps to avoid nil map assignment panics
+	resources := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			// TODO: Change the defaults once we profile the feature.
+			corev1.ResourceMemory:           resource.MustParse("768Mi"),
+			corev1.ResourceCPU:              resource.MustParse("750m"),
+			corev1.ResourceEphemeralStorage: resource.MustParse("15Gi"),
+		},
+		Limits: corev1.ResourceList{},
+	}
+
+	// Guard against nil configs or nil resources
+	if config == nil || config.resources == nil {
+		return &resources
+	}
+
+	// Set customer overrides, if defined.
+	for resourceName := range config.resources.Requests {
+		setResource(&resources.Requests, config.resources.Requests, resourceName)
+	}
+	for resourceName := range config.resources.Limits {
+		setResource(&resources.Limits, config.resources.Limits, resourceName)
+	}
+
+	return &resources
+}
+
+func setResource(target *corev1.ResourceList, override corev1.ResourceList, resourceName corev1.ResourceName) {
+	if target == nil {
+		return
+	}
+	val, ok := override[resourceName]
+	if !ok {
+		return // No value provided, skip setting
+	}
+
+	// Initialize the underlying map if it's nil and we are inserting a value
+	if *target == nil && !val.IsZero() {
+		*target = make(corev1.ResourceList)
+	}
+
+	// Remove the value if "0" is specified.
+	if val.IsZero() {
+		if *target != nil {
+			delete(*target, resourceName)
+		}
+	} else {
+		(*target)[resourceName] = val
 	}
 }

--- a/pkg/csi_driver/shared_mount_test.go
+++ b/pkg/csi_driver/shared_mount_test.go
@@ -34,6 +34,7 @@ import (
 	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
@@ -199,19 +200,30 @@ func TestPVFromVolumeID(t *testing.T) {
 }
 
 func TestCreateMounterPodSpec(t *testing.T) {
+	// Default resources expected when no overrides are provided
+	defaultResources := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceMemory:           resource.MustParse("768Mi"),
+			corev1.ResourceCPU:              resource.MustParse("750m"),
+			corev1.ResourceEphemeralStorage: resource.MustParse("15Gi"),
+		},
+		Limits: corev1.ResourceList{},
+	}
+
 	tests := []struct {
 		name   string
 		config *mounterPodConfig
 		want   *corev1.Pod
 	}{
 		{
-			name: "basic config - should succeed",
+			name: "basic config - should include default resources",
 			config: &mounterPodConfig{
 				podName:            "my-mounter-pod",
 				namespace:          "my-namespace",
 				serviceAccountName: "my-ksa",
 				nodeID:             "node-123",
 				image:              "gcr.io/my-project/my-image:v1.0.0",
+				// No config.resources override
 			},
 			want: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
@@ -232,6 +244,95 @@ func TestCreateMounterPodSpec(t *testing.T) {
 							ImagePullPolicy: corev1.PullAlways,
 							SecurityContext: &corev1.SecurityContext{
 								Privileged: ptr.To(true),
+							},
+							Resources: defaultResources, // Expect default resources
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:             mounterPodMountDir,
+									MountPath:        util.KubeletDir,
+									MountPropagation: ptr.To(corev1.MountPropagationBidirectional),
+								},
+								{
+									Name:      util.SidecarContainerTmpVolumeName,
+									MountPath: util.SidecarContainerTmpVolumePath,
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: mounterPodMountDir,
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: util.KubeletDir,
+									Type: ptr.To(corev1.HostPathDirectoryOrCreate),
+								},
+							},
+						},
+						{
+							Name: util.SidecarContainerTmpVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
+							},
+						},
+					},
+					Tolerations: []corev1.Toleration{
+						{
+							Operator: corev1.TolerationOpExists,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "config with resource overrides - should merge resources",
+			config: &mounterPodConfig{
+				podName:            "my-mounter-pod",
+				namespace:          "my-namespace",
+				serviceAccountName: "my-ksa",
+				nodeID:             "node-123",
+				image:              "gcr.io/my-project/my-image:v1.0.0",
+				resources: &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1000m"),
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("2000m"),
+						corev1.ResourceMemory: resource.MustParse("2Gi"),
+					},
+				},
+			},
+			want: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-mounter-pod",
+					Namespace: "my-namespace",
+				},
+				Spec: corev1.PodSpec{
+					NodeSelector: map[string]string{
+						"kubernetes.io/hostname": "node-123",
+						"kubernetes.io/os":       "linux",
+					},
+					ServiceAccountName: "my-ksa",
+					PriorityClassName:  mounterPodPriorityClass,
+					Containers: []corev1.Container{
+						{
+							Name:            mounterPodNamePrefix,
+							Image:           "gcr.io/my-project/my-image:v1.0.0",
+							ImagePullPolicy: corev1.PullAlways,
+							SecurityContext: &corev1.SecurityContext{
+								Privileged: ptr.To(true),
+							},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:              resource.MustParse("1000m"), // Overridden
+									corev1.ResourceMemory:           resource.MustParse("1Gi"),   // Overridden
+									corev1.ResourceEphemeralStorage: resource.MustParse("15Gi"),  // Default
+								},
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("2000m"), // Set
+									corev1.ResourceMemory: resource.MustParse("2Gi"),   // Set
+								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
@@ -836,6 +937,155 @@ func TestDeleteMounterPod(t *testing.T) {
 				if err != nil {
 					t.Fatalf("deleteMounterPod() failed unexpectedly: %v", err)
 				}
+			}
+		})
+	}
+}
+
+func TestSetResource(t *testing.T) {
+	tests := []struct {
+		name         string
+		initial      corev1.ResourceList
+		override     corev1.ResourceList
+		resourceName corev1.ResourceName
+		want         corev1.ResourceList
+	}{
+		{
+			name:         "override missing - no change",
+			initial:      corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+			override:     corev1.ResourceList{},
+			resourceName: corev1.ResourceCPU,
+			want:         corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+		},
+		{
+			name:         "override is zero - delete resource",
+			initial:      corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1"), corev1.ResourceMemory: resource.MustParse("1Gi")},
+			override:     corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("0")},
+			resourceName: corev1.ResourceCPU,
+			want:         corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("1Gi")},
+		},
+		{
+			name:         "override has value - update resource",
+			initial:      corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+			override:     corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")},
+			resourceName: corev1.ResourceCPU,
+			want:         corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Deep copy initial map to avoid mutation issues between test iterations
+			target := make(corev1.ResourceList)
+			for k, v := range tc.initial {
+				target[k] = v
+			}
+
+			setResource(&target, tc.override, tc.resourceName)
+
+			if diff := cmp.Diff(tc.want, target); diff != "" {
+				t.Errorf("setResource() returned unexpected diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+
+	t.Run("nil target pointer does not panic", func(t *testing.T) {
+		setResource(nil, corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")}, corev1.ResourceCPU)
+	})
+
+	t.Run("pointer to nil map does not panic and initializes correctly", func(t *testing.T) {
+		var target corev1.ResourceList // target map is nil
+		setResource(&target, corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")}, corev1.ResourceCPU)
+
+		want := corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")}
+		if diff := cmp.Diff(want, target); diff != "" {
+			t.Errorf("setResource() with pointer to nil map returned unexpected diff (-want +got):\n%s", diff)
+		}
+	})
+}
+
+func TestMounterPodResources(t *testing.T) {
+	defaultRequests := corev1.ResourceList{
+		corev1.ResourceMemory:           resource.MustParse("768Mi"),
+		corev1.ResourceCPU:              resource.MustParse("750m"),
+		corev1.ResourceEphemeralStorage: resource.MustParse("15Gi"),
+	}
+
+	tests := []struct {
+		name   string
+		config *mounterPodConfig
+		want   *corev1.ResourceRequirements
+	}{
+		{
+			name: "no overrides (nil config resources) - should return defaults",
+			config: &mounterPodConfig{
+				resources: nil,
+			},
+			want: &corev1.ResourceRequirements{
+				Requests: defaultRequests,
+				Limits:   corev1.ResourceList{},
+			},
+		},
+		{
+			name: "override CPU and memory requests - should succeed",
+			config: &mounterPodConfig{
+				resources: &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+					},
+				},
+			},
+			want: &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceMemory:           resource.MustParse("1Gi"),
+					corev1.ResourceCPU:              resource.MustParse("1"),
+					corev1.ResourceEphemeralStorage: resource.MustParse("15Gi"),
+				},
+				Limits: corev1.ResourceList{},
+			},
+		},
+		{
+			name: "set limits without changing requests - should succeed",
+			config: &mounterPodConfig{
+				resources: &corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("2Gi"),
+					},
+				},
+			},
+			want: &corev1.ResourceRequirements{
+				Requests: defaultRequests,
+				Limits: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+			},
+		},
+		{
+			name: "override with zero - should delete default request",
+			config: &mounterPodConfig{
+				resources: &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("0"),
+					},
+				},
+			},
+			want: &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceMemory:           resource.MustParse("768Mi"),
+					corev1.ResourceEphemeralStorage: resource.MustParse("15Gi"),
+				},
+				Limits: corev1.ResourceList{},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mounterPodResources(tc.config)
+
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("mounterPodResources() returned unexpected diff (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Allow customer to override mounter pod resources with PodTemplate.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```