### PR TITLE
Remove PVC lister to improve node driver memory usage

### DIFF
--- a/cmd/csi_driver/main.go
+++ b/cmd/csi_driver/main.go
@@ -255,13 +255,11 @@ func main() {
 		// TODO(urielguzman): Configure pod lister in the controller for shared node mount.
 		clientset.ConfigurePodLister(ctx, *nodeID)
 		clientset.ConfigureNodeLister(ctx, *nodeID)
-		// Both PVs & PVCs are needed to check count of GCSFuseVolumes
-		clientset.ConfigurePVLister(ctx)
-		clientset.ConfigurePVCLister(ctx)
 
 		if featureOptions.FeatureGCSFuseProfiles.Enabled {
 			// Curently, only the gcsfuse profiles feature actually uses these listers.
 			clientset.ConfigureSCLister(ctx)
+			clientset.ConfigurePVLister(ctx)
 		}
 
 		mounter, err = csimounter.New("", *fuseSocketDir)

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -595,6 +595,15 @@ func gcsFuseSidecarContainerImage(pod *corev1.Pod) string {
 	return ""
 }
 
+// countGcsFuseVolumes returns the number of GCSFuse CSI Ephemeral volumes or
+// PersistentVolumeClaims in the given Pod spec. We intentionally do not
+// check to see if the PVC is a GCSFuseCSI PVC because that requires additional
+// API calls or a PVC informer which previously made the node driver OOM.
+// We may end up counting some non-GCSFuse volumes, but that is acceptable
+// since this is only used to determine whether to enable metrics collection
+// on a given pod.
+// TODO(amacaskill): Make sure the PVC is a GCSFuseCSI PVC, without
+// causing an OOM in the node driver at scale.
 func (s *nodeServer) countGcsFuseVolumes(pod *corev1.Pod) (int, error) {
 	gcsFuseVolumeCount := 0
 
@@ -609,38 +618,9 @@ func (s *nodeServer) countGcsFuseVolumes(pod *corev1.Pod) (int, error) {
 			continue
 		}
 
-		if v.PersistentVolumeClaim == nil {
-			continue
-		}
-
-		// Count persistent gcsfuse volumes
-		pvc, err := s.k8sClients.GetPVC(pod.Namespace, v.PersistentVolumeClaim.ClaimName)
-
-		// A NotFound error is tolerated, but other errors will abort the count and disable metrics.
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				klog.Warningf("pvc %q not found: %v", v.PersistentVolumeClaim.ClaimName, err)
-				continue
-			}
-
-			klog.Errorf("internal error getting PVC %q: %v. Setting GCS Fuse metric count to 0", v.PersistentVolumeClaim.ClaimName, err)
-			return 0, err
-		}
-
-		pv, err := s.k8sClients.GetPV(pvc.Spec.VolumeName)
-
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				klog.Warningf("pv %q not found: %v", pvc.Spec.VolumeName, err)
-				continue
-			}
-
-			klog.Errorf("internal error getting PV %q: %v. Setting GCS Fuse metric count to 0", pvc.Spec.VolumeName, err)
-			return 0, err
-		}
-
-		if pv.Spec.CSI != nil && pv.Spec.CSI.Driver == s.driver.config.Name {
+		if v.PersistentVolumeClaim != nil {
 			gcsFuseVolumeCount++
+			continue
 		}
 	}
 

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -1435,7 +1435,7 @@ func TestCountGcsFuseVolumes(t *testing.T) {
 				gcsFuseEphemeralVolumeCount:  2,
 				gcsFusePersistentVolumeCount: 3,
 			},
-			expectedCount: 5,
+			expectedCount: 7,
 		},
 		{
 			name: "mixed csi drivers with no gcsfuse volumes",
@@ -1443,7 +1443,7 @@ func TestCountGcsFuseVolumes(t *testing.T) {
 				totalEphemeralVolumeCount:  5,
 				totalPersistentVolumeCount: 5,
 			},
-			expectedCount: 0,
+			expectedCount: 5,
 		},
 	}
 
@@ -1549,10 +1549,10 @@ func TestNodePublishVolumeAssertMetricsCollectorRegistration(t *testing.T) {
 		},
 		{
 			name:                         "should register collector with other non gcsfuse volumes",
-			totalEphemeralVolumeCount:    10,
-			totalPersistentVolumeCount:   10,
-			gcsFuseEphemeralVolumeCount:  5,
-			gcsFusePersistentVolumeCount: 5,
+			totalEphemeralVolumeCount:    5,
+			totalPersistentVolumeCount:   5,
+			gcsFuseEphemeralVolumeCount:  2,
+			gcsFusePersistentVolumeCount: 2,
 			expectCollectorRegistered:    true,
 		},
 		{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Remove PVC lister to improve node driver memory usage. We added a PVC lister in https://github.com/GoogleCloudPlatform/gcs-fuse-csi-driver/pull/1224/changes#diff-2bbc50b88c0f60adf390ecc574eaae05bec2190cab1b5516d8669308752bac08 and it is making node-driver oom on clusters with lots of PVC/PV (7k each). This PR removes the PVC lister , and now we do not export metrics unless there are less than 10 GCSFuseCSI ephemeral volumes, or 10 PVC total (without checking the provisioner type of the storage) . We can improve this later if needed. 




**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Do not export metrics if a pod has more than 10 GCSFuseCSI ephemeral volumes, or 10 PVC total (without checking the provisioner type of the storage) . This was done for node driver memory usage.
```