### PR TITLE
Automated cherry pick of #1461: Remove PVC lister to improve node driver memory usage

### DIFF
--- a/cmd/csi_driver/main.go
+++ b/cmd/csi_driver/main.go
@@ -254,13 +254,11 @@ func main() {
 
 		clientset.ConfigurePodLister(ctx, *nodeID)
 		clientset.ConfigureNodeLister(ctx, *nodeID)
-		// Both PVs & PVCs are needed to check count of GCSFuseVolumes
-		clientset.ConfigurePVLister(ctx)
-		clientset.ConfigurePVCLister(ctx)
 
 		if featureOptions.FeatureGCSFuseProfiles.Enabled {
 			// Curently, only the gcsfuse profiles feature actually uses these listers.
 			clientset.ConfigureSCLister(ctx)
+			clientset.ConfigurePVLister(ctx)
 		}
 
 		mounter, err = csimounter.New("", *fuseSocketDir)

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -595,6 +595,15 @@ func gcsFuseSidecarContainerImage(pod *corev1.Pod) string {
 	return ""
 }
 
+// countGcsFuseVolumes returns the number of GCSFuse CSI Ephemeral volumes or
+// PersistentVolumeClaims in the given Pod spec. We intentionally do not
+// check to see if the PVC is a GCSFuseCSI PVC because that requires additional
+// API calls or a PVC informer which previously made the node driver OOM.
+// We may end up counting some non-GCSFuse volumes, but that is acceptable
+// since this is only used to determine whether to enable metrics collection
+// on a given pod.
+// TODO(amacaskill): Make sure the PVC is a GCSFuseCSI PVC, without
+// causing an OOM in the node driver at scale.
 func (s *nodeServer) countGcsFuseVolumes(pod *corev1.Pod) (int, error) {
 	gcsFuseVolumeCount := 0
 
@@ -609,38 +618,9 @@ func (s *nodeServer) countGcsFuseVolumes(pod *corev1.Pod) (int, error) {
 			continue
 		}
 
-		if v.PersistentVolumeClaim == nil {
-			continue
-		}
-
-		// Count persistent gcsfuse volumes
-		pvc, err := s.k8sClients.GetPVC(pod.Namespace, v.PersistentVolumeClaim.ClaimName)
-
-		// A NotFound error is tolerated, but other errors will abort the count and disable metrics.
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				klog.Warningf("pvc %q not found: %v", v.PersistentVolumeClaim.ClaimName, err)
-				continue
-			}
-
-			klog.Errorf("internal error getting PVC %q: %v. Setting GCS Fuse metric count to 0", v.PersistentVolumeClaim.ClaimName, err)
-			return 0, err
-		}
-
-		pv, err := s.k8sClients.GetPV(pvc.Spec.VolumeName)
-
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				klog.Warningf("pv %q not found: %v", pvc.Spec.VolumeName, err)
-				continue
-			}
-
-			klog.Errorf("internal error getting PV %q: %v. Setting GCS Fuse metric count to 0", pvc.Spec.VolumeName, err)
-			return 0, err
-		}
-
-		if pv.Spec.CSI != nil && pv.Spec.CSI.Driver == s.driver.config.Name {
+		if v.PersistentVolumeClaim != nil {
 			gcsFuseVolumeCount++
+			continue
 		}
 	}
 

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -1116,7 +1116,7 @@ func TestCountGcsFuseVolumes(t *testing.T) {
 				gcsFuseEphemeralVolumeCount:  2,
 				gcsFusePersistentVolumeCount: 3,
 			},
-			expectedCount: 5,
+			expectedCount: 7,
 		},
 		{
 			name: "mixed csi drivers with no gcsfuse volumes",
@@ -1124,7 +1124,7 @@ func TestCountGcsFuseVolumes(t *testing.T) {
 				totalEphemeralVolumeCount:  5,
 				totalPersistentVolumeCount: 5,
 			},
-			expectedCount: 0,
+			expectedCount: 5,
 		},
 	}
 
@@ -1230,10 +1230,10 @@ func TestNodePublishVolumeAssertMetricsCollectorRegistration(t *testing.T) {
 		},
 		{
 			name:                         "should register collector with other non gcsfuse volumes",
-			totalEphemeralVolumeCount:    10,
-			totalPersistentVolumeCount:   10,
-			gcsFuseEphemeralVolumeCount:  5,
-			gcsFusePersistentVolumeCount: 5,
+			totalEphemeralVolumeCount:    5,
+			totalPersistentVolumeCount:   5,
+			gcsFuseEphemeralVolumeCount:  2,
+			gcsFusePersistentVolumeCount: 2,
 			expectCollectorRegistered:    true,
 		},
 		{


### PR DESCRIPTION
Cherry pick of #1461 on release-1.23.

#1461: Remove PVC lister to improve node driver memory usage

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Do not export metrics if a pod has more than 10 GCSFuseCSI ephemeral volumes, or 10 PVC total (without checking the provisioner type of the storage) . This was done for node driver memory usage.
```