### PR TITLE
Implement private sidecar feature for shared mount.

### DIFF
--- a/cmd/csi_driver/main.go
+++ b/cmd/csi_driver/main.go
@@ -74,6 +74,7 @@ var (
 	enableAutoGoMemLimit           = flag.Bool("enable-auto-gomemlimit", false, "Automatically set GOMEMLIMIT to a percentage of the container's cgroup memory limit.")
 	autoGoMemLimitRatio            = flag.Float64("auto-gomemlimit-ratio", util.GoMemLimitCgroupPercentage, "The ratio of the container's cgroup memory limit to set as GOMEMLIMIT when enable-auto-gomemlimit is enabled.")
 	universeDomain                 = flag.String("universe-domain", "googleapis.com", "The universe domain. The default value is googleapis.com.")
+	mounterPodImage                = flag.String("mounter-pod-image", "", "The image for the mounter pod.")
 
 	// GCSFuse kernel params feature.
 	enableGCSFuseKernelParams = flag.Bool("enable-gcsfuse-kernel-params", false, "Enable gcsfuse kernel params feature.")
@@ -242,6 +243,9 @@ func main() {
 		GoMemLimitOptions: &driver.GoMemLimitOptions{
 			EnableAutoGoMemLimit: *enableAutoGoMemLimit,
 			AutoGoMemLimitRatio:  *autoGoMemLimitRatio,
+		},
+		SharedMountOptions: &driver.SharedMountOptions{
+			MounterPodImage: *mounterPodImage,
 		},
 	}
 

--- a/pkg/csi_driver/controller.go
+++ b/pkg/csi_driver/controller.go
@@ -197,13 +197,28 @@ func (s *controllerServer) ControllerPublishVolume(ctx context.Context, req *csi
 		return nil, status.Error(codes.Internal, "pod template can't be nil")
 	}
 
-	// Extract resources specifically from the container named "gcsfusecsi-mount".
+	// Extract overrides specifically from the container named "gcsfusecsi-mount".
 	var containerResources *corev1.ResourceRequirements
+	var containerImage string
+	if s.driver != nil && s.driver.config != nil && s.driver.config.FeatureOptions != nil && s.driver.config.FeatureOptions.SharedMountOptions != nil {
+		containerImage = s.driver.config.FeatureOptions.SharedMountOptions.MounterPodImage
+	}
 	for i := range podTemplate.Template.Spec.Containers {
-		if podTemplate.Template.Spec.Containers[i].Name == mounterPodNamePrefix {
-			containerResources = &podTemplate.Template.Spec.Containers[i].Resources
-			break
+		container := &podTemplate.Template.Spec.Containers[i]
+		if container.Name != mounterPodNamePrefix {
+			continue
 		}
+		containerResources = &container.Resources
+		if container.Image != "" && container.Image != mounterPodManagedImageKeyword {
+			// If the image isn't the placeholder managed keyword, the user is trying to
+			// override the mounter pod's image.
+			// TODO(urielguzman): Somehow validate image so that only trustworthy repositories are allowed.
+			containerImage = container.Image
+		}
+		break
+	}
+	if containerImage == "" {
+		return nil, status.Error(codes.Internal, "mounter pod image cannot be empty")
 	}
 
 	// Prepare mounter pod config.
@@ -214,8 +229,7 @@ func (s *controllerServer) ControllerPublishVolume(ctx context.Context, req *csi
 		serviceAccountName: podTemplate.Template.Spec.ServiceAccountName,
 		resources:          containerResources,
 		nodeID:             nodeID,
-		// TODO(urielguzman): Replace with the actual mounter pod image.
-		image: "k8s.gcr.io/pause",
+		image:              containerImage,
 	}
 
 	if err := createMounterPod(clientset, ctx, podConfig); err != nil {

--- a/pkg/csi_driver/controller_test.go
+++ b/pkg/csi_driver/controller_test.go
@@ -392,7 +392,8 @@ func TestControllerPublishVolume(t *testing.T) {
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
 							{
-								Name: mounterPodNamePrefix,
+								Name:  mounterPodNamePrefix,
+								Image: mounterPodManagedImageKeyword,
 								Resources: corev1.ResourceRequirements{
 									Requests: corev1.ResourceList{
 										corev1.ResourceCPU:    resource.MustParse("150m"),
@@ -437,6 +438,59 @@ func TestControllerPublishVolume(t *testing.T) {
 
 				if !reflect.DeepEqual(container.Resources, expectedResources) {
 					t.Errorf("Mounter pod resources do not match expected overrides.\nGot: %+v\nWant: %+v", container.Resources, expectedResources)
+				}
+
+				// Default image set for testing when no custom image requested by user.
+				expectedImage := testImage
+
+				if !reflect.DeepEqual(container.Image, expectedImage) {
+					t.Errorf("Mounter pod image does not match expected overrides.\nGot: %+v\nWant: %+v", container.Image, expectedImage)
+				}
+			},
+		},
+		{
+			name: "sharedMount true - mounter pod with image override - should create pod with overridden image",
+			req: &csi.ControllerPublishVolumeRequest{
+				VolumeId:         testVolumeID,
+				NodeId:           testNodeID,
+				VolumeCapability: testVolumeCapability,
+				VolumeContext: map[string]string{
+					"sharedMount": "true",
+				},
+			},
+			setupFake: func() *clientset.FakeClientset {
+				cfg := getDefaultFakeClientsetConfig()
+				// Modify the PodTemplate to include specific resources
+				cfg.ptConfig.Template = corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  mounterPodNamePrefix,
+								Image: "gcr.io/some-project/some-random-image/v1.2.3",
+							},
+						},
+					},
+				}
+				return setupFakeBase(cfg)
+			},
+			wantPublishContext: map[string]string{
+				PublishContextKeyMounterPodNamespace: testNamespace,
+				PublishContextKeyMounterPodName:      createMounterPodName(testNodeID, testVolumeID),
+			},
+			expectErr: false,
+			verifyCreatedPod: func(t *testing.T, pod *corev1.Pod) {
+				if len(pod.Spec.Containers) != 1 {
+					t.Fatalf("Expected 1 container in created pod, got %d", len(pod.Spec.Containers))
+				}
+				container := pod.Spec.Containers[0]
+				if container.Name != mounterPodNamePrefix {
+					t.Errorf("Expected container name %q, got %q", mounterPodNamePrefix, container.Name)
+				}
+
+				expectedImage := "gcr.io/some-project/some-random-image/v1.2.3"
+
+				if !reflect.DeepEqual(container.Image, expectedImage) {
+					t.Errorf("Mounter pod image does not match expected overrides.\nGot: %+v\nWant: %+v", container.Image, expectedImage)
 				}
 			},
 		},

--- a/pkg/csi_driver/gcs_fuse_driver.go
+++ b/pkg/csi_driver/gcs_fuse_driver.go
@@ -52,10 +52,15 @@ type GoMemLimitOptions struct {
 	AutoGoMemLimitRatio  float64
 }
 
+type SharedMountOptions struct {
+	MounterPodImage string
+}
+
 type GCSDriverFeatureOptions struct {
 	EnableGCSFuseKernelParams bool
 	FeatureGCSFuseProfiles    *FeatureGCSFuseProfiles
 	GoMemLimitOptions         *GoMemLimitOptions
+	SharedMountOptions        *SharedMountOptions
 }
 
 type GCSDriverConfig struct {

--- a/pkg/csi_driver/gcs_fuse_driver_test.go
+++ b/pkg/csi_driver/gcs_fuse_driver_test.go
@@ -43,7 +43,12 @@ func initTestDriver(t *testing.T, fm *mount.FakeMounter, clientset clientset.Int
 		NetworkManager:        &fakeNetworkManager{},
 		K8sClients:            clientset,
 		MetricsManager:        metrics.NewFakeMetricsManager(),
-		FeatureOptions:        &GCSDriverFeatureOptions{FeatureGCSFuseProfiles: &FeatureGCSFuseProfiles{}},
+		FeatureOptions: &GCSDriverFeatureOptions{
+			FeatureGCSFuseProfiles: &FeatureGCSFuseProfiles{},
+			SharedMountOptions: &SharedMountOptions{
+				MounterPodImage: testImage,
+			},
+		},
 	}
 	driver, err := NewGCSDriver(config, nil)
 	if err != nil {

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -243,7 +243,7 @@ func TestExecuteNodeStageVolume(t *testing.T) {
 	if err := os.MkdirAll(mounterSocketDirValid, 0755); err != nil {
 		t.Fatalf("failed to create temp dir: %v", err)
 	}
-	validSocketFile := filepath.Join(mounterSocketDirValid, mounterSocketFile)
+	validSocketFile := filepath.Join(mounterSocketDirValid, mounterPodSocketFile)
 	if file, err := os.Create(validSocketFile); err != nil {
 		t.Fatalf("failed to create socket file: %v", err)
 	} else {
@@ -812,7 +812,7 @@ func TestNodeStageVolume(t *testing.T) {
 	if err := os.MkdirAll(mounterSocketDirValid, 0755); err != nil {
 		t.Fatalf("failed to create temp dir: %v", err)
 	}
-	validSocketFile := filepath.Join(mounterSocketDirValid, mounterSocketFile)
+	validSocketFile := filepath.Join(mounterSocketDirValid, mounterPodSocketFile)
 	if file, err := os.Create(validSocketFile); err != nil {
 		t.Fatalf("failed to create socket file: %v", err)
 	} else {

--- a/pkg/csi_driver/shared_mount.go
+++ b/pkg/csi_driver/shared_mount.go
@@ -41,10 +41,11 @@ import (
 )
 
 const (
-	mounterPodNamePrefix    = "gcsfusecsi-mount"
-	mounterPodPriorityClass = "gcsfusecsi-mount-priority"
-	mounterPodMountDir      = "mount-dir"
-	mounterSocketFile       = "mounter.sock"
+	mounterPodNamePrefix          = "gcsfusecsi-mount"
+	mounterPodPriorityClass       = "gcsfusecsi-mount-priority"
+	mounterPodMountDir            = "mount-dir"
+	mounterPodSocketFile          = "mounter.sock"
+	mounterPodManagedImageKeyword = "managed"
 )
 
 var (
@@ -392,7 +393,7 @@ func waitForMounterServer(ctx context.Context, clientset clientset.Interface, mo
 	}
 
 	// Construct the mounter socket file path.
-	mounterSocketFilePath := filepath.Join(emptyDirBasePath(podUID), mounterSocketFile)
+	mounterSocketFilePath := filepath.Join(emptyDirBasePath(podUID), mounterPodSocketFile)
 	var pod *corev1.Pod
 	var err error
 

--- a/pkg/csi_driver/shared_mount_test.go
+++ b/pkg/csi_driver/shared_mount_test.go
@@ -91,7 +91,7 @@ func TestWaitForMounterServer(t *testing.T) {
 		t.Fatalf("failed to create temp dir: %v", err)
 	}
 
-	validSocketFile := filepath.Join(mounterSocketDirValid, mounterSocketFile)
+	validSocketFile := filepath.Join(mounterSocketDirValid, mounterPodSocketFile)
 	if file, err := os.Create(validSocketFile); err != nil {
 		t.Fatalf("failed to create socket file: %v", err)
 	} else {

--- a/test/e2e/testsuites/gcsfuse_oidc_auth.go
+++ b/test/e2e/testsuites/gcsfuse_oidc_auth.go
@@ -44,14 +44,14 @@ import (
 )
 
 const (
-	oidcTestPrefix                              = "gcsfuse-csi-oidc"
-	oidcWorkloadIdentityPoolID                  = "gcs-fuse-oidc-pool"
-	oidcWorkloadIdentityProviderID              = "gcs-fuse-oidc-provider"
-	oidcConfigMapName                           = "workload-identity-credentials"
-	oidcCredentialConfigFileName                = "credential-configuration.json"
-	oidcServiceAccountName                      = "gcs-fuse-oidc-ksa"
-	oidcVolumeName                              = "gcs-volume"
-	oidcMountPath                               = "/mnt/gcs"
+	oidcTestPrefix                 = "gcsfuse-csi-oidc"
+	oidcWorkloadIdentityPoolID     = "gcs-fuse-oidc-pool"
+	oidcWorkloadIdentityProviderID = "gcs-fuse-oidc-provider"
+	oidcConfigMapName              = "workload-identity-credentials"
+	oidcCredentialConfigFileName   = "credential-configuration.json"
+	oidcServiceAccountName         = "gcs-fuse-oidc-ksa"
+	oidcVolumeName                 = "gcs-volume"
+	oidcMountPath                  = "/mnt/gcs"
 )
 
 type gcsFuseCSIOIDCTestSuite struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Implement private sidecar image for the shared mount feature. This allows the user to override the image with their own via the PodTemplate.

This PR also allows passing the managed image from the CSI Driver's controller flags.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```