### PR TITLE
Revert PVlister to only have fields needed for profiles, since metrics doesn't use this anymore

### DIFF
--- a/pkg/cloud_provider/clientset/clientset.go
+++ b/pkg/cloud_provider/clientset/clientset.go
@@ -154,30 +154,18 @@ func (c *Clientset) ConfigureNodeLister(ctx context.Context, nodeName string) {
 func (c *Clientset) ConfigurePVLister(ctx context.Context) {
 	trim := func(obj any) (any, error) {
 		pvObj, ok := obj.(*corev1.PersistentVolume)
-
 		if !ok || pvObj == nil {
 			return obj, nil
 		}
-
-		trimmedPV := &corev1.PersistentVolume{
+		return &corev1.PersistentVolume{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        pvObj.ObjectMeta.Name,
-				Annotations: pvObj.ObjectMeta.Annotations,
+				Annotations: pvObj.ObjectMeta.Annotations, // Required by the gcsfuse profiles feature to calculate smart cache recommendations.
 			},
 			Spec: corev1.PersistentVolumeSpec{
-				StorageClassName: pvObj.Spec.StorageClassName,
-				ClaimRef:         pvObj.Spec.ClaimRef,
+				StorageClassName: pvObj.Spec.StorageClassName, // Required by the gcsfuse profiles feature to map PV to SC.
 			},
-		}
-
-		if pvObj.Spec.CSI != nil {
-			trimmedPV.Spec.PersistentVolumeSource.CSI = &corev1.CSIPersistentVolumeSource{
-				Driver:       pvObj.Spec.CSI.Driver,
-				VolumeHandle: pvObj.Spec.CSI.VolumeHandle,
-			}
-		}
-
-		return trimmedPV, nil
+		}, nil
 	}
 
 	informerFactory := informers.NewSharedInformerFactoryWithOptions(

--- a/test/e2e/testsuites/gcsfuse_oidc_auth.go
+++ b/test/e2e/testsuites/gcsfuse_oidc_auth.go
@@ -44,14 +44,14 @@ import (
 )
 
 const (
-	oidcTestPrefix                              = "gcsfuse-csi-oidc"
-	oidcWorkloadIdentityPoolID                  = "gcs-fuse-oidc-pool"
-	oidcWorkloadIdentityProviderID              = "gcs-fuse-oidc-provider"
-	oidcConfigMapName                           = "workload-identity-credentials"
-	oidcCredentialConfigFileName                = "credential-configuration.json"
-	oidcServiceAccountName                      = "gcs-fuse-oidc-ksa"
-	oidcVolumeName                              = "gcs-volume"
-	oidcMountPath                               = "/mnt/gcs"
+	oidcTestPrefix                 = "gcsfuse-csi-oidc"
+	oidcWorkloadIdentityPoolID     = "gcs-fuse-oidc-pool"
+	oidcWorkloadIdentityProviderID = "gcs-fuse-oidc-provider"
+	oidcConfigMapName              = "workload-identity-credentials"
+	oidcCredentialConfigFileName   = "credential-configuration.json"
+	oidcServiceAccountName         = "gcs-fuse-oidc-ksa"
+	oidcVolumeName                 = "gcs-volume"
+	oidcMountPath                  = "/mnt/gcs"
 )
 
 type gcsFuseCSIOIDCTestSuite struct {


### PR DESCRIPTION
…s doesn't use this anymore

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup

> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Revert PVlister to only have fields needed for profiles, since metrics doesn't use this anymore. Reverts what https://github.com/GoogleCloudPlatform/gcs-fuse-csi-driver/pull/1224/changes#diff-1b9b4479f4b1eb69a345c8d85d907c55322239e7681d0cf0ddaee13e1e9a0131R191-R198 changed for the PV lister. This was missed in PR#1461

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```