### PR TITLE
Automated cherry pick of #1461: Remove PVC lister to improve node driver memory usage
#1467: Revert PVlister to only have fields needed for profiles, since metrics doesn't use this anymore

### DIFF
--- a/cmd/csi_driver/main.go
+++ b/cmd/csi_driver/main.go
@@ -254,13 +254,11 @@ func main() {
 
 		clientset.ConfigurePodLister(ctx, *nodeID)
 		clientset.ConfigureNodeLister(ctx, *nodeID)
-		// Both PVs & PVCs are needed to check count of GCSFuseVolumes
-		clientset.ConfigurePVLister(ctx)
-		clientset.ConfigurePVCLister(ctx)
 
 		if featureOptions.FeatureGCSFuseProfiles.Enabled {
 			// Curently, only the gcsfuse profiles feature actually uses these listers.
 			clientset.ConfigureSCLister(ctx)
+			clientset.ConfigurePVLister(ctx)
 		}
 
 		mounter, err = csimounter.New("", *fuseSocketDir)

--- a/pkg/cloud_provider/clientset/clientset.go
+++ b/pkg/cloud_provider/clientset/clientset.go
@@ -148,29 +148,18 @@ func (c *Clientset) ConfigureNodeLister(ctx context.Context, nodeName string) {
 func (c *Clientset) ConfigurePVLister(ctx context.Context) {
 	trim := func(obj any) (any, error) {
 		pvObj, ok := obj.(*corev1.PersistentVolume)
-
 		if !ok || pvObj == nil {
 			return obj, nil
 		}
-
-		trimmedPV := &corev1.PersistentVolume{
+		return &corev1.PersistentVolume{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        pvObj.ObjectMeta.Name,
-				Annotations: pvObj.ObjectMeta.Annotations,
+				Annotations: pvObj.ObjectMeta.Annotations, // Required by the gcsfuse profiles feature to calculate smart cache recommendations.
 			},
 			Spec: corev1.PersistentVolumeSpec{
-				StorageClassName: pvObj.Spec.StorageClassName,
+				StorageClassName: pvObj.Spec.StorageClassName, // Required by the gcsfuse profiles feature to map PV to SC.
 			},
-		}
-
-		if pvObj.Spec.CSI != nil {
-			trimmedPV.Spec.PersistentVolumeSource.CSI = &corev1.CSIPersistentVolumeSource{
-				Driver:       pvObj.Spec.CSI.Driver,
-				VolumeHandle: pvObj.Spec.CSI.VolumeHandle,
-			}
-		}
-
-		return trimmedPV, nil
+		}, nil
 	}
 
 	informerFactory := informers.NewSharedInformerFactoryWithOptions(

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -35,7 +35,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/klog/v2"
 	mount "k8s.io/mount-utils"
 )

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -595,6 +595,15 @@ func gcsFuseSidecarContainerImage(pod *corev1.Pod) string {
 	return ""
 }
 
+// countGcsFuseVolumes returns the number of GCSFuse CSI Ephemeral volumes or
+// PersistentVolumeClaims in the given Pod spec. We intentionally do not
+// check to see if the PVC is a GCSFuseCSI PVC because that requires additional
+// API calls or a PVC informer which previously made the node driver OOM.
+// We may end up counting some non-GCSFuse volumes, but that is acceptable
+// since this is only used to determine whether to enable metrics collection
+// on a given pod.
+// TODO(amacaskill): Make sure the PVC is a GCSFuseCSI PVC, without
+// causing an OOM in the node driver at scale.
 func (s *nodeServer) countGcsFuseVolumes(pod *corev1.Pod) (int, error) {
 	gcsFuseVolumeCount := 0
 
@@ -609,38 +618,9 @@ func (s *nodeServer) countGcsFuseVolumes(pod *corev1.Pod) (int, error) {
 			continue
 		}
 
-		if v.PersistentVolumeClaim == nil {
-			continue
-		}
-
-		// Count persistent gcsfuse volumes
-		pvc, err := s.k8sClients.GetPVC(pod.Namespace, v.PersistentVolumeClaim.ClaimName)
-
-		// A NotFound error is tolerated, but other errors will abort the count and disable metrics.
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				klog.Warningf("pvc %q not found: %v", v.PersistentVolumeClaim.ClaimName, err)
-				continue
-			}
-
-			klog.Errorf("internal error getting PVC %q: %v. Setting GCS Fuse metric count to 0", v.PersistentVolumeClaim.ClaimName, err)
-			return 0, err
-		}
-
-		pv, err := s.k8sClients.GetPV(pvc.Spec.VolumeName)
-
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				klog.Warningf("pv %q not found: %v", pvc.Spec.VolumeName, err)
-				continue
-			}
-
-			klog.Errorf("internal error getting PV %q: %v. Setting GCS Fuse metric count to 0", pvc.Spec.VolumeName, err)
-			return 0, err
-		}
-
-		if pv.Spec.CSI != nil && pv.Spec.CSI.Driver == s.driver.config.Name {
+		if v.PersistentVolumeClaim != nil {
 			gcsFuseVolumeCount++
+			continue
 		}
 	}
 

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -1116,7 +1116,7 @@ func TestCountGcsFuseVolumes(t *testing.T) {
 				gcsFuseEphemeralVolumeCount:  2,
 				gcsFusePersistentVolumeCount: 3,
 			},
-			expectedCount: 5,
+			expectedCount: 7,
 		},
 		{
 			name: "mixed csi drivers with no gcsfuse volumes",
@@ -1124,7 +1124,7 @@ func TestCountGcsFuseVolumes(t *testing.T) {
 				totalEphemeralVolumeCount:  5,
 				totalPersistentVolumeCount: 5,
 			},
-			expectedCount: 0,
+			expectedCount: 5,
 		},
 	}
 
@@ -1230,10 +1230,10 @@ func TestNodePublishVolumeAssertMetricsCollectorRegistration(t *testing.T) {
 		},
 		{
 			name:                         "should register collector with other non gcsfuse volumes",
-			totalEphemeralVolumeCount:    10,
-			totalPersistentVolumeCount:   10,
-			gcsFuseEphemeralVolumeCount:  5,
-			gcsFusePersistentVolumeCount: 5,
+			totalEphemeralVolumeCount:    5,
+			totalPersistentVolumeCount:   5,
+			gcsFuseEphemeralVolumeCount:  2,
+			gcsFusePersistentVolumeCount: 2,
 			expectCollectorRegistered:    true,
 		},
 		{


### PR DESCRIPTION
Cherry pick of #1461 #1467 on release-1.23.

#1461: Remove PVC lister to improve node driver memory usage
#1467: Revert PVlister to only have fields needed for profiles, since metrics doesn't use this anymore

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Do not export metrics if a pod has more than 10 GCSFuseCSI ephemeral volumes, or 10 PVC total (without checking the provisioner type of the storage) . This was done for node driver memory usage.
NONE
```