### PR TITLE
Implement lazy unmount fallback for NodeUnpublishVolume

### DIFF
--- a/pkg/csi_driver/mount_linux.go
+++ b/pkg/csi_driver/mount_linux.go
@@ -1,0 +1,42 @@
+//go:build linux
+
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import (
+	"errors"
+	"fmt"
+	"syscall"
+
+	"k8s.io/klog/v2"
+)
+
+func lazyUnmount(targetPath string) error {
+	klog.V(2).Infof("Attempting lazy unmount for target %q", targetPath)
+	err := syscall.Unmount(targetPath, syscall.MNT_DETACH)
+	if err != nil {
+		// Treat the operation as successful for errors of type
+		// EINVAL (target is already unmounted) or ENOENT (target does not exist).
+		if errors.Is(err, syscall.EINVAL) || errors.Is(err, syscall.ENOENT) {
+			klog.V(4).Infof("lazy unmount ignored error for target %q: %v", targetPath, err)
+			return nil
+		}
+		return fmt.Errorf("syscall.Unmount failed: %w", err)
+	}
+	return nil
+}

--- a/pkg/csi_driver/mount_unsupported.go
+++ b/pkg/csi_driver/mount_unsupported.go
@@ -1,0 +1,27 @@
+//go:build !linux
+
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import (
+	"fmt"
+)
+
+func lazyUnmount(targetPath string) error {
+	return fmt.Errorf("lazy unmount is not supported on this platform")
+}

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -468,12 +468,18 @@ func (s *nodeServer) NodeUnpublishVolume(_ context.Context, req *csi.NodeUnpubli
 		forceUnmounter, ok := s.mounter.(mount.MounterForceUnmounter)
 		if ok {
 			if err = forceUnmounter.UnmountWithForce(targetPath, UmountTimeout); err != nil {
-				return nil, status.Errorf(codes.Internal, "failed to force unmount target path %q: %v", targetPath, err)
+				klog.Warningf("failed to force unmount target path %q: %v. Retrying with lazy unmount.", targetPath, err)
+				if lazyErr := lazyUnmount(targetPath); lazyErr != nil {
+					return nil, status.Errorf(codes.Internal, "failed to force unmount target path %q (force failed: %v, lazy failed: %v)", targetPath, err, lazyErr)
+				}
 			}
 		} else {
 			klog.Warningf("failed to cast the mounter to a forceUnmounter, proceed with the default mounter Unmount")
 			if err = s.mounter.Unmount(targetPath); err != nil {
-				return nil, status.Errorf(codes.Internal, "failed to unmount target path %q: %v", targetPath, err)
+				klog.Warningf("failed to unmount target path %q: %v. Retrying with lazy unmount.", targetPath, err)
+				if lazyErr := lazyUnmount(targetPath); lazyErr != nil {
+					return nil, status.Errorf(codes.Internal, "failed to unmount target path %q (unmount failed: %v, lazy failed: %v)", targetPath, err, lazyErr)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### Previous Behavior / Problem
During pod deletion, Kubelet and containerd clean up volume attachments in parallel. If containerd has not finished closing all file handles when Kubelet calls the CSI driver to unmount the volume, the unmount fails with a "target is busy" error:

> failed to force unmount target path "/var/lib/kubelet/pods/.../mount": unmount failed: exit status 32
> Output: umount: /var/lib/kubelet/pods/.../mount: target is busy.

This causes SLO alerts on transient failures, despite the unmount call succeeding on the next Kubelet retry 500ms later.

### Fix Implementation
Implemented a lazy unmount fallback (`umount -l` via `syscall.Unmount` with `MNT_DETACH`) when `UnmountWithForce` fails with an error. I also included a dummy fallback for non-Linux compilation.

Note that lazy unmount is used by other FUSE CSI drivers. For example, see [juicefs-csi-driver](https://github.com/juicedata/juicefs-csi-driver/blob/master/pkg/juicefs/mount/pod_mount.go#L248). 

### Testing & Verification
Verified by running a repro script (below) that cd's into the mount point from a host-privileged container to simulate a busy mount during deletion. The CSI node driver successfully caught the failure, fell back to lazy unmount, and completed `NodeUnpublishVolume` successfully on the first try:

```
I0617 23:31:58.684470       1 mount_linux.go:881] Unmounting /var/lib/kubelet/pods/026e7bea-b79a-496c-9330-c28bed329143/volumes/kubernetes.io~csi/gcs-volume/mount
W0617 23:31:58.698574       1 node.go:471] failed to force unmount target path "/var/lib/kubelet/pods/026e7bea-b79a-496c-9330-c28bed329143/volumes/kubernetes.io~csi/gcs-volume/mount": unmount failed: exit status 32
Unmounting arguments: /var/lib/kubelet/pods/026e7bea-b79a-496c-9330-c28bed329143/volumes/kubernetes.io~csi/gcs-volume/mount
Output: umount: /var/lib/kubelet/pods/026e7bea-b79a-496c-9330-c28bed329143/volumes/kubernetes.io~csi/gcs-volume/mount: target is busy.
. Retrying with lazy unmount.
I0617 23:31:58.698707       1 mount_linux.go:30] Attempting lazy unmount for target "/var/lib/kubelet/pods/026e7bea-b79a-496c-9330-c28bed329143/volumes/kubernetes.io~csi/gcs-volume/mount"
I0617 23:31:58.698882       1 mount_helper_common.go:93] unmounting "/var/lib/kubelet/pods/026e7bea-b79a-496c-9330-c28bed329143/volumes/kubernetes.io~csi/gcs-volume/mount" (corruptedMount: false, mounterCanSkipMountPointChecks: true)
I0617 23:31:58.698985       1 mount_linux.go:402] Unmounting /var/lib/kubelet/pods/026e7bea-b79a-496c-9330-c28bed329143/volumes/kubernetes.io~csi/gcs-volume/mount
I0617 23:31:58.703450       1 mount_linux.go:920] ignoring 'not mounted' error for /var/lib/kubelet/pods/026e7bea-b79a-496c-9330-c28bed329143/volumes/kubernetes.io~csi/gcs-volume/mount
I0617 23:31:58.703484       1 mount_helper_common.go:150] Deleting path "/var/lib/kubelet/pods/026e7bea-b79a-496c-9330-c28bed329143/volumes/kubernetes.io~csi/gcs-volume/mount"
I0617 23:31:58.703857       1 node.go:492] NodeUnpublishVolume succeeded on target path "/var/lib/kubelet/pods/026e7bea-b79a-496c-9330-c28bed329143/volumes/kubernetes.io~csi/gcs-volume/mount"
I0617 23:31:58.704233       1 utils.go:176] /csi.v1.Node/NodeUnpublishVolume succeeded.
```


<details>

<summary>Full script</summary>

```
#!/bin/bash
# Script to reproduce GCSFuse CSI unmount race condition (busy mount).
set -e

if [ "$#" -ne 2 ]; then
    echo "Usage: $0 <bucket-name> <node-name>"
    exit 1
fi

BUCKET_NAME=$1
NODE_NAME=$2
POD_NAME="gcsfuse-repro-pod"
HOLDER_POD_NAME="mount-holder"

# Clean up any leftover pods from previous runs
echo "Cleaning up potential old pods..."
kubectl delete pod $POD_NAME $HOLDER_POD_NAME --wait=false || true

# 1. Create the test pod with inline GCSFuse volume
echo "Creating test pod $POD_NAME on node $NODE_NAME..."
cat <<EOF | kubectl apply -f -
apiVersion: v1
kind: Pod
metadata:
  name: $POD_NAME
  annotations:
    gke-gcsfuse/volumes: "true"
spec:
  nodeName: $NODE_NAME
  terminationGracePeriodSeconds: 5
  containers:
  - name: app
    image: busybox
    command: ["sleep", "3600"]
    volumeMounts:
    - name: gcs-volume
      mountPath: /data
  volumes:
  - name: gcs-volume
    csi:
      driver: gcsfuse.csi.storage.gke.io
      volumeAttributes:
        bucketName: $BUCKET_NAME
        mountOptions: "implicit-dirs"
EOF

echo "Waiting for $POD_NAME to be running..."
kubectl wait --for=condition=Ready pod/$POD_NAME --timeout=60s

POD_UID=$(kubectl get pod $POD_NAME -o jsonpath='{.metadata.uid}')
echo "Pod UID: $POD_UID"

# 2. Deploy the holder pod on the same node
# It mounts /var/lib/kubelet with HostToContainer propagation to see the GCSFuse mount.
echo "Creating holder pod $HOLDER_POD_NAME on node $NODE_NAME..."
cat <<EOF | kubectl apply -f -
apiVersion: v1
kind: Pod
metadata:
  name: $HOLDER_POD_NAME
spec:
  nodeName: $NODE_NAME
  containers:
  - name: holder
    image: busybox
    command: ["sleep", "3600"]
    securityContext:
      privileged: true
    volumeMounts:
    - name: kubelet-dir
      mountPath: /var/lib/kubelet
      mountPropagation: HostToContainer
  volumes:
  - name: kubelet-dir
    hostPath:
      path: /var/lib/kubelet
EOF

echo "Waiting for $HOLDER_POD_NAME to be running..."
kubectl wait --for=condition=Ready pod/$HOLDER_POD_NAME --timeout=60s

# The path to the mount inside the holder container
MOUNT_PATH="/var/lib/kubelet/pods/$POD_UID/volumes/kubernetes.io~csi/gcs-volume/mount"

echo "Starting holder process in background..."
# We exec into the holder pod, wait for mount to appear, cd into it to hold it busy, and sleep.
# 7 seconds is enough to overlap with the 5s CSI driver unmount timeout.
kubectl exec $HOLDER_POD_NAME -- sh -c "
  echo 'Waiting for mount directory to appear inside container...'
  while [ ! -d $MOUNT_PATH ]; do sleep 0.1; done
  cd $MOUNT_PATH
  echo 'Holding mount busy (cd-ed into directory)...'
  sleep 12
  echo 'Releasing mount...'
" &
HOLDER_PID=$!

# Give the background exec a moment to start and enter the directory
sleep 2

echo "Triggering deletion of test pod $POD_NAME (will run in background)..."
kubectl delete pod $POD_NAME --wait=false

# Wait for the holder background process to finish (and release the mount)
wait $HOLDER_PID

echo "Reproduction run finished. Cleaning up holder pod..."
kubectl delete pod $HOLDER_POD_NAME --wait=false

echo "================================================================="
echo "Done! Please check the CSI driver logs on node $NODE_NAME."
echo "You can view the logs by running:"
echo "  kubectl logs -n kube-system $CSI_POD -c gcs-fuse-csi-driver --since=2m"
echo "Look for:"
echo "  1. 'failed to force unmount target path ... target is busy' (Failure)"
echo "  2. 'NodeUnpublishVolume succeeded on target path' shortly after (Success)"
echo "================================================================="
```

</details>
