### PR TITLE
Allow customer to override gcsfuse buffer and cache volumes in shared

### DIFF
--- a/pkg/csi_driver/controller.go
+++ b/pkg/csi_driver/controller.go
@@ -230,6 +230,7 @@ func (s *controllerServer) ControllerPublishVolume(ctx context.Context, req *csi
 		resources:          containerResources,
 		nodeID:             nodeID,
 		image:              containerImage,
+		volumes:            podTemplate.Template.Spec.Volumes,
 	}
 
 	if err := createMounterPod(clientset, ctx, podConfig); err != nil {

--- a/pkg/csi_driver/shared_mount.go
+++ b/pkg/csi_driver/shared_mount.go
@@ -60,6 +60,7 @@ type mounterPodConfig struct {
 	image              string                       // The image for the mounter pod binary.
 	serviceAccountName string                       // The KSA name for the mounter pod.
 	resources          *corev1.ResourceRequirements // The resource requirements for the mounter pod container.
+	volumes            []corev1.Volume              // The volumes for the mounter pod.
 }
 
 // sharedMount checks if the VolumeContext enables the shared node mount feature
@@ -175,26 +176,20 @@ func createMounterPodSpec(config *mounterPodConfig) *corev1.Pod {
 							Name:      util.SidecarContainerTmpVolumeName,
 							MountPath: util.SidecarContainerTmpVolumePath,
 						},
-					},
-				},
-			},
-			Volumes: []corev1.Volume{
-				{
-					Name: mounterPodMountDir,
-					VolumeSource: corev1.VolumeSource{
-						HostPath: &corev1.HostPathVolumeSource{
-							Path: util.KubeletDir,
-							Type: ptr.To(corev1.HostPathDirectoryOrCreate),
+						{
+							Name:      webhook.SidecarContainerBufferVolumeName,
+							MountPath: webhook.SidecarContainerBufferVolumeMountPath,
 						},
-					},
-				},
-				{
-					Name: util.SidecarContainerTmpVolumeName,
-					VolumeSource: corev1.VolumeSource{
-						EmptyDir: &corev1.EmptyDirVolumeSource{},
+						{
+							Name:      webhook.SidecarContainerCacheVolumeName,
+							MountPath: webhook.SidecarContainerCacheVolumeMountPath,
+						},
+						// TODO(urielguzman): Add host network and profiles volume mounts when those features are implemented
+						// for shared mount.
 					},
 				},
 			},
+			Volumes: mounterPodVolumes(config),
 			Tolerations: []corev1.Toleration{
 				{
 					//  https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
@@ -357,6 +352,31 @@ func mounterPodResources(config *mounterPodConfig) *corev1.ResourceRequirements 
 	}
 
 	return &resources
+}
+
+// mounterPodVolumes returns the list of volumes required by the mounter pod.
+// This includes standard GCS FUSE volumes and the host path to the kubelet directory.
+func mounterPodVolumes(config *mounterPodConfig) []corev1.Volume {
+	// Get the gke-gcsfuse-tmp, gke-gcsfuse-buffer, and gke-gcsfuse-cache volumes, and allow
+	// the buffer and cache to be overridden by the PodTemplate volumes.
+	volumes := []corev1.Volume{}
+	volumes = append(volumes, config.volumes...) // Make a copy to avoid mutating the PodTemplate volumes.
+	volumes = append(volumes, webhook.GetSidecarContainerVolumeSpec(config.volumes...)...)
+
+	// Set the /var/lib/kubelet host path, so the mounter pod can mount the staging path to the node.
+	volumes = append(volumes, corev1.Volume{Name: mounterPodMountDir,
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				// TODO(urielguzman): Check if we can use /var/lib/kubelet/plugins/gcsfuse.csi.storage.gke.io/
+				// instead, to decrease the host path scope.
+				Path: util.KubeletDir,
+				Type: ptr.To(corev1.HostPathDirectoryOrCreate),
+			},
+		}})
+
+	// TODO(urielguzman): Add profiles and host network volumes when those features are implemnented for
+	// shared mount.
+	return volumes
 }
 
 func setResource(target *corev1.ResourceList, override corev1.ResourceList, resourceName corev1.ResourceName) {

--- a/pkg/csi_driver/shared_mount_test.go
+++ b/pkg/csi_driver/shared_mount_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"sync"
 	"testing"
 	"time"
@@ -32,6 +33,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/clientset"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util"
+	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/webhook"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
@@ -42,6 +44,29 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/utils/ptr"
+)
+
+var (
+	testTmpVolume = corev1.Volume{
+		Name: util.SidecarContainerTmpVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	}
+
+	testBuffVolume = corev1.Volume{
+		Name: webhook.SidecarContainerBufferVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	}
+
+	testCacheVolume = corev1.Volume{
+		Name: webhook.SidecarContainerCacheVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	}
 )
 
 func TestSharedMount(t *testing.T) {
@@ -315,6 +340,12 @@ func TestPVFromVolumeID(t *testing.T) {
 	}
 }
 
+func sortVolumes(volumes []corev1.Volume) {
+	sort.Slice(volumes, func(i, j int) bool {
+		return volumes[i].Name < volumes[j].Name
+	})
+}
+
 func TestCreateMounterPodSpec(t *testing.T) {
 	// Default resources expected when no overrides are provided
 	defaultResources := corev1.ResourceRequirements{
@@ -326,20 +357,59 @@ func TestCreateMounterPodSpec(t *testing.T) {
 		Limits: corev1.ResourceList{},
 	}
 
+	// Standard volume mounts expected in the container, IN THE EXACT ORDER as in createMounterPodSpec
+	expectedVolumeMounts := []corev1.VolumeMount{
+		{
+			Name:             mounterPodMountDir,
+			MountPath:        util.KubeletDir,
+			MountPropagation: ptr.To(corev1.MountPropagationBidirectional),
+		},
+		{
+			Name:      util.SidecarContainerTmpVolumeName,
+			MountPath: util.SidecarContainerTmpVolumePath,
+		},
+		{
+			Name:      webhook.SidecarContainerBufferVolumeName,
+			MountPath: webhook.SidecarContainerBufferVolumeMountPath,
+		},
+		{
+			Name:      webhook.SidecarContainerCacheVolumeName,
+			MountPath: webhook.SidecarContainerCacheVolumeMountPath,
+		},
+	}
+
+	// Kubelet HostPath volume always expected
+	kubeletHostPathVolume := corev1.Volume{
+		Name: mounterPodMountDir,
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: util.KubeletDir,
+				Type: ptr.To(corev1.HostPathDirectoryOrCreate),
+			},
+		},
+	}
+
+	// Custom volume for override test
+	customBufferVolume := corev1.Volume{
+		Name: webhook.SidecarContainerBufferVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory},
+		},
+	}
+
 	tests := []struct {
 		name   string
 		config *mounterPodConfig
 		want   *corev1.Pod
 	}{
 		{
-			name: "basic config - should include default resources",
+			name: "basic config - should include default volumes and resources",
 			config: &mounterPodConfig{
 				podName:            "my-mounter-pod",
 				namespace:          "my-namespace",
 				serviceAccountName: "my-ksa",
 				nodeID:             "node-123",
 				image:              "gcr.io/my-project/my-image:v1.0.0",
-				// No config.resources override
 			},
 			want: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
@@ -361,42 +431,17 @@ func TestCreateMounterPodSpec(t *testing.T) {
 							SecurityContext: &corev1.SecurityContext{
 								Privileged: ptr.To(true),
 							},
-							Resources: defaultResources, // Expect default resources
-							VolumeMounts: []corev1.VolumeMount{
-								{
-									Name:             mounterPodMountDir,
-									MountPath:        util.KubeletDir,
-									MountPropagation: ptr.To(corev1.MountPropagationBidirectional),
-								},
-								{
-									Name:      util.SidecarContainerTmpVolumeName,
-									MountPath: util.SidecarContainerTmpVolumePath,
-								},
-							},
+							Resources:    defaultResources,
+							VolumeMounts: expectedVolumeMounts,
 						},
 					},
 					Volumes: []corev1.Volume{
-						{
-							Name: mounterPodMountDir,
-							VolumeSource: corev1.VolumeSource{
-								HostPath: &corev1.HostPathVolumeSource{
-									Path: util.KubeletDir,
-									Type: ptr.To(corev1.HostPathDirectoryOrCreate),
-								},
-							},
-						},
-						{
-							Name: util.SidecarContainerTmpVolumeName,
-							VolumeSource: corev1.VolumeSource{
-								EmptyDir: &corev1.EmptyDirVolumeSource{},
-							},
-						},
+						testBuffVolume,
+						testCacheVolume,
+						testTmpVolume,
+						kubeletHostPathVolume,
 					},
-					Tolerations: []corev1.Toleration{
-						{
-							Operator: corev1.TolerationOpExists,
-						},
-					},
+					Tolerations: []corev1.Toleration{{Operator: corev1.TolerationOpExists}},
 				},
 			},
 		},
@@ -414,8 +459,7 @@ func TestCreateMounterPodSpec(t *testing.T) {
 						corev1.ResourceMemory: resource.MustParse("1Gi"),
 					},
 					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("2000m"),
-						corev1.ResourceMemory: resource.MustParse("2Gi"),
+						corev1.ResourceCPU: resource.MustParse("2000m"),
 					},
 				},
 			},
@@ -441,50 +485,68 @@ func TestCreateMounterPodSpec(t *testing.T) {
 							},
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:              resource.MustParse("1000m"), // Overridden
-									corev1.ResourceMemory:           resource.MustParse("1Gi"),   // Overridden
-									corev1.ResourceEphemeralStorage: resource.MustParse("15Gi"),  // Default
+									corev1.ResourceCPU:              resource.MustParse("1000m"),
+									corev1.ResourceMemory:           resource.MustParse("1Gi"),
+									corev1.ResourceEphemeralStorage: resource.MustParse("15Gi"),
 								},
 								Limits: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("2000m"), // Set
-									corev1.ResourceMemory: resource.MustParse("2Gi"),   // Set
+									corev1.ResourceCPU: resource.MustParse("2000m"),
 								},
 							},
-							VolumeMounts: []corev1.VolumeMount{
-								{
-									Name:             mounterPodMountDir,
-									MountPath:        util.KubeletDir,
-									MountPropagation: ptr.To(corev1.MountPropagationBidirectional),
-								},
-								{
-									Name:      util.SidecarContainerTmpVolumeName,
-									MountPath: util.SidecarContainerTmpVolumePath,
-								},
-							},
+							VolumeMounts: expectedVolumeMounts,
 						},
 					},
 					Volumes: []corev1.Volume{
+						testBuffVolume,
+						testCacheVolume,
+						testTmpVolume,
+						kubeletHostPathVolume,
+					},
+					Tolerations: []corev1.Toleration{{Operator: corev1.TolerationOpExists}},
+				},
+			},
+		},
+		{
+			name: "config with volume overrides - should use overridden volumes",
+			config: &mounterPodConfig{
+				podName:            "my-mounter-pod",
+				namespace:          "my-namespace",
+				serviceAccountName: "my-ksa",
+				nodeID:             "node-123",
+				image:              "gcr.io/my-project/my-image:v1.0.0",
+				volumes:            []corev1.Volume{customBufferVolume},
+			},
+			want: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-mounter-pod",
+					Namespace: "my-namespace",
+				},
+				Spec: corev1.PodSpec{
+					NodeSelector: map[string]string{
+						"kubernetes.io/hostname": "node-123",
+						"kubernetes.io/os":       "linux",
+					},
+					ServiceAccountName: "my-ksa",
+					PriorityClassName:  mounterPodPriorityClass,
+					Containers: []corev1.Container{
 						{
-							Name: mounterPodMountDir,
-							VolumeSource: corev1.VolumeSource{
-								HostPath: &corev1.HostPathVolumeSource{
-									Path: util.KubeletDir,
-									Type: ptr.To(corev1.HostPathDirectoryOrCreate),
-								},
+							Name:            mounterPodNamePrefix,
+							Image:           "gcr.io/my-project/my-image:v1.0.0",
+							ImagePullPolicy: corev1.PullAlways,
+							SecurityContext: &corev1.SecurityContext{
+								Privileged: ptr.To(true),
 							},
-						},
-						{
-							Name: util.SidecarContainerTmpVolumeName,
-							VolumeSource: corev1.VolumeSource{
-								EmptyDir: &corev1.EmptyDirVolumeSource{},
-							},
+							Resources:    defaultResources,
+							VolumeMounts: expectedVolumeMounts,
 						},
 					},
-					Tolerations: []corev1.Toleration{
-						{
-							Operator: corev1.TolerationOpExists,
-						},
+					Volumes: []corev1.Volume{
+						customBufferVolume, // Overridden
+						testCacheVolume,
+						testTmpVolume,
+						kubeletHostPathVolume,
 					},
+					Tolerations: []corev1.Toleration{{Operator: corev1.TolerationOpExists}},
 				},
 			},
 		},
@@ -492,11 +554,16 @@ func TestCreateMounterPodSpec(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			// Sort volumes in the 'want' spec for consistent comparison
+			sortVolumes(tc.want.Spec.Volumes)
+
 			got := createMounterPodSpec(tc.config)
 
-			// Compare the got and want Pod specs using cmp.Diff
+			// Sort volumes in the 'got' spec
+			sortVolumes(got.Spec.Volumes)
+
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("createMounterPodSpec(%v) returned an unexpected diff (-want +got):\n%s", tc.config, diff)
+				t.Errorf("createMounterPodSpec() returned an unexpected diff (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -1202,6 +1269,112 @@ func TestMounterPodResources(t *testing.T) {
 
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("mounterPodResources() returned unexpected diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestMounterPodVolumes(t *testing.T) {
+	// Expected HostPath volume for KubeletDir
+	kubeletHostPathVolume := corev1.Volume{
+		Name: mounterPodMountDir,
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: util.KubeletDir,
+				Type: ptr.To(corev1.HostPathDirectoryOrCreate),
+			},
+		},
+	}
+
+	// Custom volumes for override tests
+	customBufferVolume := corev1.Volume{
+		Name: webhook.SidecarContainerBufferVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory},
+		},
+	}
+	customCacheVolume := corev1.Volume{
+		Name: webhook.SidecarContainerCacheVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{Path: "/tmp/mycache"},
+		},
+	}
+
+	testCases := []struct {
+		name   string
+		config *mounterPodConfig
+		want   []corev1.Volume
+	}{
+		{
+			name:   "no overrides - should return defaults plus hostpath",
+			config: &mounterPodConfig{},
+			want: []corev1.Volume{
+				testTmpVolume,
+				testBuffVolume,
+				testCacheVolume,
+				kubeletHostPathVolume,
+			},
+		},
+		{
+			name: "override buffer volume - should use custom buffer",
+			config: &mounterPodConfig{
+				volumes: []corev1.Volume{customBufferVolume},
+			},
+			want: []corev1.Volume{
+				testTmpVolume,
+				testCacheVolume,
+				customBufferVolume,
+				kubeletHostPathVolume,
+			},
+		},
+		{
+			name: "override cache volume - should use custom cache",
+			config: &mounterPodConfig{
+				volumes: []corev1.Volume{customCacheVolume},
+			},
+			want: []corev1.Volume{
+				testTmpVolume,
+				testBuffVolume,
+				customCacheVolume,
+				kubeletHostPathVolume,
+			},
+		},
+		{
+			name: "override buffer and cache - should use custom volumes",
+			config: &mounterPodConfig{
+				volumes: []corev1.Volume{customBufferVolume, customCacheVolume},
+			},
+			want: []corev1.Volume{
+				testTmpVolume,
+				customBufferVolume,
+				customCacheVolume,
+				kubeletHostPathVolume,
+			},
+		},
+		{
+			name: "unrelated volumes in config - should be included",
+			config: &mounterPodConfig{
+				volumes: []corev1.Volume{{Name: "extra-vol"}},
+			},
+			want: []corev1.Volume{
+				testTmpVolume,
+				testBuffVolume,
+				testCacheVolume,
+				{Name: "extra-vol"},
+				kubeletHostPathVolume,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mounterPodVolumes(tc.config)
+
+			sortVolumes(got)
+			sortVolumes(tc.want)
+
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("mounterPodVolumes() returned unexpected diff (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
node mount.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind feature

**What this PR does / why we need it**:
Allow the customer to override the gcsfuse cache and buffer volumes when using shared mount.

Host network and profiles volumes aren't handled in this PR. They will be handled later when those individual features are implemented for shared mount.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```