### PR TITLE
update supported version for error log clean up test

### DIFF
--- a/test/e2e/utils/cluster.go
+++ b/test/e2e/utils/cluster.go
@@ -41,7 +41,7 @@ var (
 	sidecarBucketAccessCheckMinimumVersion      = version.MustParseGeneric("1.34.1")
 	gcsfuseProfilesMinimumVersion               = version.MustParseGeneric("1.35.1")
 	cloudProfilerMinimumVersion                 = version.MustParseGeneric("1.36.1")
-	errorFileCleanUpMinimumVersion              = version.MustParseGeneric("1.99.99") // Update once the driver is released with the error file cleanup feature
+	errorFileCleanUpMinimumVersion              = version.MustParseGeneric("1.36.0")
 )
 
 // gcloudCommand constructs an exec.Cmd for a gcloud command,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation

 /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
The logic for sidecar container error file cleanup is now released in 1.36 for cluster version `1.36.0-gke.3251000`. This PR enables the test for supported version, managed testgrids are currently using `8  1.36.0-gke.3960000`
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```