### PR TITLE
[Shared Mount] NodeUnstageVolume

### DIFF
--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -802,3 +802,54 @@ func (s *nodeServer) mountToNode(ctx context.Context, podUID, stagingPath, volum
 	klog.Infof("Mount succeeded at staging target path %s", stagingPath)
 	return nil
 }
+
+func (s *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {
+	// Validate arguments.
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "NodeUnstageVolume Request cannot be nil")
+	}
+	volumeID := req.GetVolumeId()
+	if len(volumeID) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "NodeUnstageVolume Volume ID must be provided")
+	}
+	stagingPath := req.GetStagingTargetPath()
+	if len(stagingPath) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "NodeUnstageVolume Staging Target Path must be provided")
+	}
+
+	// Acquire a lock on the staging path instead of volumeID, since we do not want to serialize multiple node unstage calls on the same volume.
+	if acquired := s.volumeLocks.TryAcquire(stagingPath); !acquired {
+		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, stagingPath)
+	}
+	defer s.volumeLocks.Release(stagingPath)
+
+	if err := s.cleanupStagingPath(stagingPath); err != nil {
+		return nil, err
+	}
+
+	klog.Infof("NodeUnstageVolume succeeded on staging path %q for volume %q", stagingPath, req.GetVolumeId())
+	return &csi.NodeUnstageVolumeResponse{}, nil
+}
+
+func (s *nodeServer) cleanupStagingPath(stagingPath string) error {
+	// Unmount staging path.
+	mounted, err := s.isDirMounted(stagingPath)
+	if err != nil {
+		return status.Errorf(codes.Internal, "failed to check if path %q is already mounted: %v", stagingPath, err)
+	}
+
+	if mounted {
+		if err = s.mounter.Unmount(stagingPath); err != nil {
+			return status.Errorf(codes.Internal, "failed to unmount staging path %q: %v", stagingPath, err)
+		}
+	} else {
+		klog.Infof("staging path %q was already unmounted", stagingPath)
+	}
+
+	// Cleanup the mount point.
+	if err := mount.CleanupMountPoint(stagingPath, s.mounter, false /* bind mount */); err != nil {
+		return status.Errorf(codes.Internal, "failed to cleanup the mount point %q: %v", stagingPath, err)
+	}
+
+	return nil
+}

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -1001,6 +1001,83 @@ func TestNodeStageVolume(t *testing.T) {
 	}
 }
 
+func TestNodeUnstageVolume(t *testing.T) {
+	t.Parallel()
+	stagingPath, cleanup := setupMountTarget(t)
+	defer cleanup()
+
+	cases := []struct {
+		name          string
+		mounts        []mount.MountPoint // already existing mounts
+		req           *csi.NodeUnstageVolumeRequest
+		expectedMount *mount.MountPoint
+		expectErr     error
+	}{
+		{
+			name:   "successful unmount - should return InvalidArgument error",
+			mounts: []mount.MountPoint{{Device: testVolumeID, Path: stagingPath}},
+			req: &csi.NodeUnstageVolumeRequest{
+				VolumeId:          testVolumeID,
+				StagingTargetPath: stagingPath,
+			},
+		},
+		{
+			name:      "empty request",
+			req:       nil,
+			expectErr: status.Error(codes.InvalidArgument, "NodeUnstageVolume Request cannot be nil"),
+		},
+		{
+			name: "empty volume ID -  should return InvalidArgument error",
+			req: &csi.NodeUnstageVolumeRequest{
+				VolumeId:          "",
+				StagingTargetPath: stagingPath,
+			},
+			expectErr: status.Error(codes.InvalidArgument, "NodeUnstageVolume Volume ID must be provided"),
+		},
+		{
+			name: "missing staging path - should return InvalidArgument error",
+			req: &csi.NodeUnstageVolumeRequest{
+				VolumeId:          testVolumeID,
+				StagingTargetPath: "",
+			},
+			expectErr: status.Error(codes.InvalidArgument, "NodeUnstageVolume Staging Target Path must be provided"),
+		},
+		{
+			name: "dir doesn't exist - should succeed",
+			req: &csi.NodeUnstageVolumeRequest{
+				VolumeId:          testVolumeID,
+				StagingTargetPath: "/node-unstage-dir-not-exists",
+			},
+		},
+		{
+			name: "dir not mounted - should succeed",
+			req: &csi.NodeUnstageVolumeRequest{
+				VolumeId:          testVolumeID,
+				StagingTargetPath: stagingPath,
+			},
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			testEnv := initTestNodeServer(t)
+			if test.mounts != nil {
+				testEnv.fm.MountPoints = test.mounts
+			}
+
+			_, err := testEnv.ns.NodeUnstageVolume(context.TODO(), test.req)
+			if test.expectErr == nil && err != nil {
+				t.Errorf("got error %q, expected error nil", err)
+			}
+			if test.expectErr != nil && !errors.Is(err, test.expectErr) {
+				t.Errorf("got error %q, expected error %q", err, test.expectErr)
+			}
+
+			validateMountPoint(t, testEnv.fm, test.expectedMount, nil)
+		})
+	}
+}
+
 func TestMountToNode(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:
This pr adds NodeUnstageVolume for the shared node mount feature. it is needed as part of the clean up process to remove a mount if mounted and finally clean up the mount point.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```