### PR TITLE
Add label to mounter pod to optimize informer memory usage.

### DIFF
--- a/pkg/cloud_provider/clientset/clientset.go
+++ b/pkg/cloud_provider/clientset/clientset.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/webhook"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -379,6 +380,10 @@ func (c *Clientset) ConfigurePodLister(ctx context.Context, nodeName string) {
 			if nodeName != "" {
 				options.FieldSelector = "spec.nodeName=" + nodeName
 			}
+			if c.runController {
+				// Only track mounter pods when the Pod informer is configured in the controller.
+				options.LabelSelector = fmt.Sprintf("%s=%s", webhook.SharedMountLabel, util.TrueStr)
+			}
 		}),
 		informers.WithTransform(trim),
 	)
@@ -395,6 +400,7 @@ func (c *Clientset) ConfigurePodLister(ctx context.Context, nodeName string) {
 		if err != nil {
 			klog.Fatalf("Failed to add podName indexer: %v", err)
 		}
+
 		c.podInformer = podInformer
 	}
 

--- a/pkg/csi_driver/shared_mount.go
+++ b/pkg/csi_driver/shared_mount.go
@@ -150,6 +150,9 @@ func createMounterPodSpec(config *mounterPodConfig) *corev1.Pod {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      config.podName,
 			Namespace: config.namespace,
+			Labels: map[string]string{
+				webhook.SharedMountLabel: util.TrueStr,
+			},
 		},
 		Spec: corev1.PodSpec{
 			NodeSelector: map[string]string{

--- a/pkg/csi_driver/shared_mount_test.go
+++ b/pkg/csi_driver/shared_mount_test.go
@@ -415,6 +415,9 @@ func TestCreateMounterPodSpec(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "my-mounter-pod",
 					Namespace: "my-namespace",
+					Labels: map[string]string{
+						"gke-gcsfuse/shared-mount": "true",
+					},
 				},
 				Spec: corev1.PodSpec{
 					NodeSelector: map[string]string{
@@ -467,6 +470,9 @@ func TestCreateMounterPodSpec(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "my-mounter-pod",
 					Namespace: "my-namespace",
+					Labels: map[string]string{
+						"gke-gcsfuse/shared-mount": "true",
+					},
 				},
 				Spec: corev1.PodSpec{
 					NodeSelector: map[string]string{
@@ -520,6 +526,9 @@ func TestCreateMounterPodSpec(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "my-mounter-pod",
 					Namespace: "my-namespace",
+					Labels: map[string]string{
+						"gke-gcsfuse/shared-mount": "true",
+					},
 				},
 				Spec: corev1.PodSpec{
 					NodeSelector: map[string]string{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**: Add a feature label to mounter pods so that the informers optimize memory usage.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```