### PR TITLE
Automated cherry pick of #1481: Update test/go.mod vendor folders.

### DIFF
--- a/test/go.mod
+++ b/test/go.mod
@@ -74,6 +74,7 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.53.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.53.0 // indirect
 	github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab // indirect
+	github.com/KimMachineGun/automemlimit v0.7.5 // indirect
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
@@ -146,6 +147,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/opencontainers/runtime-spec v1.2.0 // indirect
 	github.com/opencontainers/selinux v1.11.1 // indirect
+	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 // indirect
 	github.com/pelletier/go-toml v1.9.3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect

--- a/test/go.sum
+++ b/test/go.sum
@@ -74,6 +74,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapp
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.53.0/go.mod h1:cSgYe11MCNYunTnRXrKiR/tHc0eoKjICUuWpNZoVCOo=
 github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab h1:UKkYhof1njT1/xq4SEg5z+VpTgjmNeHwPGRQl7takDI=
 github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab/go.mod h1:3VYc5hodBMJ5+l/7J4xAyMeuM2PNuepvHlGs8yilUCA=
+github.com/KimMachineGun/automemlimit v0.7.5 h1:RkbaC0MwhjL1ZuBKunGDjE/ggwAX43DwZrJqVwyveTk=
+github.com/KimMachineGun/automemlimit v0.7.5/go.mod h1:QZxpHaGOQoYvFhv/r4u3U0JTC2ZcOwbSr11UZF46UBM=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
@@ -419,6 +421,8 @@ github.com/opencontainers/runtime-spec v1.2.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/
 github.com/opencontainers/selinux v1.11.1 h1:nHFvthhM0qY8/m+vfhJylliSshm8G1jJ2jDMcgULaH8=
 github.com/opencontainers/selinux v1.11.1/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
+github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 h1:onHthvaw9LFnH4t2DcNVpwGmV9E1BkGknEliJkfwQj0=
+github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58/go.mod h1:DXv8WO4yhMYhSNPKjeNKa5WY9YCIEBRbNzFFPJbWO6Y=
 github.com/pelletier/go-toml v1.9.3 h1:zeC5b1GviRUyKYd6OJPvBU/mcVDVoL1OhT17FCt5dSQ=
 github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/test/vendor/github.com/KimMachineGun/automemlimit/LICENSE
+++ b/test/vendor/github.com/KimMachineGun/automemlimit/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Geon Kim
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/test/vendor/github.com/KimMachineGun/automemlimit/memlimit/cgroups.go
+++ b/test/vendor/github.com/KimMachineGun/automemlimit/memlimit/cgroups.go
@@ -1,0 +1,441 @@
+package memlimit
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+var (
+	// ErrNoCgroup is returned when the process is not in cgroup.
+	ErrNoCgroup = errors.New("process is not in cgroup")
+	// ErrCgroupsNotSupported is returned when the system does not support cgroups.
+	ErrCgroupsNotSupported = errors.New("cgroups is not supported on this system")
+)
+
+// fromCgroup retrieves the memory limit from the cgroup.
+// The versionDetector function is used to detect the cgroup version from the mountinfo.
+func fromCgroup(versionDetector func(mis []mountInfo) (bool, bool)) (uint64, error) {
+	mf, err := os.Open("/proc/self/mountinfo")
+	if err != nil {
+		return 0, fmt.Errorf("failed to open /proc/self/mountinfo: %w", err)
+	}
+	defer mf.Close()
+
+	mis, err := parseMountInfo(mf)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse mountinfo: %w", err)
+	}
+
+	v1, v2 := versionDetector(mis)
+	if !(v1 || v2) {
+		return 0, ErrNoCgroup
+	}
+
+	cf, err := os.Open("/proc/self/cgroup")
+	if err != nil {
+		return 0, fmt.Errorf("failed to open /proc/self/cgroup: %w", err)
+	}
+	defer cf.Close()
+
+	chs, err := parseCgroupFile(cf)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse cgroup file: %w", err)
+	}
+
+	if v2 {
+		limit, err := getMemoryLimitV2(chs, mis)
+		if err == nil {
+			return limit, nil
+		} else if !v1 {
+			return 0, err
+		}
+	}
+
+	return getMemoryLimitV1(chs, mis)
+}
+
+// detectCgroupVersion detects the cgroup version from the mountinfo.
+func detectCgroupVersion(mis []mountInfo) (bool, bool) {
+	var v1, v2 bool
+	for _, mi := range mis {
+		switch mi.FilesystemType {
+		case "cgroup":
+			v1 = true
+		case "cgroup2":
+			v2 = true
+		}
+	}
+	return v1, v2
+}
+
+// getMemoryLimitV2 retrieves the memory limit from the cgroup v2 controller.
+func getMemoryLimitV2(chs []cgroupHierarchy, mis []mountInfo) (uint64, error) {
+	// find the cgroup v2 path for the memory controller.
+	// in cgroup v2, the paths are unified and the controller list is empty.
+	idx := slices.IndexFunc(chs, func(ch cgroupHierarchy) bool {
+		return ch.HierarchyID == "0" && ch.ControllerList == ""
+	})
+	if idx == -1 {
+		return 0, errors.New("cgroup v2 path not found")
+	}
+	relPath := chs[idx].CgroupPath
+
+	// find the mountpoint for the cgroup v2 controller.
+	idx = slices.IndexFunc(mis, func(mi mountInfo) bool {
+		return mi.FilesystemType == "cgroup2"
+	})
+	if idx == -1 {
+		return 0, errors.New("cgroup v2 mountpoint not found")
+	}
+	root, mountPoint := mis[idx].Root, mis[idx].MountPoint
+
+	// resolve the actual cgroup path
+	cgroupPath, err := resolveCgroupPath(mountPoint, root, relPath)
+	if err != nil {
+		return 0, err
+	}
+
+	// retrieve the memory limit from the memory.max recursively.
+	return walkCgroupV2Hierarchy(cgroupPath, mountPoint)
+}
+
+// readMemoryLimitV2FromPath reads the memory limit for cgroup v2 from the given path.
+// this function expects the path to be memory.max file.
+func readMemoryLimitV2FromPath(path string) (uint64, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return 0, ErrNoLimit
+		}
+		return 0, fmt.Errorf("failed to read memory.max: %w", err)
+	}
+
+	slimit := strings.TrimSpace(string(b))
+	if slimit == "max" {
+		return 0, ErrNoLimit
+	}
+
+	limit, err := strconv.ParseUint(slimit, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse memory.max value: %w", err)
+	}
+
+	return limit, nil
+}
+
+// walkCgroupV2Hierarchy walks up the cgroup v2 hierarchy to find the most restrictive memory limit.
+func walkCgroupV2Hierarchy(cgroupPath, mountPoint string) (uint64, error) {
+	var (
+		found              = false
+		minLimit    uint64 = math.MaxUint64
+		currentPath        = cgroupPath
+	)
+	for {
+		limit, err := readMemoryLimitV2FromPath(filepath.Join(currentPath, "memory.max"))
+		if err != nil && !errors.Is(err, ErrNoLimit) {
+			return 0, err
+		} else if err == nil {
+			found = true
+			minLimit = min(minLimit, limit)
+		}
+
+		if currentPath == mountPoint {
+			break
+		}
+
+		parent := filepath.Dir(currentPath)
+		if parent == currentPath {
+			break
+		}
+		currentPath = parent
+	}
+	if !found {
+		return 0, ErrNoLimit
+	}
+
+	return minLimit, nil
+}
+
+// getMemoryLimitV1 retrieves the memory limit from the cgroup v1 controller.
+func getMemoryLimitV1(chs []cgroupHierarchy, mis []mountInfo) (uint64, error) {
+	// find the cgroup v1 path for the memory controller.
+	idx := slices.IndexFunc(chs, func(ch cgroupHierarchy) bool {
+		return slices.Contains(strings.Split(ch.ControllerList, ","), "memory")
+	})
+	if idx == -1 {
+		return 0, errors.New("cgroup v1 path for memory controller not found")
+	}
+	relPath := chs[idx].CgroupPath
+
+	// find the mountpoint for the cgroup v1 controller.
+	idx = slices.IndexFunc(mis, func(mi mountInfo) bool {
+		return mi.FilesystemType == "cgroup" && slices.Contains(strings.Split(mi.SuperOptions, ","), "memory")
+	})
+	if idx == -1 {
+		return 0, errors.New("cgroup v1 mountpoint for memory controller not found")
+	}
+	root, mountPoint := mis[idx].Root, mis[idx].MountPoint
+
+	// resolve the actual cgroup path
+	cgroupPath, err := resolveCgroupPath(mountPoint, root, relPath)
+	if err != nil {
+		return 0, err
+	}
+
+	// retrieve the memory limit from the memory.stat and memory.limit_in_bytes files.
+	return readMemoryLimitV1FromPath(cgroupPath)
+}
+
+// getCgroupV1NoLimit returns the maximum value that is used to represent no limit in cgroup v1.
+// the max memory limit is max int64, but it should be multiple of the page size.
+func getCgroupV1NoLimit() uint64 {
+	ps := uint64(os.Getpagesize())
+	return math.MaxInt64 / ps * ps
+}
+
+// readMemoryLimitV1FromPath reads the memory limit for cgroup v1 from the given path.
+// this function expects the path to be the cgroup directory.
+func readMemoryLimitV1FromPath(cgroupPath string) (uint64, error) {
+	// read hierarchical_memory_limit and memory.limit_in_bytes files.
+	// but if hierarchical_memory_limit is not available, then use the max value as a fallback.
+	hml, err := readHierarchicalMemoryLimit(filepath.Join(cgroupPath, "memory.stat"))
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return 0, fmt.Errorf("failed to read hierarchical_memory_limit: %w", err)
+	} else if hml == 0 {
+		hml = math.MaxUint64
+	}
+
+	// read memory.limit_in_bytes file.
+	b, err := os.ReadFile(filepath.Join(cgroupPath, "memory.limit_in_bytes"))
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return 0, fmt.Errorf("failed to read memory.limit_in_bytes: %w", err)
+	}
+	lib, err := strconv.ParseUint(strings.TrimSpace(string(b)), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse memory.limit_in_bytes value: %w", err)
+	} else if lib == 0 {
+		hml = math.MaxUint64
+	}
+
+	// use the minimum value between hierarchical_memory_limit and memory.limit_in_bytes.
+	// if the limit is the maximum value, then it is considered as no limit.
+	limit := min(hml, lib)
+	if limit >= getCgroupV1NoLimit() {
+		return 0, ErrNoLimit
+	}
+
+	return limit, nil
+}
+
+// readHierarchicalMemoryLimit extracts hierarchical_memory_limit from memory.stat.
+// this function expects the path to be memory.stat file.
+func readHierarchicalMemoryLimit(path string) (uint64, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return 0, err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		fields := strings.Split(line, " ")
+		if len(fields) < 2 {
+			return 0, fmt.Errorf("failed to parse memory.stat %q: not enough fields", line)
+		}
+
+		if fields[0] == "hierarchical_memory_limit" {
+			if len(fields) > 2 {
+				return 0, fmt.Errorf("failed to parse memory.stat %q: too many fields for hierarchical_memory_limit", line)
+			}
+			return strconv.ParseUint(fields[1], 10, 64)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return 0, err
+	}
+
+	return 0, nil
+}
+
+// https://www.man7.org/linux/man-pages/man5/proc_pid_mountinfo.5.html
+// 731 771 0:59 /sysrq-trigger /proc/sysrq-trigger ro,nosuid,nodev,noexec,relatime - proc proc rw
+//
+// 36 35 98:0 /mnt1 /mnt2 rw,noatime master:1 - ext3 /dev/root rw,errors=continue
+// (1)(2)(3)   (4)   (5)      (6)      (7)   (8) (9)   (10)         (11)
+//
+// (1)  mount ID: a unique ID for the mount (may be reused after umount(2)).
+// (2)  parent ID: the ID of the parent mount (or of self for the root of this mount namespace's mount tree).
+// (3)  major:minor: the value of st_dev for files on this filesystem (see stat(2)).
+// (4)  root: the pathname of the directory in the filesystem which forms the root of this mount.
+// (5)  mount point: the pathname of the mount point relative to the process's root directory.
+// (6)  mount options: per-mount options (see mount(2)).
+// (7)  optional fields: zero or more fields of the form "tag[:value]"; see below.
+// (8)  separator: the end of the optional fields is marked by a single hyphen.
+// (9)  filesystem type: the filesystem type in the form "type[.subtype]".
+// (10) mount source: filesystem-specific information or "none".
+// (11) super options: per-superblock options (see mount(2)).
+type mountInfo struct {
+	Root           string
+	MountPoint     string
+	FilesystemType string
+	SuperOptions   string
+}
+
+// parseMountInfoLine parses a line from the mountinfo file.
+func parseMountInfoLine(line string) (mountInfo, error) {
+	if line == "" {
+		return mountInfo{}, errors.New("empty line")
+	}
+
+	fieldss := strings.SplitN(line, " - ", 2)
+	if len(fieldss) != 2 {
+		return mountInfo{}, fmt.Errorf("invalid separator")
+	}
+
+	fields1 := strings.SplitN(fieldss[0], " ", 7)
+	if len(fields1) < 6 {
+		return mountInfo{}, fmt.Errorf("not enough fields before separator: %v", fields1)
+	} else if len(fields1) == 6 {
+		fields1 = append(fields1, "")
+	}
+
+	fields2 := strings.SplitN(fieldss[1], " ", 3)
+	if len(fields2) < 3 {
+		return mountInfo{}, fmt.Errorf("not enough fields after separator: %v", fields2)
+	}
+
+	return mountInfo{
+		Root:           fields1[3],
+		MountPoint:     fields1[4],
+		FilesystemType: fields2[0],
+		SuperOptions:   fields2[2],
+	}, nil
+}
+
+// parseMountInfo parses the mountinfo file.
+func parseMountInfo(r io.Reader) ([]mountInfo, error) {
+	var (
+		s   = bufio.NewScanner(r)
+		mis []mountInfo
+	)
+	for s.Scan() {
+		line := s.Text()
+
+		mi, err := parseMountInfoLine(line)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse mountinfo file %q: %w", line, err)
+		}
+
+		mis = append(mis, mi)
+	}
+	if err := s.Err(); err != nil {
+		return nil, err
+	}
+
+	return mis, nil
+}
+
+// https://www.man7.org/linux/man-pages/man7/cgroups.7.html
+//
+// 5:cpuacct,cpu,cpuset:/daemons
+// (1)       (2)           (3)
+//
+// (1) hierarchy ID:
+//
+//	cgroups version 1 hierarchies, this field
+//	contains a unique hierarchy ID number that can be
+//	matched to a hierarchy ID in /proc/cgroups.  For the
+//	cgroups version 2 hierarchy, this field contains the
+//	value 0.
+//
+// (2) controller list:
+//
+//	For cgroups version 1 hierarchies, this field
+//	contains a comma-separated list of the controllers
+//	bound to the hierarchy.  For the cgroups version 2
+//	hierarchy, this field is empty.
+//
+// (3) cgroup path:
+//
+//	This field contains the pathname of the control group
+//	in the hierarchy to which the process belongs.  This
+//	pathname is relative to the mount point of the
+//	hierarchy.
+type cgroupHierarchy struct {
+	HierarchyID    string
+	ControllerList string
+	CgroupPath     string
+}
+
+// parseCgroupHierarchyLine parses a line from the cgroup file.
+func parseCgroupHierarchyLine(line string) (cgroupHierarchy, error) {
+	if line == "" {
+		return cgroupHierarchy{}, errors.New("empty line")
+	}
+
+	fields := strings.Split(line, ":")
+	if len(fields) < 3 {
+		return cgroupHierarchy{}, fmt.Errorf("not enough fields: %v", fields)
+	} else if len(fields) > 3 {
+		return cgroupHierarchy{}, fmt.Errorf("too many fields: %v", fields)
+	}
+
+	return cgroupHierarchy{
+		HierarchyID:    fields[0],
+		ControllerList: fields[1],
+		CgroupPath:     fields[2],
+	}, nil
+}
+
+// parseCgroupFile parses the cgroup file.
+func parseCgroupFile(r io.Reader) ([]cgroupHierarchy, error) {
+	var (
+		s   = bufio.NewScanner(r)
+		chs []cgroupHierarchy
+	)
+	for s.Scan() {
+		line := s.Text()
+
+		ch, err := parseCgroupHierarchyLine(line)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse cgroup file %q: %w", line, err)
+		}
+
+		chs = append(chs, ch)
+	}
+	if err := s.Err(); err != nil {
+		return nil, err
+	}
+
+	return chs, nil
+}
+
+// resolveCgroupPath resolves the actual cgroup path from the mountpoint, root, and cgroupRelPath.
+func resolveCgroupPath(mountpoint, root, cgroupRelPath string) (string, error) {
+	rel, err := filepath.Rel(root, cgroupRelPath)
+	if err != nil {
+		return "", err
+	}
+
+	// if the relative path is ".", then the cgroupRelPath is the root itself.
+	if rel == "." {
+		return mountpoint, nil
+	}
+
+	// if the relative path starts with "..", then it is outside the root.
+	if strings.HasPrefix(rel, "..") {
+		return "", fmt.Errorf("invalid cgroup path: %s is not under root %s", cgroupRelPath, root)
+	}
+
+	return filepath.Join(mountpoint, rel), nil
+}

--- a/test/vendor/github.com/KimMachineGun/automemlimit/memlimit/cgroups_linux.go
+++ b/test/vendor/github.com/KimMachineGun/automemlimit/memlimit/cgroups_linux.go
@@ -1,0 +1,32 @@
+//go:build linux
+// +build linux
+
+package memlimit
+
+// FromCgroup retrieves the memory limit from the cgroup.
+func FromCgroup() (uint64, error) {
+	return fromCgroup(detectCgroupVersion)
+}
+
+// FromCgroupV1 retrieves the memory limit from the cgroup v1 controller.
+// After v1.0.0, this function could be removed and FromCgroup should be used instead.
+func FromCgroupV1() (uint64, error) {
+	return fromCgroup(func(_ []mountInfo) (bool, bool) {
+		return true, false
+	})
+}
+
+// FromCgroupHybrid retrieves the memory limit from the cgroup v2 and v1 controller sequentially,
+// basically, it is equivalent to FromCgroup.
+// After v1.0.0, this function could be removed and FromCgroup should be used instead.
+func FromCgroupHybrid() (uint64, error) {
+	return FromCgroup()
+}
+
+// FromCgroupV2 retrieves the memory limit from the cgroup v2 controller.
+// After v1.0.0, this function could be removed and FromCgroup should be used instead.
+func FromCgroupV2() (uint64, error) {
+	return fromCgroup(func(_ []mountInfo) (bool, bool) {
+		return false, true
+	})
+}

--- a/test/vendor/github.com/KimMachineGun/automemlimit/memlimit/cgroups_unsupported.go
+++ b/test/vendor/github.com/KimMachineGun/automemlimit/memlimit/cgroups_unsupported.go
@@ -1,0 +1,20 @@
+//go:build !linux
+// +build !linux
+
+package memlimit
+
+func FromCgroup() (uint64, error) {
+	return 0, ErrCgroupsNotSupported
+}
+
+func FromCgroupV1() (uint64, error) {
+	return 0, ErrCgroupsNotSupported
+}
+
+func FromCgroupHybrid() (uint64, error) {
+	return 0, ErrCgroupsNotSupported
+}
+
+func FromCgroupV2() (uint64, error) {
+	return 0, ErrCgroupsNotSupported
+}

--- a/test/vendor/github.com/KimMachineGun/automemlimit/memlimit/exp_system.go
+++ b/test/vendor/github.com/KimMachineGun/automemlimit/memlimit/exp_system.go
@@ -1,0 +1,14 @@
+package memlimit
+
+import (
+	"github.com/pbnjay/memory"
+)
+
+// FromSystem returns the total memory of the system.
+func FromSystem() (uint64, error) {
+	limit := memory.TotalMemory()
+	if limit == 0 {
+		return 0, ErrNoLimit
+	}
+	return limit, nil
+}

--- a/test/vendor/github.com/KimMachineGun/automemlimit/memlimit/experiment.go
+++ b/test/vendor/github.com/KimMachineGun/automemlimit/memlimit/experiment.go
@@ -1,0 +1,59 @@
+package memlimit
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"strings"
+)
+
+const (
+	envAUTOMEMLIMIT_EXPERIMENT = "AUTOMEMLIMIT_EXPERIMENT"
+)
+
+// Experiments is a set of experiment flags.
+// It is used to enable experimental features.
+//
+// You can set the flags by setting the environment variable AUTOMEMLIMIT_EXPERIMENT.
+// The value of the environment variable is a comma-separated list of experiment names.
+//
+// The following experiment names are known:
+//
+//   - none: disable all experiments
+//   - system: enable fallback to system memory limit
+type Experiments struct {
+	// System enables fallback to system memory limit.
+	System bool
+}
+
+func parseExperiments() (Experiments, error) {
+	var exp Experiments
+
+	// Create a map of known experiment names.
+	names := make(map[string]func(bool))
+	rv := reflect.ValueOf(&exp).Elem()
+	rt := rv.Type()
+	for i := 0; i < rt.NumField(); i++ {
+		field := rv.Field(i)
+		names[strings.ToLower(rt.Field(i).Name)] = field.SetBool
+	}
+
+	// Parse names.
+	for _, f := range strings.Split(os.Getenv(envAUTOMEMLIMIT_EXPERIMENT), ",") {
+		if f == "" {
+			continue
+		}
+		if f == "none" {
+			exp = Experiments{}
+			continue
+		}
+		val := true
+		set, ok := names[f]
+		if !ok {
+			return Experiments{}, fmt.Errorf("unknown AUTOMEMLIMIT_EXPERIMENT %s", f)
+		}
+		set(val)
+	}
+
+	return exp, nil
+}

--- a/test/vendor/github.com/KimMachineGun/automemlimit/memlimit/logger.go
+++ b/test/vendor/github.com/KimMachineGun/automemlimit/memlimit/logger.go
@@ -1,0 +1,13 @@
+package memlimit
+
+import (
+	"context"
+	"log/slog"
+)
+
+type noopLogger struct{}
+
+func (noopLogger) Enabled(context.Context, slog.Level) bool  { return false }
+func (noopLogger) Handle(context.Context, slog.Record) error { return nil }
+func (d noopLogger) WithAttrs([]slog.Attr) slog.Handler      { return d }
+func (d noopLogger) WithGroup(string) slog.Handler           { return d }

--- a/test/vendor/github.com/KimMachineGun/automemlimit/memlimit/memlimit.go
+++ b/test/vendor/github.com/KimMachineGun/automemlimit/memlimit/memlimit.go
@@ -1,0 +1,285 @@
+package memlimit
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"math"
+	"os"
+	"runtime/debug"
+	"strconv"
+	"time"
+)
+
+const (
+	envGOMEMLIMIT   = "GOMEMLIMIT"
+	envAUTOMEMLIMIT = "AUTOMEMLIMIT"
+	// Deprecated: use memlimit.WithLogger instead
+	envAUTOMEMLIMIT_DEBUG = "AUTOMEMLIMIT_DEBUG"
+
+	defaultAUTOMEMLIMIT = 0.9
+)
+
+// ErrNoLimit is returned when the memory limit is not set.
+var ErrNoLimit = errors.New("memory is not limited")
+
+type config struct {
+	logger   *slog.Logger
+	ratio    float64
+	provider Provider
+	refresh  time.Duration
+}
+
+// Option is a function that configures the behavior of SetGoMemLimitWithOptions.
+type Option func(cfg *config)
+
+// WithRatio configures the ratio of the memory limit to set as GOMEMLIMIT.
+//
+// Default: 0.9
+func WithRatio(ratio float64) Option {
+	return func(cfg *config) {
+		cfg.ratio = ratio
+	}
+}
+
+// WithProvider configures the provider.
+//
+// Default: FromCgroup
+func WithProvider(provider Provider) Option {
+	return func(cfg *config) {
+		cfg.provider = provider
+	}
+}
+
+// WithLogger configures the logger.
+// It automatically attaches the "package" attribute to the logs.
+//
+// Default: slog.New(noopLogger{})
+func WithLogger(logger *slog.Logger) Option {
+	return func(cfg *config) {
+		cfg.logger = memlimitLogger(logger)
+	}
+}
+
+// WithRefreshInterval configures the refresh interval for automemlimit.
+// If a refresh interval is greater than 0, automemlimit periodically fetches
+// the memory limit from the provider and reapplies it if it has changed.
+// If the provider returns an error, it logs the error and continues.
+// ErrNoLimit is treated as math.MaxInt64.
+//
+// Default: 0 (no refresh)
+func WithRefreshInterval(refresh time.Duration) Option {
+	return func(cfg *config) {
+		cfg.refresh = refresh
+	}
+}
+
+// WithEnv configures whether to use environment variables.
+//
+// Default: false
+//
+// Deprecated: currently this does nothing.
+func WithEnv() Option {
+	return func(cfg *config) {}
+}
+
+func memlimitLogger(logger *slog.Logger) *slog.Logger {
+	if logger == nil {
+		return slog.New(noopLogger{})
+	}
+	return logger.With(slog.String("package", "github.com/KimMachineGun/automemlimit/memlimit"))
+}
+
+// SetGoMemLimitWithOpts sets GOMEMLIMIT with options and environment variables.
+//
+// You can configure how much memory of the cgroup's memory limit to set as GOMEMLIMIT
+// through AUTOMEMLIMIT environment variable in the half-open range (0.0,1.0].
+//
+// If AUTOMEMLIMIT is not set, it defaults to 0.9. (10% is the headroom for memory sources the Go runtime is unaware of.)
+// If GOMEMLIMIT is already set or AUTOMEMLIMIT=off, this function does nothing.
+//
+// If AUTOMEMLIMIT_EXPERIMENT is set, it enables experimental features.
+// Please see the documentation of Experiments for more details.
+//
+// Options:
+//   - WithRatio
+//   - WithProvider
+//   - WithLogger
+func SetGoMemLimitWithOpts(opts ...Option) (_ int64, _err error) {
+	// init config
+	cfg := &config{
+		logger:   slog.New(noopLogger{}),
+		ratio:    defaultAUTOMEMLIMIT,
+		provider: FromCgroup,
+	}
+	// TODO: remove this
+	if debug, ok := os.LookupEnv(envAUTOMEMLIMIT_DEBUG); ok {
+		defaultLogger := memlimitLogger(slog.Default())
+		defaultLogger.Warn("AUTOMEMLIMIT_DEBUG is deprecated, use memlimit.WithLogger instead")
+		if debug == "true" {
+			cfg.logger = defaultLogger
+		}
+	}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	// log error if any on return
+	defer func() {
+		if _err != nil {
+			cfg.logger.Error("failed to set GOMEMLIMIT", slog.Any("error", _err))
+		}
+	}()
+
+	// parse experiments
+	exps, err := parseExperiments()
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse experiments: %w", err)
+	}
+	if exps.System {
+		cfg.logger.Info("system experiment is enabled: using system memory limit as a fallback")
+		cfg.provider = ApplyFallback(cfg.provider, FromSystem)
+	}
+
+	// rollback to previous memory limit on panic
+	snapshot := debug.SetMemoryLimit(-1)
+	defer rollbackOnPanic(cfg.logger, snapshot, &_err)
+
+	// check if GOMEMLIMIT is already set
+	if val, ok := os.LookupEnv(envGOMEMLIMIT); ok {
+		cfg.logger.Info("GOMEMLIMIT is already set, skipping", slog.String(envGOMEMLIMIT, val))
+		return 0, nil
+	}
+
+	// parse AUTOMEMLIMIT
+	ratio := cfg.ratio
+	if val, ok := os.LookupEnv(envAUTOMEMLIMIT); ok {
+		if val == "off" {
+			cfg.logger.Info("AUTOMEMLIMIT is set to off, skipping")
+			return 0, nil
+		}
+		ratio, err = strconv.ParseFloat(val, 64)
+		if err != nil {
+			return 0, fmt.Errorf("cannot parse AUTOMEMLIMIT: %s", val)
+		}
+	}
+
+	// apply ratio to the provider
+	provider := capProvider(ApplyRatio(cfg.provider, ratio))
+
+	// set the memory limit and start refresh
+	limit, err := updateGoMemLimit(uint64(snapshot), provider, cfg.logger)
+	refresh(provider, cfg.logger, cfg.refresh)
+	if err != nil {
+		if errors.Is(err, ErrNoLimit) {
+			cfg.logger.Info("memory is not limited, skipping")
+			// TODO: consider returning the snapshot
+			return 0, nil
+		}
+		return 0, fmt.Errorf("failed to set GOMEMLIMIT: %w", err)
+	}
+
+	return int64(limit), nil
+}
+
+// updateGoMemLimit updates the Go's memory limit, if it has changed.
+func updateGoMemLimit(currLimit uint64, provider Provider, logger *slog.Logger) (uint64, error) {
+	newLimit, err := provider()
+	if err != nil {
+		return 0, err
+	}
+
+	if newLimit == currLimit {
+		logger.Debug("GOMEMLIMIT is not changed, skipping", slog.Uint64(envGOMEMLIMIT, newLimit))
+		return newLimit, nil
+	}
+
+	debug.SetMemoryLimit(int64(newLimit))
+	logger.Info("GOMEMLIMIT is updated", slog.Uint64(envGOMEMLIMIT, newLimit), slog.Uint64("previous", currLimit))
+
+	return newLimit, nil
+}
+
+// refresh spawns a goroutine that runs every refresh duration and updates the GOMEMLIMIT if it has changed.
+// See more details in the documentation of WithRefreshInterval.
+func refresh(provider Provider, logger *slog.Logger, refresh time.Duration) {
+	if refresh == 0 {
+		return
+	}
+
+	provider = noErrNoLimitProvider(provider)
+
+	t := time.NewTicker(refresh)
+	go func() {
+		for range t.C {
+			err := func() (_err error) {
+				snapshot := debug.SetMemoryLimit(-1)
+				defer rollbackOnPanic(logger, snapshot, &_err)
+
+				_, err := updateGoMemLimit(uint64(snapshot), provider, logger)
+				if err != nil {
+					return err
+				}
+
+				return nil
+			}()
+			if err != nil {
+				logger.Error("failed to refresh GOMEMLIMIT", slog.Any("error", err))
+			}
+		}
+	}()
+}
+
+// rollbackOnPanic rollbacks to the snapshot on panic.
+// Since it uses recover, it should be called in a deferred function.
+func rollbackOnPanic(logger *slog.Logger, snapshot int64, err *error) {
+	panicErr := recover()
+	if panicErr != nil {
+		if *err != nil {
+			logger.Error("failed to set GOMEMLIMIT", slog.Any("error", *err))
+		}
+		*err = fmt.Errorf("panic during setting the Go's memory limit, rolling back to previous limit %d: %v",
+			snapshot, panicErr,
+		)
+		debug.SetMemoryLimit(snapshot)
+	}
+}
+
+// SetGoMemLimitWithEnv sets GOMEMLIMIT with the value from the environment variables.
+// Since WithEnv is deprecated, this function is equivalent to SetGoMemLimitWithOpts().
+// Deprecated: use SetGoMemLimitWithOpts instead.
+func SetGoMemLimitWithEnv() {
+	_, _ = SetGoMemLimitWithOpts()
+}
+
+// SetGoMemLimit sets GOMEMLIMIT with the value from the cgroup's memory limit and given ratio.
+func SetGoMemLimit(ratio float64) (int64, error) {
+	return SetGoMemLimitWithOpts(WithRatio(ratio))
+}
+
+// SetGoMemLimitWithProvider sets GOMEMLIMIT with the value from the given provider and ratio.
+func SetGoMemLimitWithProvider(provider Provider, ratio float64) (int64, error) {
+	return SetGoMemLimitWithOpts(WithProvider(provider), WithRatio(ratio))
+}
+
+func noErrNoLimitProvider(provider Provider) Provider {
+	return func() (uint64, error) {
+		limit, err := provider()
+		if errors.Is(err, ErrNoLimit) {
+			return math.MaxInt64, nil
+		}
+		return limit, err
+	}
+}
+
+func capProvider(provider Provider) Provider {
+	return func() (uint64, error) {
+		limit, err := provider()
+		if err != nil {
+			return 0, err
+		} else if limit > math.MaxInt64 {
+			return math.MaxInt64, nil
+		}
+		return limit, nil
+	}
+}

--- a/test/vendor/github.com/KimMachineGun/automemlimit/memlimit/provider.go
+++ b/test/vendor/github.com/KimMachineGun/automemlimit/memlimit/provider.go
@@ -1,0 +1,43 @@
+package memlimit
+
+import (
+	"fmt"
+)
+
+// Provider is a function that returns the memory limit.
+type Provider func() (uint64, error)
+
+// Limit is a helper Provider function that returns the given limit.
+func Limit(limit uint64) func() (uint64, error) {
+	return func() (uint64, error) {
+		return limit, nil
+	}
+}
+
+// ApplyRationA is a helper Provider function that applies the given ratio to the given provider.
+func ApplyRatio(provider Provider, ratio float64) Provider {
+	if ratio == 1 {
+		return provider
+	}
+	return func() (uint64, error) {
+		if ratio <= 0 || ratio > 1 {
+			return 0, fmt.Errorf("invalid ratio: %f, ratio should be in the range (0.0,1.0]", ratio)
+		}
+		limit, err := provider()
+		if err != nil {
+			return 0, err
+		}
+		return uint64(float64(limit) * ratio), nil
+	}
+}
+
+// ApplyFallback is a helper Provider function that sets the fallback provider.
+func ApplyFallback(provider Provider, fallback Provider) Provider {
+	return func() (uint64, error) {
+		limit, err := provider()
+		if err != nil {
+			return fallback()
+		}
+		return limit, nil
+	}
+}

--- a/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/auth/token_sources.go
+++ b/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/auth/token_sources.go
@@ -177,7 +177,9 @@ func (ts *GCPTokenSource) FetchIdentityBindingToken(ctx context.Context, k8sSATo
 
 	stsResponse, err := stsService.V1.Token(stsRequest).Do()
 	if err != nil {
-		return nil, fmt.Errorf("IdentityBindingToken exchange error with audience %q: and request %v: error %w", audience, stsRequest, err)
+		// Redact the SubjectToken (k8s service account token) from logs to prevent leakage.
+		stsRequest.SubjectToken = "<REDACTED>"
+		return nil, fmt.Errorf("IdentityBindingToken exchange error with audience %q: request=%v: error %w", audience, stsRequest, err)
 	}
 
 	return &oauth2.Token{

--- a/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/clientset/clientset.go
+++ b/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/clientset/clientset.go
@@ -23,20 +23,28 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/webhook"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	listersv1 "k8s.io/client-go/listers/core/v1"
 	storagelisters "k8s.io/client-go/listers/storage/v1"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
+)
+
+const (
+	// PodNameIndex is the key for the indexer that indexes pods by their name.
+	PodNameIndex = "podName"
 )
 
 type Interface interface {
@@ -46,11 +54,15 @@ type Interface interface {
 	ConfigurePVLister(ctx context.Context)
 	ConfigurePVCLister(ctx context.Context)
 	ConfigureSCLister(ctx context.Context)
+	ConfigurePodTemplateLister(ctx context.Context)
 	GetPod(namespace, name string) (*corev1.Pod, error)
+	GetPodsByName(name string) ([]*corev1.Pod, error)
 	GetNode(name string) (*corev1.Node, error)
 	GetPV(name string) (*corev1.PersistentVolume, error)
 	GetPVC(namespace string, name string) (*corev1.PersistentVolumeClaim, error)
 	GetSC(name string) (*storagev1.StorageClass, error)
+	GetPodTemplate(namespace, name string) (*corev1.PodTemplate, error)
+	ListPVs() ([]*corev1.PersistentVolume, error)
 	CreateServiceAccountToken(ctx context.Context, namespace, name string, tokenRequest *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error)
 	GetGCPServiceAccountName(ctx context.Context, namespace, name string) (string, error)
 }
@@ -63,11 +75,14 @@ type PodInfo struct {
 type Clientset struct {
 	k8sClients                kubernetes.Interface
 	podLister                 listersv1.PodLister
+	podInformer               cache.SharedIndexInformer
 	nodeLister                listersv1.NodeLister
 	pvLister                  listersv1.PersistentVolumeLister
 	pvcLister                 listersv1.PersistentVolumeClaimLister
 	scLister                  storagelisters.StorageClassLister
+	podTemplateLister         listersv1.PodTemplateLister
 	informerResyncDurationSec int
+	runController             bool
 }
 
 const (
@@ -148,29 +163,19 @@ func (c *Clientset) ConfigureNodeLister(ctx context.Context, nodeName string) {
 func (c *Clientset) ConfigurePVLister(ctx context.Context) {
 	trim := func(obj any) (any, error) {
 		pvObj, ok := obj.(*corev1.PersistentVolume)
-
 		if !ok || pvObj == nil {
 			return obj, nil
 		}
-
-		trimmedPV := &corev1.PersistentVolume{
+		return &corev1.PersistentVolume{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        pvObj.ObjectMeta.Name,
-				Annotations: pvObj.ObjectMeta.Annotations,
+				Annotations: pvObj.ObjectMeta.Annotations, // Required by the gcsfuse profiles feature to calculate smart cache recommendations.
 			},
 			Spec: corev1.PersistentVolumeSpec{
-				StorageClassName: pvObj.Spec.StorageClassName,
+				StorageClassName: pvObj.Spec.StorageClassName, // Required by the gcsfuse profiles feature to map PV to SC.
+				ClaimRef:         pvObj.Spec.ClaimRef,         // Required by the shared node mount feature to identify the bound PVC.
 			},
-		}
-
-		if pvObj.Spec.CSI != nil {
-			trimmedPV.Spec.PersistentVolumeSource.CSI = &corev1.CSIPersistentVolumeSource{
-				Driver:       pvObj.Spec.CSI.Driver,
-				VolumeHandle: pvObj.Spec.CSI.VolumeHandle,
-			}
-		}
-
-		return trimmedPV, nil
+		}, nil
 	}
 
 	informerFactory := informers.NewSharedInformerFactoryWithOptions(
@@ -189,13 +194,20 @@ func (c *Clientset) ConfigurePVLister(ctx context.Context) {
 func (c *Clientset) ConfigurePVCLister(ctx context.Context) {
 	trim := func(obj any) (any, error) {
 		pvcObj, ok := obj.(*corev1.PersistentVolumeClaim)
-		if !ok {
+		if !ok || pvcObj == nil {
 			return obj, nil
+		}
+		var annotations map[string]string
+		if val, ok := pvcObj.ObjectMeta.Annotations[webhook.MounterPodTemplateAnnotation]; ok {
+			annotations = map[string]string{
+				webhook.MounterPodTemplateAnnotation: val,
+			}
 		}
 		return &corev1.PersistentVolumeClaim{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      pvcObj.ObjectMeta.Name,
-				Namespace: pvcObj.ObjectMeta.Namespace,
+				Name:        pvcObj.ObjectMeta.Name,
+				Namespace:   pvcObj.ObjectMeta.Namespace,
+				Annotations: annotations, // only store the mounter pod template annotation to optimize memory.
 			},
 			Spec: corev1.PersistentVolumeClaimSpec{
 				VolumeName: pvcObj.Spec.VolumeName,
@@ -220,7 +232,7 @@ func (c *Clientset) ConfigurePVCLister(ctx context.Context) {
 func (c *Clientset) ConfigureSCLister(ctx context.Context) {
 	trim := func(obj any) (any, error) {
 		scObj, ok := obj.(*storagev1.StorageClass)
-		if !ok {
+		if !ok || scObj == nil {
 			return obj, nil
 		}
 		return &storagev1.StorageClass{
@@ -246,7 +258,37 @@ func (c *Clientset) ConfigureSCLister(ctx context.Context) {
 	c.scLister = scLister
 }
 
-func New(kubeconfigPath string, informerResyncDurationSec int) (Interface, error) {
+func (c *Clientset) ConfigurePodTemplateLister(ctx context.Context) {
+	trim := func(obj any) (any, error) {
+		podTemplateObj, ok := obj.(*corev1.PodTemplate)
+		if !ok || podTemplateObj == nil {
+			return obj, nil
+		}
+		return &corev1.PodTemplate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      podTemplateObj.ObjectMeta.Name,
+				Namespace: podTemplateObj.Namespace,
+			},
+			Template: corev1.PodTemplateSpec{
+				Spec: podTemplateObj.Template.Spec,
+			},
+		}, nil
+	}
+
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(
+		c.k8sClients,
+		time.Duration(c.informerResyncDurationSec)*time.Second,
+		informers.WithTransform(trim),
+	)
+	podTemplateLister := informerFactory.Core().V1().PodTemplates().Lister()
+
+	informerFactory.Start(ctx.Done())
+	informerFactory.WaitForCacheSync(ctx.Done())
+
+	c.podTemplateLister = podTemplateLister
+}
+
+func New(kubeconfigPath string, informerResyncDurationSec int, runController bool) (Interface, error) {
 	var err error
 	var rc *rest.Config
 	if kubeconfigPath != "" {
@@ -266,7 +308,16 @@ func New(kubeconfigPath string, informerResyncDurationSec int) (Interface, error
 		return nil, fmt.Errorf("failed to configure k8s client: %w", err)
 	}
 
-	return &Clientset{k8sClients: clientset, informerResyncDurationSec: informerResyncDurationSec}, nil
+	return &Clientset{k8sClients: clientset, informerResyncDurationSec: informerResyncDurationSec, runController: runController}, nil
+}
+
+// PodNameIndexFunc is an IndexFunc that indexes pods by their name.
+func PodNameIndexFunc(obj interface{}) ([]string, error) {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return []string{}, nil
+	}
+	return []string{pod.Name}, nil
 }
 
 func (c *Clientset) ConfigurePodLister(ctx context.Context, nodeName string) {
@@ -282,6 +333,10 @@ func (c *Clientset) ConfigurePodLister(ctx context.Context, nodeName string) {
 		// https://github.com/GoogleCloudPlatform/gcs-fuse-csi-driver/blob/547cab9a9aea4cdbda581885880020fb9266dc03/pkg/csi_driver/node.go#L85
 		podObj, ok := obj.(*corev1.Pod)
 		if !ok {
+			return obj, nil
+		}
+
+		if c.runController {
 			return obj, nil
 		}
 
@@ -330,16 +385,62 @@ func (c *Clientset) ConfigurePodLister(ctx context.Context, nodeName string) {
 		c.k8sClients,
 		time.Duration(c.informerResyncDurationSec)*time.Second,
 		informers.WithTweakListOptions(func(options *metav1.ListOptions) {
-			options.FieldSelector = "spec.nodeName=" + nodeName
+			if nodeName != "" {
+				options.FieldSelector = "spec.nodeName=" + nodeName
+			}
+			if c.runController {
+				// Only track mounter pods when the Pod informer is configured in the controller.
+				options.LabelSelector = fmt.Sprintf("%s=%s", webhook.SharedMountLabel, util.TrueStr)
+			}
 		}),
 		informers.WithTransform(trim),
 	)
 	podLister := informerFactory.Core().V1().Pods().Lister()
 
+	if c.runController {
+		podInformer := informerFactory.Core().V1().Pods().Informer()
+		// Add an indexer to allow efficient lookup of pods by name across all namespaces.
+		// This is used by the controller to quickly find specific pods (e.g., mounter pods)
+		// by their known name without needing to iterate through all pods or know the namespace.
+		err := podInformer.AddIndexers(cache.Indexers{
+			PodNameIndex: PodNameIndexFunc,
+		})
+		if err != nil {
+			klog.Fatalf("Failed to add podName indexer: %v", err)
+		}
+
+		c.podInformer = podInformer
+	}
+
 	informerFactory.Start(ctx.Done())
 	informerFactory.WaitForCacheSync(ctx.Done())
 
 	c.podLister = podLister
+}
+
+func (c *Clientset) GetPodsByName(podName string) ([]*corev1.Pod, error) {
+	if c.podInformer == nil {
+		return nil, fmt.Errorf("podInformer is not initialized")
+	}
+
+	// objs is a slice of interface{}, each element is a *corev1.Pod
+	objs, err := c.podInformer.GetIndexer().ByIndex(PodNameIndex, podName)
+	if err != nil {
+		return nil, err
+	}
+
+	pods := make([]*corev1.Pod, 0, len(objs))
+	for _, obj := range objs {
+		pod, ok := obj.(*corev1.Pod)
+		if !ok {
+			// This should not happen if the indexer is set up correctly,
+			// but good practice to handle nonetheless.
+			return nil, fmt.Errorf("unexpected type in indexer: got %T, want *corev1.Pod", obj)
+		}
+		pods = append(pods, pod)
+	}
+
+	return pods, nil
 }
 
 func (c *Clientset) GetPod(namespace, name string) (*corev1.Pod, error) {
@@ -366,6 +467,15 @@ func (c *Clientset) GetPV(name string) (*corev1.PersistentVolume, error) {
 	return c.pvLister.Get(name)
 }
 
+func (c *Clientset) ListPVs() ([]*corev1.PersistentVolume, error) {
+	if c.pvLister == nil {
+		return nil, errors.New("pv informer is not ready")
+	}
+
+	// TODO(urielguzman): Add volumeHandle indexer to reduce O(N) -> O(1) for shared mount ControllerPublishVolume.
+	return c.pvLister.List(labels.Everything())
+}
+
 func (c *Clientset) GetPVC(namespace, name string) (*corev1.PersistentVolumeClaim, error) {
 	if c.pvcLister == nil {
 		return nil, errors.New("pvc informer is not ready")
@@ -380,6 +490,14 @@ func (c *Clientset) GetSC(name string) (*storagev1.StorageClass, error) {
 	}
 
 	return c.scLister.Get(name)
+}
+
+func (c *Clientset) GetPodTemplate(namespace, name string) (*corev1.PodTemplate, error) {
+	if c.podTemplateLister == nil {
+		return nil, errors.New("pod template informer is not ready")
+	}
+
+	return c.podTemplateLister.PodTemplates(namespace).Get(name)
 }
 
 func (c *Clientset) CreateServiceAccountToken(ctx context.Context, namespace, name string, tokenRequest *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error) {

--- a/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/clientset/fake.go
+++ b/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/clientset/fake.go
@@ -26,7 +26,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 type FakeNodeConfig struct {
@@ -36,21 +39,30 @@ type FakeNodeConfig struct {
 }
 
 type FakePodConfig struct {
+	Name               string
+	Namespace          string
 	HostNetworkEnabled bool
 	SidecarLimits      corev1.ResourceList
+	DeletionTimestamp  *metav1.Time
+	UID                types.UID
+	PodStatus          *corev1.PodStatus
+	NodeName           string
 }
 
 type FakePVConfig struct {
-	Annotations map[string]string
-	SCName      string
-	DriverName  string
-	Name        string
+	Annotations  map[string]string
+	SCName       string
+	DriverName   string
+	Name         string
+	VolumeHandle string
+	ClaimRef     *corev1.ObjectReference
 }
 
 type FakePVCConfig struct {
-	Name       string
-	VolumeName string
-	Namespace  string
+	Name        string
+	VolumeName  string
+	Namespace   string
+	Annotations map[string]string
 }
 
 type FakeSCConfig struct {
@@ -59,19 +71,36 @@ type FakeSCConfig struct {
 	MountOptions []string
 }
 
-type FakeClientset struct {
-	fakePod  *corev1.Pod
-	fakeNode *corev1.Node
-	fakePVs  map[string]*corev1.PersistentVolume
-	fakePVCs map[string]*corev1.PersistentVolumeClaim
-	fakeSCs  map[string]*storagev1.StorageClass
+type FakePodTemplateConfig struct {
+	Name      string
+	Namespace string
+	Template  corev1.PodTemplateSpec
 }
 
-func NewFakeClientset() *FakeClientset {
+type FakeClientset struct {
+	Client            kubernetes.Interface
+	fakePod           *corev1.Pod
+	fakeNode          *corev1.Node
+	fakePVs           map[string]*corev1.PersistentVolume
+	fakePVCs          map[string]*corev1.PersistentVolumeClaim
+	fakeSCs           map[string]*storagev1.StorageClass
+	fakePods          []*corev1.Pod
+	fakePodTemplates  map[string]*corev1.PodTemplate
+	ListPVErr         error
+	ListPodErr        error
+	GetPodErr         error
+	GetPodTemplateErr error
+}
+
+func NewFakeClientset(objects ...runtime.Object) *FakeClientset {
+	fakeK8sClient := fake.NewSimpleClientset(objects...)
 	fakeClientSet := &FakeClientset{
-		fakePVs:  make(map[string]*corev1.PersistentVolume),
-		fakePVCs: make(map[string]*corev1.PersistentVolumeClaim),
-		fakeSCs:  make(map[string]*storagev1.StorageClass),
+		Client:           fakeK8sClient,
+		fakePVs:          make(map[string]*corev1.PersistentVolume),
+		fakePVCs:         make(map[string]*corev1.PersistentVolumeClaim),
+		fakeSCs:          make(map[string]*storagev1.StorageClass),
+		fakePodTemplates: make(map[string]*corev1.PodTemplate),
+		fakePods:         []*corev1.Pod{},
 	}
 	// Default setting for most unit tests is pod doesn't use host network & workload identity is enabled on the node
 	fakeClientSet.CreatePod(FakePodConfig{HostNetworkEnabled: false})
@@ -79,12 +108,13 @@ func NewFakeClientset() *FakeClientset {
 	fakeClientSet.CreatePV(FakePVConfig{})
 	fakeClientSet.CreatePVC(FakePVCConfig{})
 	fakeClientSet.CreateSC(FakeSCConfig{})
+	fakeClientSet.CreatePodTemplate(FakePodTemplateConfig{})
 
 	return fakeClientSet
 }
 
 func (c *FakeClientset) K8sClient() kubernetes.Interface {
-	return nil
+	return c.Client
 }
 
 func (c *FakeClientset) ConfigurePodLister(_ context.Context, _ string) {}
@@ -97,6 +127,8 @@ func (c *FakeClientset) ConfigurePVCLister(_ context.Context) {}
 
 func (c *FakeClientset) ConfigureSCLister(_ context.Context) {}
 
+func (c *FakeClientset) ConfigurePodTemplateLister(_ context.Context) {}
+
 func (c *FakeClientset) CreatePod(podConfig FakePodConfig) {
 	config := webhook.FakeConfig()
 
@@ -107,8 +139,9 @@ func (c *FakeClientset) CreatePod(podConfig FakePodConfig) {
 
 	c.fakePod = &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "",
-			Namespace: "",
+			Name:      podConfig.Name,
+			Namespace: podConfig.Namespace,
+			UID:       podConfig.UID,
 		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
@@ -131,6 +164,20 @@ func (c *FakeClientset) CreatePod(podConfig FakePodConfig) {
 	if podConfig.HostNetworkEnabled {
 		c.fakePod.Spec.HostNetwork = true
 	}
+
+	if podConfig.DeletionTimestamp != nil {
+		c.fakePod.DeletionTimestamp = podConfig.DeletionTimestamp
+	}
+
+	if podConfig.PodStatus != nil {
+		c.fakePod.Status = *podConfig.PodStatus
+	}
+
+	if podConfig.NodeName != "" {
+		c.fakePod.Spec.NodeName = podConfig.NodeName
+	}
+
+	c.fakePods = append(c.fakePods, c.fakePod)
 }
 
 func (c *FakeClientset) CreateNode(nodeConfig FakeNodeConfig) {
@@ -160,9 +207,11 @@ func (c *FakeClientset) CreatePV(pvConfig FakePVConfig) {
 			StorageClassName: pvConfig.SCName,
 			PersistentVolumeSource: corev1.PersistentVolumeSource{
 				CSI: &corev1.CSIPersistentVolumeSource{
-					Driver: pvConfig.DriverName,
+					Driver:       pvConfig.DriverName,
+					VolumeHandle: pvConfig.VolumeHandle,
 				},
 			},
+			ClaimRef: pvConfig.ClaimRef,
 		},
 	}
 
@@ -172,8 +221,9 @@ func (c *FakeClientset) CreatePV(pvConfig FakePVConfig) {
 func (c *FakeClientset) CreatePVC(pvcConfig FakePVCConfig) {
 	pvc := &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   pvcConfig.Name,
-			Labels: map[string]string{},
+			Name:        pvcConfig.Name,
+			Labels:      map[string]string{},
+			Annotations: pvcConfig.Annotations,
 		},
 	}
 
@@ -197,6 +247,18 @@ func (c *FakeClientset) CreateSC(scConfig FakeSCConfig) {
 	c.fakeSCs[sc.Name] = sc
 }
 
+func (c *FakeClientset) CreatePodTemplate(podTemplateConfig FakePodTemplateConfig) {
+	podTemplate := &corev1.PodTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podTemplateConfig.Name,
+			Namespace: podTemplateConfig.Namespace,
+		},
+		Template: podTemplateConfig.Template,
+	}
+
+	c.fakePodTemplates[podTemplate.Name] = podTemplate
+}
+
 func (c *FakeClientset) AddPodVolumes(volumes []corev1.Volume) {
 	if c.fakePod != nil {
 		c.fakePod.Spec.Volumes = append(c.fakePod.Spec.Volumes, volumes...)
@@ -204,6 +266,9 @@ func (c *FakeClientset) AddPodVolumes(volumes []corev1.Volume) {
 }
 
 func (c *FakeClientset) GetPod(namespace, name string) (*corev1.Pod, error) {
+	if c.GetPodErr != nil {
+		return nil, c.GetPodErr
+	}
 	c.fakePod.ObjectMeta.Name = name
 	c.fakePod.ObjectMeta.Namespace = namespace
 
@@ -224,6 +289,30 @@ func (c *FakeClientset) GetPV(name string) (*corev1.PersistentVolume, error) {
 	return c.fakePVs[""], nil
 }
 
+func (c *FakeClientset) ListPVs() ([]*corev1.PersistentVolume, error) {
+	if c.ListPVErr != nil {
+		return nil, c.ListPVErr
+	}
+	var pvs []*corev1.PersistentVolume
+	for _, pv := range c.fakePVs {
+		pvs = append(pvs, pv)
+	}
+	return pvs, nil
+}
+
+func (c *FakeClientset) GetPodsByName(podName string) ([]*corev1.Pod, error) {
+	if c.ListPodErr != nil {
+		return nil, c.ListPodErr
+	}
+	var pods []*corev1.Pod
+	for _, pod := range c.fakePods {
+		if pod != nil && pod.Name == podName {
+			pods = append(pods, pod)
+		}
+	}
+	return pods, nil
+}
+
 func (c *FakeClientset) GetPVC(namespace, name string) (*corev1.PersistentVolumeClaim, error) {
 	if pvc, ok := c.fakePVCs[name]; ok {
 		return pvc, nil
@@ -238,6 +327,17 @@ func (c *FakeClientset) GetSC(name string) (*storagev1.StorageClass, error) {
 	}
 
 	return c.fakeSCs[""], nil
+}
+
+func (c *FakeClientset) GetPodTemplate(namespace, name string) (*corev1.PodTemplate, error) {
+	if c.GetPodTemplateErr != nil {
+		return nil, c.GetPodTemplateErr
+	}
+	if podTemplate, ok := c.fakePodTemplates[name]; ok {
+		return podTemplate, nil
+	}
+
+	return c.fakePodTemplates[""], nil
 }
 
 func (c *FakeClientset) CreateServiceAccountToken(_ context.Context, _, _ string, _ *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error) {

--- a/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/storage/fake.go
+++ b/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/storage/fake.go
@@ -42,7 +42,7 @@ type fakeServiceManager struct {
 	createdBuckets map[string]*ServiceBucket
 }
 
-func (manager *fakeServiceManager) SetupService(_ context.Context, _ oauth2.TokenSource) (Service, error) {
+func (manager *fakeServiceManager) SetupService(_ context.Context, _ oauth2.TokenSource, _ string) (Service, error) {
 	return &fakeService{sm: *manager}, nil
 }
 
@@ -50,7 +50,7 @@ func (manager *fakeServiceManager) SetupServiceWithDefaultCredential(_ context.C
 	return &fakeService{sm: *manager}, nil
 }
 
-func (manager *fakeServiceManager) SetupStorageServiceForSidecar(_ context.Context, _ oauth2.TokenSource) (Service, error) {
+func (manager *fakeServiceManager) SetupStorageServiceForSidecar(_ context.Context, _ oauth2.TokenSource, _ string) (Service, error) {
 	return &fakeService{sm: *manager}, nil
 }
 

--- a/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/storage/storage.go
+++ b/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/storage/storage.go
@@ -66,9 +66,9 @@ type Service interface {
 }
 
 type ServiceManager interface {
-	SetupService(ctx context.Context, ts oauth2.TokenSource) (Service, error)
+	SetupService(ctx context.Context, ts oauth2.TokenSource, customEndpoint string) (Service, error)
 	SetupServiceWithDefaultCredential(ctx context.Context, enableZB bool) (Service, error)
-	SetupStorageServiceForSidecar(ctx context.Context, ts oauth2.TokenSource) (Service, error)
+	SetupStorageServiceForSidecar(ctx context.Context, ts oauth2.TokenSource, customEndpoint string) (Service, error)
 }
 
 type gcsService struct {
@@ -83,7 +83,7 @@ func NewGCSServiceManager() (ServiceManager, error) {
 	return &gcsServiceManager{}, nil
 }
 
-func (manager *gcsServiceManager) SetupService(ctx context.Context, ts oauth2.TokenSource) (Service, error) {
+func (manager *gcsServiceManager) SetupService(ctx context.Context, ts oauth2.TokenSource, customEndpoint string) (Service, error) {
 	if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 30*time.Second, true, func(context.Context) (bool, error) {
 		if _, err := ts.Token(); err != nil {
 			klog.Errorf("error fetching initial token: %v", err)
@@ -97,12 +97,12 @@ func (manager *gcsServiceManager) SetupService(ctx context.Context, ts oauth2.To
 	}
 
 	client := oauth2.NewClient(ctx, ts)
-	storageClient, err := storage.NewClient(ctx, option.WithHTTPClient(client))
+	storageClient, err := storage.NewClient(ctx, withCustomEndpoint([]option.ClientOption{option.WithHTTPClient(client)}, customEndpoint)...)
 	if err != nil {
 		return nil, err
 	}
 
-	controlClient, err := control.NewStorageControlClient(ctx, option.WithTokenSource(ts))
+	controlClient, err := control.NewStorageControlClient(ctx, withCustomEndpoint([]option.ClientOption{option.WithTokenSource(ts)}, customEndpoint)...)
 	if err != nil {
 		storageClient.Close()
 		return nil, err
@@ -432,7 +432,16 @@ func isBucketAZonalBucket(ctx context.Context, client *storage.Client, bucketNam
 	return attrs.StorageClass == "RAPID", nil
 }
 
-func (manager *gcsServiceManager) SetupStorageServiceForSidecar(ctx context.Context, ts oauth2.TokenSource) (Service, error) {
+func withCustomEndpoint(opts []option.ClientOption, customEndpoint string) []option.ClientOption {
+	// Use a custom endpoint, if provided.
+	// TODO(urielguzman): Dynamically fetch the Google Universe if custom endpoint isn't provided.
+	if customEndpoint != "" {
+		return append(opts, option.WithEndpoint(customEndpoint))
+	}
+	return opts
+}
+
+func (manager *gcsServiceManager) SetupStorageServiceForSidecar(ctx context.Context, ts oauth2.TokenSource, customEndpoint string) (Service, error) {
 	var storageOpts []option.ClientOption
 	var controlOpts []option.ClientOption
 
@@ -445,12 +454,12 @@ func (manager *gcsServiceManager) SetupStorageServiceForSidecar(ctx context.Cont
 		controlOpts = append(controlOpts, option.WithTokenSource(ts))
 	}
 
-	storageClient, err := storage.NewClient(ctx, storageOpts...)
+	storageClient, err := storage.NewClient(ctx, withCustomEndpoint(storageOpts, customEndpoint)...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create storage client: %w", err)
 	}
 
-	controlClient, err := control.NewStorageControlClient(ctx, controlOpts...)
+	controlClient, err := control.NewStorageControlClient(ctx, withCustomEndpoint(controlOpts, customEndpoint)...)
 	if err != nil {
 		storageClient.Close()
 		return nil, fmt.Errorf("failed to create control client: %w", err)

--- a/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/csi_driver/controller.go
+++ b/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/csi_driver/controller.go
@@ -18,6 +18,7 @@ limitations under the License.
 package driver
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -25,9 +26,10 @@ import (
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/storage"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/profiles"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/klog/v2"
 )
 
@@ -125,6 +127,181 @@ func (s *controllerServer) ValidateVolumeCapabilities(ctx context.Context, req *
 			Parameters:         req.GetParameters(),
 		},
 	}, nil
+}
+
+func (s *controllerServer) ControllerPublishVolume(ctx context.Context, req *csi.ControllerPublishVolumeRequest) (*csi.ControllerPublishVolumeResponse, error) {
+	// Validate arguments
+	volumeID := req.GetVolumeId()
+	if len(volumeID) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "ControllerPublishVolume Volume ID must be provided")
+	}
+	if err := s.driver.validateVolumeCapabilities([]*csi.VolumeCapability{req.GetVolumeCapability()}); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+	nodeID := req.GetNodeId()
+	if len(nodeID) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "ControllerPublishVolume Node ID must be provided")
+	}
+
+	// Acquires the lock for the volume on that node only, because we need to support the ability
+	// to publish the same volume onto different nodes concurrently
+	lockingVolumeID := fmt.Sprintf("%s/%s", nodeID, volumeID)
+	if acquired := s.volumeLocks.TryAcquire(lockingVolumeID); !acquired {
+		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, lockingVolumeID)
+	}
+	defer s.volumeLocks.Release(lockingVolumeID)
+
+	// Skip ControllerPublishVolume if the volume is not using the shared mount feature.
+	vc := req.GetVolumeContext()
+	if !sharedMount(vc) {
+		return &csi.ControllerPublishVolumeResponse{}, nil
+	}
+
+	// Find the workload namespace where the mounter pod should be created by identifying the PVC
+	// bound to this volume's PV.
+	clientset := s.driver.config.K8sClients
+	pvName := vc[util.VolumeContextKeyPVName]
+	if pvName == "" {
+		return nil, status.Errorf(codes.Internal, "PV name not found in VolumeContext (key %q)", util.VolumeContextKeyPVName)
+	}
+	klog.V(6).Infof("ControllerPublishVolume: directly fetching PV %q from VolumeContext for volume %q, context: %v", pvName, volumeID, vc)
+	pv, err := clientset.GetPV(pvName)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, status.Error(codes.NotFound, err.Error())
+		}
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	if pv.Spec.ClaimRef == nil {
+		// The PV should be bound if ControllerPublishVolume is called. Return error since this is unexpected.
+		return nil, status.Errorf(codes.Internal, "pv %q is not bound to any pvc", pv.Name)
+	}
+	pvcName := pv.Spec.ClaimRef.Name
+	pvcNamespace := pv.Spec.ClaimRef.Namespace
+	if pvcNamespace == "" || pvcName == "" {
+		return nil, status.Errorf(codes.Internal, "pv claimRef namespace and name can't be empty, namespace: %q, name: %q", pvcNamespace, pvcName)
+	}
+	podNamespace := pvcNamespace
+
+	// Find the PodTemplate from the PVC to allow mounter pod config overrides.
+	pvc, err := clientset.GetPVC(pvcNamespace, pvcName)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, status.Error(codes.NotFound, err.Error())
+		}
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	podTemplate, err := mounterPodTemplate(clientset, pvc)
+	if err != nil {
+		return nil, err
+	}
+	if podTemplate == nil {
+		return nil, status.Error(codes.Internal, "pod template can't be nil")
+	}
+
+	// Extract overrides specifically from the container named "gcsfusecsi-mount".
+	var containerResources *corev1.ResourceRequirements
+	var containerImage string
+	if s.driver != nil && s.driver.config != nil && s.driver.config.FeatureOptions != nil && s.driver.config.FeatureOptions.SharedMountOptions != nil {
+		containerImage = s.driver.config.FeatureOptions.SharedMountOptions.MounterPodImage
+	}
+	for i := range podTemplate.Template.Spec.Containers {
+		container := &podTemplate.Template.Spec.Containers[i]
+		if container.Name != mounterPodNamePrefix {
+			continue
+		}
+		containerResources = &container.Resources
+		if container.Image != "" && container.Image != mounterPodManagedImageKeyword {
+			// If the image isn't the placeholder managed keyword, the user is trying to
+			// override the mounter pod's image.
+			// TODO(urielguzman): Somehow validate image so that only trustworthy repositories are allowed.
+			containerImage = container.Image
+		}
+		break
+	}
+	if containerImage == "" {
+		return nil, status.Error(codes.Internal, "mounter pod image cannot be empty")
+	}
+
+	// Prepare mounter pod config.
+	podName := createMounterPodName(nodeID, volumeID)
+	podConfig := &mounterPodConfig{
+		podName:            podName,
+		namespace:          podNamespace,
+		serviceAccountName: podTemplate.Template.Spec.ServiceAccountName,
+		resources:          containerResources,
+		nodeID:             nodeID,
+		image:              containerImage,
+		volumes:            podTemplate.Template.Spec.Volumes,
+	}
+
+	if err := createMounterPod(clientset, ctx, podConfig); err != nil {
+		return nil, err
+	}
+
+	// Wait until the mounter pod is scheduled to a node.
+	// This ensures that the mounter pod can be scheduled even if there are resource constraints on the node,
+	// such as needing to wait for a regular pod to be evicted first.
+	// Without this check, NodeStageVolume could return an internal error because the mounter pod is not yet scheduled.
+	if err := waitForMounterPodScheduled(clientset, ctx, podNamespace, podName, nodeID); err != nil {
+		return nil, err
+	}
+
+	klog.Infof("ControllerPublishVolume succeeded for mounter pod %s/%s. Node: %q, volume %q", podConfig.namespace, podConfig.podName, nodeID, volumeID)
+	return &csi.ControllerPublishVolumeResponse{
+		PublishContext: map[string]string{
+			// Pass the mounter pod's namespace and name to subsequent NodeStageVolume and
+			// NodePublishVolume calls to avoid re-computation.
+			PublishContextKeyMounterPodNamespace: podNamespace,
+			PublishContextKeyMounterPodName:      podName,
+		},
+	}, nil
+}
+
+// TODO(urielguzman): implement ControllerUnpublishVolume.
+func (s *controllerServer) ControllerUnpublishVolume(ctx context.Context, req *csi.ControllerUnpublishVolumeRequest) (*csi.ControllerUnpublishVolumeResponse, error) {
+	// Validate arguments.
+	volumeID := req.GetVolumeId()
+	if len(volumeID) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "ControllerUnpublishVolume Volume ID must be provided")
+	}
+	nodeID := req.NodeId
+	if len(nodeID) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "ControllerUnpublishVolume Node ID must be provided")
+	}
+
+	// Acquires the lock for the volume on that node only, because we need to support the ability
+	// to publish the same volume onto different nodes concurrently
+	lockingVolumeID := fmt.Sprintf("%s/%s", nodeID, volumeID)
+	if acquired := s.volumeLocks.TryAcquire(lockingVolumeID); !acquired {
+		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, lockingVolumeID)
+	}
+	defer s.volumeLocks.Release(lockingVolumeID)
+
+	// Delete the mounter pod, if it exists.
+	podName := createMounterPodName(nodeID, volumeID)
+	mounterPods, err := s.driver.config.K8sClients.GetPodsByName(podName)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to list pods: %v", err)
+	}
+
+	if len(mounterPods) == 0 {
+		klog.Infof("ControllerUnpublishVolume succeeded for volume %q on node %q", volumeID, nodeID)
+		return &csi.ControllerUnpublishVolumeResponse{}, nil
+	}
+	if len(mounterPods) > 1 {
+		// Each nodeID/volumeID pair should match exactly to 1 mounter pod. If there are more than 1 in that node,
+		// this signals an internal bug on how the mounter pods are being handled by the CSI Driver.
+		return nil, status.Errorf(codes.Internal, "expected 1 mounter pod for volume %q on node %q, found: %d", volumeID, nodeID, len(mounterPods))
+	}
+
+	podNamespace := mounterPods[0].Namespace
+	if err := deleteMounterPod(ctx, s.driver.config.K8sClients, podNamespace, podName); err != nil {
+		return nil, err
+	}
+
+	klog.Infof("ControllerUnpublishVolume succeeded for volume %q on node %q", volumeID, nodeID)
+	return &csi.ControllerUnpublishVolumeResponse{}, nil
 }
 
 func (s *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
@@ -238,7 +415,8 @@ func (s *controllerServer) prepareStorageService(ctx context.Context, secrets ma
 	}
 
 	ts := s.driver.config.TokenManager.GetTokenSourceFromK8sServiceAccount(serviceAccountNamespace, serviceAccountName, "", "" /*audience*/, false)
-	storageService, err := s.storageServiceManager.SetupService(ctx, ts)
+	// TODO(urielguzman): Dynamically fetch the Google Universe if custom endpoint isn't provided.
+	storageService, err := s.storageServiceManager.SetupService(ctx, ts, "")
 	if err != nil {
 		return nil, fmt.Errorf("storage service manager failed to setup service: %w", err)
 	}

--- a/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/csi_driver/gcs_fuse_driver.go
+++ b/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/csi_driver/gcs_fuse_driver.go
@@ -45,9 +45,24 @@ type FeatureGCSFuseProfiles struct {
 	EnableGcsfuseProfilesInternal bool
 }
 
+type GoMemLimitOptions struct {
+	EnableAutoGoMemLimit bool
+	AutoGoMemLimitRatio  float64
+}
+
+type SharedMountOptions struct {
+	Enabled         bool
+	MounterPodImage string
+	FuseSocketDir   string
+	// Needed to override the mounter pods emptydir base path, otherwise tests will try to write to var/lib/kubelet which it won't have access to.
+	EmptyDirBasePath func(podUID string) string
+}
+
 type GCSDriverFeatureOptions struct {
 	EnableGCSFuseKernelParams bool
 	FeatureGCSFuseProfiles    *FeatureGCSFuseProfiles
+	GoMemLimitOptions         *GoMemLimitOptions
+	SharedMountOptions        *SharedMountOptions
 }
 
 type GCSDriverConfig struct {
@@ -68,6 +83,7 @@ type GCSDriverConfig struct {
 	EnableCloudProfilerForSidecar  bool
 	FeatureOptions                 *GCSDriverFeatureOptions
 	AssumeGoodSidecarVersion       bool
+	UniverseDomain                 string
 }
 
 type GCSDriver struct {
@@ -119,12 +135,18 @@ func NewGCSDriver(config *GCSDriverConfig, recorder record.EventRecorder) (*GCSD
 		nscap := []csi.NodeServiceCapability_RPC_Type{
 			csi.NodeServiceCapability_RPC_VOLUME_MOUNT_GROUP,
 		}
+		if config.FeatureOptions != nil && config.FeatureOptions.SharedMountOptions != nil && config.FeatureOptions.SharedMountOptions.Enabled {
+			nscap = append(nscap, csi.NodeServiceCapability_RPC_STAGE_UNSTAGE_VOLUME)
+		}
 		driver.ns = newNodeServer(driver, config.Mounter)
 		driver.addNodeServiceCapabilities(nscap)
 	}
 	if config.RunController {
 		csc := []csi.ControllerServiceCapability_RPC_Type{
 			csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME,
+		}
+		if config.FeatureOptions != nil && config.FeatureOptions.SharedMountOptions != nil && config.FeatureOptions.SharedMountOptions.Enabled {
+			csc = append(csc, csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME)
 		}
 		driver.addControllerServiceCapabilities(csc)
 

--- a/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/csi_driver/node.go
+++ b/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/csi_driver/node.go
@@ -20,6 +20,7 @@ package driver
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -32,7 +33,9 @@ import (
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/webhook"
 	"golang.org/x/net/context"
 	"golang.org/x/time/rate"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -164,9 +167,10 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 
 	// Check if the given Service Account has the access to the GCS bucket, and the bucket exists.
 	// skip check if it has ever succeeded
+	storageEndpoint := storageEndpointFromUniverseDomain(s.driver.config.UniverseDomain)
 	if vs != nil && !args.skipCSIBucketAccessCheck {
 		if !vs.BucketAccessCheckPassed {
-			storageService, err := s.prepareStorageService(ctx, vc)
+			storageService, err := s.prepareStorageService(ctx, vc, storageEndpoint)
 			if err != nil {
 				return nil, status.Errorf(codes.Unauthenticated, "failed to prepare storage service: %v", err)
 			}
@@ -180,7 +184,11 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 		}
 	}
 
-	enableSidecarBucketAccessCheckForSidecarVersion := s.driver.config.EnableSidecarBucketAccessCheck && gcsFuseSidecarImage != "" && s.driver.isSidecarVersionSupportedForGivenFeature(gcsFuseSidecarImage, SidecarBucketAccessCheckMinVersion)
+	sidecarCheckVal := getInternalMountOptionValue(args.fuseMountOptions, util.EnableSidecarBucketAccessCheckConst)
+	userExplicitlyEnabled := sidecarCheckVal == util.TrueStr
+	userExplicitlyDisabled := sidecarCheckVal == util.FalseStr
+	enableSidecarBucketAccessCheckForSidecarVersion := s.driver.isSidecarVersionSupportedForGivenFeature(gcsFuseSidecarImage, SidecarBucketAccessCheckMinVersion) &&
+		(userExplicitlyEnabled || (s.driver.config.EnableSidecarBucketAccessCheck && !userExplicitlyDisabled))
 	identityProvider := ""
 	if s.shouldPopulateIdentityProvider(pod, args.optInHostnetworkKSA, args.userSpecifiedIdentityProvider != "") {
 		if args.userSpecifiedIdentityProvider != "" {
@@ -190,9 +198,9 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 		}
 		klog.V(6).Infof("NodePublishVolume populating identity provider %q in mount options", identityProvider)
 		args.fuseMountOptions = joinMountOptions(args.fuseMountOptions, []string{util.OptInHnw + "=true", util.TokenServerIdentityProviderConst + "=" + identityProvider})
-	} else if enableSidecarBucketAccessCheckForSidecarVersion {
+	} else if enableSidecarBucketAccessCheckForSidecarVersion && !userExplicitlyEnabled {
 		//Enable sidecar bucket access check only for Workload Identity workloads. This feature consumes additional quota for Host Network pods as we do not have token caching.
-		args.fuseMountOptions = joinMountOptions(args.fuseMountOptions, []string{util.EnableSidecarBucketAccessCheckConst + "=" + strconv.FormatBool(s.driver.config.EnableSidecarBucketAccessCheck)})
+		args.fuseMountOptions = joinMountOptions(args.fuseMountOptions, []string{util.EnableSidecarBucketAccessCheckConst + "=true"})
 	}
 
 	if enableSidecarBucketAccessCheckForSidecarVersion {
@@ -209,12 +217,48 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 			util.TokenServerIdentityPoolConst + "=" + identityPool})
 	}
 
-	if args.enableCloudProfilerForSidecar && gcsFuseSidecarImage != "" && s.driver.isSidecarVersionSupportedForGivenFeature(gcsFuseSidecarImage, SidecarCloudProfilerMinVersion) {
+	if args.enableCloudProfilerForSidecar && s.driver.isSidecarVersionSupportedForGivenFeature(gcsFuseSidecarImage, SidecarCloudProfilerMinVersion) {
 		args.fuseMountOptions = joinMountOptions(args.fuseMountOptions, []string{
 			util.EnableCloudProfilerForSidecarConst + "=" + strconv.FormatBool(args.enableCloudProfilerForSidecar),
 			util.PodNameConst + "=" + vc[VolumeContextKeyPodName],
 			util.PodUIDConst + "=" + string(pod.UID),
 		})
+	}
+
+	// Check if the user explicitly provided GOMEMLIMIT flags in their
+	// volume's mountOptions.
+	userProvidedAutoMemLimit := false
+	userProvidedRatio := false
+	for _, opt := range args.fuseMountOptions {
+		if opt == util.EnableAutoGoMemLimitConst || strings.HasPrefix(opt, util.EnableAutoGoMemLimitConst+"=") {
+			userProvidedAutoMemLimit = true
+		}
+		if strings.HasPrefix(opt, util.AutoGoMemLimitRatioConst+"=") {
+			userProvidedRatio = true
+		}
+	}
+
+	// Inject driver defaults if the sidecar supports the GOMEMLIMIT feature.
+	// We evaluate the ratio independently so users who manually opt-in via
+	// mountOptions without specifying a ratio still receive the driver's
+	// default.
+	if s.driver.isSidecarVersionSupportedForGivenFeature(gcsFuseSidecarImage, SidecarAutoGoMemLimitMinVersion) {
+		var extraOpts []string
+		enableAutoGoMemLimit := s.driver.config.FeatureOptions.GoMemLimitOptions != nil && s.driver.config.FeatureOptions.GoMemLimitOptions.EnableAutoGoMemLimit
+		if enableAutoGoMemLimit && !userProvidedAutoMemLimit {
+			extraOpts = append(extraOpts, util.EnableAutoGoMemLimitConst+"=true")
+		}
+		//  We check this to prevent injecting the ratio and adding unnecessary
+		// noise to the mount options when the feature is completely disabled.
+		sidecarFeatureWillBeEnabled := enableAutoGoMemLimit || userProvidedAutoMemLimit
+		if !userProvidedRatio && sidecarFeatureWillBeEnabled && s.driver.config.FeatureOptions.GoMemLimitOptions != nil {
+			autoGoMemLimitRatio := s.driver.config.FeatureOptions.GoMemLimitOptions.AutoGoMemLimitRatio
+			extraOpts = append(extraOpts, util.AutoGoMemLimitRatioConst+"="+strconv.FormatFloat(autoGoMemLimitRatio, 'f', -1, 64))
+		}
+
+		if len(extraOpts) > 0 {
+			args.fuseMountOptions = joinMountOptions(args.fuseMountOptions, extraOpts)
+		}
 	}
 
 	node, err := s.k8sClients.GetNode(s.driver.config.NodeID)
@@ -267,7 +311,7 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 	}
 
 	// Only pass mountOptions flags for defaulting if sidecar container is managed and satisifies min version requirement
-	if gcsFuseSidecarImage != "" && s.driver.isSidecarVersionSupportedForGivenFeature(gcsFuseSidecarImage, MachineTypeAutoConfigSidecarMinVersion) {
+	if s.driver.isSidecarVersionSupportedForGivenFeature(gcsFuseSidecarImage, MachineTypeAutoConfigSidecarMinVersion) {
 		shouldDisableAutoConfig := s.driver.config.DisableAutoconfig
 		machineType, ok := node.Labels[clientset.MachineTypeKey]
 		if ok {
@@ -347,6 +391,12 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 
 	disallowedFlags := s.driver.generateDisallowedFlagsMap(gcsFuseSidecarImage)
 	args.fuseMountOptions = removeDisallowedMountOptions(args.fuseMountOptions, disallowedFlags)
+
+	// Pass the universe-aware storage endpoint if the sidecar version supports it.
+	if s.driver.isSidecarVersionSupportedForGivenFeature(gcsFuseSidecarImage, StorageEndpointInternalMinVersion) {
+		args.fuseMountOptions = overrideStorageEndpointInternal(args.fuseMountOptions, storageEndpoint)
+	}
+
 	// Start to mount
 	if err = s.mounter.Mount(args.bucketName, targetPath, FuseMountType, args.fuseMountOptions); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to mount volume %q to target path %q: %v", args.bucketName, targetPath, err)
@@ -380,7 +430,6 @@ func (s *nodeServer) startGcsFuseKernelParamsMonitoring(targetPath, gcsFuseSidec
 func (s *nodeServer) isGcsFuseKernelParamsFeatureSupported(gcsFuseSidecarImage string, vs *util.VolumeState) bool {
 	return vs != nil &&
 		s.driver.config.FeatureOptions.EnableGCSFuseKernelParams &&
-		gcsFuseSidecarImage != "" &&
 		s.driver.isSidecarVersionSupportedForGivenFeature(gcsFuseSidecarImage, GCSFuseKernelParamsMinVersion)
 }
 
@@ -493,9 +542,9 @@ func (s *nodeServer) setupMultiNIC(args *requestArgs, pod *corev1.Pod, sidecarSu
 }
 
 // prepareStorageService prepares the GCS Storage Service using the Kubernetes Service Account from VolumeContext.
-func (s *nodeServer) prepareStorageService(ctx context.Context, vc map[string]string) (storage.Service, error) {
+func (s *nodeServer) prepareStorageService(ctx context.Context, vc map[string]string, customEndpoint string) (storage.Service, error) {
 	ts := s.driver.config.TokenManager.GetTokenSourceFromK8sServiceAccount(vc[VolumeContextKeyPodNamespace], vc[VolumeContextKeyServiceAccountName], vc[VolumeContextKeyServiceAccountToken], "" /*audience*/, false)
-	storageService, err := s.storageServiceManager.SetupService(ctx, ts)
+	storageService, err := s.storageServiceManager.SetupService(ctx, ts, customEndpoint)
 	if err != nil {
 		return nil, fmt.Errorf("storage service manager failed to setup service: %w", err)
 	}
@@ -549,6 +598,15 @@ func gcsFuseSidecarContainerImage(pod *corev1.Pod) string {
 	return ""
 }
 
+// countGcsFuseVolumes returns the number of GCSFuse CSI Ephemeral volumes or
+// PersistentVolumeClaims in the given Pod spec. We intentionally do not
+// check to see if the PVC is a GCSFuseCSI PVC because that requires additional
+// API calls or a PVC informer which previously made the node driver OOM.
+// We may end up counting some non-GCSFuse volumes, but that is acceptable
+// since this is only used to determine whether to enable metrics collection
+// on a given pod.
+// TODO(amacaskill): Make sure the PVC is a GCSFuseCSI PVC, without
+// causing an OOM in the node driver at scale.
 func (s *nodeServer) countGcsFuseVolumes(pod *corev1.Pod) (int, error) {
 	gcsFuseVolumeCount := 0
 
@@ -563,40 +621,235 @@ func (s *nodeServer) countGcsFuseVolumes(pod *corev1.Pod) (int, error) {
 			continue
 		}
 
-		if v.PersistentVolumeClaim == nil {
-			continue
-		}
-
-		// Count persistent gcsfuse volumes
-		pvc, err := s.k8sClients.GetPVC(pod.Namespace, v.PersistentVolumeClaim.ClaimName)
-
-		// A NotFound error is tolerated, but other errors will abort the count and disable metrics.
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				klog.Warningf("pvc %q not found: %v", v.PersistentVolumeClaim.ClaimName, err)
-				continue
-			}
-
-			klog.Errorf("internal error getting PVC %q: %v. Setting GCS Fuse metric count to 0", v.PersistentVolumeClaim.ClaimName, err)
-			return 0, err
-		}
-
-		pv, err := s.k8sClients.GetPV(pvc.Spec.VolumeName)
-
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				klog.Warningf("pv %q not found: %v", pvc.Spec.VolumeName, err)
-				continue
-			}
-
-			klog.Errorf("internal error getting PV %q: %v. Setting GCS Fuse metric count to 0", pvc.Spec.VolumeName, err)
-			return 0, err
-		}
-
-		if pv.Spec.CSI != nil && pv.Spec.CSI.Driver == s.driver.config.Name {
+		if v.PersistentVolumeClaim != nil {
 			gcsFuseVolumeCount++
+			continue
 		}
 	}
 
 	return gcsFuseVolumeCount, nil
+}
+
+func (s *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
+	// Validate arguments.
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "NodeStageVolume Request cannot be nil")
+	}
+	volumeID := req.GetVolumeId()
+	if len(volumeID) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "NodeStageVolume Volume ID must be provided")
+	}
+	if req.GetVolumeCapability() == nil {
+		return nil, status.Error(codes.InvalidArgument, "NodeStageVolume Volume capability must be provided")
+	}
+	if err := s.driver.validateVolumeCapabilities([]*csi.VolumeCapability{req.GetVolumeCapability()}); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+	stagingPath := req.GetStagingTargetPath()
+	if len(stagingPath) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "NodeStageVolume Staging Target Path must be provided")
+	}
+	// Skip NodeStageVolume for sidecar mounted volumes.
+	if !sharedMount(req.GetVolumeContext()) {
+		return &csi.NodeStageVolumeResponse{}, nil
+	}
+
+	publishContext := req.GetPublishContext()
+	if publishContext == nil {
+		return nil, status.Error(codes.InvalidArgument, "publishContext must be provided")
+	}
+
+	podName, ok := publishContext[PublishContextKeyMounterPodName]
+	if !ok {
+		return nil, status.Error(codes.InvalidArgument, "publishContext must contain mounter pod name")
+	}
+	if podName == "" {
+		return nil, status.Error(codes.InvalidArgument, "mounter pod name in publishContext cannot be empty")
+	}
+
+	podNamespace, ok := publishContext[PublishContextKeyMounterPodNamespace]
+	if !ok {
+		return nil, status.Error(codes.InvalidArgument, "publishContext must contain mounter pod namespace")
+	}
+	if podNamespace == "" {
+		return nil, status.Error(codes.InvalidArgument, "mounter pod namespace in publishContext cannot be empty")
+	}
+
+	// Acquire a lock on the staging path.
+	if acquired := s.volumeLocks.TryAcquire(stagingPath); !acquired {
+		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, stagingPath)
+	}
+	defer s.volumeLocks.Release(stagingPath)
+
+	resp, err := s.executeNodeStageVolume(ctx, req)
+
+	if err != nil {
+		klog.Errorf("NodeStageVolume failed on staging path %q for volume %q: %v)", stagingPath, volumeID, err)
+	}
+
+	return resp, err
+}
+
+func (s *nodeServer) executeNodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
+	clientset := s.driver.config.K8sClients
+	stagingPath := req.GetStagingTargetPath()
+
+	// Validate staging path and mounter pod information from the request.
+	publishContext := req.GetPublishContext()
+	podName := publishContext[PublishContextKeyMounterPodName]
+	podNamespace := publishContext[PublishContextKeyMounterPodNamespace]
+
+	klog.Infof("Executing NodeStageVolume. Mounter pod: %s/%s, node: %q, volume: %q, staging path: %q", podNamespace, podName, s.driver.config.NodeID, req.GetVolumeId(), stagingPath)
+
+	// Verify mounter pod exists.
+	pod, err := clientset.GetPod(podNamespace, podName)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, status.Errorf(codes.FailedPrecondition, "mounter pod %s/%s expected to exist but was not found", podNamespace, podName)
+		}
+		return nil, status.Errorf(codes.Internal, "failed to get mounter pod %s/%s: %v", podNamespace, podName, err)
+	}
+	if pod == nil {
+		return nil, status.Errorf(codes.Internal, "mounter pod %s/%s can't be nil", podNamespace, podName)
+	}
+
+	// Check if the staging path is already mounted.
+	mounted, err := s.isDirMounted(stagingPath)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to check if path %q is already mounted: %v", stagingPath, err)
+	}
+	if mounted {
+		klog.Infof("NodeStageVolume succeeded on staging path %q for volume %q, mount already exists.", stagingPath, req.GetVolumeId())
+		return &csi.NodeStageVolumeResponse{}, nil
+	}
+
+	// Make the staging path.
+	klog.Infof("NodeStageVolume attempting mkdir for staging path %q", stagingPath)
+	if err := os.MkdirAll(stagingPath, 0750); err != nil {
+		return nil, status.Errorf(codes.Internal, "mkdir failed for path %q: %v", stagingPath, err)
+	}
+
+	// Wait for the mounter pod grpc server to be ready.
+	if err := waitForMounterServer(ctx, clientset, podNamespace, podName, string(pod.UID), s.driver.config.FeatureOptions.SharedMountOptions.EmptyDirBasePath); err != nil {
+		return nil, err
+	}
+
+	podUID := string(pod.UID)
+
+	// Send GRPC to mounter pod to start GCSFuse.
+	if err := s.mountToNode(ctx, podUID, stagingPath, req.GetVolumeId()); err != nil {
+		return nil, err
+	}
+
+	klog.Infof("Mounter pod %s/%s is running and staging path %s is mounted", podNamespace, podName, stagingPath)
+
+	klog.Infof("NodeStageVolume succeeded on staging path %q for volume %q", stagingPath, req.GetVolumeId())
+	return &csi.NodeStageVolumeResponse{}, nil
+}
+
+// mountToNode connects to the mounter server, at which point it initializes the GCSFuse process.
+func (s *nodeServer) mountToNode(ctx context.Context, podUID, stagingPath, volumeID string) error {
+	if s.driver.config.FeatureOptions == nil || s.driver.config.FeatureOptions.SharedMountOptions == nil {
+		return status.Errorf(codes.Internal, "shared mount options are not fully configured")
+	}
+
+	if s.driver.config.FeatureOptions.SharedMountOptions.EmptyDirBasePath == nil {
+		return status.Errorf(codes.Internal, "empty dir base path must be provided for shared mount")
+	}
+	emptyDirBasePath := s.driver.config.FeatureOptions.SharedMountOptions.EmptyDirBasePath(podUID)
+	socketFile := filepath.Join(emptyDirBasePath, mounterPodSocketFile)
+
+	// Create a symlink to bypass the 108-character limit for Unix domain sockets
+	// when dialing the connection from the Node Server.
+	if s.driver.config.FeatureOptions.SharedMountOptions.FuseSocketDir == "" {
+		return status.Errorf(codes.Internal, "fuse socket dir must be provided for shared mount")
+	}
+	symlink := filepath.Join(s.driver.config.FeatureOptions.SharedMountOptions.FuseSocketDir, mounterPodSocketDir, podUID)
+	if err := os.MkdirAll(filepath.Dir(symlink), 0750); err != nil {
+		return status.Errorf(codes.Internal, "failed to create dir for symlink %q: %v", symlink, err)
+	}
+
+	if err := os.Remove(symlink); err != nil && !os.IsNotExist(err) {
+		klog.Errorf("failed to remove stale symlink %q: %v", symlink, err)
+	}
+
+	if err := os.Symlink(socketFile, symlink); err != nil {
+		return status.Errorf(codes.Internal, "failed to create symlink to %q: %v", socketFile, err)
+	}
+	defer os.Remove(symlink)
+
+	// Connect to the socket using the short symlink path.
+	socketPath := fmt.Sprintf("unix:%s", symlink)
+	conn, err := grpc.NewClient(socketPath, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		klog.Errorf("Failed to connect to the server: %v", err)
+		return status.Errorf(codes.Internal, "failed to connect to the mounter pod grpc server: %v", err)
+	}
+	klog.Infof("Connected to MounterServer at %s", socketPath)
+	defer conn.Close()
+
+	/*
+		TODO(FUECHR): Implement the mounter client and mount request once we have a mounter service defined.
+		c := mounter.NewMounterClient(conn)
+		if _, err := c.Mount(ctx, &mounter.MountRequest{
+			Mountpoint: stagingPath,
+			VolumeID:   volumeID,
+		}); err != nil {
+			return status.Errorf(codes.Internal, "failed to mount: %v", err)
+		}
+	*/
+
+	klog.Infof("Mount succeeded at staging target path %s", stagingPath)
+	return nil
+}
+
+func (s *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {
+	// Validate arguments.
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "NodeUnstageVolume Request cannot be nil")
+	}
+	volumeID := req.GetVolumeId()
+	if len(volumeID) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "NodeUnstageVolume Volume ID must be provided")
+	}
+	stagingPath := req.GetStagingTargetPath()
+	if len(stagingPath) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "NodeUnstageVolume Staging Target Path must be provided")
+	}
+
+	// Acquire a lock on the staging path instead of volumeID, since we do not want to serialize multiple node unstage calls on the same volume.
+	if acquired := s.volumeLocks.TryAcquire(stagingPath); !acquired {
+		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, stagingPath)
+	}
+	defer s.volumeLocks.Release(stagingPath)
+
+	if err := s.cleanupStagingPath(stagingPath); err != nil {
+		return nil, err
+	}
+
+	klog.Infof("NodeUnstageVolume succeeded on staging path %q for volume %q", stagingPath, req.GetVolumeId())
+	return &csi.NodeUnstageVolumeResponse{}, nil
+}
+
+func (s *nodeServer) cleanupStagingPath(stagingPath string) error {
+	// Unmount staging path.
+	mounted, err := s.isDirMounted(stagingPath)
+	if err != nil {
+		return status.Errorf(codes.Internal, "failed to check if path %q is already mounted: %v", stagingPath, err)
+	}
+
+	if mounted {
+		if err = s.mounter.Unmount(stagingPath); err != nil {
+			return status.Errorf(codes.Internal, "failed to unmount staging path %q: %v", stagingPath, err)
+		}
+	} else {
+		klog.Infof("staging path %q was already unmounted", stagingPath)
+	}
+
+	// Cleanup the mount point.
+	if err := mount.CleanupMountPoint(stagingPath, s.mounter, false /* bind mount */); err != nil {
+		return status.Errorf(codes.Internal, "failed to cleanup the mount point %q: %v", stagingPath, err)
+	}
+
+	return nil
 }

--- a/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/csi_driver/shared_mount.go
+++ b/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/csi_driver/shared_mount.go
@@ -1,0 +1,471 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import (
+	"crypto/sha1"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"context"
+
+	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/clientset"
+	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util"
+	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/webhook"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
+)
+
+const (
+	mounterPodNamePrefix          = "gcsfusecsi-mount"
+	mounterPodPriorityClass       = "gcsfusecsi-mount-priority"
+	mounterPodMountDir            = "mount-dir"
+	mounterPodSocketFile          = "mounter.sock"
+	mounterPodManagedImageKeyword = "managed"
+	mounterPodSocketDir           = "mount-socket"
+)
+
+var (
+	mounterPodPollInterval = 1 * time.Second
+)
+
+// mounterPodConfig holds the configuration parameters required to define and manage a mounter pod.
+type mounterPodConfig struct {
+	podName            string                       // The name to assign to the mounter pod.
+	nodeID             string                       // The specific node ID where the pod should be scheduled.
+	namespace          string                       // The Kubernetes namespace in which to create the pod.
+	image              string                       // The image for the mounter pod binary.
+	serviceAccountName string                       // The KSA name for the mounter pod.
+	resources          *corev1.ResourceRequirements // The resource requirements for the mounter pod container.
+	volumes            []corev1.Volume              // The volumes for the mounter pod.
+}
+
+// sharedMount checks if the VolumeContext enables the shared node mount feature
+// by checking the sharedMount: true volumeAttribute.
+func sharedMount(vc map[string]string) bool {
+	if v, ok := vc[VolumeContextSharedNodeMount]; ok && v == util.TrueStr {
+		return true
+	}
+	return false
+}
+
+// createMounterPodName returns a unique name for the mounter pod. The name is composed by
+// the node and volume IDs, evaluated on a SHA1 hash for length shortening.
+func createMounterPodName(nodeID, volumeID string) string {
+	str := fmt.Sprintf("%s_%s", nodeID, volumeID)
+	h := sha1.New()
+	// Write the string to the hash
+	io.WriteString(h, str)
+	// Convert the byte slice to a hexadecimal string
+	sha1Hash := fmt.Sprintf("%x", h.Sum(nil))
+	return fmt.Sprintf("%s-%s", mounterPodNamePrefix, sha1Hash)
+}
+
+// createMounterPod handles the creation of the mounter pod using the Kubernetes API client.
+func createMounterPod(clientset clientset.Interface, ctx context.Context, config *mounterPodConfig) error {
+	if clientset == nil || clientset.K8sClient() == nil {
+		return status.Error(codes.Internal, "kubernetes client is uninitialized")
+	}
+	if config == nil {
+		return status.Error(codes.Internal, "mounter pod config cannot be nil")
+	}
+	// Check if the mounter pod already exists, but was marked for deletion.
+	// This requires calling the API server directly to retrieve the most up-to-date pod status.
+	pod, err := clientset.K8sClient().CoreV1().Pods(config.namespace).Get(ctx, config.podName, metav1.GetOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		return status.Errorf(codes.Internal, "failed to get mounter pod %s/%s: %v", config.namespace, config.podName, err)
+	}
+	// GET always returns a pointer to the pod, even if the pod doesn't exist.
+	// Therefore, we cannot rely on a nil pointer to determine the pod's existence.
+	if errors.IsNotFound(err) {
+		podSpec := createMounterPodSpec(config)
+		if _, err = clientset.K8sClient().CoreV1().Pods(config.namespace).Create(ctx, podSpec, metav1.CreateOptions{}); err != nil {
+			if errors.IsAlreadyExists(err) {
+				klog.Infof("Mounter pod %s/%s already exists.", config.namespace, config.podName)
+				return nil
+			}
+			return status.Errorf(codes.Internal, "failed to create mounter pod %s/%s: %v", config.namespace, config.podName, err)
+		}
+		return nil
+	}
+	// If the mounter pod is marked for deletion, prevent ControllerPublishVolume from succeeding.
+	if pod == nil {
+		return status.Errorf(codes.Internal, "mounter pod %s/%s was found but returned as nil", config.namespace, config.podName)
+	}
+	if pod.ObjectMeta.DeletionTimestamp != nil {
+		return status.Errorf(
+			codes.Aborted,
+			"Mounter pod %s/%s is marked for deletion. Waiting for pod deletion to complete.",
+			config.namespace, config.podName,
+		)
+	}
+	klog.Infof("Mounter pod %s/%s already exists.", config.namespace, config.podName)
+	return nil
+}
+
+// createMounterPodSpec returns the pod spec for the mounter pod.
+func createMounterPodSpec(config *mounterPodConfig) *corev1.Pod {
+	spec := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      config.podName,
+			Namespace: config.namespace,
+			Labels: map[string]string{
+				webhook.SharedMountLabel: util.TrueStr,
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeSelector: map[string]string{
+				// Use NodeSelector rather than NodeName in the mounter pod spec,
+				// since NodeName will bypass kube-scheduler.
+				"kubernetes.io/hostname": config.nodeID,
+				"kubernetes.io/os":       "linux",
+			},
+			PriorityClassName: mounterPodPriorityClass,
+			Containers: []corev1.Container{
+				{
+					Name:            mounterPodNamePrefix,
+					Image:           config.image,
+					ImagePullPolicy: corev1.PullAlways,
+					SecurityContext: &corev1.SecurityContext{
+						Privileged: ptr.To(true),
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:             mounterPodMountDir,
+							MountPath:        util.KubeletDir,
+							MountPropagation: ptr.To(corev1.MountPropagationBidirectional),
+						},
+						{
+							Name:      util.SidecarContainerTmpVolumeName,
+							MountPath: util.SidecarContainerTmpVolumePath,
+						},
+						{
+							Name:      webhook.SidecarContainerBufferVolumeName,
+							MountPath: webhook.SidecarContainerBufferVolumeMountPath,
+						},
+						{
+							Name:      webhook.SidecarContainerCacheVolumeName,
+							MountPath: webhook.SidecarContainerCacheVolumeMountPath,
+						},
+						// TODO(urielguzman): Add host network and profiles volume mounts when those features are implemented
+						// for shared mount.
+					},
+				},
+			},
+			Volumes: mounterPodVolumes(config),
+			Tolerations: []corev1.Toleration{
+				{
+					//  https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+					//  See "special case". This will tolerate everything. Mounter pod should
+					//  be possible to be scheduled on all nodes where the workloads are scheduled.
+					Operator: corev1.TolerationOpExists,
+				},
+			},
+		},
+	}
+
+	if config.serviceAccountName != "" {
+		spec.Spec.ServiceAccountName = config.serviceAccountName
+	}
+
+	spec.Spec.Containers[0].Resources = *mounterPodResources(config)
+
+	return spec
+}
+
+// waitForMounterPodScheduled wait for mounter pod to be scheduled.
+func waitForMounterPodScheduled(clientset clientset.Interface, ctx context.Context, namespace, podName, nodeID string) error {
+	if clientset == nil {
+		return status.Error(codes.Internal, "kubernetes client is uninitialized")
+	}
+
+	checkIfScheduled := func() (bool, error) {
+		pod, err := clientset.GetPod(namespace, podName)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, status.Errorf(codes.Internal, "failed to get mounter pod %s/%s: %v", namespace, podName, err)
+		}
+		if pod != nil && pod.Spec.NodeName != "" {
+			if pod.Spec.NodeName != nodeID {
+				return false, status.Errorf(codes.Internal, "mounter pod %s/%s expected to be scheduled to node %q, instead, was scheduled to node %q", namespace, podName, nodeID, pod.Spec.NodeName)
+			}
+			for _, condition := range pod.Status.Conditions {
+				if condition.Type == corev1.PodScheduled && condition.Status == corev1.ConditionTrue {
+					klog.Infof("Mounter pod %s/%s has been scheduled to node %s", namespace, podName, pod.Spec.NodeName)
+					return true, nil
+				}
+			}
+		}
+		return false, nil
+	}
+
+	// Check immediately to avoid waiting if the pod is already scheduled.
+	if scheduled, err := checkIfScheduled(); err != nil || scheduled {
+		return err
+	}
+
+	klog.Infof("Waiting for mounter pod %s/%s to be scheduled. Polling every %v", namespace, podName, mounterPodPollInterval)
+
+	ticker := time.NewTicker(mounterPodPollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			if scheduled, err := checkIfScheduled(); err != nil || scheduled {
+				return err
+			}
+		case <-ctx.Done():
+			code := codes.DeadlineExceeded
+			if ctx.Err() == context.Canceled {
+				code = codes.Canceled
+			}
+			return status.Errorf(code, "timeout waiting for mounter pod %s/%s to be scheduled to node %q: %v", namespace, podName, nodeID, ctx.Err())
+		}
+	}
+}
+
+// mounterPodTemplate retrieves the referenced mounter PodTemplate for a PVC if the annotation is present.
+func mounterPodTemplate(clientset clientset.Interface, pvc *corev1.PersistentVolumeClaim) (*corev1.PodTemplate, error) {
+	if pvc == nil {
+		return nil, status.Errorf(codes.InvalidArgument, "pvc cannot be nil")
+	}
+	if pvc.Annotations == nil {
+		return nil, status.Errorf(codes.InvalidArgument, "mounter pod template annotation must be provided")
+	}
+	templateName, ok := pvc.Annotations[webhook.MounterPodTemplateAnnotation]
+	if !ok || templateName == "" {
+		return nil, status.Errorf(codes.InvalidArgument, "mounter pod template annotation must be provided")
+	}
+
+	podTemplate, err := clientset.GetPodTemplate(pvc.Namespace, templateName)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, status.Error(codes.NotFound, err.Error())
+		}
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	return podTemplate, nil
+}
+
+// deleteMounterPod handles the deletion of the mounter pod, if it exists.
+// It will retry until it is deleted or return an error if the number of retries have exceeded the limit.
+// deleteMounterPod returns only after mounter pod has terminated and deleted from the API server.
+func deleteMounterPod(ctx context.Context, clientset clientset.Interface, podNamespace, podName string) error {
+	if clientset == nil || clientset.K8sClient() == nil {
+		return status.Error(codes.Internal, "kubernetes client is uninitialized")
+	}
+	if err := clientset.K8sClient().CoreV1().Pods(podNamespace).Delete(ctx, podName, metav1.DeleteOptions{}); err != nil {
+		if errors.IsNotFound(err) {
+			// If the pod is not found, it's not an error
+			klog.Infof("Mounter pod %s/%s was already deleted.", podNamespace, podName)
+			return nil
+		}
+		return status.Errorf(codes.Internal, "failed to delete pod %s/%s: %v", podNamespace, podName, err)
+	}
+	pollInterval := mounterPodPollInterval
+	klog.Infof("Waiting for mounter pod %s/%s deletion to complete. Polling every %s",
+		podNamespace, podName, pollInterval)
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			code := codes.DeadlineExceeded
+			if ctx.Err() == context.Canceled {
+				code = codes.Canceled
+			}
+			return status.Errorf(code, "timed out waiting for mounter pod %s/%s to be deleted", podNamespace, podName)
+		case <-ticker.C:
+			if _, err := clientset.GetPod(podNamespace, podName); err != nil {
+				if errors.IsNotFound(err) {
+					klog.Infof("Mounter pod %s/%s was successfully deleted.", podNamespace, podName)
+					return nil
+				}
+				return status.Errorf(codes.Internal, "failed to get pod %s/%s: %v", podNamespace, podName, err)
+			}
+		}
+	}
+}
+
+func mounterPodResources(config *mounterPodConfig) *corev1.ResourceRequirements {
+	// Instantiate maps to avoid nil map assignment panics
+	resources := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			// TODO: Change the defaults once we profile the feature.
+			corev1.ResourceMemory:           resource.MustParse("768Mi"),
+			corev1.ResourceCPU:              resource.MustParse("750m"),
+			corev1.ResourceEphemeralStorage: resource.MustParse("15Gi"),
+		},
+		Limits: corev1.ResourceList{},
+	}
+
+	// Guard against nil configs or nil resources
+	if config == nil || config.resources == nil {
+		return &resources
+	}
+
+	// Set customer overrides, if defined.
+	for resourceName := range config.resources.Requests {
+		setResource(&resources.Requests, config.resources.Requests, resourceName)
+	}
+	for resourceName := range config.resources.Limits {
+		setResource(&resources.Limits, config.resources.Limits, resourceName)
+	}
+
+	return &resources
+}
+
+// mounterPodVolumes returns the list of volumes required by the mounter pod.
+// This includes standard GCS FUSE volumes and the host path to the kubelet directory.
+func mounterPodVolumes(config *mounterPodConfig) []corev1.Volume {
+	// Get the gke-gcsfuse-tmp, gke-gcsfuse-buffer, and gke-gcsfuse-cache volumes, and allow
+	// the buffer and cache to be overridden by the PodTemplate volumes.
+	volumes := []corev1.Volume{}
+	volumes = append(volumes, config.volumes...) // Make a copy to avoid mutating the PodTemplate volumes.
+	volumes = append(volumes, webhook.GetSidecarContainerVolumeSpec(config.volumes...)...)
+
+	// Set the /var/lib/kubelet host path, so the mounter pod can mount the staging path to the node.
+	volumes = append(volumes, corev1.Volume{Name: mounterPodMountDir,
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				// TODO(urielguzman): Check if we can use /var/lib/kubelet/plugins/gcsfuse.csi.storage.gke.io/
+				// instead, to decrease the host path scope.
+				Path: util.KubeletDir,
+				Type: ptr.To(corev1.HostPathDirectoryOrCreate),
+			},
+		}})
+
+	// TODO(urielguzman): Add profiles and host network volumes when those features are implemnented for
+	// shared mount.
+	return volumes
+}
+
+func setResource(target *corev1.ResourceList, override corev1.ResourceList, resourceName corev1.ResourceName) {
+	if target == nil {
+		return
+	}
+	val, ok := override[resourceName]
+	if !ok {
+		return // No value provided, skip setting
+	}
+
+	// Initialize the underlying map if it's nil and we are inserting a value
+	if *target == nil && !val.IsZero() {
+		*target = make(corev1.ResourceList)
+	}
+
+	// Remove the value if "0" is specified.
+	if val.IsZero() {
+		if *target != nil {
+			delete(*target, resourceName)
+		}
+	} else {
+		(*target)[resourceName] = val
+	}
+}
+
+// waitForMounterServer waits for the mounter pod's gRPC server to be ready.
+func waitForMounterServer(ctx context.Context, clientset clientset.Interface, mounterPodNamespace, mounterPodName, podUID string, emptyDirBasePath func(string) string) error {
+	if clientset == nil {
+		return status.Error(codes.Internal, "kubernetes client is uninitialized")
+	}
+	if emptyDirBasePath == nil {
+		return status.Error(codes.Internal, "emptyDirBasePath function is uninitialized")
+	}
+
+	// Construct the mounter socket file path.
+	mounterSocketFilePath := filepath.Join(emptyDirBasePath(podUID), mounterPodSocketFile)
+	var pod *corev1.Pod
+	var err error
+
+	checkIfReady := func() (bool, error) {
+		// Get the mounter pod status.
+		if pod, err = clientset.GetPod(mounterPodNamespace, mounterPodName); err != nil {
+			// Mounter Pod should exist by this point.
+			if errors.IsNotFound(err) {
+				return false, status.Errorf(codes.FailedPrecondition, "mounter pod %s/%s expected to exist but was not found", mounterPodNamespace, mounterPodName)
+			}
+			return false, status.Errorf(codes.Internal, "failed to get mounter pod %s/%s: %v", mounterPodNamespace, mounterPodName, err)
+		}
+
+		// If the pod is not pending or running, it's in an unexpected state.
+		if pod.Status.Phase != corev1.PodRunning && pod.Status.Phase != corev1.PodPending {
+			return false, status.Errorf(codes.Internal, "mounter pod %s/%s found with an unexpected status: %s", mounterPodNamespace, mounterPodName, pod.Status.Phase)
+		}
+
+		// If the pod is pending, retry.
+		if pod.Status.Phase == corev1.PodPending {
+			klog.Infof("Mounter pod %s/%s is still Pending. Retrying...", mounterPodNamespace, mounterPodName)
+			return false, nil
+		}
+
+		// Mounter pod is running, check if the socket file is available.
+		// TODO(FUECHR): Investigate symlink traversal vulnerabilities for os.Stat vs os.Lstat.
+		if _, err = os.Stat(mounterSocketFilePath); err == nil {
+			klog.Infof("Mounter pod %s/%s is running and socket file %q is available.", mounterPodNamespace, mounterPodName, mounterSocketFilePath)
+			return true, nil
+		}
+		if !os.IsNotExist(err) {
+			return false, status.Errorf(codes.Internal, "error checking socket file %q for mounter pod %s/%s: %v", mounterSocketFilePath, mounterPodNamespace, mounterPodName, err)
+		}
+		klog.Infof("Mounter pod %s/%s is running but socket file %q is not yet available. Retrying...", mounterPodNamespace, mounterPodName, mounterSocketFilePath)
+		return false, nil
+	}
+
+	// Check immediately to avoid waiting if the pod and socket are already ready.
+	if ready, err := checkIfReady(); err != nil || ready {
+		return err
+	}
+
+	klog.Infof("Waiting for mounter pod %s/%s to start running and the mounter pod socket file %q to become available. Polling every %s",
+		mounterPodNamespace, mounterPodName, mounterSocketFilePath, mounterPodPollInterval)
+
+	ticker := time.NewTicker(mounterPodPollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			if ready, err := checkIfReady(); err != nil || ready {
+				return err
+			}
+		case <-ctx.Done():
+			code := codes.DeadlineExceeded
+			if ctx.Err() == context.Canceled {
+				code = codes.Canceled
+			}
+			errMsg := fmt.Sprintf("timeout waiting for mounter pod %s/%s gRPC server to become available at %s: %v",
+				mounterPodNamespace, mounterPodName, mounterSocketFilePath, ctx.Err())
+			if pod != nil { // Catches the case where context is cancelled before GetPod is first called.
+				errMsg += fmt.Sprintf(", pod status: %+v", pod.Status)
+			}
+			return status.Error(code, errMsg)
+		}
+	}
+}

--- a/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/csi_driver/utils.go
+++ b/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/csi_driver/utils.go
@@ -20,11 +20,14 @@ package driver
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
+
+	"golang.org/x/sys/unix"
 
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util"
@@ -63,6 +66,7 @@ const (
 	VolumeContextKeyIdentityPool               = "identityPool"
 	VolumeContextKeyMultiNICIndex              = "multiNICIndex"
 	VolumeContextEnableCloudProfilerForSidecar = "enableCloudProfilerForSidecar"
+	VolumeContextSharedNodeMount               = "sharedMount"
 	// Legacy key, kept for backward compatibility
 	//nolint:revive,stylecheck
 	VolumeContextKeyMetadataCacheTtlSeconds = "metadataCacheTtlSeconds"
@@ -77,15 +81,19 @@ const (
 	VolumeContextKeyBucketName             = "bucketName"
 	TokenServerSidecarMinVersion           = "v1.17.2-gke.0" // #nosec G101
 	SidecarBucketAccessCheckMinVersion     = "v1.20.0-gke.0"
-	SidecarCloudProfilerMinVersion         = "v1.19.0-gke.0"
+	SidecarCloudProfilerMinVersion         = "v1.23.7-gke.0"
 	MachineTypeAutoConfigSidecarMinVersion = "v1.15.1-gke.0" // #nosec G101
 	GCSFuseProfilesMinVersion              = "v1.19.3-gke.0"
 	GCSFuseFileCacheMediumMinVersion       = "v1.21.0-gke.0"
 	GCSFuseKernelParamsMinVersion          = "v1.22.0-gke.0"
 	MultiNICMinVersion                     = "v1.22.2-gke.0"
+	SidecarAutoGoMemLimitMinVersion        = "v1.23.11-gke.0"
+	StorageEndpointInternalMinVersion      = "v1.23.14-gke.0"
 	FlagFileForDefaultingPath              = "flags-for-defaulting"
 	GCSFuseProfileFlag                     = "profile"
 	LocalSocketAddressArg                  = "experimental-local-socket-address"
+	PublishContextKeyMounterPodName        = "mounter-pod-name"
+	PublishContextKeyMounterPodNamespace   = "mounter-pod-namespace"
 )
 
 var (
@@ -372,6 +380,39 @@ func parseRequestArguments(req *csi.NodePublishVolumeRequest, vc map[string]stri
 	return args, err
 }
 
+// storageEndpointFromUniverseDomain returns the storage endpoint for the universe domain,
+// in the format storage.UNIVERSE_DOMAIN:443. If no universe domain is provided, googleapis.com
+// will be used as default.
+func storageEndpointFromUniverseDomain(universeDomain string) string {
+	if universeDomain == "" {
+		universeDomain = "googleapis.com"
+	}
+	return fmt.Sprintf("storage.%s:443", universeDomain)
+}
+
+// overrideStorageEndpointInternal adds the storage-endpoint-internal flag to the mountOptions.
+// If it already exists, it will be overridden.
+func overrideStorageEndpointInternal(opts []string, storageEndpoint string) []string {
+	prefix := fmt.Sprintf("%s=", util.StorageEndpointInternal)
+	replacement := fmt.Sprintf("%s%s", prefix, storageEndpoint)
+	newMountOptions := make([]string, 0, len(opts)+1)
+
+	for _, opt := range opts {
+		if strings.HasPrefix(opt, prefix) {
+			if opt != replacement {
+				// Log a warning if we are actively changing an existing value.
+				klog.Warningf("Found flag %q, replaced with %q", opt, replacement)
+			}
+			// Skip adding the old/incorrect flag to the new slice.
+			continue
+		}
+		newMountOptions = append(newMountOptions, opt)
+	}
+
+	// Always append the correct/updated flag at the end.
+	return append(newMountOptions, replacement)
+}
+
 func putExitFile(pod *corev1.Pod, targetPath string) error {
 	podIsTerminating := pod.DeletionTimestamp != nil
 	podRestartPolicyIsNever := pod.Spec.RestartPolicy == corev1.RestartPolicyNever
@@ -420,14 +461,24 @@ func putExitFile(pod *corev1.Pod, targetPath string) error {
 		}
 
 		exitFilePath := filepath.Dir(emptyDirBasePath) + "/exit"
-		f, err := os.Create(exitFilePath)
-		if err != nil {
-			return fmt.Errorf("failed to put the exit file: %w", err)
-		}
-		f.Close()
+		exitParentDir := filepath.Dir(exitFilePath)
 
-		err = os.Chown(exitFilePath, webhook.NobodyUID, webhook.NobodyGID)
+		// Pin the parent directory by opening its file descriptor with O_DIRECTORY and O_NOFOLLOW.
+		// This locks the parent directory inode in memory, preventing concurrent TOCTOU symlink-swapping
+		// attacks during subsequent relative operations (using unix.Openat).
+		parentFd, err := unix.Open(exitParentDir, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW, 0)
 		if err != nil {
+			return fmt.Errorf("failed to open parent directory %q: %w", exitParentDir, err)
+		}
+		defer unix.Close(parentFd)
+
+		fd, err := unix.Openat(parentFd, filepath.Base(exitFilePath), unix.O_RDWR|unix.O_CREAT|unix.O_TRUNC|unix.O_NOFOLLOW, 0644)
+		if err != nil {
+			return fmt.Errorf("failed to securely open exit file: %w", err)
+		}
+		f := os.NewFile(uintptr(fd), exitFilePath)
+		defer f.Close()
+		if err := f.Chown(webhook.NobodyUID, webhook.NobodyGID); err != nil {
 			return fmt.Errorf("failed to change ownership on the exit file: %w", err)
 		}
 	}
@@ -452,21 +503,44 @@ func checkGcsFuseErr(isInitContainer bool, pod *corev1.Pod, targetPath string) (
 		return code, fmt.Errorf("failed to get emptyDir path: %w", err)
 	}
 
-	klog.V(4).Infof("checkGcsFuseErr read file %s", emptyDirBasePath+"/error")
+	errorFilePath := emptyDirBasePath + "/error"
+	klog.V(4).Infof("[Pod %v/%v] checking sidecar container error status", pod.Namespace, pod.Name)
 
-	errMsg, err := os.ReadFile(emptyDirBasePath + "/error")
-	if err != nil && !os.IsNotExist(err) {
-		return code, fmt.Errorf("failed to open error file %q: %w", emptyDirBasePath+"/error", err)
+	parentDir := filepath.Dir(errorFilePath)
+
+	// Pin the parent directory by opening its file descriptor with O_DIRECTORY and O_NOFOLLOW.
+	// This locks the parent directory inode in memory, preventing concurrent TOCTOU symlink-swapping
+	// attacks during subsequent relative operations (using unix.Openat).
+	parentFd, err := unix.Open(parentDir, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return codes.OK, nil
+		}
+		return code, fmt.Errorf("failed to open parent directory %q: %w", parentDir, err)
+	}
+	defer unix.Close(parentFd)
+
+	fd, err := unix.Openat(parentFd, filepath.Base(errorFilePath), unix.O_RDONLY|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return codes.OK, nil
+		}
+		return code, fmt.Errorf("failed to open error file %q: %w", errorFilePath, err)
 	}
 
-	return extractErrorFromGcsFuseErrorFile(errMsg, err)
+	f := os.NewFile(uintptr(fd), errorFilePath)
+	defer f.Close()
+
+	errMsg, err := io.ReadAll(f)
+	if err != nil {
+		return code, fmt.Errorf("failed to read error file %q: %w", errorFilePath, err)
+	}
+
+	return extractErrorFromGcsFuseErrorFile(errMsg)
 }
 
-func extractErrorFromGcsFuseErrorFile(errMsg []byte, err error) (codes.Code, error) {
-	if err != nil && !os.IsNotExist(err) {
-		return codes.Internal, fmt.Errorf("error occurred while trying to read gcsfuse error file: %w", err)
-	}
-	if err == nil && len(errMsg) > 0 {
+func extractErrorFromGcsFuseErrorFile(errMsg []byte) (codes.Code, error) {
+	if len(errMsg) > 0 {
 		// TODO: We need a standard for scraping errors from GCSFuse.
 		// A change in string format in GCSFuse would break this function.
 		// If we are aware of such change, its also tedious to catch and
@@ -570,6 +644,10 @@ func isManagedSidecarImage(imageName string) bool {
 }
 
 func (d *GCSDriver) isSidecarVersionSupportedForGivenFeature(imageName string, sidecarMinSupportedVersion string) bool {
+	if imageName == "" {
+		return false
+	}
+
 	if d.config.AssumeGoodSidecarVersion {
 		klog.V(4).Infof("Assuming good sidecar version from flag")
 		return true
@@ -603,17 +681,28 @@ func PutFlagsFromDriverToTargetPath(flagMap map[string]string, targetPath string
 	absolutePath := filepath.Dir(emptyDirBasePath) + "/" + fileName
 	klog.V(4).Infof("Writing flags needed for gcsfuse defaulting logic to file %q: %v", absolutePath, flagMap)
 
-	// This file is truncated/cleared if it already exists.
-	f, err := os.Create(absolutePath)
+	parentDir := filepath.Dir(emptyDirBasePath)
+
+	// Pin the parent directory by opening its file descriptor with O_DIRECTORY and O_NOFOLLOW.
+	// This locks the parent directory inode in memory, preventing concurrent TOCTOU symlink-swapping
+	// attacks during subsequent relative operations (using unix.Openat).
+	parentFd, err := unix.Open(parentDir, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW, 0)
 	if err != nil {
-		return fmt.Errorf("failed to create defaulting-flag file: %w", err)
+		return fmt.Errorf("failed to open parent directory %q: %w", parentDir, err)
 	}
+	defer unix.Close(parentFd)
+
+	fd, err := unix.Openat(parentFd, filepath.Base(fileName), unix.O_RDWR|unix.O_CREAT|unix.O_TRUNC|unix.O_NOFOLLOW, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to securely open defaulting-flag file: %w", err)
+	}
+	f := os.NewFile(uintptr(fd), absolutePath)
+	defer f.Close()
+
 	content := prepareFileContentFromFlagMap(flagMap)
 	if _, err := f.WriteString(content); err != nil {
 		return fmt.Errorf("failed to write defaulting-flag file: %w", err)
 	}
-
-	f.Close()
 
 	return nil
 }
@@ -690,4 +779,17 @@ func transformKeysToSet(inputMap map[string]string) map[string]struct{} {
 		outputSet[key] = struct{}{}
 	}
 	return outputSet
+}
+
+func getInternalMountOptionValue(options []string, key string) string {
+	for i := len(options) - 1; i >= 0; i-- {
+		k, v, found := strings.Cut(options[i], "=")
+		if k == key {
+			if found {
+				return v
+			}
+			return ""
+		}
+	}
+	return ""
 }

--- a/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/metrics/metrics.go
+++ b/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/metrics/metrics.go
@@ -321,80 +321,86 @@ func ProcessMetricsData(metricsReader io.Reader) (map[string]*dto.MetricFamily, 
 
 // emitMetricFamily iterates MetricFamily, converts metricFamily.Metric to prometheus.Metric, and emits the metric via the given chan.
 func (c *metricsCollector) emitMetricFamily(metricFamily *dto.MetricFamily, ch chan<- prometheus.Metric) {
-	var valType prometheus.ValueType
-	var val float64
+	name := metricFamily.GetName()
+	help := metricFamily.GetHelp()
+	metricType := metricFamily.GetType()
+
+	var cachedDesc *prometheus.Desc
+
+	var cachedLabelNames []string
 
 	for _, metric := range metricFamily.GetMetric() {
-		var LabelNames []string
-		var LabelValues []string
-		for _, label := range metric.GetLabel() {
-			LabelNames = append(LabelNames, label.GetName())
-			LabelValues = append(LabelValues, label.GetValue())
+		labels := metric.GetLabel()
+
+		var desc *prometheus.Desc
+		// Reuse cached prometheus.Desc assuming identical label ordering.
+		if cachedDesc != nil && len(cachedLabelNames) == len(labels) {
+			desc = cachedDesc
+			for i, label := range labels {
+				if cachedLabelNames[i] != label.GetName() {
+					// Cache new prometheus.Desc to reduce garbage collection overhead and expensive string formatting.
+					desc = nil
+					break
+				}
+			}
 		}
 
-		for n, v := range c.constLabels {
-			LabelNames = append(LabelNames, n)
-			LabelValues = append(LabelValues, v)
+		if desc == nil {
+			labelNames := make([]string, len(labels))
+			for i, label := range labels {
+				labelNames[i] = label.GetName()
+			}
+			desc = prometheus.NewDesc(name, help, labelNames, prometheus.Labels(c.constLabels))
+			cachedDesc = desc
+			cachedLabelNames = labelNames
 		}
 
-		emitNewConstMetric := func() {
-			ch <- prometheus.MustNewConstMetric(
-				prometheus.NewDesc(
-					metricFamily.GetName(),
-					metricFamily.GetHelp(),
-					LabelNames, nil,
-				),
-				valType, val, LabelValues...,
-			)
+		labelValues := make([]string, len(labels))
+		for i, label := range labels {
+			labelValues[i] = label.GetValue()
 		}
 
-		metricType := metricFamily.GetType()
 		switch metricType {
 		case dto.MetricType_COUNTER:
-			valType = prometheus.CounterValue
-			val = metric.GetCounter().GetValue()
-			emitNewConstMetric()
+			ch <- prometheus.MustNewConstMetric(
+				desc,
+				prometheus.CounterValue, metric.GetCounter().GetValue(), labelValues...,
+			)
 
 		case dto.MetricType_GAUGE:
-			valType = prometheus.GaugeValue
-			val = metric.GetGauge().GetValue()
-			emitNewConstMetric()
+			ch <- prometheus.MustNewConstMetric(
+				desc,
+				prometheus.GaugeValue, metric.GetGauge().GetValue(), labelValues...,
+			)
 
 		case dto.MetricType_UNTYPED:
-			valType = prometheus.UntypedValue
-			val = metric.GetUntyped().GetValue()
-			emitNewConstMetric()
+			ch <- prometheus.MustNewConstMetric(
+				desc,
+				prometheus.UntypedValue, metric.GetUntyped().GetValue(), labelValues...,
+			)
 
 		case dto.MetricType_SUMMARY:
-			quantiles := map[float64]float64{}
+			quantiles := make(map[float64]float64, len(metric.GetSummary().GetQuantile()))
 			for _, q := range metric.GetSummary().GetQuantile() {
 				quantiles[q.GetQuantile()] = q.GetValue()
 			}
 			ch <- prometheus.MustNewConstSummary(
-				prometheus.NewDesc(
-					metricFamily.GetName(),
-					metricFamily.GetHelp(),
-					LabelNames, nil,
-				),
+				desc,
 				metric.GetSummary().GetSampleCount(),
 				metric.GetSummary().GetSampleSum(),
-				quantiles, LabelValues...,
+				quantiles, labelValues...,
 			)
 
 		case dto.MetricType_HISTOGRAM, dto.MetricType_GAUGE_HISTOGRAM:
-			buckets := map[float64]uint64{}
+			buckets := make(map[float64]uint64, len(metric.GetHistogram().GetBucket()))
 			for _, b := range metric.GetHistogram().GetBucket() {
 				buckets[b.GetUpperBound()] = b.GetCumulativeCount()
 			}
 			ch <- prometheus.MustNewConstHistogram(
-				prometheus.NewDesc(
-					metricFamily.GetName(),
-					metricFamily.GetHelp(),
-					LabelNames, nil,
-				),
+				desc,
 				metric.GetHistogram().GetSampleCount(),
 				metric.GetHistogram().GetSampleSum(),
-				buckets, LabelValues...,
+				buckets, labelValues...,
 			)
 
 		default:

--- a/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/profiles/recommender.go
+++ b/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/profiles/recommender.go
@@ -70,6 +70,10 @@ const (
 	metadataStatCacheBytesPerObjectFlat int64 = 1700
 	// mib represents 1024 * 1024 bytes.
 	mib int64 = 1024 * 1024
+	// The minimum size for the metadata stat cache size. The value is obtained from
+	// https://docs.cloud.google.com/storage/docs/cloud-storage-fuse/cli-options#stat-cache-max-size-mb,
+	// which claims that it's enough to cover up to 20,000 files.
+	minMetadataStatCacheMBSize = 34
 
 	// Mount option names.
 	statCacheConfigFileKey = "metadata-cache:stat-cache-max-size-mb"
@@ -189,7 +193,7 @@ func BuildProfileConfig(params *BuildProfileConfigParams) (*ProfileConfig, error
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			// Skip the profiles feature for ephemeral volumes.
-			klog.Warningf("pv %q not found: %v, disabling profiles feature for this volume", volumeName, err)
+			klog.V(6).Infof("pv %q not found: %v, disabling profiles feature for this volume", volumeName, err)
 			return nil, nil
 		}
 		return nil, status.Errorf(codes.Internal, "failed to get pv %q: %v", volumeName, err)
@@ -198,7 +202,7 @@ func BuildProfileConfig(params *BuildProfileConfigParams) (*ProfileConfig, error
 	// Get the StorageClassName from the PV object.
 	scName := pv.Spec.StorageClassName
 	if scName == "" {
-		klog.Warningf("pv %q has empty StorageClassName, disabling profiles feature for this volume", pv.Name)
+		klog.V(6).Infof("pv %q has empty StorageClassName, disabling profiles feature for this volume", pv.Name)
 		return nil, nil
 	}
 
@@ -206,14 +210,14 @@ func BuildProfileConfig(params *BuildProfileConfigParams) (*ProfileConfig, error
 	sc, err := params.Clientset.GetSC(scName)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			klog.Warningf("sc %q not found: %v, disabling profiles feature for this volume", scName, err)
+			klog.V(6).Infof("sc %q not found: %v, disabling profiles feature for this volume", scName, err)
 			return nil, nil
 		}
 		return nil, status.Errorf(codes.Internal, "failed to get StorageClass %q: %v", scName, err)
 	}
 
 	if !profilesutil.IsProfile(sc) {
-		klog.Warningf("sc %q found but missing the profile label: %v, disabling profiles feature for this volume", scName, err)
+		klog.V(6).Infof("sc %q found but missing the profile label: %v, disabling profiles feature for this volume", scName, err)
 		return nil, nil
 	}
 
@@ -456,6 +460,14 @@ func buildCacheRequirements(pvDetails *pvDetails) *cacheRequirements {
 		statCacheAvgBytesPerFile = metadataStatCacheBytesPerObjectHNS
 	}
 	reqs.metadataStatCacheBytes = pvDetails.numObjects * statCacheAvgBytesPerFile
+	minMetadataStatCacheBytes := mibToBytes(minMetadataStatCacheMBSize)
+
+	if reqs.metadataStatCacheBytes < minMetadataStatCacheBytes {
+		// If the bucket is empty or has very few objects, use a minimum value instead of disabling the metadata stat cache,
+		// since files may be created later.
+		klog.V(6).Infof("Required metadata stat cache bytes %d is smaller than the minimum recommended: %d, using the minimum recommended instead.", reqs.metadataStatCacheBytes, minMetadataStatCacheBytes)
+		reqs.metadataStatCacheBytes = minMetadataStatCacheBytes
+	}
 	if isZonalBucket(pvDetails.locationType) {
 		klog.Infof("Bucket location type is %q, file cache not required. Disabling file cache.", pvDetails.locationType)
 		reqs.fileCacheBytes = 0

--- a/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/profiles/scanner.go
+++ b/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/profiles/scanner.go
@@ -347,7 +347,7 @@ func generateTokenSource(ctx context.Context, configFile *ConfigFile) (oauth2.To
 	// If configFile.Global.TokenURL is defined use AltTokenSource
 	if configFile != nil && configFile.Global.TokenURL != "" && configFile.Global.TokenURL != "nil" {
 		tokenSource := auth.NewAltTokenSource(ctx, configFile.Global.TokenURL, configFile.Global.TokenBody)
-		klog.Infof("Using AltTokenSource %#v", tokenSource)
+		klog.Infof("Using AltTokenSource with token url %q", configFile.Global.TokenURL)
 		return tokenSource, nil
 	}
 
@@ -382,8 +382,7 @@ func buildCloudConfig(configPath string) (*ConfigFile, error) {
 	if err := gcfg.FatalOnly(gcfg.ReadInto(cfg, reader)); err != nil {
 		return nil, fmt.Errorf("couldn't read cloud provider configuration at %s: %w", configPath, err)
 	}
-	klog.Infof("Config file read %#v", cfg)
-
+	klog.Infof("Config file read with token url %q", cfg.Global.TokenURL)
 	return cfg, nil
 }
 

--- a/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/sidecar_mounter/logger.go
+++ b/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/sidecar_mounter/logger.go
@@ -28,6 +28,7 @@ import (
 type stderrWriterInterface interface {
 	io.Writer
 	WriteMsg(errMsg string)
+	Clean() error
 }
 
 type stderrWriter struct {
@@ -36,6 +37,22 @@ type stderrWriter struct {
 
 func NewErrorWriter(errorFile string) stderrWriterInterface {
 	return &stderrWriter{errorFile: errorFile}
+}
+
+func (w *stderrWriter) Clean() error {
+	if w.errorFile != "" {
+		err := os.Remove(w.errorFile)
+		if os.IsNotExist(err) {
+			// File does not exist.
+			klog.V(4).Infof("File '%s' not found. No action needed.", w.errorFile)
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("failed to clean up error file %q: %w", w.errorFile, err)
+		}
+		klog.V(4).Infof("Cleaned up error file %q", w.errorFile)
+	}
+	return nil
 }
 
 // Write writes the error message to a given local file.

--- a/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/sidecar_mounter/sidecar_mounter.go
+++ b/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/sidecar_mounter/sidecar_mounter.go
@@ -40,6 +40,7 @@ import (
 	cpmeta "github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/metadata"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/storage"
 
+	"github.com/KimMachineGun/automemlimit/memlimit"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/clientset"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/metrics"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util"
@@ -72,6 +73,7 @@ func New(mounterPath string) *Mounter {
 }
 
 func (m *Mounter) Mount(ctx context.Context, mc *MountConfig) error {
+	mc.EnsureErrWriter()
 	// Start the token server for HostNetwork enabled pods.
 	// For managed sidecar, the token server identity provider is only populated when host network pod ksa feature is opted in.
 	var tokenSource oauth2.TokenSource
@@ -101,6 +103,12 @@ func (m *Mounter) Mount(ctx context.Context, mc *MountConfig) error {
 		if err != nil {
 			return status.Errorf(codes.Unauthenticated, "failed to prepare storage service or check bucket access, failed with error: %v", err)
 		}
+	}
+
+	// Clear the GCS Fuse error file after the sidecar bucket access check completes and just before the GCS Fuse mount starts.
+	// This ensures the NodePublish volume will always fail if the error persists until the GCS Fuse mount actually starts.
+	if err := mc.ErrWriter.Clean(); err != nil {
+		klog.Warningf("failed to cleanup error file: %v", err)
 	}
 
 	klog.Infof("start to mount bucket %q for volume %q", mc.BucketName, mc.VolumeName)
@@ -141,6 +149,24 @@ func (m *Mounter) Mount(ctx context.Context, mc *MountConfig) error {
 	//nolint: gosec
 	klog.Infof("gcsfuse mounting with %s %v...", cmdName, args)
 	cmd := exec.CommandContext(ctx, cmdName, args...)
+
+	if mc.EnableAutoGoMemLimit {
+		//  Set for the sidecar mounter process
+		appliedLimit, err := memlimit.SetGoMemLimitWithOpts(
+			memlimit.WithRatio(mc.AutoGoMemLimitRatio),
+			memlimit.WithProvider(memlimit.FromCgroup),
+		)
+		if err != nil {
+			klog.V(4).Infof("GOMEMLIMIT not set (expected if gke-gcsfuse-sidecar memory limit is unset): %v", err)
+		} else if appliedLimit > 0 {
+			// Export GOMEMLIMIT for the gcsfuse child process.
+			// If appliedLimit is 0, it means GOMEMLIMIT was already set in
+			// the environment or there is no memory limit; in both cases we
+			// should not override.
+			cmd.Env = append(os.Environ(), fmt.Sprintf("GOMEMLIMIT=%d", appliedLimit))
+			klog.Infof("Successfully set GOMEMLIMIT=%d for gcsfuse and sidecar_mounter", appliedLimit)
+		}
+	}
 
 	cmd.ExtraFiles = []*os.File{os.NewFile(uintptr(mc.FileDescriptor), "/dev/fuse")}
 	cmd.Stdout = os.Stdout
@@ -460,7 +486,7 @@ func (m *Mounter) checkBucketAccessWithRetry(ctx context.Context, tokenSource oa
 	var ss storage.Service
 	ssCreateAndBucketCheckFunc := func(ctx context.Context) (bool, error) {
 		if ss == nil {
-			ss, err = m.StorageServiceManager.SetupStorageServiceForSidecar(ctx, tokenSource)
+			ss, err = m.StorageServiceManager.SetupStorageServiceForSidecar(ctx, tokenSource, mc.StorageEndpoint)
 			if err != nil {
 				mc.ErrWriter.WriteMsg(retryableError(fmt.Sprintf("%q: %v %v, retrying...", util.StorageServiceErrorStr, storage.ParseErrCode(err), err)))
 				return false, nil
@@ -510,6 +536,8 @@ func getAudienceFromContextAndIdentityProvider(ctx context.Context, identityProv
 }
 
 func (m *Mounter) SetupTokenAndStorageManager(ctx context.Context, clientset clientset.Interface, mc *MountConfig) error {
+	mc.EnsureErrWriter()
+
 	if mc.TokenServerIdentityPool != "" && mc.TokenServerIdentityProvider != "" {
 		var tm auth.TokenManager
 		var ssm storage.ServiceManager

--- a/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/sidecar_mounter/sidecar_mounter_config.go
+++ b/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/sidecar_mounter/sidecar_mounter_config.go
@@ -26,7 +26,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-
 	"syscall"
 	"time"
 
@@ -70,9 +69,30 @@ type MountConfig struct {
 	SidecarRetryConfig             sidecarRetryConfig    `json:"-"`
 	FileCacheMedium                string                `json:"-"`
 	GcsFuseNumaNode                int                   `json:"-"`
+	CustomEndpoint                 string                `json:"-"`
+	EnableAutoGoMemLimit           bool                  `json:"-"`
+	AutoGoMemLimitRatio            float64               `json:"-"`
+	StorageEndpoint                string                `json:"-"`
 }
 
-// sidecarRetryConfig controls the retry configurations for sidecarRetry behivior for storage service creation and bucket access check.
+// EnsureErrWriter safely initializes ErrWriter to the correct writer if it is nil.
+func (mc *MountConfig) EnsureErrWriter() {
+	if mc == nil {
+		return
+	}
+	if mc.ErrWriter != nil {
+		return
+	}
+	if mc.TempDir != "" {
+		mc.ErrWriter = NewErrorWriter(filepath.Join(mc.TempDir, util.ErrorFileName))
+		klog.V(4).Infof("Initialized ErrWriter for volume %q", mc.VolumeName)
+		return
+	}
+	klog.Warningf("ErrWriter initialization failed for volume %q, creating a no-op error writer", mc.VolumeName)
+	mc.ErrWriter = NewErrorWriter("")
+}
+
+// sidecarRetryConfig controls the retry configurations for sidecarRetry behavior for storage service creation and bucket access check.
 type sidecarRetryConfig struct {
 	Duration time.Duration
 	Factor   float64
@@ -117,12 +137,13 @@ func NewMountConfig(sp string, flagMapFromDriver map[string]string) *MountConfig
 	tempDir := filepath.Dir(sp)
 	volumeName := filepath.Base(tempDir)
 	mc := MountConfig{
-		VolumeName: volumeName,
-		BufferDir:  filepath.Join(webhook.SidecarContainerBufferVolumeMountPath, ".volumes", volumeName),
-		CacheDir:   filepath.Join(webhook.SidecarContainerCacheVolumeMountPath, ".volumes", volumeName),
-		TempDir:    tempDir,
-		ConfigFile: filepath.Join(webhook.SidecarContainerTmpVolumeMountPath, ".volumes", volumeName, "config.yaml"),
-		ErrWriter:  NewErrorWriter(filepath.Join(tempDir, "error")),
+		VolumeName:          volumeName,
+		BufferDir:           filepath.Join(webhook.SidecarContainerBufferVolumeMountPath, ".volumes", volumeName),
+		CacheDir:            filepath.Join(webhook.SidecarContainerCacheVolumeMountPath, ".volumes", volumeName),
+		TempDir:             tempDir,
+		ConfigFile:          filepath.Join(webhook.SidecarContainerTmpVolumeMountPath, ".volumes", volumeName, "config.yaml"),
+		ErrWriter:           NewErrorWriter(filepath.Join(tempDir, util.ErrorFileName)),
+		AutoGoMemLimitRatio: util.GoMemLimitCgroupPercentage,
 	}
 
 	klog.Infof("connecting to socket %q", sp)
@@ -311,6 +332,23 @@ func (mc *MountConfig) prepareMountArgs() {
 		case util.EnableGCSFuseKernelParams:
 			mc.EnableGCSFuseKernelParams = value == util.TrueStr
 			continue
+
+		case util.EnableAutoGoMemLimitConst:
+			mc.EnableAutoGoMemLimit = value == util.TrueStr
+			continue
+
+		case util.AutoGoMemLimitRatioConst:
+			ratio, err := strconv.ParseFloat(value, 64)
+			if err != nil || ratio <= 0 || ratio > 1 {
+				invalidArgs = append(invalidArgs, arg)
+			} else {
+				mc.AutoGoMemLimitRatio = ratio
+			}
+			continue
+
+		case util.StorageEndpointInternal:
+			mc.StorageEndpoint = value
+			continue
 		}
 
 		if flag == util.GCSFuseAppNameArg {
@@ -352,18 +390,23 @@ func (mc *MountConfig) prepareMountArgs() {
 	}
 
 	if mc.EnableCloudProfilerForSidecar {
-		// Inject Cloud Profiler flags supported by gcsfuse.
-		flagMap["enable-cloud-profiler"] = ""
-		flagMap["cloud-profiler-cpu"] = ""
-		flagMap["cloud-profiler-heap"] = ""
-		flagMap["cloud-profiler-goroutines"] = ""
-		flagMap["cloud-profiler-mutex"] = ""
-		flagMap["cloud-profiler-allocated-heap"] = ""
+		enableProfiler := true
+		val, ok := flagMap[util.EnableCloudProfilerConst]
+		if ok {
+			if parsed, err := strconv.ParseBool(val); err == nil && !parsed {
+				enableProfiler = false
+			}
+		}
 
-		// Get Hostname.
-		customLabel := util.GetCloudProfilerServiceVersion(mc.PodName, mc.PodUID)
-		flagMap["cloud-profiler-label"] = customLabel
-		klog.Infof("Setting label in GCSFuse mount options: %q", customLabel)
+		if enableProfiler {
+			// Inject Cloud Profiler flags supported by gcsfuse.
+			flagMap[util.EnableCloudProfilerConst] = ""
+			customLabel := util.GetCloudProfilerServiceVersion(mc.PodName, mc.PodUID)
+			flagMap["cloud-profiler-label"] = customLabel
+			klog.Infof("Setting label in GCSFuse mount options: %q", customLabel)
+		} else {
+			klog.Infof("Cloud Profiler for GCSFuse is disabled via mount options: %s=%s", util.EnableCloudProfilerConst, val)
+		}
 	}
 
 	mc.FlagMap = flagMap

--- a/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util/kernel_params_contract.go
+++ b/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util/kernel_params_contract.go
@@ -20,7 +20,11 @@ package util
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
 )
 
 // File kernel_params_contract.go defines the strict schema and contract used for
@@ -95,10 +99,29 @@ type KernelParamsConfig struct {
 // It returns error in case of contract mismatch or parsing error.
 // GCSFuse writes this file atomically so it's safe to read this file at any point.
 func parseKernelParamsConfig(kernelParamsFilePath string) (*KernelParamsConfig, error) {
-	data, err := os.ReadFile(kernelParamsFilePath)
+	parentDir := filepath.Dir(kernelParamsFilePath)
+
+	// Pin the parent directory by opening its file descriptor with O_DIRECTORY and O_NOFOLLOW.
+	// This locks the parent directory inode in memory, preventing concurrent TOCTOU symlink-swapping
+	// attacks during subsequent relative operations (using unix.Openat).
+	parentFd, err := unix.Open(parentDir, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open parent directory %q: %w", parentDir, err)
+	}
+	defer unix.Close(parentFd)
+
+	fd, err := unix.Openat(parentFd, filepath.Base(kernelParamsFilePath), unix.O_RDONLY|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open kernel params file %q: %w", kernelParamsFilePath, err)
+	}
+	f := os.NewFile(uintptr(fd), kernelParamsFilePath)
+	defer f.Close()
+
+	data, err := io.ReadAll(f)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read kernel params file %q: %w", kernelParamsFilePath, err)
 	}
+
 	var config KernelParamsConfig
 	if err := json.Unmarshal(data, &config); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal kernel params config: %w", err)

--- a/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util/kernel_params_monitoring.go
+++ b/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util/kernel_params_monitoring.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -52,12 +53,41 @@ func getDeviceMajorMinor(targetPath string) (major uint32, minor uint32, err err
 	return
 }
 
+// validateParamValue converts the string value to an integer and checks it against safe bounds.
+func validateParamValue(name ParamName, value string) error {
+	valInt, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return fmt.Errorf("value %q is not a valid integer", value)
+	}
+
+	// Enforce safe minimum and maximum boundaries for each parameter to prevent node instability.
+	switch name {
+	case MaxReadAheadKb:
+		if valInt < 0 || valInt > 1048576 { // 1 GB
+			return fmt.Errorf("value %d is outside safe bounds for %s", valInt, name)
+		}
+	case MaxBackgroundRequests:
+		if valInt < 1 || valInt > 1000 {
+			return fmt.Errorf("value %d is outside safe bounds for %s", valInt, name)
+		}
+	case CongestionWindowThreshold:
+		if valInt < 0 || valInt > 1000 {
+			return fmt.Errorf("value %d is outside safe bounds for %s", valInt, name)
+		}
+	default:
+		// Fail-closed for unknown parameters
+		return fmt.Errorf("validation rules missing for parameter %s", name)
+	}
+
+	return nil
+}
+
 // checkAndApplyKernelParams checks for the existence of the kernel parameters file,
 // parses the configuration, and applies the parameters to the system if they differ
 // from the current values.
 func checkAndApplyKernelParams(kernelParamsFilePath string, pathForParam map[ParamName]string, logPrefix string) error {
-	// Check for file existence to avoid unnecessary parsing attempts.
-	if _, statErr := os.Stat(kernelParamsFilePath); statErr != nil {
+	// Check for file existence to avoid unnecessary parsing attempts. Use Lstat to prevent following symlinks.
+	if _, statErr := os.Lstat(kernelParamsFilePath); statErr != nil {
 		// If file is missing, wait for the next interval.
 		return nil
 	}
@@ -73,6 +103,13 @@ func checkAndApplyKernelParams(kernelParamsFilePath string, pathForParam map[Par
 			klog.Warningf("%v Unknown parameter name %q found in kernel parameters config for requestID %q. Skipping...", logPrefix, param.Name, config.RequestID)
 			continue
 		}
+
+		param.Value = strings.TrimSpace(param.Value)
+		if err := validateParamValue(param.Name, param.Value); err != nil {
+			klog.Warningf("%v Invalid value for parameter %q (requestID %q): %v. Skipping...", logPrefix, param.Name, config.RequestID, err)
+			continue
+		}
+
 		currValBytes, err := os.ReadFile(path)
 		if err != nil {
 			klog.Warningf("%v Failed to read kernel parameter %q from file path %q: %v", logPrefix, param.Name, path, err)

--- a/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util/util.go
+++ b/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util/util.go
@@ -53,16 +53,27 @@ const (
 	FileCacheMediumConst                = "file-cache-medium"
 	EnableGCSFuseKernelParams           = "enable-gcsfuse-kernel-params"
 	GCSFuseKernelParamsFileName         = "kernel-params.json"
+	ErrorFileName                       = "error"
 	MediumRAM                           = "ram"
 	MediumLSSD                          = "lssd"
 	OptInHnw                            = "hnw-ksa"
 	EnableCloudProfilerForSidecarConst  = "enable-cloud-profiler-for-sidecar"
+	EnableCloudProfilerConst            = "enable-cloud-profiler"
 	SidecarContainerTmpVolumeName       = "gke-gcsfuse-tmp"
+	SidecarContainerTmpVolumePath       = "/gke-gcsfuse-tmp"
 	SidecarBucketAccessCheckErrorPrefix = "sidecar bucket access check error"
 	StorageServiceErrorStr              = "failed to setup storage service"
 	GCSFuseCsiDriverName                = "gcsfuse.csi.storage.gke.io"
 	GCSFuseNumaNodeArg                  = "gcs-fuse-numa-node"
 	GCSFuseAppNameArg                   = "app-name"
+	CustomEndpointConfigFileFlag        = "gcs-connection:custom-endpoint"
+	CustomEndpointCLIFlag               = "custom-endpoint"
+	EnableAutoGoMemLimitConst           = "enable-auto-gomemlimit"
+	AutoGoMemLimitRatioConst            = "auto-gomemlimit-ratio"
+	GoMemLimitCgroupPercentage          = 0.95
+	StorageEndpointInternal             = "storage-endpoint-internal"
+	KubeletDir                          = "/var/lib/kubelet"
+	VolumeContextKeyPVName              = "csi.storage.k8s.io/pv/name"
 )
 
 var (
@@ -305,6 +316,23 @@ func ParseBool(str string) (bool, error) {
 
 // GetCloudProfilerServiceVersion returns the service version for Cloud Profiler.
 // It returns the provided podName and podUID joined by an underscore.
+// If both podName and podUID are empty, it returns an empty string.
 func GetCloudProfilerServiceVersion(podName, podUID string) string {
+	if podName == "" && podUID == "" {
+		return ""
+	}
 	return fmt.Sprintf("%s_%s", podName, podUID)
+}
+
+// CheckNotSymlink verifies that the given path is not a symbolic link.
+// This is used to prevent TOCTOU symlink takeover attacks.
+func CheckNotSymlink(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return fmt.Errorf("failed to stat path %q: %w", path, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("security error: path %q is a symlink", path)
+	}
+	return nil
 }

--- a/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/webhook/client.go
+++ b/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/webhook/client.go
@@ -94,3 +94,13 @@ func (si *SidecarInjector) GetVolumesStorageClass(volume *corev1.PersistentVolum
 	}
 	return sc, nil
 }
+
+// GetPodTemplate retrieves the referenced PodTemplate object from the informer cache.
+func (si *SidecarInjector) GetPodTemplate(namespace, name string) (*corev1.PodTemplate, error) {
+	podTemplate, err := si.PodTemplateLister.PodTemplates(namespace).Get(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return podTemplate, nil
+}

--- a/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/webhook/config.go
+++ b/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/webhook/config.go
@@ -31,6 +31,7 @@ import (
 type Config struct {
 	ShouldInjectSAVolume  bool   `json:"-"`
 	EnableGcsfuseProfiles bool   `json:"-"`
+	EnableSharedNodeMount bool   `json:"-"`
 	PodHostNetworkSetting bool   `json:"-"`
 	EnableNumaPinning     bool   `json:"enable-numa-pinning,omitempty"`
 	ContainerImage        string `json:"-"`
@@ -69,7 +70,7 @@ func FakeConfig() *Config {
 }
 
 func FakePrefetchConfig() *Config {
-	return LoadConfig("fake-image", "Always", "10m", "50m", "10Mi", "10Mi", "10Mi", "10Mi")
+	return LoadConfig("fake-image", "Always", "10m", "50m", "10Mi", "250Mi", "10Mi", "0")
 }
 
 func prepareResourceList(c *Config) (corev1.ResourceList, corev1.ResourceList) {

--- a/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/webhook/mutatingwebhook.go
+++ b/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/webhook/mutatingwebhook.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"path/filepath"
 	"slices"
+	"strings"
 
 	"cloud.google.com/go/compute/metadata"
 	putil "github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/profiles/util"
@@ -56,6 +57,11 @@ const (
 	metadataPrefetchMemoryRequestAnnotation          = "gke-gcsfuse/metadata-prefetch-memory-request"
 	GCPWorkloadIdentityCredentialConfigMapAnnotation = "gke-gcsfuse/workload-identity-credential-configmap"
 	NumaPinningAnnotation                            = "gke-gcsfuse/enable-numa-pinning"
+	// AdditionalVolumeMountsAnnotation is used to specify additional volumes to mount into the GCS Fuse sidecar.
+	// The expected format is a comma-separated list of volumeName:mountPath (e.g., "vol1:/path1,vol2:/path2").
+	AdditionalVolumeMountsAnnotation = "gke-gcsfuse/additional-volume-mounts"
+
+	GoogleExternalAccountAllowExecutablesEnvVar = "GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES"
 )
 
 var (
@@ -73,13 +79,14 @@ type SidecarInjector struct {
 	PvcLister              listersv1.PersistentVolumeClaimLister
 	PvLister               listersv1.PersistentVolumeLister
 	ScLister               listerstoragev1.StorageClassLister
+	PodTemplateLister      listersv1.PodTemplateLister
 	ServerVersion          *version.Version
 	K8SClient              kubernetes.Interface
 }
 
 // Handle injects a gcsfuse sidecar container and a emptyDir to incoming qualified pods.
 func (si *SidecarInjector) Handle(ctx context.Context, req admission.Request) admission.Response {
-	if req.Kind.Kind == "PersistentVolume" && si.Config.EnableGcsfuseProfiles { // Currently only handling pvs for gcsfuse profiles
+	if req.Kind.Kind == "PersistentVolume" {
 		pv := &corev1.PersistentVolume{}
 		if err := si.Decoder.Decode(req, pv); err != nil {
 			klog.Errorf("Could not decode PersistentVolume object: %v", err)
@@ -87,10 +94,34 @@ func (si *SidecarInjector) Handle(ctx context.Context, req admission.Request) ad
 		}
 		klog.Infof("Mutating webhook is handling PersistentVolume: %s", pv.Name)
 
-		if err := si.validatePersistentVolumeForGCSFuseProfiles(pv); err != nil {
-			klog.Errorf("PersistentVolume validation failed: %v", err)
-			return admission.Errored(http.StatusBadRequest, err)
+		if pv.Spec.CSI == nil || pv.Spec.CSI.Driver != util.GCSFuseCsiDriverName {
+			// Not a gcsfuse CSI driver volume, skip validation/mutation
+			return admission.Allowed(fmt.Sprintf("No mutation Required on PersistentVolume: %s", pv.Name))
 		}
+
+		if si.Config.EnableGcsfuseProfiles {
+			if err := si.validatePersistentVolumeForGCSFuseProfiles(pv); err != nil {
+				klog.Errorf("PersistentVolume validation failed: %v", err)
+				return admission.Errored(http.StatusBadRequest, err)
+			}
+		}
+
+		// Patch the label to PV if it uses shared node mount.
+		if si.Config.EnableSharedNodeMount && pv.Spec.CSI.VolumeAttributes != nil && pv.Spec.CSI.VolumeAttributes[SharedMountVolumeAttribute] == util.TrueStr {
+			if pv.Labels[SharedMountLabel] != util.TrueStr || pv.Spec.CSI.VolumeAttributes[util.VolumeContextKeyPVName] != pv.Name {
+				if pv.Labels == nil {
+					pv.Labels = make(map[string]string)
+				}
+				pv.Labels[SharedMountLabel] = util.TrueStr
+				pv.Spec.CSI.VolumeAttributes[util.VolumeContextKeyPVName] = pv.Name
+				marshaledPV, err := json.Marshal(pv)
+				if err != nil {
+					return admission.Errored(http.StatusInternalServerError, fmt.Errorf("failed to marshal pv: %w", err))
+				}
+				return admission.PatchResponseFromRaw(req.Object.Raw, marshaledPV)
+			}
+		}
+
 		return admission.Allowed(fmt.Sprintf("No mutation Required on PersistentVolume: %s", pv.Name))
 	}
 
@@ -105,6 +136,92 @@ func (si *SidecarInjector) Handle(ctx context.Context, req admission.Request) ad
 
 	if req.Operation != admissionv1.Create {
 		return admission.Allowed(fmt.Sprintf("No injection required for operation %v.", req.Operation))
+	}
+
+	// Classify Pod volumes to check if they are GCSFuse volumes and if they use shared node mount.
+	var hasSharedNodeMount bool
+	var hasStandardMount bool
+
+	for _, volume := range pod.Spec.Volumes {
+		isGcsfuse, _, volumeAttributes, pv, err := si.isGcsFuseCSIVolume(volume, pod.Namespace)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				klog.Warningf("PVC does not exist, skipping volume %q: %v", volume.Name, err)
+				continue
+			}
+			klog.Errorf("Failed to check if volume %q is GCSFuse volume: %v", volume.Name, err)
+			return admission.Errored(http.StatusInternalServerError, err)
+		}
+		if !isGcsfuse {
+			continue
+		}
+
+		isSharedNodeMount := si.Config.EnableSharedNodeMount && pv != nil && volumeAttributes != nil && volumeAttributes[SharedMountVolumeAttribute] == util.TrueStr
+
+		if isSharedNodeMount {
+			hasSharedNodeMount = true
+			if volume.PersistentVolumeClaim != nil {
+				pvc, err := si.GetPVC(pod.Namespace, volume.PersistentVolumeClaim.ClaimName)
+				if err != nil {
+					return admission.Errored(http.StatusBadRequest, fmt.Errorf("failed to get PVC %q: %w", volume.PersistentVolumeClaim.ClaimName, err))
+				}
+
+				podTemplate, err := si.getMounterPodTemplate(pod.Namespace, pvc)
+				if err != nil {
+					if apierrors.IsNotFound(err) {
+						klog.Warningf("Skip volume %q verification because the referenced PodTemplate was not found: %v", volume.Name, err)
+						continue
+					}
+					klog.Errorf("failed to get mounter PodTemplate for PVC %q: %v", pvc.Name, err)
+					return admission.Errored(http.StatusInternalServerError, err)
+				}
+				if podTemplate == nil {
+					return admission.Errored(http.StatusBadRequest, fmt.Errorf("volume %q uses shared node mount but its PVC %q is missing a referenced PodTemplate annotation %q", volume.Name, pvc.Name, MounterPodTemplateAnnotation))
+				}
+
+				// Validate that Pod fsGroup matches the requirements of the referenced PVC PodTemplate.
+				if err := si.validateFSGroup(pod, podTemplate); err != nil {
+					klog.Errorf("fsGroup validation failed: %v", err)
+					return admission.Errored(http.StatusBadRequest, err)
+				}
+
+				// Validate that Pod serviceAccountName matches the requirements of the referenced PVC PodTemplate.
+				if err := si.validateServiceAccountName(pod, podTemplate); err != nil {
+					klog.Errorf("serviceAccountName validation failed: %v", err)
+					return admission.Errored(http.StatusBadRequest, err)
+				}
+			}
+		} else {
+			hasStandardMount = true
+		}
+	}
+
+	// Prevent mixing shared node mount and standard mount GCSFuse volumes in the same Pod.
+	if hasSharedNodeMount && hasStandardMount {
+		return admission.Errored(http.StatusBadRequest, fmt.Errorf("mixing shared node mount and non-shared node mount GCSFuse volumes in the same Pod is not allowed"))
+	}
+
+	// Handle Pod mutation and validations for shared node mount mode.
+	if hasSharedNodeMount {
+		// Inject profiles label and scheduling gate if storage profiles are enabled and match.
+		if si.Config.EnableGcsfuseProfiles {
+			profilesEnabled, err := si.IsGCSFuseProfilesEnabled(pod)
+			if err != nil {
+				return admission.Errored(http.StatusBadRequest, err)
+			}
+			if profilesEnabled {
+				if err := ModifyPodSpecForGCSFuseProfiles(pod, false, true); err != nil {
+					return admission.Errored(http.StatusBadRequest, err)
+				}
+				marshaledPod, err := json.Marshal(pod)
+				if err != nil {
+					return admission.Errored(http.StatusBadRequest, fmt.Errorf("failed to marshal pod: %w", err))
+				}
+				return admission.PatchResponseFromRaw(req.Object.Raw, marshaledPod)
+			}
+		}
+
+		return admission.Allowed("No sidecar injection required for shared node mount mode.")
 	}
 
 	enableGcsfuseVolumes, ok := pod.Annotations[GcsFuseVolumeEnableAnnotation]
@@ -136,27 +253,74 @@ func (si *SidecarInjector) Handle(ctx context.Context, req admission.Request) ad
 	var sidecarCredentialConfig *SidecarContainerCredentialConfiguration
 	// Inject GCP workload identity credential config configmap and token.
 	if configMapName, ok := pod.Annotations[GCPWorkloadIdentityCredentialConfigMapAnnotation]; ok && configMapName != "" && si.K8SClient != nil {
-		// Validate that OIDC authentication is not used with hostNetwork pods
-		if pod.Spec.HostNetwork {
-			return admission.Errored(http.StatusBadRequest,
-				fmt.Errorf("OIDC authentication (annotation %q) is not supported for pods with hostNetwork=true. "+
-					"HostNetwork pods use a different authentication mechanism (Google Workload Identity). "+
-					"Please either remove hostNetwork or use standard Workload Identity authentication. ",
-					GCPWorkloadIdentityCredentialConfigMapAnnotation))
-		}
-
 		filename, credentialConfig, err := appendWorkloadCredentialConfigurationVolumes(si.K8SClient, pod, configMapName)
 		if err != nil {
 			return admission.Errored(http.StatusBadRequest, err)
 		}
+
+		// Validate that OIDC authentication (file-based) is not used with hostNetwork pods.
+		// Executable-sourced credentials are supported since they do not rely on projected SA token volumes.
+		if pod.Spec.HostNetwork && credentialConfig.CredentialSource.Executable == nil {
+			return admission.Errored(http.StatusBadRequest,
+				fmt.Errorf("OIDC authentication (file-based, annotation %q) is not supported for pods with hostNetwork=true. "+
+					"HostNetwork pods use a different authentication mechanism (Google Workload Identity). "+
+					"Please either remove hostNetwork or use standard Workload Identity authentication. ",
+					GCPWorkloadIdentityCredentialConfigMapAnnotation))
+		}
+		credentialVolumeMounts := []corev1.VolumeMount{
+			{Name: SidecarContainerWICredentialConfigMapVolumeName, MountPath: SidecarContainerWICredentialConfigMapVolumeMountPath},
+		}
+		var envVars []corev1.EnvVar
+		if credentialConfig.CredentialSource.Executable == nil {
+			mountPath := filepath.Dir(credentialConfig.CredentialSource.File)
+			credentialVolumeMounts = append(credentialVolumeMounts, corev1.VolumeMount{Name: SidecarContainerWITokenVolumeName, MountPath: mountPath})
+		} else {
+			envVars = append(envVars, corev1.EnvVar{Name: GoogleExternalAccountAllowExecutablesEnvVar, Value: "1"})
+		}
+
 		sidecarCredentialConfig = &SidecarContainerCredentialConfiguration{
-			GacEnv: &corev1.EnvVar{Name: "GOOGLE_APPLICATION_CREDENTIALS", Value: fmt.Sprintf("%s/%s", SidecarContainerWICredentialConfigMapVolumeMountPath, filename)},
-			CredentialVolumeMounts: []corev1.VolumeMount{
-				{Name: SidecarContainerWITokenVolumeName, MountPath: filepath.Dir(credentialConfig.CredentialSource.File)},
-				{Name: SidecarContainerWICredentialConfigMapVolumeName, MountPath: SidecarContainerWICredentialConfigMapVolumeMountPath},
-			},
+			GacEnv:                 &corev1.EnvVar{Name: "GOOGLE_APPLICATION_CREDENTIALS", Value: fmt.Sprintf("%s/%s", SidecarContainerWICredentialConfigMapVolumeMountPath, filename)},
+			CredentialVolumeMounts: credentialVolumeMounts,
+			EnvVars:                envVars,
 		}
 		klog.Infof("Injected GCP workload identity credential configuration configMap %s in namespace %s", configMapName, pod.Namespace)
+	}
+
+	if additionalMounts, ok := pod.Annotations[AdditionalVolumeMountsAnnotation]; ok && additionalMounts != "" {
+		if sidecarCredentialConfig == nil {
+			sidecarCredentialConfig = &SidecarContainerCredentialConfiguration{}
+		}
+		mounts := strings.Split(additionalMounts, ",")
+		for _, mount := range mounts {
+			mount = strings.TrimSpace(mount)
+			if mount == "" {
+				continue
+			}
+			volName, mountPath, found := strings.Cut(mount, ":")
+			if !found {
+				return admission.Errored(http.StatusBadRequest, fmt.Errorf("invalid format for %s: %q, expected \"volume-name:mount-path\"", AdditionalVolumeMountsAnnotation, mount))
+			}
+			volName = strings.TrimSpace(volName)
+			mountPath = strings.TrimSpace(mountPath)
+
+			if volName == "" || mountPath == "" {
+				return admission.Errored(http.StatusBadRequest, fmt.Errorf("invalid empty volume name or mount path in %s: %q", AdditionalVolumeMountsAnnotation, mount))
+			}
+
+			if !strings.HasPrefix(mountPath, "/") {
+				return admission.Errored(http.StatusBadRequest, fmt.Errorf("mount path %q specified in %s is not an absolute path", mountPath, AdditionalVolumeMountsAnnotation))
+			}
+
+			if !volumeExists(pod.Spec.Volumes, volName) {
+				return admission.Errored(http.StatusBadRequest, fmt.Errorf("volume %q specified in %s not found in pod spec", volName, AdditionalVolumeMountsAnnotation))
+			}
+
+			sidecarCredentialConfig.CredentialVolumeMounts = append(sidecarCredentialConfig.CredentialVolumeMounts, corev1.VolumeMount{
+				Name:      volName,
+				MountPath: mountPath,
+				ReadOnly:  true,
+			})
+		}
 	}
 
 	// Inject Fuse Side Car container.
@@ -198,7 +362,7 @@ func (si *SidecarInjector) Handle(ctx context.Context, req admission.Request) ad
 		}
 		klog.Infof("Pod %q has at least one volume using gcsfuse profiles", pod.Name)
 		if profilesEnabled {
-			err = ModifyPodSpecForGCSFuseProfiles(pod, cacheCreatedByUser)
+			err = ModifyPodSpecForGCSFuseProfiles(pod, cacheCreatedByUser, false)
 			if err != nil {
 				return admission.Errored(http.StatusBadRequest, err)
 			}
@@ -251,7 +415,7 @@ func audienceForInjectedSATokenVolume(projectID string, pod *corev1.Pod) string 
 }
 
 // Modifies the pod spec to add gcsfuse profile related features. This includes adding a label, scheduling gate, and placeholder file cache volumes
-func ModifyPodSpecForGCSFuseProfiles(pod *corev1.Pod, cacheCreatedByUser bool) error {
+func ModifyPodSpecForGCSFuseProfiles(pod *corev1.Pod, cacheCreatedByUser bool, isSharedMount bool) error {
 	// Always apply the gcsfuse profile label when gcsfuse profiles are enabled for pod informer's Kubernetes API efficient filtering
 	if pod.Labels == nil {
 		pod.Labels = make(map[string]string)
@@ -278,6 +442,10 @@ func ModifyPodSpecForGCSFuseProfiles(pod *corev1.Pod, cacheCreatedByUser bool) e
 		pod.Spec.SchedulingGates = append(pod.Spec.SchedulingGates, profilesGate)
 	} else {
 		klog.Warningf("Pod %s/%s already has the %s scheduling gate, skipping injection of gcsfuse profiles scheduling gate.", pod.Namespace, pod.Name, BucketScanPendingSchedulingGate)
+	}
+
+	if isSharedMount {
+		return nil
 	}
 
 	// Inject placeholder file cache volumes
@@ -417,23 +585,25 @@ func appendWorkloadCredentialConfigurationVolumes(client kubernetes.Interface, p
 	}
 	klog.Infof("Parsed the workload identity credential configuration configMap %s in namespace %s %+v", configMapName, pod.Namespace, credConfig)
 
-	pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
-		Name: SidecarContainerWITokenVolumeName,
-		VolumeSource: corev1.VolumeSource{
-			Projected: &corev1.ProjectedVolumeSource{
-				Sources: []corev1.VolumeProjection{
-					{
-						ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
-							Audience:          fmt.Sprintf("https:%s", credConfig.Audience), // Add the "https:" prefix to the audience.
-							ExpirationSeconds: &tokenExpirationSeconds,
-							Path:              filepath.Base(credConfig.CredentialSource.File),
+	if credConfig.CredentialSource.Executable == nil && !volumeExists(pod.Spec.Volumes, SidecarContainerWITokenVolumeName) {
+		pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
+			Name: SidecarContainerWITokenVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				Projected: &corev1.ProjectedVolumeSource{
+					Sources: []corev1.VolumeProjection{
+						{
+							ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+								Audience:          fmt.Sprintf("https:%s", credConfig.Audience), // Add the "https:" prefix to the audience.
+								ExpirationSeconds: &tokenExpirationSeconds,
+								Path:              filepath.Base(credConfig.CredentialSource.File),
+							},
 						},
 					},
+					DefaultMode: &defaultMode,
 				},
-				DefaultMode: &defaultMode,
 			},
-		},
-	})
+		})
+	}
 
 	// Secondly try to add workload identity credential configuration configMap as volume.
 	if !checkConfigMapVolumeExists(pod) {
@@ -467,7 +637,10 @@ func checkConfigMapVolumeExists(pod *corev1.Pod) bool {
 type CredentialConfig struct {
 	Audience         string `json:"audience"`
 	CredentialSource struct {
-		File string `json:"file"`
+		File       string `json:"file,omitempty"`
+		Executable *struct {
+			Command string `json:"command"`
+		} `json:"executable,omitempty"`
 	} `json:"credential_source"`
 }
 
@@ -502,4 +675,65 @@ func parseCredentialConfigurationConfigMap(client kubernetes.Interface, pod *cor
 	}
 
 	return filename, &credConfig, nil
+}
+
+// getMounterPodTemplate retrieves the referenced mounter PodTemplate for a PVC if the annotation is present.
+func (si *SidecarInjector) getMounterPodTemplate(namespace string, pvc *corev1.PersistentVolumeClaim) (*corev1.PodTemplate, error) {
+	if pvc.Annotations == nil {
+		return nil, nil
+	}
+	templateName, ok := pvc.Annotations[MounterPodTemplateAnnotation]
+	if !ok || templateName == "" {
+		return nil, nil
+	}
+
+	podTemplate, err := si.GetPodTemplate(namespace, templateName)
+	if err != nil {
+		return nil, err
+	}
+	return podTemplate, nil
+}
+
+// validateFSGroup checks if the Pod's fsGroup matches the one specified in the volume's referenced mounter PodTemplate.
+func (si *SidecarInjector) validateFSGroup(pod *corev1.Pod, podTemplate *corev1.PodTemplate) error {
+	templateName := podTemplate.Name
+	templateHasFSGroup := podTemplate.Template.Spec.SecurityContext != nil && podTemplate.Template.Spec.SecurityContext.FSGroup != nil
+	podHasFSGroup := pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.FSGroup != nil
+
+	// Enforce strict matching between Pod and PodTemplate fsGroup settings to prevent shared mount permission conflicts.
+	if templateHasFSGroup {
+		expectedFSGroup := *podTemplate.Template.Spec.SecurityContext.FSGroup
+		if !podHasFSGroup {
+			return fmt.Errorf("Pod fsGroup is not set, but volume's PodTemplate %q requires fsGroup %d", templateName, expectedFSGroup)
+		}
+		actualFSGroup := *pod.Spec.SecurityContext.FSGroup
+		if actualFSGroup != expectedFSGroup {
+			return fmt.Errorf("Pod fsGroup %d does not match the one specified in volume's PodTemplate %q (%d)", actualFSGroup, templateName, expectedFSGroup)
+		}
+		return nil
+	}
+
+	if podHasFSGroup {
+		return fmt.Errorf("Pod has fsGroup set, but volume's PodTemplate %q does not specify one (not allowed for shared node mount)", templateName)
+	}
+
+	return nil
+}
+
+// validateServiceAccountName checks if the Pod's serviceAccountName matches the one specified in the volume's referenced mounter PodTemplate.
+func (si *SidecarInjector) validateServiceAccountName(pod *corev1.Pod, podTemplate *corev1.PodTemplate) error {
+	templateSA := podTemplate.Template.Spec.ServiceAccountName
+	if templateSA == "" {
+		templateSA = "default"
+	}
+	podSA := pod.Spec.ServiceAccountName
+	if podSA == "" {
+		podSA = "default"
+	}
+
+	if templateSA != podSA {
+		return fmt.Errorf("Pod serviceAccountName %q does not match the one specified in volume's PodTemplate %q (%q)", podSA, podTemplate.Name, templateSA)
+	}
+
+	return nil
 }

--- a/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/webhook/sidecar_spec.go
+++ b/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/webhook/sidecar_spec.go
@@ -43,6 +43,11 @@ const (
 
 	// Webhook relevant volume attributes.
 	gcsFuseMetadataPrefetchOnMountVolumeAttribute = "gcsfuseMetadataPrefetchOnMount"
+	SharedMountVolumeAttribute                    = "sharedMount"
+
+	// Webhook relevant labels and annotations.
+	SharedMountLabel             = "gke-gcsfuse/shared-mount"
+	MounterPodTemplateAnnotation = "gke-gcsfuse/mounter-pod-template"
 
 	// gcsfuse profiles constants
 	GcsfuseProfilesManagedLabel                           = "gke-gcsfuse/profile-managed"
@@ -118,6 +123,7 @@ var (
 type SidecarContainerCredentialConfiguration struct {
 	GacEnv                 *corev1.EnvVar       // This is the environment variable for GOOGLE_APPLICATION_CREDENTIALS that will be injected into the sidecar container.
 	CredentialVolumeMounts []corev1.VolumeMount // These are the volume mounts for the credential files that will be injected into the sidecar container.
+	EnvVars                []corev1.EnvVar      // These are generic environment variables that will be injected into the sidecar container.
 }
 
 func GetNativeSidecarContainerSpec(c *Config, credentialConfig *SidecarContainerCredentialConfiguration) corev1.Container {
@@ -159,6 +165,10 @@ func GetSidecarContainerSpec(c *Config, credentialConfig *SidecarContainerCreden
 			container.Env = append(container.Env, *credentialConfig.GacEnv)
 		}
 
+		// Inject generic environment variables.
+		if len(credentialConfig.EnvVars) > 0 {
+			container.Env = append(container.Env, credentialConfig.EnvVars...)
+		}
 		// Inject the volume mounts for the credential files.
 		if len(credentialConfig.CredentialVolumeMounts) > 0 {
 			container.VolumeMounts = append(container.VolumeMounts, credentialConfig.CredentialVolumeMounts...)

--- a/test/vendor/github.com/pbnjay/memory/LICENSE
+++ b/test/vendor/github.com/pbnjay/memory/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2017, Jeremy Jay
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/test/vendor/github.com/pbnjay/memory/README.md
+++ b/test/vendor/github.com/pbnjay/memory/README.md
@@ -1,0 +1,41 @@
+# memory
+
+Package `memory` provides two methods reporting total physical system memory
+accessible to the kernel, and free memory available to the running application.
+
+This package has no external dependency besides the standard library and default operating system tools.
+
+Documentation:
+[![GoDoc](https://godoc.org/github.com/pbnjay/memory?status.svg)](https://godoc.org/github.com/pbnjay/memory)
+
+This is useful for dynamic code to minimize thrashing and other contention, similar to the stdlib `runtime.NumCPU`
+See some history of the proposal at https://github.com/golang/go/issues/21816
+
+
+## Example
+
+```go
+fmt.Printf("Total system memory: %d\n", memory.TotalMemory())
+fmt.Printf("Free memory: %d\n", memory.FreeMemory())
+```
+
+
+## Testing
+
+Tested/working on:
+ - macOS 10.12.6 (16G29), 10.15.7 (19H2)
+ - Windows 10 1511 (10586.1045)
+ - Linux RHEL (3.10.0-327.3.1.el7.x86_64)
+ - Raspberry Pi 3 (ARMv8) on Raspbian, ODROID-C1+ (ARMv7) on Ubuntu, C.H.I.P
+   (ARMv7).
+ - Amazon Linux 2 aarch64 (m6a.large, 4.14.203-156.332.amzn2.aarch64)
+
+Tested on virtual machines:
+ - Windows 7 SP1 386
+ - Debian stretch 386
+ - NetBSD 7.1 amd64 + 386
+ - OpenBSD 6.1 amd64 + 386
+ - FreeBSD 11.1 amd64 + 386
+ - DragonFly BSD 4.8.1 amd64
+
+If you have access to untested systems please test and report success/bugs.

--- a/test/vendor/github.com/pbnjay/memory/doc.go
+++ b/test/vendor/github.com/pbnjay/memory/doc.go
@@ -1,0 +1,24 @@
+// Package memory provides a single method reporting total system memory
+// accessible to the kernel.
+package memory
+
+// TotalMemory returns the total accessible system memory in bytes.
+//
+// The total accessible memory is installed physical memory size minus reserved
+// areas for the kernel and hardware, if such reservations are reported by
+// the operating system.
+//
+// If accessible memory size could not be determined, then 0 is returned.
+func TotalMemory() uint64 {
+	return sysTotalMemory()
+}
+
+// FreeMemory returns the total free system memory in bytes.
+//
+// The total free memory is installed physical memory size minus reserved
+// areas for other applications running on the same system.
+//
+// If free memory size could not be determined, then 0 is returned.
+func FreeMemory() uint64 {
+	return sysFreeMemory()
+}

--- a/test/vendor/github.com/pbnjay/memory/memory_bsd.go
+++ b/test/vendor/github.com/pbnjay/memory/memory_bsd.go
@@ -1,0 +1,19 @@
+// +build freebsd openbsd dragonfly netbsd
+
+package memory
+
+func sysTotalMemory() uint64 {
+	s, err := sysctlUint64("hw.physmem")
+	if err != nil {
+		return 0
+	}
+	return s
+}
+
+func sysFreeMemory() uint64 {
+	s, err := sysctlUint64("hw.usermem")
+	if err != nil {
+		return 0
+	}
+	return s
+}

--- a/test/vendor/github.com/pbnjay/memory/memory_darwin.go
+++ b/test/vendor/github.com/pbnjay/memory/memory_darwin.go
@@ -1,0 +1,49 @@
+// +build darwin
+
+package memory
+
+import (
+	"os/exec"
+	"regexp"
+	"strconv"
+)
+
+func sysTotalMemory() uint64 {
+	s, err := sysctlUint64("hw.memsize")
+	if err != nil {
+		return 0
+	}
+	return s
+}
+
+func sysFreeMemory() uint64 {
+	cmd := exec.Command("vm_stat")
+	outBytes, err := cmd.Output()
+	if err != nil {
+		return 0
+	}
+
+	rePageSize := regexp.MustCompile("page size of ([0-9]*) bytes")
+	reFreePages := regexp.MustCompile("Pages free: *([0-9]*)\\.")
+
+	// default: page size of 4096 bytes
+	matches := rePageSize.FindSubmatchIndex(outBytes)
+	pageSize := uint64(4096)
+	if len(matches) == 4 {
+		pageSize, err = strconv.ParseUint(string(outBytes[matches[2]:matches[3]]), 10, 64)
+		if err != nil {
+			return 0
+		}
+	}
+
+	// ex: Pages free:                             1126961.
+	matches = reFreePages.FindSubmatchIndex(outBytes)
+	freePages := uint64(0)
+	if len(matches) == 4 {
+		freePages, err = strconv.ParseUint(string(outBytes[matches[2]:matches[3]]), 10, 64)
+		if err != nil {
+			return 0
+		}
+	}
+	return freePages * pageSize
+}

--- a/test/vendor/github.com/pbnjay/memory/memory_linux.go
+++ b/test/vendor/github.com/pbnjay/memory/memory_linux.go
@@ -1,0 +1,29 @@
+// +build linux
+
+package memory
+
+import "syscall"
+
+func sysTotalMemory() uint64 {
+	in := &syscall.Sysinfo_t{}
+	err := syscall.Sysinfo(in)
+	if err != nil {
+		return 0
+	}
+	// If this is a 32-bit system, then these fields are
+	// uint32 instead of uint64.
+	// So we always convert to uint64 to match signature.
+	return uint64(in.Totalram) * uint64(in.Unit)
+}
+
+func sysFreeMemory() uint64 {
+	in := &syscall.Sysinfo_t{}
+	err := syscall.Sysinfo(in)
+	if err != nil {
+		return 0
+	}
+	// If this is a 32-bit system, then these fields are
+	// uint32 instead of uint64.
+	// So we always convert to uint64 to match signature.
+	return uint64(in.Freeram) * uint64(in.Unit)
+}

--- a/test/vendor/github.com/pbnjay/memory/memory_windows.go
+++ b/test/vendor/github.com/pbnjay/memory/memory_windows.go
@@ -1,0 +1,60 @@
+// +build windows
+
+package memory
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+// omitting a few fields for brevity...
+// https://msdn.microsoft.com/en-us/library/windows/desktop/aa366589(v=vs.85).aspx
+type memStatusEx struct {
+	dwLength     uint32
+	dwMemoryLoad uint32
+	ullTotalPhys uint64
+	ullAvailPhys uint64
+	unused       [5]uint64
+}
+
+func sysTotalMemory() uint64 {
+	kernel32, err := syscall.LoadDLL("kernel32.dll")
+	if err != nil {
+		return 0
+	}
+	// GetPhysicallyInstalledSystemMemory is simpler, but broken on
+	// older versions of windows (and uses this under the hood anyway).
+	globalMemoryStatusEx, err := kernel32.FindProc("GlobalMemoryStatusEx")
+	if err != nil {
+		return 0
+	}
+	msx := &memStatusEx{
+		dwLength: 64,
+	}
+	r, _, _ := globalMemoryStatusEx.Call(uintptr(unsafe.Pointer(msx)))
+	if r == 0 {
+		return 0
+	}
+	return msx.ullTotalPhys
+}
+
+func sysFreeMemory() uint64 {
+	kernel32, err := syscall.LoadDLL("kernel32.dll")
+	if err != nil {
+		return 0
+	}
+	// GetPhysicallyInstalledSystemMemory is simpler, but broken on
+	// older versions of windows (and uses this under the hood anyway).
+	globalMemoryStatusEx, err := kernel32.FindProc("GlobalMemoryStatusEx")
+	if err != nil {
+		return 0
+	}
+	msx := &memStatusEx{
+		dwLength: 64,
+	}
+	r, _, _ := globalMemoryStatusEx.Call(uintptr(unsafe.Pointer(msx)))
+	if r == 0 {
+		return 0
+	}
+	return msx.ullAvailPhys
+}

--- a/test/vendor/github.com/pbnjay/memory/memsysctl.go
+++ b/test/vendor/github.com/pbnjay/memory/memsysctl.go
@@ -1,0 +1,21 @@
+// +build darwin freebsd openbsd dragonfly netbsd
+
+package memory
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+func sysctlUint64(name string) (uint64, error) {
+	s, err := syscall.Sysctl(name)
+	if err != nil {
+		return 0, err
+	}
+	// hack because the string conversion above drops a \0
+	b := []byte(s)
+	if len(b) < 8 {
+		b = append(b, 0)
+	}
+	return *(*uint64)(unsafe.Pointer(&b[0])), nil
+}

--- a/test/vendor/github.com/pbnjay/memory/stub.go
+++ b/test/vendor/github.com/pbnjay/memory/stub.go
@@ -1,0 +1,10 @@
+// +build !linux,!darwin,!windows,!freebsd,!dragonfly,!netbsd,!openbsd
+
+package memory
+
+func sysTotalMemory() uint64 {
+	return 0
+}
+func sysFreeMemory() uint64 {
+	return 0
+}

--- a/test/vendor/modules.txt
+++ b/test/vendor/modules.txt
@@ -75,6 +75,9 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapp
 # github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
 ## explicit
 github.com/JeffAshton/win_pdh
+# github.com/KimMachineGun/automemlimit v0.7.5
+## explicit; go 1.22.0
+github.com/KimMachineGun/automemlimit/memlimit
 # github.com/Masterminds/semver/v3 v3.4.0
 ## explicit; go 1.21
 github.com/Masterminds/semver/v3
@@ -536,6 +539,9 @@ github.com/opencontainers/runtime-spec/specs-go
 github.com/opencontainers/selinux/go-selinux
 github.com/opencontainers/selinux/go-selinux/label
 github.com/opencontainers/selinux/pkg/pwalkdir
+# github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
+## explicit; go 1.16
+github.com/pbnjay/memory
 # github.com/pelletier/go-toml v1.9.3
 ## explicit; go 1.12
 github.com/pelletier/go-toml


### PR DESCRIPTION
Cherry pick of #1481 on release-1.23.

#1481: Update test/go.mod vendor folders.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```