### PR TITLE
Add e2e tests for GCS Fuse + Lustre combination scenarios: large-file transfer, mixed I/O, file-cache backing, network disruption resilience, and cross-mount permissions

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -40,17 +40,18 @@ import (
 )
 
 var (
-	err              error
-	c                clientset.Interface
-	m                metadata.Service
-	clientProtocol   = flag.String("client-protocol", "http", "the test bucket location")
-	bucketLocation   = flag.String("test-bucket-location", "us-central1", "the test bucket location")
-	skipGcpSaTest    = flag.Bool("skip-gcp-sa-test", true, "skip GCP SA test")
-	apiEnv           = flag.String("api-env", "prod", "cluster API env")
-	zbFlag           = flag.Bool("enable-zb", false, "use GCS Zonal Buckets for the tests")
-	profilesFlag     = flag.Bool("enable-gcsfuse-profiles-test", false, "enable gcsfuse profiles for the tests")
-	kernelParamsFlag = flag.Bool("enable-gcsfuse-kernel-params-test", false, "enable kernel params for the tests")
-	pdStorageClass   = flag.String("pd-storage-class", "standard-rwo", "StorageClass used for PD-backed PVCs in dual CSI volume tests")
+	err                error
+	c                  clientset.Interface
+	m                  metadata.Service
+	clientProtocol     = flag.String("client-protocol", "http", "the test bucket location")
+	bucketLocation     = flag.String("test-bucket-location", "us-central1", "the test bucket location")
+	skipGcpSaTest      = flag.Bool("skip-gcp-sa-test", true, "skip GCP SA test")
+	apiEnv             = flag.String("api-env", "prod", "cluster API env")
+	zbFlag             = flag.Bool("enable-zb", false, "use GCS Zonal Buckets for the tests")
+	profilesFlag       = flag.Bool("enable-gcsfuse-profiles-test", false, "enable gcsfuse profiles for the tests")
+	kernelParamsFlag   = flag.Bool("enable-gcsfuse-kernel-params-test", false, "enable kernel params for the tests")
+	pdStorageClass     = flag.String("pd-storage-class", "standard-rwo", "StorageClass used for PD-backed PVCs in dual CSI volume tests")
+	lustreStorageClass = flag.String("lustre-storage-class", "lustre-rwx", "StorageClass used to dynamically provision Lustre PVCs in GCS Fuse + Lustre performance/resilience tests; if empty, those tests are skipped")
 )
 
 var _ = func() bool {
@@ -89,6 +90,7 @@ var _ = func() bool {
 	}
 
 	testsuites.GCSFuseVersionStr = specs.GetGCSFuseVersion()
+	testsuites.LustreStorageClass = *lustreStorageClass
 	return true
 }()
 
@@ -130,6 +132,7 @@ var _ = ginkgo.Describe("E2E Test Suite", func() {
 			testsuites.InitGcsFuseCSICloudProfilerTestSuite,
 			testsuites.InitGcsFuseCSIWorkloadIdentityFederationTestSuite,
 			testsuites.InitGcsFuseCSIDualCSIVolumeTestSuite,
+			testsuites.InitGcsFuseLustrePerfResilienceTestSuite,
 		}
 
 		if *profilesFlag {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -92,6 +92,7 @@ var _ = func() bool {
 
 	testsuites.LustreStorageClass = *lustreStorageClass
 	testsuites.GCSFuseVersionStr = specs.GetGCSFuseVersion()
+	testsuites.LustreStorageClass = *lustreStorageClass
 	return true
 }()
 
@@ -134,6 +135,7 @@ var _ = ginkgo.Describe("E2E Test Suite", func() {
 			testsuites.InitGcsFuseCSIWorkloadIdentityFederationTestSuite,
 			testsuites.InitGcsFuseCSIDualCSIVolumeTestSuite,
 			testsuites.InitGcsFuseCSILustreDataPipelineTestSuite,
+			testsuites.InitGcsFuseLustrePerfResilienceTestSuite,
 		}
 
 		if *profilesFlag {

--- a/test/e2e/testsuites/gcsfuse_lustre.go
+++ b/test/e2e/testsuites/gcsfuse_lustre.go
@@ -26,8 +26,10 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
@@ -375,5 +377,148 @@ func (t *gcsFuseLustrePerfResilienceTestSuite) DefineTests(driver storageframewo
 		tPod2.VerifyExecInPodSucceed(f, specs.TesterContainerName,
 			fmt.Sprintf("echo 'cache-extended' > %v/extra.txt && grep 'cache-extended' %v/extra.txt",
 				gcsFuseLustreGCSMountPath, gcsFuseLustreGCSMountPath))
+	})
+
+	// Lustre disruption resilience with GCS Fuse unaffected: a NetworkPolicy
+	// blocks egress on port 988 (Lustre wire protocol) from the test namespace
+	// to the provisioned Lustre instance IP, simulating a network partition to
+	// the MDS/OSS. The test verifies that the GCS Fuse mount and its sidecar
+	// remain fully operational during the disruption, then confirms both volumes
+	// recover once the NetworkPolicy is removed.
+	//
+	// Prerequisite: the GKE cluster must have a NetworkPolicy-enforcing CNI
+	// (e.g. Calico or GKE Dataplane V2) enabled.
+	ginkgo.It("should keep GCS Fuse healthy and serving data when Lustre network connectivity is disrupted and recover after connectivity is restored", func() {
+		skipIfLustreNotAvailable("Lustre disruption resilience test")
+
+		init()
+		defer cleanup()
+
+		ginkgo.By("Creating a dynamically provisioned Lustre PVC")
+		pvc, cleanupPVC := createLustrePVC("lustre-disrupt-pvc-")
+		defer cleanupPVC()
+
+		ginkgo.By("Fetching the bound PVC to read its PV name")
+		boundPVC, err := f.ClientSet.CoreV1().PersistentVolumeClaims(f.Namespace.Name).Get(ctx, pvc.Name, metav1.GetOptions{})
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Extracting the Lustre instance IP from the PV volume attributes")
+		pv, err := f.ClientSet.CoreV1().PersistentVolumes().Get(ctx, boundPVC.Spec.VolumeName, metav1.GetOptions{})
+		framework.ExpectNoError(err)
+		lustreIP := pv.Spec.CSI.VolumeAttributes["ip"]
+		if lustreIP == "" {
+			framework.Failf("could not extract Lustre instance IP from PV %s volume attributes; got: %v",
+				pv.Name, pv.Spec.CSI.VolumeAttributes)
+		}
+		framework.Logf("Lustre instance IP: %s", lustreIP)
+
+		ginkgo.By("Configuring the pod with both GCS Fuse and Lustre volumes")
+		tPod := specs.NewTestPod(f.ClientSet, f.Namespace)
+		tPod.SetupVolume(l.gcsFuseResource, gcsFuseLustreGCSVolName, gcsFuseLustreGCSMountPath, false)
+		tPod.SetupVolume(&storageframework.VolumeResource{Pvc: pvc}, gcsFuseLustreVolName, gcsFuseLustreMountPath, false)
+		tPod.Create(ctx)
+		defer tPod.Cleanup(ctx)
+		tPod.WaitForRunning(ctx)
+
+		ginkgo.By("Writing baseline data to both volumes to confirm they are initially healthy")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("echo 'gcs-baseline' > %v/baseline.txt", gcsFuseLustreGCSMountPath))
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("echo 'lustre-baseline' > %v/baseline.txt", gcsFuseLustreMountPath))
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("grep 'gcs-baseline' %v/baseline.txt && grep 'lustre-baseline' %v/baseline.txt",
+				gcsFuseLustreGCSMountPath, gcsFuseLustreMountPath))
+
+		ginkgo.By(fmt.Sprintf("Applying a NetworkPolicy to block port 988 egress to Lustre IP %s (simulating MDS/OSS network partition)", lustreIP))
+		tcpProto := corev1.ProtocolTCP
+		udpProto := corev1.ProtocolUDP
+		lustreCIDR := lustreIP + "/32"
+		port1 := intstr.FromInt32(1)
+		port989 := intstr.FromInt32(989)
+		endPort987 := int32(987)
+		endPort65535 := int32(65535)
+
+		// The policy allows all egress to non-Lustre destinations (covering GCS,
+		// DNS, k8s API, etc.) and allows non-988 ports to the Lustre IP. Port 988
+		// (Lustre wire protocol) to the Lustre instance IP is left unmatched and
+		// therefore dropped by the namespace-scoped egress restriction.
+		netpol := &networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "block-lustre-port-",
+				Namespace:    f.Namespace.Name,
+			},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{},
+				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
+				Egress: []networkingv1.NetworkPolicyEgressRule{
+					// Allow all egress to IPs other than the Lustre instance.
+					{
+						To: []networkingv1.NetworkPolicyPeer{
+							{IPBlock: &networkingv1.IPBlock{CIDR: "0.0.0.0/0", Except: []string{lustreCIDR}}},
+						},
+					},
+					// Allow egress to the Lustre IP on ports 1–987 (pre-Lustre range).
+					{
+						To: []networkingv1.NetworkPolicyPeer{{IPBlock: &networkingv1.IPBlock{CIDR: lustreCIDR}}},
+						Ports: []networkingv1.NetworkPolicyPort{
+							{Protocol: &tcpProto, Port: &port1, EndPort: &endPort987},
+							{Protocol: &udpProto, Port: &port1, EndPort: &endPort987},
+						},
+					},
+					// Allow egress to the Lustre IP on ports 989–65535 (post-Lustre range).
+					{
+						To: []networkingv1.NetworkPolicyPeer{{IPBlock: &networkingv1.IPBlock{CIDR: lustreCIDR}}},
+						Ports: []networkingv1.NetworkPolicyPort{
+							{Protocol: &tcpProto, Port: &port989, EndPort: &endPort65535},
+							{Protocol: &udpProto, Port: &port989, EndPort: &endPort65535},
+						},
+					},
+				},
+			},
+		}
+		netpol, err = f.ClientSet.NetworkingV1().NetworkPolicies(f.Namespace.Name).Create(ctx, netpol, metav1.CreateOptions{})
+		framework.ExpectNoError(err)
+		defer func() {
+			if netpol != nil {
+				_ = f.ClientSet.NetworkingV1().NetworkPolicies(f.Namespace.Name).Delete(
+					ctx, netpol.Name, metav1.DeleteOptions{})
+			}
+		}()
+
+		ginkgo.By("Verifying GCS Fuse mount remains readable while Lustre port 988 is blocked")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("grep 'gcs-baseline' %v/baseline.txt", gcsFuseLustreGCSMountPath))
+
+		ginkgo.By("Verifying GCS Fuse mount remains writable while Lustre port 988 is blocked")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("echo 'gcs-during-disruption' > %v/during.txt && grep 'gcs-during-disruption' %v/during.txt",
+				gcsFuseLustreGCSMountPath, gcsFuseLustreGCSMountPath))
+
+		ginkgo.By("Verifying the GCS Fuse FUSE mount is still present in the mount table during disruption")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("mount | grep %v", gcsFuseLustreGCSMountPath))
+
+		ginkgo.By("Removing the NetworkPolicy to restore Lustre port 988 connectivity")
+		framework.ExpectNoError(f.ClientSet.NetworkingV1().NetworkPolicies(f.Namespace.Name).Delete(
+			ctx, netpol.Name, metav1.DeleteOptions{}))
+		netpol = nil // prevent double deletion in deferred cleanup
+
+		ginkgo.By("Waiting 60s for the Lustre client to reconnect after connectivity is restored")
+		time.Sleep(60 * time.Second)
+
+		ginkgo.By("Verifying Lustre mount is readable after recovery")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("grep 'lustre-baseline' %v/baseline.txt", gcsFuseLustreMountPath))
+
+		ginkgo.By("Verifying Lustre mount is writable after recovery")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("echo 'lustre-recovered' > %v/recovery.txt && grep 'lustre-recovered' %v/recovery.txt",
+				gcsFuseLustreMountPath, gcsFuseLustreMountPath))
+
+		ginkgo.By("Verifying both mounts are healthy after Lustre recovery")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("mount | grep %v", gcsFuseLustreGCSMountPath))
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("mount | grep %v", gcsFuseLustreMountPath))
 	})
 }

--- a/test/e2e/testsuites/gcsfuse_lustre.go
+++ b/test/e2e/testsuites/gcsfuse_lustre.go
@@ -1,0 +1,227 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+Copyright 2022 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testsuites
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"local/test/e2e/specs"
+
+	"github.com/onsi/ginkgo/v2"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
+	e2evolume "k8s.io/kubernetes/test/e2e/framework/volume"
+	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+// LustreStorageClass is the StorageClass used to dynamically provision
+// Lustre-backed PVCs in the GCS Fuse + Lustre performance/resilience tests.
+// Overridden via --lustre-storage-class in e2e_test.go. If empty, these tests
+// are skipped.
+var LustreStorageClass = "lustre-rwx"
+
+const (
+	gcsFuseLustreCSIDriverName = "lustre.csi.storage.gke.io"
+	gcsFuseLustreMountPath     = "/mnt/lustre"
+	gcsFuseLustreVolName       = "lustre-vol"
+	gcsFuseLustreGCSMountPath  = "/mnt/gcs"
+	gcsFuseLustreGCSVolName    = "gcs-vol"
+	gcsFuseLustrePVCSize       = "9000Gi"
+	// gcsFuseLustrePVCBindTimeout accounts for Managed Lustre instance
+	// provisioning, which can take 10+ minutes for large capacities like
+	// gcsFuseLustrePVCSize.
+	gcsFuseLustrePVCBindTimeout = 20 * time.Minute
+)
+
+type gcsFuseLustrePerfResilienceTestSuite struct {
+	tsInfo storageframework.TestSuiteInfo
+}
+
+// InitGcsFuseLustrePerfResilienceTestSuite returns
+// gcsFuseLustrePerfResilienceTestSuite that implements TestSuite interface.
+func InitGcsFuseLustrePerfResilienceTestSuite() storageframework.TestSuite {
+	return &gcsFuseLustrePerfResilienceTestSuite{
+		tsInfo: storageframework.TestSuiteInfo{
+			Name: "gcsfuse-lustre-perf-resilience",
+			TestPatterns: []storageframework.TestPattern{
+				storageframework.DefaultFsPreprovisionedPV,
+			},
+		},
+	}
+}
+
+func (t *gcsFuseLustrePerfResilienceTestSuite) GetTestSuiteInfo() storageframework.TestSuiteInfo {
+	return t.tsInfo
+}
+
+func (t *gcsFuseLustrePerfResilienceTestSuite) SkipUnsupportedTests(_ storageframework.TestDriver, _ storageframework.TestPattern) {
+}
+
+func (t *gcsFuseLustrePerfResilienceTestSuite) DefineTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {
+	type local struct {
+		config          *storageframework.PerTestConfig
+		gcsFuseResource *storageframework.VolumeResource
+	}
+	var l local
+	ctx := context.Background()
+
+	f := framework.NewFrameworkWithCustomTimeouts("gcsfuse-lustre-perf-resilience", storageframework.GetDriverTimeouts(driver))
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	init := func() {
+		l = local{}
+		l.config = driver.PrepareTest(ctx, f)
+		l.config.Prefix = specs.SkipCSIBucketAccessCheckPrefix
+		l.gcsFuseResource = storageframework.CreateVolumeResource(ctx, driver, l.config, pattern, e2evolume.SizeRange{})
+	}
+
+	cleanup := func() {
+		if l.gcsFuseResource != nil {
+			framework.ExpectNoError(l.gcsFuseResource.CleanupResource(ctx))
+		}
+	}
+
+	// skipIfLustreNotAvailable skips the test when the Lustre CSIDriver is not
+	// installed on the cluster, no StorageClass is configured, or the named
+	// StorageClass doesn't exist on the cluster. The lustre-rwx StorageClass is
+	// not created automatically by the Lustre CSI driver/addon — its `network`
+	// parameter must match the cluster's VPC, so it has to be created per
+	// cluster (see docs/lustre-gcsfuse-dual-mount-cluster-setup.md). Checking
+	// for it here avoids createLustrePVC hanging for its full bind timeout on a
+	// PVC that can never be provisioned.
+	skipIfLustreNotAvailable := func(testName string) {
+		if LustreStorageClass == "" {
+			e2eskipper.Skipf("--lustre-storage-class not set, skipping %s", testName)
+		}
+		if _, err := f.ClientSet.StorageV1().CSIDrivers().Get(ctx, gcsFuseLustreCSIDriverName, metav1.GetOptions{}); err != nil {
+			e2eskipper.Skipf("%s CSIDriver not found, skipping %s: %v", gcsFuseLustreCSIDriverName, testName, err)
+		}
+		if _, err := f.ClientSet.StorageV1().StorageClasses().Get(ctx, LustreStorageClass, metav1.GetOptions{}); err != nil {
+			e2eskipper.Skipf("StorageClass %q not found, skipping %s: %v. Create it first (see docs/lustre-gcsfuse-dual-mount-cluster-setup.md).", LustreStorageClass, testName, err)
+		}
+	}
+
+	// createLustrePVC dynamically provisions a Lustre-backed PVC via
+	// LustreStorageClass and waits for it to reach Bound before returning, so
+	// callers can safely attach it to a pod immediately. Managed Lustre
+	// instance provisioning can take several minutes for large capacities, so
+	// this uses a generous timeout.
+	createLustrePVC := func(namePrefix string) (*corev1.PersistentVolumeClaim, func()) {
+		scName := LustreStorageClass
+		pvc := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: namePrefix,
+				Namespace:    f.Namespace.Name,
+			},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany},
+				StorageClassName: &scName,
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceStorage: resource.MustParse(gcsFuseLustrePVCSize),
+					},
+				},
+			},
+		}
+		pvc, err := f.ClientSet.CoreV1().PersistentVolumeClaims(f.Namespace.Name).Create(ctx, pvc, metav1.CreateOptions{})
+		framework.ExpectNoError(err)
+		ginkgo.By(fmt.Sprintf("Waiting for Lustre PVC %s to be bound (up to %v, silently polling)", pvc.Name, gcsFuseLustrePVCBindTimeout))
+		start := time.Now()
+		framework.ExpectNoError(wait.PollUntilContextTimeout(ctx, framework.Poll, gcsFuseLustrePVCBindTimeout, true, func(ctx context.Context) (bool, error) {
+			current, err := f.ClientSet.CoreV1().PersistentVolumeClaims(f.Namespace.Name).Get(ctx, pvc.Name, metav1.GetOptions{})
+			if err != nil {
+				return false, nil
+			}
+			return current.Status.Phase == corev1.ClaimBound, nil
+		}))
+		framework.Logf("Lustre PVC %s bound after %v", pvc.Name, time.Since(start))
+		return pvc, func() {
+			framework.ExpectNoError(f.ClientSet.CoreV1().PersistentVolumeClaims(f.Namespace.Name).Delete(
+				ctx, pvc.Name, metav1.DeleteOptions{}))
+		}
+	}
+
+	// Large file / high-throughput transfer: writes a 1 GB file on Lustre,
+	// copies it to GCS Fuse and back, verifies checksums match in both
+	// directions, and confirms both mounts remain stable throughout.
+	ginkgo.It("should transfer a 1GB file between Lustre and GCS Fuse mounts with matching checksums and no mount instability", func() {
+		skipIfLustreNotAvailable("large file high-throughput transfer test")
+
+		init()
+		defer cleanup()
+
+		ginkgo.By("Creating a dynamically provisioned Lustre PVC")
+		pvc, cleanupPVC := createLustrePVC("lustre-largefile-pvc-")
+		defer cleanupPVC()
+
+		ginkgo.By("Configuring the pod with both GCS Fuse and Lustre volumes")
+		tPod := specs.NewTestPod(f.ClientSet, f.Namespace)
+		tPod.SetupVolume(l.gcsFuseResource, gcsFuseLustreGCSVolName, gcsFuseLustreGCSMountPath, false)
+		tPod.SetupVolume(&storageframework.VolumeResource{Pvc: pvc}, gcsFuseLustreVolName, gcsFuseLustreMountPath, false)
+		tPod.Create(ctx)
+		defer tPod.Cleanup(ctx)
+		tPod.WaitForRunning(ctx)
+
+		ginkgo.By("Writing a 1 GB file to the Lustre mount")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("dd if=/dev/urandom of=%v/large.bin bs=1M count=1024 conv=fsync", gcsFuseLustreMountPath))
+
+		ginkgo.By("Computing checksum of the source file on Lustre")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("md5sum %v/large.bin > /tmp/lustre.md5", gcsFuseLustreMountPath))
+
+		ginkgo.By("Copying the 1 GB file from Lustre to GCS Fuse")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("cp %v/large.bin %v/large.bin", gcsFuseLustreMountPath, gcsFuseLustreGCSMountPath))
+
+		ginkgo.By("Verifying the checksum of the file on GCS Fuse matches the Lustre source")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf(
+				"md5sum %v/large.bin > /tmp/gcs.md5 && "+
+					"LUSTRE_SUM=$(awk '{print $1}' /tmp/lustre.md5) && "+
+					"GCS_SUM=$(awk '{print $1}' /tmp/gcs.md5) && "+
+					"[ \"$LUSTRE_SUM\" = \"$GCS_SUM\" ]",
+				gcsFuseLustreGCSMountPath))
+
+		ginkgo.By("Copying the file back from GCS Fuse to Lustre")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("cp %v/large.bin %v/large-from-gcs.bin", gcsFuseLustreGCSMountPath, gcsFuseLustreMountPath))
+
+		ginkgo.By("Verifying the round-trip checksum matches the original")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf(
+				"md5sum %v/large-from-gcs.bin > /tmp/back.md5 && "+
+					"LUSTRE_SUM=$(awk '{print $1}' /tmp/lustre.md5) && "+
+					"BACK_SUM=$(awk '{print $1}' /tmp/back.md5) && "+
+					"[ \"$LUSTRE_SUM\" = \"$BACK_SUM\" ]",
+				gcsFuseLustreMountPath))
+
+		ginkgo.By("Verifying both mounts remain stable after large transfers")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("mount | grep %v", gcsFuseLustreMountPath))
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("mount | grep %v", gcsFuseLustreGCSMountPath))
+	})
+}

--- a/test/e2e/testsuites/gcsfuse_lustre.go
+++ b/test/e2e/testsuites/gcsfuse_lustre.go
@@ -173,7 +173,7 @@ func (t *gcsFuseLustrePerfResilienceTestSuite) DefineTests(driver storageframewo
 	// Large file / high-throughput transfer: writes a 1 GB file on Lustre,
 	// copies it to GCS Fuse and back, verifies checksums match in both
 	// directions, and confirms both mounts remain stable throughout.
-	ginkgo.It("should transfer a 1GB file between Lustre and GCS Fuse mounts with matching checksums and no mount instability", func() {
+	ginkgo.It("[Feature: Lustre+GCSFuse] should transfer a 1GB file between Lustre and GCS Fuse mounts with matching checksums and no mount instability", func() {
 		skipIfLustreNotAvailable("large file high-throughput transfer test")
 
 		init()
@@ -235,7 +235,7 @@ func (t *gcsFuseLustrePerfResilienceTestSuite) DefineTests(driver storageframewo
 	// Mixed I/O pattern: many small-file reads/writes on GCS Fuse run
 	// concurrently with sequential large-file I/O on Lustre. Verifies no
 	// cross-driver resource contention and that both mounts remain healthy.
-	ginkgo.It("should handle concurrent small-file I/O on GCS Fuse and sequential large-file I/O on Lustre without contention", func() {
+	ginkgo.It("[Feature: Lustre+GCSFuse] should handle concurrent small-file I/O on GCS Fuse and sequential large-file I/O on Lustre without contention", func() {
 		skipIfLustreNotAvailable("mixed I/O pattern test")
 
 		init()
@@ -290,7 +290,7 @@ func (t *gcsFuseLustrePerfResilienceTestSuite) DefineTests(driver storageframewo
 	// restarts and shareable across nodes. The test verifies that GCS Fuse
 	// reads populate the Lustre-backed cache and that a replacement pod finds
 	// the pre-warmed cache intact.
-	ginkgo.It("should store GCS Fuse file cache on a Lustre-backed volume and serve cache hits from Lustre across pod restarts", func() {
+	ginkgo.It("[Feature: Lustre+GCSFuse] should store GCS Fuse file cache on a Lustre-backed volume and serve cache hits from Lustre across pod restarts", func() {
 		skipIfLustreNotAvailable("GCS Fuse file-cache backed by Lustre test")
 
 		// EnableFileCachePrefix provisions the GCS Fuse PV with fileCacheCapacity
@@ -388,7 +388,7 @@ func (t *gcsFuseLustrePerfResilienceTestSuite) DefineTests(driver storageframewo
 	//
 	// Prerequisite: the GKE cluster must have a NetworkPolicy-enforcing CNI
 	// (e.g. Calico or GKE Dataplane V2) enabled.
-	ginkgo.It("should keep GCS Fuse healthy and serving data when Lustre network connectivity is disrupted and recover after connectivity is restored", func() {
+	ginkgo.It("[Feature: Lustre+GCSFuse] should keep GCS Fuse healthy and serving data when Lustre network connectivity is disrupted and recover after connectivity is restored", func() {
 		skipIfLustreNotAvailable("Lustre disruption resilience test")
 
 		init()
@@ -405,6 +405,9 @@ func (t *gcsFuseLustrePerfResilienceTestSuite) DefineTests(driver storageframewo
 		ginkgo.By("Extracting the Lustre instance IP from the PV volume attributes")
 		pv, err := f.ClientSet.CoreV1().PersistentVolumes().Get(ctx, boundPVC.Spec.VolumeName, metav1.GetOptions{})
 		framework.ExpectNoError(err)
+		if pv.Spec.CSI == nil || pv.Spec.CSI.VolumeAttributes == nil {
+			framework.Failf("PV %s does not have CSI volume attributes populated", pv.Name)
+		}
 		lustreIP := pv.Spec.CSI.VolumeAttributes["ip"]
 		if lustreIP == "" {
 			framework.Failf("could not extract Lustre instance IP from PV %s volume attributes; got: %v",
@@ -531,7 +534,7 @@ func (t *gcsFuseLustrePerfResilienceTestSuite) DefineTests(driver storageframewo
 	// report its configured uid for files copied in from Lustre, and that
 	// Lustre preserves the real process-owner uid/gid for files copied in from
 	// GCS Fuse.
-	ginkgo.It("should preserve or correctly remap ownership and permissions when copying files between the GCS Fuse and Lustre mounts", func() {
+	ginkgo.It("[Feature: Lustre+GCSFuse] should preserve or correctly remap ownership and permissions when copying files between the GCS Fuse and Lustre mounts", func() {
 		skipIfLustreNotAvailable("cross-mount permission/ownership consistency test")
 
 		const gcsFuseMappedUID = 1001

--- a/test/e2e/testsuites/gcsfuse_lustre.go
+++ b/test/e2e/testsuites/gcsfuse_lustre.go
@@ -521,4 +521,77 @@ func (t *gcsFuseLustrePerfResilienceTestSuite) DefineTests(driver storageframewo
 		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
 			fmt.Sprintf("mount | grep %v", gcsFuseLustreMountPath))
 	})
+
+	// Cross-mount permission/ownership consistency: the GCS Fuse volume is
+	// mounted with an explicit uid mount option (so GCS Fuse remaps every
+	// file's reported owner to that uid, regardless of which process actually
+	// wrote it), while the Lustre volume is a native POSIX filesystem that
+	// reports the real uid/gid of the writing process. The test copies a file
+	// from each mount to the other and verifies that GCS Fuse continues to
+	// report its configured uid for files copied in from Lustre, and that
+	// Lustre preserves the real process-owner uid/gid for files copied in from
+	// GCS Fuse.
+	ginkgo.It("should preserve or correctly remap ownership and permissions when copying files between the GCS Fuse and Lustre mounts", func() {
+		skipIfLustreNotAvailable("cross-mount permission/ownership consistency test")
+
+		const gcsFuseMappedUID = 1001
+
+		// SkipCSIBucketAccessCheckAndNonRootVolumePrefix mounts the GCS Fuse
+		// volume with "uid=1001", so every file on this mount reports owner
+		// uid 1001 no matter which uid actually wrote it.
+		l = local{}
+		l.config = driver.PrepareTest(ctx, f)
+		l.config.Prefix = specs.SkipCSIBucketAccessCheckAndNonRootVolumePrefix
+		l.gcsFuseResource = storageframework.CreateVolumeResource(ctx, driver, l.config, pattern, e2evolume.SizeRange{})
+		defer cleanup()
+
+		ginkgo.By("Creating a dynamically provisioned Lustre PVC")
+		pvc, cleanupPVC := createLustrePVC("lustre-perm-pvc-")
+		defer cleanupPVC()
+
+		ginkgo.By("Configuring the pod with both GCS Fuse (uid=1001 mapped) and Lustre volumes")
+		tPod := specs.NewTestPod(f.ClientSet, f.Namespace)
+		tPod.SetupVolume(l.gcsFuseResource, gcsFuseLustreGCSVolName, gcsFuseLustreGCSMountPath, false)
+		tPod.SetupVolume(&storageframework.VolumeResource{Pvc: pvc}, gcsFuseLustreVolName, gcsFuseLustreMountPath, false)
+		tPod.Create(ctx)
+		defer tPod.Cleanup(ctx)
+		tPod.WaitForRunning(ctx)
+
+		ginkgo.By("Writing a file on the Lustre mount as the pod's real process owner (root)")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("echo 'from-lustre' > %v/from-lustre.txt && chmod 644 %v/from-lustre.txt", gcsFuseLustreMountPath, gcsFuseLustreMountPath))
+
+		ginkgo.By("Verifying the Lustre file reports the real process owner uid (0/root)")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("test $(stat -c%%u %v/from-lustre.txt) -eq 0", gcsFuseLustreMountPath))
+
+		ginkgo.By("Copying the Lustre-owned file onto the GCS Fuse mount")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("cp %v/from-lustre.txt %v/from-lustre.txt", gcsFuseLustreMountPath, gcsFuseLustreGCSMountPath))
+
+		ginkgo.By(fmt.Sprintf("Verifying GCS Fuse remaps the copied file's owner to the mounted uid (%d), not the real writer uid", gcsFuseMappedUID))
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("test $(stat -c%%u %v/from-lustre.txt) -eq %d", gcsFuseLustreGCSMountPath, gcsFuseMappedUID))
+
+		ginkgo.By("Writing a file directly on the GCS Fuse mount")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("echo 'from-gcs' > %v/from-gcs.txt", gcsFuseLustreGCSMountPath))
+
+		ginkgo.By(fmt.Sprintf("Verifying the GCS Fuse file also reports the mounted uid (%d)", gcsFuseMappedUID))
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("test $(stat -c%%u %v/from-gcs.txt) -eq %d", gcsFuseLustreGCSMountPath, gcsFuseMappedUID))
+
+		ginkgo.By("Copying the GCS Fuse file onto the Lustre mount")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("cp %v/from-gcs.txt %v/from-gcs.txt", gcsFuseLustreGCSMountPath, gcsFuseLustreMountPath))
+
+		ginkgo.By("Verifying Lustre preserves the real process-owner uid (0/root) for the copy, not the GCS Fuse mapped uid")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("test $(stat -c%%u %v/from-gcs.txt) -eq 0", gcsFuseLustreMountPath))
+
+		ginkgo.By("Verifying file contents survived both cross-mount copies intact")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("grep 'from-lustre' %v/from-lustre.txt && grep 'from-gcs' %v/from-gcs.txt",
+				gcsFuseLustreGCSMountPath, gcsFuseLustreMountPath))
+	})
 }

--- a/test/e2e/testsuites/gcsfuse_lustre.go
+++ b/test/e2e/testsuites/gcsfuse_lustre.go
@@ -224,4 +224,56 @@ func (t *gcsFuseLustrePerfResilienceTestSuite) DefineTests(driver storageframewo
 		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
 			fmt.Sprintf("mount | grep %v", gcsFuseLustreGCSMountPath))
 	})
+
+	// Mixed I/O pattern: many small-file reads/writes on GCS Fuse run
+	// concurrently with sequential large-file I/O on Lustre. Verifies no
+	// cross-driver resource contention and that both mounts remain healthy.
+	ginkgo.It("should handle concurrent small-file I/O on GCS Fuse and sequential large-file I/O on Lustre without contention", func() {
+		skipIfLustreNotAvailable("mixed I/O pattern test")
+
+		init()
+		defer cleanup()
+
+		ginkgo.By("Creating a dynamically provisioned Lustre PVC")
+		pvc, cleanupPVC := createLustrePVC("lustre-mixedio-pvc-")
+		defer cleanupPVC()
+
+		ginkgo.By("Configuring the pod with both GCS Fuse and Lustre volumes")
+		tPod := specs.NewTestPod(f.ClientSet, f.Namespace)
+		tPod.SetupVolume(l.gcsFuseResource, gcsFuseLustreGCSVolName, gcsFuseLustreGCSMountPath, false)
+		tPod.SetupVolume(&storageframework.VolumeResource{Pvc: pvc}, gcsFuseLustreVolName, gcsFuseLustreMountPath, false)
+		tPod.Create(ctx)
+		defer tPod.Cleanup(ctx)
+		tPod.WaitForRunning(ctx)
+
+		ginkgo.By("Running concurrent GCS Fuse small-file writes and Lustre sequential large-file I/O")
+		// Launches 100 small-file writes to GCS Fuse in the background while
+		// simultaneously performing a 512 MB sequential write + read on Lustre,
+		// then waits for the GCS workload to finish before asserting exit codes.
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf(
+				"sh -c 'set -e; "+
+					"for i in $(seq 1 100); do echo \"small-${i}\" > %v/small-${i}.txt; done & GCS_PID=$!; "+
+					"dd if=/dev/zero of=%v/seq.bin bs=1M count=512 conv=fsync; "+
+					"dd if=%v/seq.bin of=/dev/null bs=1M; "+
+					"wait $GCS_PID'",
+				gcsFuseLustreGCSMountPath, gcsFuseLustreMountPath, gcsFuseLustreMountPath))
+
+		ginkgo.By("Verifying a sample of small files written to GCS Fuse are readable")
+		for _, i := range []int{1, 25, 50, 75, 100} {
+			tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+				fmt.Sprintf("grep 'small-%d' %v/small-%d.txt", i, gcsFuseLustreGCSMountPath, i))
+		}
+
+		ginkgo.By("Verifying the sequential Lustre file is intact")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("test -f %v/seq.bin && stat -c%%s %v/seq.bin | grep -q 536870912",
+				gcsFuseLustreMountPath, gcsFuseLustreMountPath))
+
+		ginkgo.By("Verifying both mounts remain healthy after mixed I/O")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("mount | grep %v", gcsFuseLustreMountPath))
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("mount | grep %v", gcsFuseLustreGCSMountPath))
+	})
 }

--- a/test/e2e/testsuites/gcsfuse_lustre.go
+++ b/test/e2e/testsuites/gcsfuse_lustre.go
@@ -53,6 +53,11 @@ const (
 	// provisioning, which can take 10+ minutes for large capacities like
 	// gcsFuseLustrePVCSize.
 	gcsFuseLustrePVCBindTimeout = 20 * time.Minute
+	// gcsFuseLustreSidecarCacheVolName is the well-known volume name injected by
+	// the GCS Fuse webhook for the sidecar's file-cache directory. Pre-defining
+	// this volume in the pod spec causes the webhook to use our PVC instead of
+	// the default node-local emptyDir.
+	gcsFuseLustreSidecarCacheVolName = "gke-gcsfuse-cache"
 )
 
 type gcsFuseLustrePerfResilienceTestSuite struct {
@@ -275,5 +280,100 @@ func (t *gcsFuseLustrePerfResilienceTestSuite) DefineTests(driver storageframewo
 			fmt.Sprintf("mount | grep %v", gcsFuseLustreMountPath))
 		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
 			fmt.Sprintf("mount | grep %v", gcsFuseLustreGCSMountPath))
+	})
+
+	// GCS Fuse file-cache backed by Lustre: the GCS Fuse sidecar's file-cache
+	// volume (gke-gcsfuse-cache) is backed by a Lustre PVC instead of the
+	// default node-local emptyDir. This makes the cache durable across pod
+	// restarts and shareable across nodes. The test verifies that GCS Fuse
+	// reads populate the Lustre-backed cache and that a replacement pod finds
+	// the pre-warmed cache intact.
+	ginkgo.It("should store GCS Fuse file cache on a Lustre-backed volume and serve cache hits from Lustre across pod restarts", func() {
+		skipIfLustreNotAvailable("GCS Fuse file-cache backed by Lustre test")
+
+		// EnableFileCachePrefix provisions the GCS Fuse PV with fileCacheCapacity
+		// set, which tells the sidecar to enable file-level caching.
+		l = local{}
+		l.config = driver.PrepareTest(ctx, f)
+		l.config.Prefix = specs.EnableFileCachePrefix
+		l.gcsFuseResource = storageframework.CreateVolumeResource(ctx, driver, l.config, pattern, e2evolume.SizeRange{})
+		defer cleanup()
+
+		ginkgo.By("Creating a Lustre PVC to back the GCS Fuse sidecar file cache")
+		pvc, cleanupPVC := createLustrePVC("lustre-gcsfuse-cache-pvc-")
+		defer cleanupPVC()
+
+		// The Lustre CSIDriver declares fsGroupPolicy: ReadWriteOnceWithFSType,
+		// so kubelet skips applying fsGroup ownership for this ReadWriteMany PVC.
+		// The Lustre root directory therefore keeps its default root-only
+		// permissions, which blocks the GCS Fuse sidecar (running as non-root)
+		// from creating its cache directory. Open up permissions once, from a
+		// plain pod with no GCS Fuse volumes (so the webhook doesn't inject the
+		// sidecar here), before the sidecar ever touches this volume.
+		ginkgo.By("Opening up permissions on the Lustre-backed cache volume for the non-root GCS Fuse sidecar")
+		permFixPod := specs.NewTestPod(f.ClientSet, f.Namespace)
+		permFixPod.SetupVolume(&storageframework.VolumeResource{Pvc: pvc}, gcsFuseLustreVolName, gcsFuseLustreMountPath, false)
+		permFixPod.Create(ctx)
+		permFixPod.WaitForRunning(ctx)
+		permFixPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("chmod 1777 %v", gcsFuseLustreMountPath))
+		permFixPod.Cleanup(ctx)
+
+		ginkgo.By("Creating Pod-1: GCS Fuse with Lustre PVC as the sidecar file-cache backing")
+		tPod1 := specs.NewTestPod(f.ClientSet, f.Namespace)
+		tPod1.SetupVolume(l.gcsFuseResource, gcsFuseLustreGCSVolName, gcsFuseLustreGCSMountPath, false)
+		// Pre-define gke-gcsfuse-cache as the Lustre PVC. The webhook detects this
+		// pre-existing volume and skips injecting its default node-local emptyDir,
+		// so the sidecar writes its cache entries to Lustre instead.
+		tPod1.SetupVolume(&storageframework.VolumeResource{Pvc: pvc}, gcsFuseLustreSidecarCacheVolName, "/gcsfuse-cache", false)
+		// Add a second mount path for the same gke-gcsfuse-cache volume (not a
+		// second `volumes:` entry for the PVC) so the test container can inspect
+		// what the sidecar cached there. Declaring the same PVC under two
+		// separate pod.spec.volumes entries instead causes kubelet's volume
+		// reconciler on vanilla kubeadm clusters to never mark the second entry
+		// as mounted, hanging the pod in ContainerCreating indefinitely.
+		tPod1.SetupCacheVolumeMount(gcsFuseLustreMountPath)
+		tPod1.Create(ctx)
+		tPod1.WaitForRunning(ctx)
+
+		ginkgo.By("Pod-1: writing test files to the GCS Fuse mount")
+		tPod1.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("for i in $(seq 1 5); do echo \"content-${i}\" > %v/file-${i}.txt; done", gcsFuseLustreGCSMountPath))
+
+		ginkgo.By("Pod-1: reading files from GCS Fuse to populate the Lustre-backed file cache")
+		for i := 1; i <= 5; i++ {
+			tPod1.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+				fmt.Sprintf("grep 'content-%d' %v/file-%d.txt", i, gcsFuseLustreGCSMountPath, i))
+		}
+
+		ginkgo.By("Pod-1: verifying the Lustre volume contains file cache entries written by the GCS Fuse sidecar")
+		tPod1.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("test $(ls -A %v | wc -l) -gt 0", gcsFuseLustreMountPath))
+
+		ginkgo.By("Deleting Pod-1 to simulate a pod restart")
+		tPod1.Cleanup(ctx)
+
+		ginkgo.By("Creating Pod-2 with the same Lustre PVC as the GCS Fuse file-cache backing")
+		tPod2 := specs.NewTestPod(f.ClientSet, f.Namespace)
+		tPod2.SetupVolume(l.gcsFuseResource, gcsFuseLustreGCSVolName, gcsFuseLustreGCSMountPath, false)
+		tPod2.SetupVolume(&storageframework.VolumeResource{Pvc: pvc}, gcsFuseLustreSidecarCacheVolName, "/gcsfuse-cache", false)
+		tPod2.SetupCacheVolumeMount(gcsFuseLustreMountPath)
+		tPod2.Create(ctx)
+		defer tPod2.Cleanup(ctx)
+		tPod2.WaitForRunning(ctx)
+
+		ginkgo.By("Pod-2: reading files from GCS Fuse — cache hits now served from the persisted Lustre-backed cache")
+		for i := 1; i <= 5; i++ {
+			tPod2.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+				fmt.Sprintf("grep 'content-%d' %v/file-%d.txt", i, gcsFuseLustreGCSMountPath, i))
+		}
+
+		ginkgo.By("Pod-2: verifying the Lustre-backed file cache is still intact and populated")
+		tPod2.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("test $(ls -A %v | wc -l) -gt 0", gcsFuseLustreMountPath))
+
+		ginkgo.By("Pod-2: writing an additional file to GCS Fuse to extend the Lustre-backed cache")
+		tPod2.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("echo 'cache-extended' > %v/extra.txt && grep 'cache-extended' %v/extra.txt",
+				gcsFuseLustreGCSMountPath, gcsFuseLustreGCSMountPath))
 	})
 }

--- a/test/e2e/testsuites/gcsfuse_lustre.go
+++ b/test/e2e/testsuites/gcsfuse_lustre.go
@@ -47,6 +47,11 @@ const (
 	// provisioning, which can take 10+ minutes for large capacities like
 	// gcsFuseLustrePVCSize.
 	gcsFuseLustrePVCBindTimeout = 20 * time.Minute
+	// gcsFuseLustreSidecarCacheVolName is the well-known volume name injected by
+	// the GCS Fuse webhook for the sidecar's file-cache directory. Pre-defining
+	// this volume in the pod spec causes the webhook to use our PVC instead of
+	// the default node-local emptyDir.
+	gcsFuseLustreSidecarCacheVolName = "gke-gcsfuse-cache"
 )
 
 type gcsFuseLustrePerfResilienceTestSuite struct {
@@ -269,5 +274,100 @@ func (t *gcsFuseLustrePerfResilienceTestSuite) DefineTests(driver storageframewo
 			fmt.Sprintf("mount | grep %v", gcsFuseLustreMountPath))
 		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
 			fmt.Sprintf("mount | grep %v", gcsFuseLustreGCSMountPath))
+	})
+
+	// GCS Fuse file-cache backed by Lustre: the GCS Fuse sidecar's file-cache
+	// volume (gke-gcsfuse-cache) is backed by a Lustre PVC instead of the
+	// default node-local emptyDir. This makes the cache durable across pod
+	// restarts and shareable across nodes. The test verifies that GCS Fuse
+	// reads populate the Lustre-backed cache and that a replacement pod finds
+	// the pre-warmed cache intact.
+	ginkgo.It("should store GCS Fuse file cache on a Lustre-backed volume and serve cache hits from Lustre across pod restarts", func() {
+		skipIfLustreNotAvailable("GCS Fuse file-cache backed by Lustre test")
+
+		// EnableFileCachePrefix provisions the GCS Fuse PV with fileCacheCapacity
+		// set, which tells the sidecar to enable file-level caching.
+		l = local{}
+		l.config = driver.PrepareTest(ctx, f)
+		l.config.Prefix = specs.EnableFileCachePrefix
+		l.gcsFuseResource = storageframework.CreateVolumeResource(ctx, driver, l.config, pattern, e2evolume.SizeRange{})
+		defer cleanup()
+
+		ginkgo.By("Creating a Lustre PVC to back the GCS Fuse sidecar file cache")
+		pvc, cleanupPVC := createLustrePVC("lustre-gcsfuse-cache-pvc-")
+		defer cleanupPVC()
+
+		// The Lustre CSIDriver declares fsGroupPolicy: ReadWriteOnceWithFSType,
+		// so kubelet skips applying fsGroup ownership for this ReadWriteMany PVC.
+		// The Lustre root directory therefore keeps its default root-only
+		// permissions, which blocks the GCS Fuse sidecar (running as non-root)
+		// from creating its cache directory. Open up permissions once, from a
+		// plain pod with no GCS Fuse volumes (so the webhook doesn't inject the
+		// sidecar here), before the sidecar ever touches this volume.
+		ginkgo.By("Opening up permissions on the Lustre-backed cache volume for the non-root GCS Fuse sidecar")
+		permFixPod := specs.NewTestPod(f.ClientSet, f.Namespace)
+		permFixPod.SetupVolume(&storageframework.VolumeResource{Pvc: pvc}, gcsFuseLustreVolName, gcsFuseLustreMountPath, false)
+		permFixPod.Create(ctx)
+		permFixPod.WaitForRunning(ctx)
+		permFixPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("chmod 1777 %v", gcsFuseLustreMountPath))
+		permFixPod.Cleanup(ctx)
+
+		ginkgo.By("Creating Pod-1: GCS Fuse with Lustre PVC as the sidecar file-cache backing")
+		tPod1 := specs.NewTestPod(f.ClientSet, f.Namespace)
+		tPod1.SetupVolume(l.gcsFuseResource, gcsFuseLustreGCSVolName, gcsFuseLustreGCSMountPath, false)
+		// Pre-define gke-gcsfuse-cache as the Lustre PVC. The webhook detects this
+		// pre-existing volume and skips injecting its default node-local emptyDir,
+		// so the sidecar writes its cache entries to Lustre instead.
+		tPod1.SetupVolume(&storageframework.VolumeResource{Pvc: pvc}, gcsFuseLustreSidecarCacheVolName, "/gcsfuse-cache", false)
+		// Add a second mount path for the same gke-gcsfuse-cache volume (not a
+		// second `volumes:` entry for the PVC) so the test container can inspect
+		// what the sidecar cached there. Declaring the same PVC under two
+		// separate pod.spec.volumes entries instead causes kubelet's volume
+		// reconciler on vanilla kubeadm clusters to never mark the second entry
+		// as mounted, hanging the pod in ContainerCreating indefinitely.
+		tPod1.SetupCacheVolumeMount(gcsFuseLustreMountPath)
+		tPod1.Create(ctx)
+		tPod1.WaitForRunning(ctx)
+
+		ginkgo.By("Pod-1: writing test files to the GCS Fuse mount")
+		tPod1.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("for i in $(seq 1 5); do echo \"content-${i}\" > %v/file-${i}.txt; done", gcsFuseLustreGCSMountPath))
+
+		ginkgo.By("Pod-1: reading files from GCS Fuse to populate the Lustre-backed file cache")
+		for i := 1; i <= 5; i++ {
+			tPod1.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+				fmt.Sprintf("grep 'content-%d' %v/file-%d.txt", i, gcsFuseLustreGCSMountPath, i))
+		}
+
+		ginkgo.By("Pod-1: verifying the Lustre volume contains file cache entries written by the GCS Fuse sidecar")
+		tPod1.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("test $(ls -A %v | wc -l) -gt 0", gcsFuseLustreMountPath))
+
+		ginkgo.By("Deleting Pod-1 to simulate a pod restart")
+		tPod1.Cleanup(ctx)
+
+		ginkgo.By("Creating Pod-2 with the same Lustre PVC as the GCS Fuse file-cache backing")
+		tPod2 := specs.NewTestPod(f.ClientSet, f.Namespace)
+		tPod2.SetupVolume(l.gcsFuseResource, gcsFuseLustreGCSVolName, gcsFuseLustreGCSMountPath, false)
+		tPod2.SetupVolume(&storageframework.VolumeResource{Pvc: pvc}, gcsFuseLustreSidecarCacheVolName, "/gcsfuse-cache", false)
+		tPod2.SetupCacheVolumeMount(gcsFuseLustreMountPath)
+		tPod2.Create(ctx)
+		defer tPod2.Cleanup(ctx)
+		tPod2.WaitForRunning(ctx)
+
+		ginkgo.By("Pod-2: reading files from GCS Fuse — cache hits now served from the persisted Lustre-backed cache")
+		for i := 1; i <= 5; i++ {
+			tPod2.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+				fmt.Sprintf("grep 'content-%d' %v/file-%d.txt", i, gcsFuseLustreGCSMountPath, i))
+		}
+
+		ginkgo.By("Pod-2: verifying the Lustre-backed file cache is still intact and populated")
+		tPod2.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("test $(ls -A %v | wc -l) -gt 0", gcsFuseLustreMountPath))
+
+		ginkgo.By("Pod-2: writing an additional file to GCS Fuse to extend the Lustre-backed cache")
+		tPod2.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("echo 'cache-extended' > %v/extra.txt && grep 'cache-extended' %v/extra.txt",
+				gcsFuseLustreGCSMountPath, gcsFuseLustreGCSMountPath))
 	})
 }

--- a/test/e2e/testsuites/gcsfuse_lustre.go
+++ b/test/e2e/testsuites/gcsfuse_lustre.go
@@ -167,7 +167,7 @@ func (t *gcsFuseLustrePerfResilienceTestSuite) DefineTests(driver storageframewo
 	// Large file / high-throughput transfer: writes a 1 GB file on Lustre,
 	// copies it to GCS Fuse and back, verifies checksums match in both
 	// directions, and confirms both mounts remain stable throughout.
-	ginkgo.It("should transfer a 1GB file between Lustre and GCS Fuse mounts with matching checksums and no mount instability", func() {
+	ginkgo.It("[Feature: Lustre+GCSFuse] should transfer a 1GB file between Lustre and GCS Fuse mounts with matching checksums and no mount instability", func() {
 		skipIfLustreNotAvailable("large file high-throughput transfer test")
 
 		init()
@@ -229,7 +229,7 @@ func (t *gcsFuseLustrePerfResilienceTestSuite) DefineTests(driver storageframewo
 	// Mixed I/O pattern: many small-file reads/writes on GCS Fuse run
 	// concurrently with sequential large-file I/O on Lustre. Verifies no
 	// cross-driver resource contention and that both mounts remain healthy.
-	ginkgo.It("should handle concurrent small-file I/O on GCS Fuse and sequential large-file I/O on Lustre without contention", func() {
+	ginkgo.It("[Feature: Lustre+GCSFuse] should handle concurrent small-file I/O on GCS Fuse and sequential large-file I/O on Lustre without contention", func() {
 		skipIfLustreNotAvailable("mixed I/O pattern test")
 
 		init()
@@ -284,7 +284,7 @@ func (t *gcsFuseLustrePerfResilienceTestSuite) DefineTests(driver storageframewo
 	// restarts and shareable across nodes. The test verifies that GCS Fuse
 	// reads populate the Lustre-backed cache and that a replacement pod finds
 	// the pre-warmed cache intact.
-	ginkgo.It("should store GCS Fuse file cache on a Lustre-backed volume and serve cache hits from Lustre across pod restarts", func() {
+	ginkgo.It("[Feature: Lustre+GCSFuse] should store GCS Fuse file cache on a Lustre-backed volume and serve cache hits from Lustre across pod restarts", func() {
 		skipIfLustreNotAvailable("GCS Fuse file-cache backed by Lustre test")
 
 		// EnableFileCachePrefix provisions the GCS Fuse PV with fileCacheCapacity
@@ -382,7 +382,7 @@ func (t *gcsFuseLustrePerfResilienceTestSuite) DefineTests(driver storageframewo
 	//
 	// Prerequisite: the GKE cluster must have a NetworkPolicy-enforcing CNI
 	// (e.g. Calico or GKE Dataplane V2) enabled.
-	ginkgo.It("should keep GCS Fuse healthy and serving data when Lustre network connectivity is disrupted and recover after connectivity is restored", func() {
+	ginkgo.It("[Feature: Lustre+GCSFuse] should keep GCS Fuse healthy and serving data when Lustre network connectivity is disrupted and recover after connectivity is restored", func() {
 		skipIfLustreNotAvailable("Lustre disruption resilience test")
 
 		init()
@@ -399,6 +399,9 @@ func (t *gcsFuseLustrePerfResilienceTestSuite) DefineTests(driver storageframewo
 		ginkgo.By("Extracting the Lustre instance IP from the PV volume attributes")
 		pv, err := f.ClientSet.CoreV1().PersistentVolumes().Get(ctx, boundPVC.Spec.VolumeName, metav1.GetOptions{})
 		framework.ExpectNoError(err)
+		if pv.Spec.CSI == nil || pv.Spec.CSI.VolumeAttributes == nil {
+			framework.Failf("PV %s does not have CSI volume attributes populated", pv.Name)
+		}
 		lustreIP := pv.Spec.CSI.VolumeAttributes["ip"]
 		if lustreIP == "" {
 			framework.Failf("could not extract Lustre instance IP from PV %s volume attributes; got: %v",
@@ -525,7 +528,7 @@ func (t *gcsFuseLustrePerfResilienceTestSuite) DefineTests(driver storageframewo
 	// report its configured uid for files copied in from Lustre, and that
 	// Lustre preserves the real process-owner uid/gid for files copied in from
 	// GCS Fuse.
-	ginkgo.It("should preserve or correctly remap ownership and permissions when copying files between the GCS Fuse and Lustre mounts", func() {
+	ginkgo.It("[Feature: Lustre+GCSFuse] should preserve or correctly remap ownership and permissions when copying files between the GCS Fuse and Lustre mounts", func() {
 		skipIfLustreNotAvailable("cross-mount permission/ownership consistency test")
 
 		const gcsFuseMappedUID = 1001

--- a/test/e2e/testsuites/gcsfuse_lustre.go
+++ b/test/e2e/testsuites/gcsfuse_lustre.go
@@ -515,4 +515,77 @@ func (t *gcsFuseLustrePerfResilienceTestSuite) DefineTests(driver storageframewo
 		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
 			fmt.Sprintf("mount | grep %v", gcsFuseLustreMountPath))
 	})
+
+	// Cross-mount permission/ownership consistency: the GCS Fuse volume is
+	// mounted with an explicit uid mount option (so GCS Fuse remaps every
+	// file's reported owner to that uid, regardless of which process actually
+	// wrote it), while the Lustre volume is a native POSIX filesystem that
+	// reports the real uid/gid of the writing process. The test copies a file
+	// from each mount to the other and verifies that GCS Fuse continues to
+	// report its configured uid for files copied in from Lustre, and that
+	// Lustre preserves the real process-owner uid/gid for files copied in from
+	// GCS Fuse.
+	ginkgo.It("should preserve or correctly remap ownership and permissions when copying files between the GCS Fuse and Lustre mounts", func() {
+		skipIfLustreNotAvailable("cross-mount permission/ownership consistency test")
+
+		const gcsFuseMappedUID = 1001
+
+		// SkipCSIBucketAccessCheckAndNonRootVolumePrefix mounts the GCS Fuse
+		// volume with "uid=1001", so every file on this mount reports owner
+		// uid 1001 no matter which uid actually wrote it.
+		l = local{}
+		l.config = driver.PrepareTest(ctx, f)
+		l.config.Prefix = specs.SkipCSIBucketAccessCheckAndNonRootVolumePrefix
+		l.gcsFuseResource = storageframework.CreateVolumeResource(ctx, driver, l.config, pattern, e2evolume.SizeRange{})
+		defer cleanup()
+
+		ginkgo.By("Creating a dynamically provisioned Lustre PVC")
+		pvc, cleanupPVC := createLustrePVC("lustre-perm-pvc-")
+		defer cleanupPVC()
+
+		ginkgo.By("Configuring the pod with both GCS Fuse (uid=1001 mapped) and Lustre volumes")
+		tPod := specs.NewTestPod(f.ClientSet, f.Namespace)
+		tPod.SetupVolume(l.gcsFuseResource, gcsFuseLustreGCSVolName, gcsFuseLustreGCSMountPath, false)
+		tPod.SetupVolume(&storageframework.VolumeResource{Pvc: pvc}, gcsFuseLustreVolName, gcsFuseLustreMountPath, false)
+		tPod.Create(ctx)
+		defer tPod.Cleanup(ctx)
+		tPod.WaitForRunning(ctx)
+
+		ginkgo.By("Writing a file on the Lustre mount as the pod's real process owner (root)")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("echo 'from-lustre' > %v/from-lustre.txt && chmod 644 %v/from-lustre.txt", gcsFuseLustreMountPath, gcsFuseLustreMountPath))
+
+		ginkgo.By("Verifying the Lustre file reports the real process owner uid (0/root)")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("test $(stat -c%%u %v/from-lustre.txt) -eq 0", gcsFuseLustreMountPath))
+
+		ginkgo.By("Copying the Lustre-owned file onto the GCS Fuse mount")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("cp %v/from-lustre.txt %v/from-lustre.txt", gcsFuseLustreMountPath, gcsFuseLustreGCSMountPath))
+
+		ginkgo.By(fmt.Sprintf("Verifying GCS Fuse remaps the copied file's owner to the mounted uid (%d), not the real writer uid", gcsFuseMappedUID))
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("test $(stat -c%%u %v/from-lustre.txt) -eq %d", gcsFuseLustreGCSMountPath, gcsFuseMappedUID))
+
+		ginkgo.By("Writing a file directly on the GCS Fuse mount")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("echo 'from-gcs' > %v/from-gcs.txt", gcsFuseLustreGCSMountPath))
+
+		ginkgo.By(fmt.Sprintf("Verifying the GCS Fuse file also reports the mounted uid (%d)", gcsFuseMappedUID))
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("test $(stat -c%%u %v/from-gcs.txt) -eq %d", gcsFuseLustreGCSMountPath, gcsFuseMappedUID))
+
+		ginkgo.By("Copying the GCS Fuse file onto the Lustre mount")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("cp %v/from-gcs.txt %v/from-gcs.txt", gcsFuseLustreGCSMountPath, gcsFuseLustreMountPath))
+
+		ginkgo.By("Verifying Lustre preserves the real process-owner uid (0/root) for the copy, not the GCS Fuse mapped uid")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("test $(stat -c%%u %v/from-gcs.txt) -eq 0", gcsFuseLustreMountPath))
+
+		ginkgo.By("Verifying file contents survived both cross-mount copies intact")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("grep 'from-lustre' %v/from-lustre.txt && grep 'from-gcs' %v/from-gcs.txt",
+				gcsFuseLustreGCSMountPath, gcsFuseLustreMountPath))
+	})
 }

--- a/test/e2e/testsuites/gcsfuse_lustre.go
+++ b/test/e2e/testsuites/gcsfuse_lustre.go
@@ -218,4 +218,56 @@ func (t *gcsFuseLustrePerfResilienceTestSuite) DefineTests(driver storageframewo
 		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
 			fmt.Sprintf("mount | grep %v", gcsFuseLustreGCSMountPath))
 	})
+
+	// Mixed I/O pattern: many small-file reads/writes on GCS Fuse run
+	// concurrently with sequential large-file I/O on Lustre. Verifies no
+	// cross-driver resource contention and that both mounts remain healthy.
+	ginkgo.It("should handle concurrent small-file I/O on GCS Fuse and sequential large-file I/O on Lustre without contention", func() {
+		skipIfLustreNotAvailable("mixed I/O pattern test")
+
+		init()
+		defer cleanup()
+
+		ginkgo.By("Creating a dynamically provisioned Lustre PVC")
+		pvc, cleanupPVC := createLustrePVC("lustre-mixedio-pvc-")
+		defer cleanupPVC()
+
+		ginkgo.By("Configuring the pod with both GCS Fuse and Lustre volumes")
+		tPod := specs.NewTestPod(f.ClientSet, f.Namespace)
+		tPod.SetupVolume(l.gcsFuseResource, gcsFuseLustreGCSVolName, gcsFuseLustreGCSMountPath, false)
+		tPod.SetupVolume(&storageframework.VolumeResource{Pvc: pvc}, gcsFuseLustreVolName, gcsFuseLustreMountPath, false)
+		tPod.Create(ctx)
+		defer tPod.Cleanup(ctx)
+		tPod.WaitForRunning(ctx)
+
+		ginkgo.By("Running concurrent GCS Fuse small-file writes and Lustre sequential large-file I/O")
+		// Launches 100 small-file writes to GCS Fuse in the background while
+		// simultaneously performing a 512 MB sequential write + read on Lustre,
+		// then waits for the GCS workload to finish before asserting exit codes.
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf(
+				"sh -c 'set -e; "+
+					"for i in $(seq 1 100); do echo \"small-${i}\" > %v/small-${i}.txt; done & GCS_PID=$!; "+
+					"dd if=/dev/zero of=%v/seq.bin bs=1M count=512 conv=fsync; "+
+					"dd if=%v/seq.bin of=/dev/null bs=1M; "+
+					"wait $GCS_PID'",
+				gcsFuseLustreGCSMountPath, gcsFuseLustreMountPath, gcsFuseLustreMountPath))
+
+		ginkgo.By("Verifying a sample of small files written to GCS Fuse are readable")
+		for _, i := range []int{1, 25, 50, 75, 100} {
+			tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+				fmt.Sprintf("grep 'small-%d' %v/small-%d.txt", i, gcsFuseLustreGCSMountPath, i))
+		}
+
+		ginkgo.By("Verifying the sequential Lustre file is intact")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("test -f %v/seq.bin && stat -c%%s %v/seq.bin | grep -q 536870912",
+				gcsFuseLustreMountPath, gcsFuseLustreMountPath))
+
+		ginkgo.By("Verifying both mounts remain healthy after mixed I/O")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("mount | grep %v", gcsFuseLustreMountPath))
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("mount | grep %v", gcsFuseLustreGCSMountPath))
+	})
 }

--- a/test/e2e/testsuites/gcsfuse_lustre.go
+++ b/test/e2e/testsuites/gcsfuse_lustre.go
@@ -26,8 +26,10 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
@@ -369,5 +371,148 @@ func (t *gcsFuseLustrePerfResilienceTestSuite) DefineTests(driver storageframewo
 		tPod2.VerifyExecInPodSucceed(f, specs.TesterContainerName,
 			fmt.Sprintf("echo 'cache-extended' > %v/extra.txt && grep 'cache-extended' %v/extra.txt",
 				gcsFuseLustreGCSMountPath, gcsFuseLustreGCSMountPath))
+	})
+
+	// Lustre disruption resilience with GCS Fuse unaffected: a NetworkPolicy
+	// blocks egress on port 988 (Lustre wire protocol) from the test namespace
+	// to the provisioned Lustre instance IP, simulating a network partition to
+	// the MDS/OSS. The test verifies that the GCS Fuse mount and its sidecar
+	// remain fully operational during the disruption, then confirms both volumes
+	// recover once the NetworkPolicy is removed.
+	//
+	// Prerequisite: the GKE cluster must have a NetworkPolicy-enforcing CNI
+	// (e.g. Calico or GKE Dataplane V2) enabled.
+	ginkgo.It("should keep GCS Fuse healthy and serving data when Lustre network connectivity is disrupted and recover after connectivity is restored", func() {
+		skipIfLustreNotAvailable("Lustre disruption resilience test")
+
+		init()
+		defer cleanup()
+
+		ginkgo.By("Creating a dynamically provisioned Lustre PVC")
+		pvc, cleanupPVC := createLustrePVC("lustre-disrupt-pvc-")
+		defer cleanupPVC()
+
+		ginkgo.By("Fetching the bound PVC to read its PV name")
+		boundPVC, err := f.ClientSet.CoreV1().PersistentVolumeClaims(f.Namespace.Name).Get(ctx, pvc.Name, metav1.GetOptions{})
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Extracting the Lustre instance IP from the PV volume attributes")
+		pv, err := f.ClientSet.CoreV1().PersistentVolumes().Get(ctx, boundPVC.Spec.VolumeName, metav1.GetOptions{})
+		framework.ExpectNoError(err)
+		lustreIP := pv.Spec.CSI.VolumeAttributes["ip"]
+		if lustreIP == "" {
+			framework.Failf("could not extract Lustre instance IP from PV %s volume attributes; got: %v",
+				pv.Name, pv.Spec.CSI.VolumeAttributes)
+		}
+		framework.Logf("Lustre instance IP: %s", lustreIP)
+
+		ginkgo.By("Configuring the pod with both GCS Fuse and Lustre volumes")
+		tPod := specs.NewTestPod(f.ClientSet, f.Namespace)
+		tPod.SetupVolume(l.gcsFuseResource, gcsFuseLustreGCSVolName, gcsFuseLustreGCSMountPath, false)
+		tPod.SetupVolume(&storageframework.VolumeResource{Pvc: pvc}, gcsFuseLustreVolName, gcsFuseLustreMountPath, false)
+		tPod.Create(ctx)
+		defer tPod.Cleanup(ctx)
+		tPod.WaitForRunning(ctx)
+
+		ginkgo.By("Writing baseline data to both volumes to confirm they are initially healthy")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("echo 'gcs-baseline' > %v/baseline.txt", gcsFuseLustreGCSMountPath))
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("echo 'lustre-baseline' > %v/baseline.txt", gcsFuseLustreMountPath))
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("grep 'gcs-baseline' %v/baseline.txt && grep 'lustre-baseline' %v/baseline.txt",
+				gcsFuseLustreGCSMountPath, gcsFuseLustreMountPath))
+
+		ginkgo.By(fmt.Sprintf("Applying a NetworkPolicy to block port 988 egress to Lustre IP %s (simulating MDS/OSS network partition)", lustreIP))
+		tcpProto := corev1.ProtocolTCP
+		udpProto := corev1.ProtocolUDP
+		lustreCIDR := lustreIP + "/32"
+		port1 := intstr.FromInt32(1)
+		port989 := intstr.FromInt32(989)
+		endPort987 := int32(987)
+		endPort65535 := int32(65535)
+
+		// The policy allows all egress to non-Lustre destinations (covering GCS,
+		// DNS, k8s API, etc.) and allows non-988 ports to the Lustre IP. Port 988
+		// (Lustre wire protocol) to the Lustre instance IP is left unmatched and
+		// therefore dropped by the namespace-scoped egress restriction.
+		netpol := &networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "block-lustre-port-",
+				Namespace:    f.Namespace.Name,
+			},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{},
+				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
+				Egress: []networkingv1.NetworkPolicyEgressRule{
+					// Allow all egress to IPs other than the Lustre instance.
+					{
+						To: []networkingv1.NetworkPolicyPeer{
+							{IPBlock: &networkingv1.IPBlock{CIDR: "0.0.0.0/0", Except: []string{lustreCIDR}}},
+						},
+					},
+					// Allow egress to the Lustre IP on ports 1–987 (pre-Lustre range).
+					{
+						To: []networkingv1.NetworkPolicyPeer{{IPBlock: &networkingv1.IPBlock{CIDR: lustreCIDR}}},
+						Ports: []networkingv1.NetworkPolicyPort{
+							{Protocol: &tcpProto, Port: &port1, EndPort: &endPort987},
+							{Protocol: &udpProto, Port: &port1, EndPort: &endPort987},
+						},
+					},
+					// Allow egress to the Lustre IP on ports 989–65535 (post-Lustre range).
+					{
+						To: []networkingv1.NetworkPolicyPeer{{IPBlock: &networkingv1.IPBlock{CIDR: lustreCIDR}}},
+						Ports: []networkingv1.NetworkPolicyPort{
+							{Protocol: &tcpProto, Port: &port989, EndPort: &endPort65535},
+							{Protocol: &udpProto, Port: &port989, EndPort: &endPort65535},
+						},
+					},
+				},
+			},
+		}
+		netpol, err = f.ClientSet.NetworkingV1().NetworkPolicies(f.Namespace.Name).Create(ctx, netpol, metav1.CreateOptions{})
+		framework.ExpectNoError(err)
+		defer func() {
+			if netpol != nil {
+				_ = f.ClientSet.NetworkingV1().NetworkPolicies(f.Namespace.Name).Delete(
+					ctx, netpol.Name, metav1.DeleteOptions{})
+			}
+		}()
+
+		ginkgo.By("Verifying GCS Fuse mount remains readable while Lustre port 988 is blocked")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("grep 'gcs-baseline' %v/baseline.txt", gcsFuseLustreGCSMountPath))
+
+		ginkgo.By("Verifying GCS Fuse mount remains writable while Lustre port 988 is blocked")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("echo 'gcs-during-disruption' > %v/during.txt && grep 'gcs-during-disruption' %v/during.txt",
+				gcsFuseLustreGCSMountPath, gcsFuseLustreGCSMountPath))
+
+		ginkgo.By("Verifying the GCS Fuse FUSE mount is still present in the mount table during disruption")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("mount | grep %v", gcsFuseLustreGCSMountPath))
+
+		ginkgo.By("Removing the NetworkPolicy to restore Lustre port 988 connectivity")
+		framework.ExpectNoError(f.ClientSet.NetworkingV1().NetworkPolicies(f.Namespace.Name).Delete(
+			ctx, netpol.Name, metav1.DeleteOptions{}))
+		netpol = nil // prevent double deletion in deferred cleanup
+
+		ginkgo.By("Waiting 60s for the Lustre client to reconnect after connectivity is restored")
+		time.Sleep(60 * time.Second)
+
+		ginkgo.By("Verifying Lustre mount is readable after recovery")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("grep 'lustre-baseline' %v/baseline.txt", gcsFuseLustreMountPath))
+
+		ginkgo.By("Verifying Lustre mount is writable after recovery")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("echo 'lustre-recovered' > %v/recovery.txt && grep 'lustre-recovered' %v/recovery.txt",
+				gcsFuseLustreMountPath, gcsFuseLustreMountPath))
+
+		ginkgo.By("Verifying both mounts are healthy after Lustre recovery")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("mount | grep %v", gcsFuseLustreGCSMountPath))
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("mount | grep %v", gcsFuseLustreMountPath))
 	})
 }

--- a/test/e2e/testsuites/gcsfuse_lustre.go
+++ b/test/e2e/testsuites/gcsfuse_lustre.go
@@ -1,0 +1,221 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+Copyright 2022 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testsuites
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"local/test/e2e/specs"
+
+	"github.com/onsi/ginkgo/v2"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
+	e2evolume "k8s.io/kubernetes/test/e2e/framework/volume"
+	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+const (
+	gcsFuseLustreCSIDriverName = "lustre.csi.storage.gke.io"
+	gcsFuseLustreMountPath     = "/mnt/lustre"
+	gcsFuseLustreVolName       = "lustre-vol"
+	gcsFuseLustreGCSMountPath  = "/mnt/gcs"
+	gcsFuseLustreGCSVolName    = "gcs-vol"
+	gcsFuseLustrePVCSize       = "9000Gi"
+	// gcsFuseLustrePVCBindTimeout accounts for Managed Lustre instance
+	// provisioning, which can take 10+ minutes for large capacities like
+	// gcsFuseLustrePVCSize.
+	gcsFuseLustrePVCBindTimeout = 20 * time.Minute
+)
+
+type gcsFuseLustrePerfResilienceTestSuite struct {
+	tsInfo storageframework.TestSuiteInfo
+}
+
+// InitGcsFuseLustrePerfResilienceTestSuite returns
+// gcsFuseLustrePerfResilienceTestSuite that implements TestSuite interface.
+func InitGcsFuseLustrePerfResilienceTestSuite() storageframework.TestSuite {
+	return &gcsFuseLustrePerfResilienceTestSuite{
+		tsInfo: storageframework.TestSuiteInfo{
+			Name: "gcsfuse-lustre-perf-resilience",
+			TestPatterns: []storageframework.TestPattern{
+				storageframework.DefaultFsPreprovisionedPV,
+			},
+		},
+	}
+}
+
+func (t *gcsFuseLustrePerfResilienceTestSuite) GetTestSuiteInfo() storageframework.TestSuiteInfo {
+	return t.tsInfo
+}
+
+func (t *gcsFuseLustrePerfResilienceTestSuite) SkipUnsupportedTests(_ storageframework.TestDriver, _ storageframework.TestPattern) {
+}
+
+func (t *gcsFuseLustrePerfResilienceTestSuite) DefineTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {
+	type local struct {
+		config          *storageframework.PerTestConfig
+		gcsFuseResource *storageframework.VolumeResource
+	}
+	var l local
+	ctx := context.Background()
+
+	f := framework.NewFrameworkWithCustomTimeouts("gcsfuse-lustre-perf-resilience", storageframework.GetDriverTimeouts(driver))
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	init := func() {
+		l = local{}
+		l.config = driver.PrepareTest(ctx, f)
+		l.config.Prefix = specs.SkipCSIBucketAccessCheckPrefix
+		l.gcsFuseResource = storageframework.CreateVolumeResource(ctx, driver, l.config, pattern, e2evolume.SizeRange{})
+	}
+
+	cleanup := func() {
+		if l.gcsFuseResource != nil {
+			framework.ExpectNoError(l.gcsFuseResource.CleanupResource(ctx))
+		}
+	}
+
+	// skipIfLustreNotAvailable skips the test when the Lustre CSIDriver is not
+	// installed on the cluster, no StorageClass is configured, or the named
+	// StorageClass doesn't exist on the cluster. The lustre-rwx StorageClass is
+	// not created automatically by the Lustre CSI driver/addon — its `network`
+	// parameter must match the cluster's VPC, so it has to be created per
+	// cluster (see docs/lustre-gcsfuse-dual-mount-cluster-setup.md). Checking
+	// for it here avoids createLustrePVC hanging for its full bind timeout on a
+	// PVC that can never be provisioned.
+	skipIfLustreNotAvailable := func(testName string) {
+		if LustreStorageClass == "" {
+			e2eskipper.Skipf("--lustre-storage-class not set, skipping %s", testName)
+		}
+		if _, err := f.ClientSet.StorageV1().CSIDrivers().Get(ctx, gcsFuseLustreCSIDriverName, metav1.GetOptions{}); err != nil {
+			e2eskipper.Skipf("%s CSIDriver not found, skipping %s: %v", gcsFuseLustreCSIDriverName, testName, err)
+		}
+		if _, err := f.ClientSet.StorageV1().StorageClasses().Get(ctx, LustreStorageClass, metav1.GetOptions{}); err != nil {
+			e2eskipper.Skipf("StorageClass %q not found, skipping %s: %v. Create it first (see docs/lustre-gcsfuse-dual-mount-cluster-setup.md).", LustreStorageClass, testName, err)
+		}
+	}
+
+	// createLustrePVC dynamically provisions a Lustre-backed PVC via
+	// LustreStorageClass and waits for it to reach Bound before returning, so
+	// callers can safely attach it to a pod immediately. Managed Lustre
+	// instance provisioning can take several minutes for large capacities, so
+	// this uses a generous timeout.
+	createLustrePVC := func(namePrefix string) (*corev1.PersistentVolumeClaim, func()) {
+		scName := LustreStorageClass
+		pvc := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: namePrefix,
+				Namespace:    f.Namespace.Name,
+			},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany},
+				StorageClassName: &scName,
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceStorage: resource.MustParse(gcsFuseLustrePVCSize),
+					},
+				},
+			},
+		}
+		pvc, err := f.ClientSet.CoreV1().PersistentVolumeClaims(f.Namespace.Name).Create(ctx, pvc, metav1.CreateOptions{})
+		framework.ExpectNoError(err)
+		ginkgo.By(fmt.Sprintf("Waiting for Lustre PVC %s to be bound (up to %v, silently polling)", pvc.Name, gcsFuseLustrePVCBindTimeout))
+		start := time.Now()
+		framework.ExpectNoError(wait.PollUntilContextTimeout(ctx, framework.Poll, gcsFuseLustrePVCBindTimeout, true, func(ctx context.Context) (bool, error) {
+			current, err := f.ClientSet.CoreV1().PersistentVolumeClaims(f.Namespace.Name).Get(ctx, pvc.Name, metav1.GetOptions{})
+			if err != nil {
+				return false, nil
+			}
+			return current.Status.Phase == corev1.ClaimBound, nil
+		}))
+		framework.Logf("Lustre PVC %s bound after %v", pvc.Name, time.Since(start))
+		return pvc, func() {
+			framework.ExpectNoError(f.ClientSet.CoreV1().PersistentVolumeClaims(f.Namespace.Name).Delete(
+				ctx, pvc.Name, metav1.DeleteOptions{}))
+		}
+	}
+
+	// Large file / high-throughput transfer: writes a 1 GB file on Lustre,
+	// copies it to GCS Fuse and back, verifies checksums match in both
+	// directions, and confirms both mounts remain stable throughout.
+	ginkgo.It("should transfer a 1GB file between Lustre and GCS Fuse mounts with matching checksums and no mount instability", func() {
+		skipIfLustreNotAvailable("large file high-throughput transfer test")
+
+		init()
+		defer cleanup()
+
+		ginkgo.By("Creating a dynamically provisioned Lustre PVC")
+		pvc, cleanupPVC := createLustrePVC("lustre-largefile-pvc-")
+		defer cleanupPVC()
+
+		ginkgo.By("Configuring the pod with both GCS Fuse and Lustre volumes")
+		tPod := specs.NewTestPod(f.ClientSet, f.Namespace)
+		tPod.SetupVolume(l.gcsFuseResource, gcsFuseLustreGCSVolName, gcsFuseLustreGCSMountPath, false)
+		tPod.SetupVolume(&storageframework.VolumeResource{Pvc: pvc}, gcsFuseLustreVolName, gcsFuseLustreMountPath, false)
+		tPod.Create(ctx)
+		defer tPod.Cleanup(ctx)
+		tPod.WaitForRunning(ctx)
+
+		ginkgo.By("Writing a 1 GB file to the Lustre mount")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("dd if=/dev/urandom of=%v/large.bin bs=1M count=1024 conv=fsync", gcsFuseLustreMountPath))
+
+		ginkgo.By("Computing checksum of the source file on Lustre")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("md5sum %v/large.bin > /tmp/lustre.md5", gcsFuseLustreMountPath))
+
+		ginkgo.By("Copying the 1 GB file from Lustre to GCS Fuse")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("cp %v/large.bin %v/large.bin", gcsFuseLustreMountPath, gcsFuseLustreGCSMountPath))
+
+		ginkgo.By("Verifying the checksum of the file on GCS Fuse matches the Lustre source")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf(
+				"md5sum %v/large.bin > /tmp/gcs.md5 && "+
+					"LUSTRE_SUM=$(awk '{print $1}' /tmp/lustre.md5) && "+
+					"GCS_SUM=$(awk '{print $1}' /tmp/gcs.md5) && "+
+					"[ \"$LUSTRE_SUM\" = \"$GCS_SUM\" ]",
+				gcsFuseLustreGCSMountPath))
+
+		ginkgo.By("Copying the file back from GCS Fuse to Lustre")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("cp %v/large.bin %v/large-from-gcs.bin", gcsFuseLustreGCSMountPath, gcsFuseLustreMountPath))
+
+		ginkgo.By("Verifying the round-trip checksum matches the original")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf(
+				"md5sum %v/large-from-gcs.bin > /tmp/back.md5 && "+
+					"LUSTRE_SUM=$(awk '{print $1}' /tmp/lustre.md5) && "+
+					"BACK_SUM=$(awk '{print $1}' /tmp/back.md5) && "+
+					"[ \"$LUSTRE_SUM\" = \"$BACK_SUM\" ]",
+				gcsFuseLustreMountPath))
+
+		ginkgo.By("Verifying both mounts remain stable after large transfers")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("mount | grep %v", gcsFuseLustreMountPath))
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName,
+			fmt.Sprintf("mount | grep %v", gcsFuseLustreGCSMountPath))
+	})
+}


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:

Adds a new e2e test suite (`gcsfuse-lustre-perf-resilience`) in `test/e2e/testsuites/gcsfuse_lustre.go` covering pods that mount both a GCS Fuse volume and a dynamically-provisioned Lustre (`lustre.csi.storage.gke.io`) volume together. This suite extends the GCS Fuse + Lustre combination coverage with performance, caching, and resilience scenarios:

- **Large-file / high-throughput transfer**: writes a 1GB file to Lustre, copies it to GCS Fuse and back, and verifies checksums match in both directions with no mount instability.
- **Mixed I/O pattern**: runs concurrent small-file writes on GCS Fuse alongside sequential large-file I/O on Lustre, verifying no cross-driver contention and that both mounts stay healthy.
- **GCS Fuse file-cache backed by Lustre**: backs the GCS Fuse sidecar's file-cache volume with a Lustre PVC instead of the default node-local emptyDir, and verifies cache entries persist and are served correctly across a pod restart.
- **Lustre disruption resilience**: applies a NetworkPolicy that blocks egress on port 988 (Lustre wire protocol) to simulate an MDS/OSS network partition, verifying the GCS Fuse mount stays fully operational throughout, then confirms Lustre recovers once connectivity is restored.
- **Cross-mount permission/ownership consistency**: copies files between a uid-mapped GCS Fuse mount and a native-POSIX Lustre mount, verifying GCS Fuse remaps ownership to its configured uid while Lustre preserves the real process-owner uid/gid.

Each test skips cleanly (rather than failing or hanging) when the Lustre CSI driver, `--lustre-storage-class` flag, or the named StorageClass isn't available on the cluster.

**Which issue(s) this PR fixes**:

N/A

**Does this PR introduce a user-facing change?**:

```
None
```