### PR TITLE
Automated cherry pick of #1365: Vulnerability fix: prevent symlink traversal and hijack in unprivileged directories

### DIFF
--- a/pkg/csi_driver/utils.go
+++ b/pkg/csi_driver/utils.go
@@ -20,11 +20,14 @@ package driver
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
+
+	"golang.org/x/sys/unix"
 
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util"
@@ -420,14 +423,24 @@ func putExitFile(pod *corev1.Pod, targetPath string) error {
 		}
 
 		exitFilePath := filepath.Dir(emptyDirBasePath) + "/exit"
-		f, err := os.Create(exitFilePath)
-		if err != nil {
-			return fmt.Errorf("failed to put the exit file: %w", err)
-		}
-		f.Close()
+		exitParentDir := filepath.Dir(exitFilePath)
 
-		err = os.Chown(exitFilePath, webhook.NobodyUID, webhook.NobodyGID)
+		// Pin the parent directory by opening its file descriptor with O_DIRECTORY and O_NOFOLLOW.
+		// This locks the parent directory inode in memory, preventing concurrent TOCTOU symlink-swapping
+		// attacks during subsequent relative operations (using unix.Openat).
+		parentFd, err := unix.Open(exitParentDir, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW, 0)
 		if err != nil {
+			return fmt.Errorf("failed to open parent directory %q: %w", exitParentDir, err)
+		}
+		defer unix.Close(parentFd)
+
+		fd, err := unix.Openat(parentFd, filepath.Base(exitFilePath), unix.O_RDWR|unix.O_CREAT|unix.O_TRUNC|unix.O_NOFOLLOW, 0644)
+		if err != nil {
+			return fmt.Errorf("failed to securely open exit file: %w", err)
+		}
+		f := os.NewFile(uintptr(fd), exitFilePath)
+		defer f.Close()
+		if err := f.Chown(webhook.NobodyUID, webhook.NobodyGID); err != nil {
 			return fmt.Errorf("failed to change ownership on the exit file: %w", err)
 		}
 	}
@@ -452,21 +465,44 @@ func checkGcsFuseErr(isInitContainer bool, pod *corev1.Pod, targetPath string) (
 		return code, fmt.Errorf("failed to get emptyDir path: %w", err)
 	}
 
-	klog.V(4).Infof("checkGcsFuseErr read file %s", emptyDirBasePath+"/error")
+	errorFilePath := emptyDirBasePath + "/error"
+	klog.V(4).Infof("[Pod %v/%v] checking sidecar container error status", pod.Namespace, pod.Name)
 
-	errMsg, err := os.ReadFile(emptyDirBasePath + "/error")
-	if err != nil && !os.IsNotExist(err) {
-		return code, fmt.Errorf("failed to open error file %q: %w", emptyDirBasePath+"/error", err)
+	parentDir := filepath.Dir(errorFilePath)
+
+	// Pin the parent directory by opening its file descriptor with O_DIRECTORY and O_NOFOLLOW.
+	// This locks the parent directory inode in memory, preventing concurrent TOCTOU symlink-swapping
+	// attacks during subsequent relative operations (using unix.Openat).
+	parentFd, err := unix.Open(parentDir, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return codes.OK, nil
+		}
+		return code, fmt.Errorf("failed to open parent directory %q: %w", parentDir, err)
+	}
+	defer unix.Close(parentFd)
+
+	fd, err := unix.Openat(parentFd, filepath.Base(errorFilePath), unix.O_RDONLY|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return codes.OK, nil
+		}
+		return code, fmt.Errorf("failed to open error file %q: %w", errorFilePath, err)
 	}
 
-	return extractErrorFromGcsFuseErrorFile(errMsg, err)
+	f := os.NewFile(uintptr(fd), errorFilePath)
+	defer f.Close()
+
+	errMsg, err := io.ReadAll(f)
+	if err != nil {
+		return code, fmt.Errorf("failed to read error file %q: %w", errorFilePath, err)
+	}
+
+	return extractErrorFromGcsFuseErrorFile(errMsg)
 }
 
-func extractErrorFromGcsFuseErrorFile(errMsg []byte, err error) (codes.Code, error) {
-	if err != nil && !os.IsNotExist(err) {
-		return codes.Internal, fmt.Errorf("error occurred while trying to read gcsfuse error file: %w", err)
-	}
-	if err == nil && len(errMsg) > 0 {
+func extractErrorFromGcsFuseErrorFile(errMsg []byte) (codes.Code, error) {
+	if len(errMsg) > 0 {
 		// TODO: We need a standard for scraping errors from GCSFuse.
 		// A change in string format in GCSFuse would break this function.
 		// If we are aware of such change, its also tedious to catch and
@@ -603,17 +639,28 @@ func PutFlagsFromDriverToTargetPath(flagMap map[string]string, targetPath string
 	absolutePath := filepath.Dir(emptyDirBasePath) + "/" + fileName
 	klog.V(4).Infof("Writing flags needed for gcsfuse defaulting logic to file %q: %v", absolutePath, flagMap)
 
-	// This file is truncated/cleared if it already exists.
-	f, err := os.Create(absolutePath)
+	parentDir := filepath.Dir(emptyDirBasePath)
+
+	// Pin the parent directory by opening its file descriptor with O_DIRECTORY and O_NOFOLLOW.
+	// This locks the parent directory inode in memory, preventing concurrent TOCTOU symlink-swapping
+	// attacks during subsequent relative operations (using unix.Openat).
+	parentFd, err := unix.Open(parentDir, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW, 0)
 	if err != nil {
-		return fmt.Errorf("failed to create defaulting-flag file: %w", err)
+		return fmt.Errorf("failed to open parent directory %q: %w", parentDir, err)
 	}
+	defer unix.Close(parentFd)
+
+	fd, err := unix.Openat(parentFd, filepath.Base(fileName), unix.O_RDWR|unix.O_CREAT|unix.O_TRUNC|unix.O_NOFOLLOW, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to securely open defaulting-flag file: %w", err)
+	}
+	f := os.NewFile(uintptr(fd), absolutePath)
+	defer f.Close()
+
 	content := prepareFileContentFromFlagMap(flagMap)
 	if _, err := f.WriteString(content); err != nil {
 		return fmt.Errorf("failed to write defaulting-flag file: %w", err)
 	}
-
-	f.Close()
 
 	return nil
 }

--- a/pkg/csi_driver/utils_test.go
+++ b/pkg/csi_driver/utils_test.go
@@ -19,7 +19,6 @@ package driver
 
 import (
 	"fmt"
-	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -41,7 +40,6 @@ func TestExtractErrorFromGcsFuseErrorFile(t *testing.T) {
 		testCases := []struct {
 			name                string
 			errorMessage        []byte
-			err                 error
 			expectedCode        codes.Code
 			expectedErrorSubstr string
 		}{
@@ -91,18 +89,6 @@ func TestExtractErrorFromGcsFuseErrorFile(t *testing.T) {
 				expectedCode: codes.Internal,
 			},
 			{
-				name:         "internal error passed in",
-				errorMessage: []byte(""),
-				expectedCode: codes.Internal,
-				err:          fmt.Errorf("Some error that occurred trying to read the gcsfuse error file"),
-			},
-			{
-				name:         "no error",
-				errorMessage: []byte(""),
-				expectedCode: codes.OK,
-				err:          os.ErrNotExist,
-			},
-			{
 				name:                "sidecar bucket access checked error bucket does not exist",
 				errorMessage:        []byte(fmt.Sprintf("%v: bucket doesn't exist", util.SidecarBucketAccessCheckErrorPrefix)),
 				expectedCode:        codes.NotFound,
@@ -130,7 +116,7 @@ func TestExtractErrorFromGcsFuseErrorFile(t *testing.T) {
 
 		for _, tc := range testCases {
 			t.Logf("test case: %s", tc.name)
-			actualCode, err := extractErrorFromGcsFuseErrorFile(tc.errorMessage, tc.err)
+			actualCode, err := extractErrorFromGcsFuseErrorFile(tc.errorMessage)
 			if actualCode != tc.expectedCode {
 				t.Errorf("Got value %v, but expected %v", actualCode, tc.expectedCode)
 			}

--- a/pkg/csi_mounter/csi_mounter.go
+++ b/pkg/csi_mounter/csi_mounter.go
@@ -274,17 +274,23 @@ func (m *Mounter) createSocket(target string, logPrefix string) (net.Listener, e
 	// 3. Change ownership of the mount socket itself.
 
 	targetSocketPath := filepath.Join(emptyDirBasePath, socketName)
+	baseDir := filepath.Dir(emptyDirBasePath)
+	if err := util.CheckNotSymlink(baseDir); err != nil {
+		return nil, fmt.Errorf("failed to verify base directory before changing ownership: %w", err)
+	}
 	// First changing ownership of parent directory where socket resides.
 	// Full path: /var/lib/kubelet/pods/<pod-uid>/volumes/kubernetes.io~empty-dir/gke-gcsfuse-tmp/.volumes/
-	baseDir := filepath.Dir(emptyDirBasePath)
-	if err = os.Chown(baseDir, webhook.NobodyUID, webhook.NobodyGID); err != nil {
+	if err = os.Lchown(baseDir, webhook.NobodyUID, webhook.NobodyGID); err != nil {
 		return nil, fmt.Errorf("failed to change ownership on base of emptyDirBasePath: %w", err)
 	}
 	klog.V(4).Infof("Chown on basedir %s done", baseDir)
 
+	if err = util.CheckNotSymlink(emptyDirBasePath); err != nil {
+		return nil, fmt.Errorf("failed to verify volume directory before changing ownership: %w", err)
+	}
 	// Changing ownership of base path directory.
 	// Full path: /var/lib/kubelet/pods/<pod-uid>/volumes/kubernetes.io~empty-dir/gke-gcsfuse-tmp/.volumes/my-vol
-	if err = os.Chown(emptyDirBasePath, webhook.NobodyUID, webhook.NobodyGID); err != nil {
+	if err = os.Lchown(emptyDirBasePath, webhook.NobodyUID, webhook.NobodyGID); err != nil {
 		return nil, fmt.Errorf("failed to change ownership on emptyDirBasePath: %w", err)
 	}
 	_, err = os.Stat(emptyDirBasePath)
@@ -294,9 +300,12 @@ func (m *Mounter) createSocket(target string, logPrefix string) (net.Listener, e
 
 	klog.V(4).Infof("Chown on emptyDirBasePath %s success", emptyDirBasePath)
 
+	if err := util.CheckNotSymlink(targetSocketPath); err != nil {
+		return nil, fmt.Errorf("failed to verify socket path before changing ownership: %w", err)
+	}
 	// Changing ownership of socket itself.
 	// Full path: /var/lib/kubelet/pods/<pod-uid>/volumes/kubernetes.io~empty-dir/gke-gcsfuse-tmp/.volumes/my-vol/socket
-	if err = os.Chown(targetSocketPath, webhook.NobodyUID, webhook.NobodyGID); err != nil {
+	if err = os.Lchown(targetSocketPath, webhook.NobodyUID, webhook.NobodyGID); err != nil {
 		return nil, fmt.Errorf("failed to change ownership on targetSocketPath: %w", err)
 	}
 

--- a/pkg/util/kernel_params_contract.go
+++ b/pkg/util/kernel_params_contract.go
@@ -20,7 +20,11 @@ package util
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
 )
 
 // File kernel_params_contract.go defines the strict schema and contract used for
@@ -95,10 +99,29 @@ type KernelParamsConfig struct {
 // It returns error in case of contract mismatch or parsing error.
 // GCSFuse writes this file atomically so it's safe to read this file at any point.
 func parseKernelParamsConfig(kernelParamsFilePath string) (*KernelParamsConfig, error) {
-	data, err := os.ReadFile(kernelParamsFilePath)
+	parentDir := filepath.Dir(kernelParamsFilePath)
+
+	// Pin the parent directory by opening its file descriptor with O_DIRECTORY and O_NOFOLLOW.
+	// This locks the parent directory inode in memory, preventing concurrent TOCTOU symlink-swapping
+	// attacks during subsequent relative operations (using unix.Openat).
+	parentFd, err := unix.Open(parentDir, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open parent directory %q: %w", parentDir, err)
+	}
+	defer unix.Close(parentFd)
+
+	fd, err := unix.Openat(parentFd, filepath.Base(kernelParamsFilePath), unix.O_RDONLY|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open kernel params file %q: %w", kernelParamsFilePath, err)
+	}
+	f := os.NewFile(uintptr(fd), kernelParamsFilePath)
+	defer f.Close()
+
+	data, err := io.ReadAll(f)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read kernel params file %q: %w", kernelParamsFilePath, err)
 	}
+
 	var config KernelParamsConfig
 	if err := json.Unmarshal(data, &config); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal kernel params config: %w", err)

--- a/pkg/util/kernel_params_monitoring.go
+++ b/pkg/util/kernel_params_monitoring.go
@@ -56,8 +56,8 @@ func getDeviceMajorMinor(targetPath string) (major uint32, minor uint32, err err
 // parses the configuration, and applies the parameters to the system if they differ
 // from the current values.
 func checkAndApplyKernelParams(kernelParamsFilePath string, pathForParam map[ParamName]string, logPrefix string) error {
-	// Check for file existence to avoid unnecessary parsing attempts.
-	if _, statErr := os.Stat(kernelParamsFilePath); statErr != nil {
+	// Check for file existence to avoid unnecessary parsing attempts. Use Lstat to prevent following symlinks.
+	if _, statErr := os.Lstat(kernelParamsFilePath); statErr != nil {
 		// If file is missing, wait for the next interval.
 		return nil
 	}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -300,3 +300,15 @@ func ParseBool(str string) (bool, error) {
 		return false, fmt.Errorf("could not parse string to bool: the acceptable values for %q are 'True', 'true', 'false' or 'False'", str)
 	}
 }
+// CheckNotSymlink verifies that the given path is not a symbolic link.
+// This is used to prevent TOCTOU symlink takeover attacks.
+func CheckNotSymlink(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return fmt.Errorf("failed to stat path %q: %w", path, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("security error: path %q is a symlink", path)
+	}
+	return nil
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -300,6 +300,7 @@ func ParseBool(str string) (bool, error) {
 		return false, fmt.Errorf("could not parse string to bool: the acceptable values for %q are 'True', 'true', 'false' or 'False'", str)
 	}
 }
+
 // CheckNotSymlink verifies that the given path is not a symbolic link.
 // This is used to prevent TOCTOU symlink takeover attacks.
 func CheckNotSymlink(path string) error {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -549,3 +549,74 @@ func TestIsGKEIdentityProvider(t *testing.T) {
 		}
 	}
 }
+func TestCheckNotSymlink(t *testing.T) {
+	t.Parallel()
+
+	// Set up a temporary directory for the test files
+	base, err := os.MkdirTemp("", "symlink-test")
+	if err != nil {
+		t.Fatalf("failed to setup testdir: %v", err)
+	}
+	defer os.RemoveAll(base)
+
+	// Create test files, directories, and symlinks
+	normalFile := filepath.Join(base, "normal.txt")
+	os.WriteFile(normalFile, []byte("test data"), 0644)
+
+	normalDir := filepath.Join(base, "normal_dir")
+	os.MkdirAll(normalDir, 0755)
+
+	symlinkToFile := filepath.Join(base, "symlink_file")
+	os.Symlink(normalFile, symlinkToFile)
+
+	symlinkToDir := filepath.Join(base, "symlink_dir")
+	os.Symlink(normalDir, symlinkToDir)
+
+	nonExistentPath := filepath.Join(base, "does_not_exist")
+
+	testCases := []struct {
+		name          string
+		path          string
+		expectedError bool
+	}{
+		{
+			name:          "regular file should pass",
+			path:          normalFile,
+			expectedError: false,
+		},
+		{
+			name:          "regular directory should pass",
+			path:          normalDir,
+			expectedError: false,
+		},
+		{
+			name:          "symlink to file should fail",
+			path:          symlinkToFile,
+			expectedError: true,
+		},
+		{
+			name:          "symlink to directory should fail",
+			path:          symlinkToDir,
+			expectedError: true,
+		},
+		{
+			name:          "non-existent path should fail",
+			path:          nonExistentPath,
+			expectedError: true, // os.Lstat returns an error for non-existent files
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := CheckNotSymlink(tc.path)
+
+			if tc.expectedError && err == nil {
+				t.Errorf("Expected error but got none")
+			}
+
+			if !tc.expectedError && err != nil {
+				t.Errorf("Did not expect error but got: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Cherry pick of #1365 on release-1.22.

#1365: Vulnerability fix: prevent symlink traversal and hijack in unprivileged directories

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```