### PR TITLE
Bump GCSFuse binary to 3.10.0

### DIFF
--- a/cmd/sidecar_mounter/gcsfuse_binary
+++ b/cmd/sidecar_mounter/gcsfuse_binary
@@ -1,1 +1,1 @@
-gs://gke-release-staging/gcsfuse/v3.9.2-gke.0/gcsfuse_bin
+gs://gke-release-staging/gcsfuse/v3.10.0-gke.0/gcsfuse_bin


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:
Bump GCSFuse binary to 3.10.0

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
I did not test since no new tests are needed, and GCSFuse master branch testgrid is green : https://testgrid.corp.google.com/gcs-fuse-csi-driver#gke-1.36-standard-regional-master, and matching our testgrid on 3.9.2: https://testgrid.corp.google.com/gcs-fuse-csi-driver#gke-1.36-standard-regional. I confirmed the GCS binary exists in gs://gke-release-staging/gcsfuse/v3.10.0-gke.0

I will monitor the testgrid after merging. 


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Bump GCSFuse binary to 3.10.0
```