### PR TITLE
Implement NodePublishVolume for shared mount

### DIFF
--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -90,6 +90,48 @@ func (s *nodeServer) NodeGetCapabilities(_ context.Context, _ *csi.NodeGetCapabi
 	}, nil
 }
 
+func (s *nodeServer) NodePublishVolumeForSharedMount(_ context.Context, req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
+	// Validate arguments
+	stagingPath := req.GetStagingTargetPath()
+	if len(stagingPath) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "NodePublishVolume Staging Target Path must be provided")
+	}
+	publishContext := req.GetPublishContext()
+	if publishContext == nil {
+		return nil, status.Error(codes.InvalidArgument, "NodePublishVolume Publish Context must be provided")
+	}
+	mounterPodNamespace := publishContext[PublishContextKeyMounterPodNamespace]
+	if len(mounterPodNamespace) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "NodePublishVolume Mounter Pod Namespace must be provided")
+	}
+	mounterPodName := publishContext[PublishContextKeyMounterPodName]
+	if len(mounterPodName) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "NodePublishVolume Mounter Pod Name must be provided")
+	}
+
+	// Verify mounter pod exists.
+	mounterPod, err := s.k8sClients.GetPod(mounterPodNamespace, mounterPodName)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, status.Errorf(codes.FailedPrecondition, "failed to get mounter pod: %v", err)
+		}
+		return nil, status.Errorf(codes.Internal, "failed to get mounter pod: %v", err)
+	}
+	if mounterPod == nil {
+		return nil, status.Errorf(codes.Internal, "mounter pod %s/%s cannot be nil", mounterPodNamespace, mounterPodName)
+	}
+
+	// NodePublish is guaranteed to be called after NodeStage has waited for mounter pod to become running.
+	// Mounter pod not running at this stage means that the pod started and failed (e.g. killed by Kubelet
+	// during OOMKILL).
+	if mounterPod.Status.Phase != corev1.PodRunning {
+		return nil, status.Errorf(codes.Internal, "mounter pod %s/%s was found with an unexpected status: %+v", mounterPodNamespace, mounterPodName, mounterPod.Status)
+	}
+
+	// TODO(urielguzman): Implement the rest of the NodePublishVolume logic for shared mount.
+	return &csi.NodePublishVolumeResponse{}, nil
+}
+
 func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
 	// Rate limit NodePublishVolume calls to avoid kube API throttling.
 	if err := s.limiter.Wait(ctx); err != nil {
@@ -102,8 +144,13 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 		return nil, status.Errorf(codes.InvalidArgument, "NodePublishVolume target path must be provided")
 	}
 
-	// Get the Pod object.
+	// Switch to shared mount logic if the volume context indicates that shared mount is enabled.
 	vc := req.GetVolumeContext()
+	if sharedMount(vc) {
+		return s.NodePublishVolumeForSharedMount(ctx, req)
+	}
+
+	// Get the Pod object.
 	pod, err := s.k8sClients.GetPod(vc[VolumeContextKeyPodNamespace], vc[VolumeContextKeyPodName])
 	if err != nil {
 		return nil, status.Errorf(codes.NotFound, "failed to get pod: %v", err)

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -107,27 +107,30 @@ func initTestNodeServerWithCustomClientset(t *testing.T, clientSet *clientset.Fa
 	}
 }
 
-func setupMountTarget(t *testing.T) (string, func()) {
+func setupTestDir(t *testing.T, path string) (string, func()) {
 	t.Helper()
-	defaultPerm := os.FileMode(0o750) + os.ModeDir
-	// Setup mount target path
-	tmpDir := "/tmp/var/lib/kubelet/pods/test-pod-id/volumes/kubernetes.io~csi/"
-	if err := os.MkdirAll(tmpDir, defaultPerm); err != nil {
-		t.Fatalf("failed to setup tmp dir path: %v", err)
-	}
-	base, err := os.MkdirTemp(tmpDir, "node-publish-")
+	// Create a temporary directory for the test
+	tempDir := t.TempDir()
+	// Append the full path
+	fullPath := filepath.Join(tempDir, path)
+	// Create the directory path (including any parent directories)
+	err := os.MkdirAll(fullPath, 0755)
 	if err != nil {
-		t.Fatalf("failed to setup testdir: %v", err)
+		t.Fatalf("failed to create path: %v", err)
 	}
-	testTargetPath := filepath.Join(base, "mount")
-	if err = os.MkdirAll(testTargetPath, defaultPerm); err != nil {
-		t.Fatalf("failed to setup target path: %v", err)
-	}
-	return testTargetPath, func() { defer os.RemoveAll(base) }
+	t.Logf("Created test path %q", fullPath)
+	return fullPath, func() { os.RemoveAll(tempDir) }
+}
+
+func setupTestTargetPath(t *testing.T) (string, func()) {
+	return setupTestDir(t, "/var/lib/kubelet/pods/test-pod-id/volumes/kubernetes.io~csi/node-publish/mount")
+}
+func setupTestStagingPath(t *testing.T) (string, func()) {
+	return setupTestDir(t, "/var/lib/kubelet/plugins/kubernetes.io/csi/gcsfuse.csi.storage.gke.io/fake-pv/globalmount")
 }
 
 func TestNodePublishVolume(t *testing.T) {
-	testTargetPath, cleanup := setupMountTarget(t)
+	testTargetPath, cleanup := setupTestTargetPath(t)
 	defer cleanup()
 
 	cases := []struct {
@@ -228,7 +231,7 @@ func TestNodePublishVolume(t *testing.T) {
 func TestExecuteNodeStageVolume(t *testing.T) {
 	t.Parallel()
 
-	stagingPath, cleanup := setupMountTarget(t)
+	stagingPath, cleanup := setupTestStagingPath(t)
 	defer cleanup()
 
 	nodeID := "test-node" // default from initTestDriver
@@ -369,7 +372,7 @@ func TestExecuteNodeStageVolume(t *testing.T) {
 
 func TestNodePublishVolumeWIDisabledOnNode(t *testing.T) {
 	t.Parallel()
-	testTargetPath, cleanup := setupMountTarget(t)
+	testTargetPath, cleanup := setupTestTargetPath(t)
 	defer cleanup()
 
 	req := &csi.NodePublishVolumeRequest{
@@ -425,7 +428,7 @@ func TestNodePublishVolumeWIDisabledOnNode(t *testing.T) {
 }
 
 func TestNodePublishVolumeMultiNIC(t *testing.T) {
-	testTargetPath, cleanup := setupMountTarget(t)
+	testTargetPath, cleanup := setupTestTargetPath(t)
 	defer cleanup()
 
 	for _, tc := range []struct {
@@ -662,7 +665,7 @@ func TestNodePublishVolumeEnableAutoGoMemLimit(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			testTargetPath, cleanup := setupMountTarget(t)
+			testTargetPath, cleanup := setupTestTargetPath(t)
 			defer cleanup()
 
 			volumeContext := map[string]string{
@@ -734,7 +737,7 @@ func TestNodePublishVolumeEnableAutoGoMemLimit(t *testing.T) {
 
 func TestNodeUnpublishVolume(t *testing.T) {
 	t.Parallel()
-	testTargetPath, cleanup := setupMountTarget(t)
+	testTargetPath, cleanup := setupTestTargetPath(t)
 	defer cleanup()
 
 	cases := []struct {
@@ -799,7 +802,7 @@ func TestNodeUnpublishVolume(t *testing.T) {
 func TestNodeStageVolume(t *testing.T) {
 	t.Parallel()
 
-	stagingPath, cleanup := setupMountTarget(t)
+	stagingPath, cleanup := setupTestStagingPath(t)
 	defer cleanup()
 	nodeID := "test-node" // default from initTestDriver
 	volID := testVolumeID
@@ -1003,7 +1006,7 @@ func TestNodeStageVolume(t *testing.T) {
 
 func TestNodeUnstageVolume(t *testing.T) {
 	t.Parallel()
-	stagingPath, cleanup := setupMountTarget(t)
+	stagingPath, cleanup := setupTestStagingPath(t)
 	defer cleanup()
 
 	cases := []struct {
@@ -1208,7 +1211,7 @@ func TestConcurrentMapWrites(t *testing.T) {
 func TestNodePublishVolumeWILabelCheck(t *testing.T) {
 	t.Parallel()
 
-	testTargetPath, cleanup := setupMountTarget(t)
+	testTargetPath, cleanup := setupTestTargetPath(t)
 	defer cleanup()
 
 	req := &csi.NodePublishVolumeRequest{
@@ -1294,7 +1297,7 @@ func TestNodePublishVolumeEnableGCSFuseKernelParams(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			testTargetPath, cleanup := setupMountTarget(t)
+			testTargetPath, cleanup := setupTestTargetPath(t)
 			defer cleanup()
 
 			req := &csi.NodePublishVolumeRequest{
@@ -1410,7 +1413,7 @@ func TestNodePublishVolumeRespectEnableSidecarBucketAccessCheck(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			testTargetPath, cleanup := setupMountTarget(t)
+			testTargetPath, cleanup := setupTestTargetPath(t)
 			defer cleanup()
 
 			volumeContext := map[string]string{
@@ -1649,7 +1652,7 @@ func TestCountGcsFuseVolumes(t *testing.T) {
 
 func TestNodePublishVolumeAssertMetricsCollectorRegistration(t *testing.T) {
 	t.Parallel()
-	testTargetPath, cleanup := setupMountTarget(t)
+	testTargetPath, cleanup := setupTestTargetPath(t)
 	defer cleanup()
 
 	baseReq := &csi.NodePublishVolumeRequest{
@@ -1819,7 +1822,7 @@ func TestNodePublishVolumeStorageEndpointInternal(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			testTargetPath, cleanup := setupMountTarget(t)
+			testTargetPath, cleanup := setupTestTargetPath(t)
 			defer cleanup()
 
 			req := &csi.NodePublishVolumeRequest{
@@ -1861,6 +1864,248 @@ func TestNodePublishVolumeStorageEndpointInternal(t *testing.T) {
 					if strings.HasPrefix(opt, "storage-endpoint-internal=") {
 						t.Errorf("found unexpected storage-endpoint-internal flag option: %s", opt)
 					}
+				}
+			}
+		})
+	}
+}
+
+func TestNodePublishVolumeForSharedMount(t *testing.T) {
+	t.Parallel()
+
+	nodeID := "test-node"
+	volID := testVolumeID
+	podNamespace := "test-ns"
+	podName := createMounterPodName(nodeID, volID)
+	podUID := types.UID(podName)
+
+	cases := []struct {
+		name          string
+		reqBuilder    func(t *testing.T, targetPath, stagingPath string) *csi.NodePublishVolumeRequest
+		setupClient   func() *clientset.FakeClientset
+		expectErrCode codes.Code
+	}{
+		{
+			name: "valid request - should succeed",
+			reqBuilder: func(t *testing.T, targetPath, stagingPath string) *csi.NodePublishVolumeRequest {
+				return &csi.NodePublishVolumeRequest{
+					TargetPath:        targetPath,
+					StagingTargetPath: stagingPath,
+					VolumeContext: map[string]string{
+						VolumeContextSharedNodeMount: "true",
+					},
+					PublishContext: map[string]string{
+						PublishContextKeyMounterPodName:      podName,
+						PublishContextKeyMounterPodNamespace: podNamespace,
+					},
+				}
+			},
+			setupClient: func() *clientset.FakeClientset {
+				fc := clientset.NewFakeClientset()
+				fc.CreatePod(clientset.FakePodConfig{
+					Name:      podName,
+					Namespace: podNamespace,
+					UID:       podUID,
+					PodStatus: &corev1.PodStatus{Phase: corev1.PodRunning},
+				})
+				return fc
+			},
+			expectErrCode: codes.OK,
+		},
+		{
+			name: "missing staging path - should return InvalidArgument error",
+			reqBuilder: func(t *testing.T, targetPath, stagingPath string) *csi.NodePublishVolumeRequest {
+				return &csi.NodePublishVolumeRequest{
+					TargetPath: targetPath,
+					// StagingTargetPath: "", // Missing
+					VolumeContext: map[string]string{
+						VolumeContextSharedNodeMount: "true",
+					},
+					PublishContext: map[string]string{
+						PublishContextKeyMounterPodName:      podName,
+						PublishContextKeyMounterPodNamespace: podNamespace,
+					},
+				}
+			},
+			setupClient:   func() *clientset.FakeClientset { return clientset.NewFakeClientset() },
+			expectErrCode: codes.InvalidArgument,
+		},
+		{
+			name: "missing target path - should return InvalidArgument error",
+			reqBuilder: func(t *testing.T, targetPath, stagingPath string) *csi.NodePublishVolumeRequest {
+				return &csi.NodePublishVolumeRequest{
+					// TargetPath:        "", // Missing
+					StagingTargetPath: stagingPath,
+					VolumeContext: map[string]string{
+						VolumeContextSharedNodeMount: "true",
+					},
+					PublishContext: map[string]string{
+						PublishContextKeyMounterPodName:      podName,
+						PublishContextKeyMounterPodNamespace: podNamespace,
+					},
+				}
+			},
+			setupClient:   func() *clientset.FakeClientset { return clientset.NewFakeClientset() },
+			expectErrCode: codes.InvalidArgument,
+		},
+		{
+			name: "missing publish context - should return InvalidArgument error",
+			reqBuilder: func(t *testing.T, targetPath, stagingPath string) *csi.NodePublishVolumeRequest {
+				return &csi.NodePublishVolumeRequest{
+					TargetPath:        targetPath,
+					StagingTargetPath: stagingPath,
+					VolumeContext: map[string]string{
+						VolumeContextSharedNodeMount: "true",
+					},
+					// PublishContext:    nil, // Missing
+				}
+			},
+			setupClient:   func() *clientset.FakeClientset { return clientset.NewFakeClientset() },
+			expectErrCode: codes.InvalidArgument,
+		},
+		{
+			name: "missing mounter pod namespace - should return InvalidArgument error",
+			reqBuilder: func(t *testing.T, targetPath, stagingPath string) *csi.NodePublishVolumeRequest {
+				return &csi.NodePublishVolumeRequest{
+					TargetPath:        targetPath,
+					StagingTargetPath: stagingPath,
+					PublishContext: map[string]string{
+						PublishContextKeyMounterPodName: podName,
+					},
+					VolumeContext: map[string]string{
+						VolumeContextSharedNodeMount: "true",
+					},
+				}
+			},
+			setupClient:   func() *clientset.FakeClientset { return clientset.NewFakeClientset() },
+			expectErrCode: codes.InvalidArgument,
+		},
+		{
+			name: "missing mounter pod name - should return InvalidArgument error",
+			reqBuilder: func(t *testing.T, targetPath, stagingPath string) *csi.NodePublishVolumeRequest {
+				return &csi.NodePublishVolumeRequest{
+					TargetPath:        targetPath,
+					StagingTargetPath: stagingPath,
+					PublishContext: map[string]string{
+						PublishContextKeyMounterPodNamespace: podNamespace,
+					},
+					VolumeContext: map[string]string{
+						VolumeContextSharedNodeMount: "true",
+					},
+				}
+			},
+			setupClient:   func() *clientset.FakeClientset { return clientset.NewFakeClientset() },
+			expectErrCode: codes.InvalidArgument,
+		},
+		{
+			name: "mounter pod not found - should return FailedPrecondition error",
+			reqBuilder: func(t *testing.T, targetPath, stagingPath string) *csi.NodePublishVolumeRequest {
+				return &csi.NodePublishVolumeRequest{
+					TargetPath:        targetPath,
+					StagingTargetPath: stagingPath,
+					PublishContext: map[string]string{
+						PublishContextKeyMounterPodName:      podName,
+						PublishContextKeyMounterPodNamespace: podNamespace,
+					},
+					VolumeContext: map[string]string{
+						VolumeContextSharedNodeMount: "true",
+					},
+				}
+			},
+			setupClient: func() *clientset.FakeClientset {
+				fc := clientset.NewFakeClientset()
+				fc.GetPodErr = apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, podName)
+				return fc
+			},
+			expectErrCode: codes.FailedPrecondition,
+		},
+		{
+			name: "mounter pod not running - should return Internal error",
+			reqBuilder: func(t *testing.T, targetPath, stagingPath string) *csi.NodePublishVolumeRequest {
+				return &csi.NodePublishVolumeRequest{
+					TargetPath:        targetPath,
+					StagingTargetPath: stagingPath,
+					PublishContext: map[string]string{
+						PublishContextKeyMounterPodName:      podName,
+						PublishContextKeyMounterPodNamespace: podNamespace,
+					},
+					VolumeContext: map[string]string{
+						VolumeContextSharedNodeMount: "true",
+					},
+				}
+			},
+			setupClient: func() *clientset.FakeClientset {
+				fc := clientset.NewFakeClientset()
+				fc.CreatePod(clientset.FakePodConfig{
+					Name:      podName,
+					Namespace: podNamespace,
+					UID:       podUID,
+					PodStatus: &corev1.PodStatus{Phase: corev1.PodFailed}, // Not running
+				})
+				return fc
+			},
+			expectErrCode: codes.Internal,
+		},
+		{
+			name: "error getting mounter pod - should return Internal error",
+			reqBuilder: func(t *testing.T, targetPath, stagingPath string) *csi.NodePublishVolumeRequest {
+				return &csi.NodePublishVolumeRequest{
+					TargetPath:        targetPath,
+					StagingTargetPath: stagingPath,
+					PublishContext: map[string]string{
+						PublishContextKeyMounterPodName:      podName,
+						PublishContextKeyMounterPodNamespace: podNamespace,
+					},
+					VolumeContext: map[string]string{
+						VolumeContextSharedNodeMount: "true",
+					},
+				}
+			},
+			setupClient: func() *clientset.FakeClientset {
+				fc := clientset.NewFakeClientset()
+				fc.GetPodErr = errors.New("simulated api server error")
+				return fc
+			},
+			expectErrCode: codes.Internal,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			testTargetPath, cleanupTarget := setupTestTargetPath(t)
+			defer cleanupTarget()
+
+			testStagingPath, cleanupStaging := setupTestStagingPath(t)
+			defer cleanupStaging()
+
+			fakeClientSet := tc.setupClient()
+			testEnv := initTestNodeServerWithCustomClientset(t, fakeClientSet, false)
+			ns, ok := testEnv.ns.(*nodeServer)
+			if !ok {
+				t.Fatalf("Failed to cast NodeServer to *nodeServer")
+			}
+
+			req := tc.reqBuilder(t, testTargetPath, testStagingPath)
+			// Fields not validated by the current function, but needed for other NodePublishVolume calls
+			req.VolumeId = volID
+			req.VolumeCapability = testVolumeCapability
+
+			_, err := ns.NodePublishVolume(context.TODO(), req)
+
+			if tc.expectErrCode != codes.OK {
+				if err == nil {
+					t.Errorf("Got error nil, expected error with code %v", tc.expectErrCode)
+				} else {
+					st, ok := status.FromError(err)
+					if !ok {
+						t.Errorf("Got non-status error %v, expected status error with code %v", err, tc.expectErrCode)
+					} else if st.Code() != tc.expectErrCode {
+						t.Errorf("Got error code %v, expected %v, err: %v", st.Code(), tc.expectErrCode, err)
+					}
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Got error %q, expected error nil", err)
 				}
 			}
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**: Impelement NodePublishVolume for shared node mount. This PR verifies basic arguments and verifies the mounter pod exists. If it does, it checks for its status. If it's non-running, it returns an error. This PR also allows NodePublishVolume to be continue the original code execution plan when shared mount is not enabled.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```