### PR TITLE
Automated cherry pick of #1494: Bump GCSFuse binary to 3.10.0

### DIFF
--- a/cmd/sidecar_mounter/gcsfuse_binary
+++ b/cmd/sidecar_mounter/gcsfuse_binary
@@ -1,1 +1,1 @@
-gs://gke-release-staging/gcsfuse/v3.9.2-gke.0/gcsfuse_bin
+gs://gke-release-staging/gcsfuse/v3.10.0-gke.0/gcsfuse_bin


### PR DESCRIPTION
Cherry pick of #1494 on release-1.23.

#1494: Bump GCSFuse binary to 3.10.0

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Bump GCSFuse binary to 3.10.0
```