### PR TITLE
Implement NodePublishVolumeForSharedMount logic to read gcsfuse error

### DIFF
--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -123,6 +123,20 @@ func (s *nodeServer) NodePublishVolumeForSharedMount(_ context.Context, req *csi
 		return nil, status.Errorf(codes.Internal, "mounter pod %s/%s cannot be nil", mounterPodNamespace, mounterPodName)
 	}
 
+	// Surface any GCSFuse error to the user.
+	if s.driver.config.FeatureOptions == nil || s.driver.config.FeatureOptions.SharedMountOptions == nil {
+		return nil, status.Error(codes.Internal, "shared mount options can't be nil")
+	}
+	config := s.driver.config.FeatureOptions.SharedMountOptions
+	if config.EmptyDirBasePath == nil {
+		return nil, status.Error(codes.Internal, "empty dir base path function can't be nil")
+	}
+	emptyDirPath := config.EmptyDirBasePath(string(mounterPod.UID))
+	code, err := checkMounterPodErrorFile(emptyDirPath)
+	if err != nil {
+		return nil, status.Error(code, err.Error())
+	}
+
 	// NodePublish is guaranteed to be called after NodeStage has waited for mounter pod to become running.
 	// Mounter pod not running at this stage means that the pod started and failed (e.g. killed by Kubelet
 	// during OOMKILL).
@@ -856,8 +870,13 @@ func (s *nodeServer) mountToNode(ctx context.Context, podUID, stagingPath, volum
 		return status.Errorf(codes.Internal, "failed to create dir for symlink %q: %v", symlink, err)
 	}
 
+	// Clear stale files from a previous mount attempt.
+	if err := util.CheckAndDeleteStaleFile(emptyDirBasePath, util.ErrorFileName); err != nil {
+		return status.Errorf(codes.Internal, "failed to check and delete stale error file: %v", err)
+	}
+	// Clear stale symlink from a previous mount attempt. os.Remove operates on symlinks, so it will not remove the target file if the symlink is stale.
 	if err := os.Remove(symlink); err != nil && !os.IsNotExist(err) {
-		klog.Errorf("failed to remove stale symlink %q: %v", symlink, err)
+		return status.Errorf(codes.Internal, "failed to remove stale symlink %q: %v", symlink, err)
 	}
 
 	if err := os.Symlink(socketFile, symlink); err != nil {

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -170,6 +170,17 @@ func setupTestStagingPath(t *testing.T) (string, func()) {
 	return setupTestDir(t, "/var/lib/kubelet/plugins/kubernetes.io/csi/gcsfuse.csi.storage.gke.io/fake-pv/globalmount")
 }
 
+func createErrorFile(t *testing.T, emptyDirPath, content string) {
+	t.Helper()
+	if err := os.MkdirAll(emptyDirPath, 0755); err != nil {
+		t.Fatalf("failed to create emptyDir path: %v", err)
+	}
+	errorFilePath := filepath.Join(emptyDirPath, util.ErrorFileName)
+	if err := os.WriteFile(errorFilePath, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to create error file: %v", err)
+	}
+}
+
 func TestNodePublishVolume(t *testing.T) {
 	testTargetPath, cleanup := setupTestTargetPath(t)
 	defer cleanup()
@@ -2004,10 +2015,11 @@ func TestNodePublishVolumeForSharedMount(t *testing.T) {
 	podUID := types.UID(podName)
 
 	cases := []struct {
-		name          string
-		reqBuilder    func(t *testing.T, targetPath, stagingPath string) *csi.NodePublishVolumeRequest
-		setupClient   func() *clientset.FakeClientset
-		expectErrCode codes.Code
+		name             string
+		reqBuilder       func(t *testing.T, targetPath, stagingPath string) *csi.NodePublishVolumeRequest
+		setupClient      func() *clientset.FakeClientset
+		errorFileContent string
+		expectErrCode    codes.Code
 	}{
 		{
 			name: "valid request - should succeed",
@@ -2192,6 +2204,34 @@ func TestNodePublishVolumeForSharedMount(t *testing.T) {
 			},
 			expectErrCode: codes.Internal,
 		},
+		{
+			name: "mounter pod error file exists - should return error from file",
+			reqBuilder: func(t *testing.T, targetPath, stagingPath string) *csi.NodePublishVolumeRequest {
+				return &csi.NodePublishVolumeRequest{
+					TargetPath:        targetPath,
+					StagingTargetPath: stagingPath,
+					VolumeContext: map[string]string{
+						VolumeContextSharedNodeMount: "true",
+					},
+					PublishContext: map[string]string{
+						PublishContextKeyMounterPodName:      podName,
+						PublishContextKeyMounterPodNamespace: podNamespace,
+					},
+				}
+			},
+			setupClient: func() *clientset.FakeClientset {
+				fc := clientset.NewFakeClientset()
+				fc.CreatePod(clientset.FakePodConfig{
+					Name:      podName,
+					Namespace: podNamespace,
+					UID:       podUID,
+					PodStatus: &corev1.PodStatus{Phase: corev1.PodRunning},
+				})
+				return fc
+			},
+			errorFileContent: "gcsfuse failed with error: bucket doesn't exist",
+			expectErrCode:    codes.NotFound,
+		},
 	}
 
 	for _, tc := range cases {
@@ -2207,6 +2247,18 @@ func TestNodePublishVolumeForSharedMount(t *testing.T) {
 			ns, ok := testEnv.ns.(*nodeServer)
 			if !ok {
 				t.Fatalf("Failed to cast NodeServer to *nodeServer")
+			}
+
+			// Setup EmptyDirBasePath for this test case
+			tempDir := t.TempDir()
+			ns.driver.config.FeatureOptions.SharedMountOptions.EmptyDirBasePath = func(uid string) string {
+				return filepath.Join(tempDir, uid)
+			}
+
+			// Create error file if specified
+			if tc.errorFileContent != "" {
+				emptyDirPath := ns.driver.config.FeatureOptions.SharedMountOptions.EmptyDirBasePath(string(podUID))
+				createErrorFile(t, emptyDirPath, tc.errorFileContent)
 			}
 
 			req := tc.reqBuilder(t, testTargetPath, testStagingPath)

--- a/pkg/csi_driver/shared_mount.go
+++ b/pkg/csi_driver/shared_mount.go
@@ -490,3 +490,16 @@ func waitForMounterServer(ctx context.Context, clientset clientset.Interface, mo
 		}
 	}
 }
+
+func checkMounterPodErrorFile(emptyDirPath string) (codes.Code, error) {
+	if emptyDirPath == "" {
+		return codes.Internal, fmt.Errorf("empty dir path is empty")
+	}
+	errorFilePath := filepath.Join(emptyDirPath, util.ErrorFileName)
+	errMsg, err := extractErrorMsgFromGcsFuseErrorFile(errorFilePath)
+	if err != nil {
+		return codes.Internal, err
+	}
+
+	return extractErrorFromGcsFuseErrorFile(errMsg)
+}

--- a/pkg/csi_driver/utils.go
+++ b/pkg/csi_driver/utils.go
@@ -487,10 +487,9 @@ func putExitFile(pod *corev1.Pod, targetPath string) error {
 }
 
 func checkGcsFuseErr(isInitContainer bool, pod *corev1.Pod, targetPath string) (codes.Code, error) {
-	code := codes.Internal
 	cs, err := getSidecarContainerStatus(isInitContainer, pod)
 	if err != nil {
-		return code, err
+		return codes.Internal, err
 	}
 
 	// the sidecar container has not started, skip the check
@@ -500,12 +499,21 @@ func checkGcsFuseErr(isInitContainer bool, pod *corev1.Pod, targetPath string) (
 
 	emptyDirBasePath, err := util.PrepareEmptyDir(targetPath, false)
 	if err != nil {
-		return code, fmt.Errorf("failed to get emptyDir path: %w", err)
+		return codes.Internal, fmt.Errorf("failed to get emptyDir path: %w", err)
 	}
 
-	errorFilePath := emptyDirBasePath + "/error"
+	errorFilePath := filepath.Join(emptyDirBasePath, util.ErrorFileName)
 	klog.V(4).Infof("[Pod %v/%v] checking sidecar container error status", pod.Namespace, pod.Name)
 
+	errMsg, err := extractErrorMsgFromGcsFuseErrorFile(errorFilePath)
+	if err != nil {
+		return codes.Internal, err
+	}
+
+	return extractErrorFromGcsFuseErrorFile(errMsg)
+}
+
+func extractErrorMsgFromGcsFuseErrorFile(errorFilePath string) ([]byte, error) {
 	parentDir := filepath.Dir(errorFilePath)
 
 	// Pin the parent directory by opening its file descriptor with O_DIRECTORY and O_NOFOLLOW.
@@ -514,18 +522,18 @@ func checkGcsFuseErr(isInitContainer bool, pod *corev1.Pod, targetPath string) (
 	parentFd, err := unix.Open(parentDir, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW, 0)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return codes.OK, nil
+			return nil, nil
 		}
-		return code, fmt.Errorf("failed to open parent directory %q: %w", parentDir, err)
+		return nil, fmt.Errorf("failed to open parent directory %q: %w", parentDir, err)
 	}
 	defer unix.Close(parentFd)
 
 	fd, err := unix.Openat(parentFd, filepath.Base(errorFilePath), unix.O_RDONLY|unix.O_NOFOLLOW, 0)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return codes.OK, nil
+			return nil, nil
 		}
-		return code, fmt.Errorf("failed to open error file %q: %w", errorFilePath, err)
+		return nil, fmt.Errorf("failed to open error file %q: %w", errorFilePath, err)
 	}
 
 	f := os.NewFile(uintptr(fd), errorFilePath)
@@ -533,10 +541,10 @@ func checkGcsFuseErr(isInitContainer bool, pod *corev1.Pod, targetPath string) (
 
 	errMsg, err := io.ReadAll(f)
 	if err != nil {
-		return code, fmt.Errorf("failed to read error file %q: %w", errorFilePath, err)
+		return nil, fmt.Errorf("failed to read error file %q: %w", errorFilePath, err)
 	}
 
-	return extractErrorFromGcsFuseErrorFile(errMsg)
+	return errMsg, nil
 }
 
 func extractErrorFromGcsFuseErrorFile(errMsg []byte) (codes.Code, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This change enhances error handling for shared mounts by checking for any errors reported by the mounter pod's GCSFuse process during the NodePublishVolume operation.

This PR introduces the following:

Error File Check: In NodePublishVolumeForSharedMount, the driver now checks for the existence and content of an error file (util.ErrorFileName) within the mounter pod's emptyDir. This file is expected to be populated by the mounter pod if GCSFuse encounters a critical error.
New Helper Function: The checkMounterPodErrorFile function is added to encapsulate the logic for reading and parsing the error file, translating the error message into an appropriate gRPC status code.
Unit Test: A new test case has been added to TestNodePublishVolumeForSharedMount to validate that errors from the mounter pod's error file are correctly detected and returned to the caller, ensuring the user is informed of the failure.
This change improves the debuggability and reliability of the shared mount feature by providing more transparent error propagation from the underlying GCSFuse process.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```