### PR TITLE
Kernel Parameters Integration for shared mount

### DIFF
--- a/pkg/cloud_provider/clientset/fake.go
+++ b/pkg/cloud_provider/clientset/fake.go
@@ -151,7 +151,8 @@ func (c *FakeClientset) CreatePod(podConfig FakePodConfig) {
 				if podConfig.IsMounterPod {
 					return []corev1.Container{
 						{
-							Name: util.MounterPodNamePrefix,
+							Name:  util.MounterPodNamePrefix,
+							Image: webhook.FakeConfig().ContainerImage,
 							Resources: corev1.ResourceRequirements{
 								Limits: podConfig.SidecarLimits,
 							},

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -271,13 +271,13 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 
 	// Use target path as an volume identifier because it corresponds to Pods and volumes.
 	// Pods may belong to different namespaces and would need their own bucket access check.
-	// We initialize volumeState iff bucket name is NOT "_", I.e. It's not a dynamic mount.
+	// We initialize volumeState if bucket name is NOT "_", I.e. It's not a dynamic mount.
 	var vs *util.VolumeState
 	if args.bucketName != "_" {
 		var ok bool
 		if vs, ok = s.volumeStateStore.Load(targetPath); !ok {
-			s.volumeStateStore.Store(targetPath, &util.VolumeState{})
-			vs, _ = s.volumeStateStore.Load(targetPath)
+			vs = &util.VolumeState{}
+			s.volumeStateStore.Store(targetPath, vs)
 		}
 	}
 	// volumeState is safe to access if its not nil for remaining of function since volumeLock prevents
@@ -442,6 +442,16 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 		}
 	}
 
+	var podUID, volumeName, emptyDirBasePath string
+	if s.isGcsFuseKernelParamsFeatureSupported(gcsFuseSidecarImage, vs) {
+		var err error
+		if podUID, volumeName, err = util.ParsePodIDVolumeFromTargetpath(targetPath); err != nil {
+			klog.Warningf("Failed to parse pod ID and volume name from target path %q for kernel params monitor: %v. Monitor will not be started.", targetPath, err)
+		} else if emptyDirBasePath, err = util.PrepareEmptyDir(targetPath, false); err != nil {
+			klog.Warningf("Failed to prepare empty dir from target path %q for kernel params monitor: %v. Monitor will not be started.", targetPath, err)
+		}
+	}
+
 	// Check if the target path is already mounted
 	mounted, err := s.isDirMounted(targetPath)
 	if err != nil {
@@ -474,7 +484,9 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 		// TODO: Check if the socket listener timed out
 
 		// Restart monitoring goroutine if the driver restarts for existing mounts.
-		s.startGcsFuseKernelParamsMonitoring(targetPath, gcsFuseSidecarImage, vs)
+		if emptyDirBasePath != "" {
+			s.startGcsFuseKernelParamsMonitoring(targetPath, emptyDirBasePath, podUID, volumeName, gcsFuseSidecarImage, vs)
+		}
 
 		klog.V(4).Infof("NodePublishVolume succeeded on volume %q to target path %q, mount already exists.", args.bucketName, targetPath)
 
@@ -521,34 +533,38 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 	}
 
 	// Start monitoring goroutine for new mounts.
-	s.startGcsFuseKernelParamsMonitoring(targetPath, gcsFuseSidecarImage, vs)
+	if emptyDirBasePath != "" {
+		s.startGcsFuseKernelParamsMonitoring(targetPath, emptyDirBasePath, podUID, volumeName, gcsFuseSidecarImage, vs)
+	}
 	klog.V(4).Infof("NodePublishVolume succeeded on volume %q to target path %q", args.bucketName, targetPath)
 
 	return &csi.NodePublishVolumeResponse{}, nil
 }
 
 // startGcsFuseKernelParamsMonitoring starts a single long lived goroutine to monitor the
-// GCSFuse kernel parameters file per target path if the feature is enabled and supported.
-// It uses sync.Once to ensure the monitor is started only once. This monitoring goroutine is
-// stopped in the NodeUnpublishVolume operation.
-func (s *nodeServer) startGcsFuseKernelParamsMonitoring(targetPath, gcsFuseSidecarImage string, vs *util.VolumeState) {
-	if s.isGcsFuseKernelParamsFeatureSupported(gcsFuseSidecarImage, vs) {
+// GCSFuse kernel parameters file per mount point if the feature is enabled and supported.
+// It uses sync.Once to ensure the monitor is started only once.
+func (s *nodeServer) startGcsFuseKernelParamsMonitoring(mountPoint, emptyDirBasePath, podUID, volumeName, gcsFuseContainerImage string, vs *util.VolumeState) {
+	if s.isGcsFuseKernelParamsFeatureSupported(gcsFuseContainerImage, vs) {
 		vs.GCSFuseKernelMonitorState.StartKernelParamsFileMonitorOnce.Do(func() {
 			ctx, cancel := context.WithCancel(context.Background())
 			vs.GCSFuseKernelMonitorState.CancelFunc = cancel
+			logPrefix := fmt.Sprintf("Kernel Params Monitor[Pod %v, Volume %v]", podUID, volumeName)
+
 			// Fire kernel params monitoring goroutine.
-			go util.MonitorKernelParamsFile(ctx, targetPath, GCSFuseKernelParamsFilePollInterval)
+			go util.MonitorKernelParamsFile(ctx, mountPoint, emptyDirBasePath, logPrefix, GCSFuseKernelParamsFilePollInterval)
 		})
 	}
 }
 
-// isGcsFuseKernelParamsFeatureSupported returns true if the GCSFuse kernel parameters feature is enabled and supported by sidecar version.
+// isGcsFuseKernelParamsFeatureSupported returns true if the GCSFuse kernel parameters feature is enabled and supported by sidecar/mounter version.
 // GCSFuse Kernel Params feature is not applicable for dynamic mounts as a single kernel parameter setting doesn’t apply for different type
 // of buckets that a dynamic mount serves. This feature is only applicable for non-dynamic mounts i.e when volumeState(vs) is not nil.
-func (s *nodeServer) isGcsFuseKernelParamsFeatureSupported(gcsFuseSidecarImage string, vs *util.VolumeState) bool {
+func (s *nodeServer) isGcsFuseKernelParamsFeatureSupported(gcsFuseContainerImage string, vs *util.VolumeState) bool {
 	return vs != nil &&
+		s.driver.config.FeatureOptions != nil &&
 		s.driver.config.FeatureOptions.EnableGCSFuseKernelParams &&
-		s.driver.isSidecarVersionSupportedForGivenFeature(gcsFuseSidecarImage, GCSFuseKernelParamsMinVersion)
+		s.driver.isSidecarVersionSupportedForGivenFeature(gcsFuseContainerImage, GCSFuseKernelParamsMinVersion)
 }
 
 func (s *nodeServer) NodeUnpublishVolume(_ context.Context, req *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
@@ -571,7 +587,7 @@ func (s *nodeServer) NodeUnpublishVolume(_ context.Context, req *csi.NodeUnpubli
 	}
 
 	// Stop GCSFuse Kernel Params monitoring.
-	if vs, ok := s.volumeStateStore.Load(targetPath); ok {
+	if vs, ok := s.volumeStateStore.Load(targetPath); ok && vs != nil {
 		if vs.GCSFuseKernelMonitorState.CancelFunc != nil {
 			vs.GCSFuseKernelMonitorState.CancelFunc()
 		}
@@ -809,6 +825,12 @@ func (s *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolu
 }
 
 func (s *nodeServer) executeNodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
+	if s.driver.config.FeatureOptions == nil ||
+		s.driver.config.FeatureOptions.SharedMountOptions == nil ||
+		s.driver.config.FeatureOptions.SharedMountOptions.EmptyDirBasePath == nil {
+		return nil, status.Errorf(codes.Internal, "shared mount options are not fully configured")
+	}
+
 	clientset := s.driver.config.K8sClients
 	stagingPath := req.GetStagingTargetPath()
 
@@ -831,18 +853,12 @@ func (s *nodeServer) executeNodeStageVolume(ctx context.Context, req *csi.NodeSt
 		return nil, status.Errorf(codes.Internal, "mounter pod %s/%s can't be nil", podNamespace, podName)
 	}
 
-	// Check if the staging path is already mounted.
-	mounted, err := s.isDirMounted(stagingPath)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to check if path %q is already mounted: %v", stagingPath, err)
-	}
-	if mounted {
-		klog.Infof("NodeStageVolume succeeded on staging path %q for volume %q, mount already exists.", stagingPath, req.GetVolumeId())
-		return &csi.NodeStageVolumeResponse{}, nil
-	}
-
 	volumeID := req.GetVolumeId()
 	vc := req.GetVolumeContext()
+	pvName := vc[util.VolumeContextKeyPVName]
+	if pvName == "" {
+		return nil, status.Errorf(codes.Internal, "PV name not found in VolumeContext (key %q)", util.VolumeContextKeyPVName)
+	}
 
 	// Build profile config and merge recommended mount options if storage profiles are enabled.
 	profilesEnabled := s.driver.config.FeatureOptions.FeatureGCSFuseProfiles.Enabled
@@ -879,6 +895,42 @@ func (s *nodeServer) executeNodeStageVolume(ctx context.Context, req *csi.NodeSt
 		}
 	}
 
+	// We initialize volumeState if bucket name is NOT "_", I.e. It's not a dynamic mount.
+	var vs *util.VolumeState
+	if args.bucketName != "_" {
+		var ok bool
+		if vs, ok = s.volumeStateStore.Load(stagingPath); !ok {
+			vs = &util.VolumeState{}
+			s.volumeStateStore.Store(stagingPath, vs)
+		}
+	}
+
+	mounterPodImage, err := mounterPodImage(pod)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to get image of mounter pod %s/%s: %v", podNamespace, podName, err)
+	}
+
+	podUID := string(pod.UID)
+	emptyDirBasePath := s.driver.config.FeatureOptions.SharedMountOptions.EmptyDirBasePath(podUID)
+
+	// Check if the staging path is already mounted.
+	mounted, err := s.isDirMounted(stagingPath)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to check if path %q is already mounted: %v", stagingPath, err)
+	}
+	if mounted {
+		// Restart monitoring goroutine if the driver restarts for existing mounts.
+		s.startGcsFuseKernelParamsMonitoring(stagingPath, emptyDirBasePath, podUID, pvName, mounterPodImage, vs)
+
+		klog.Infof("NodeStageVolume succeeded on staging path %q for volume %q, mount already exists.", stagingPath, req.GetVolumeId())
+		return &csi.NodeStageVolumeResponse{}, nil
+	}
+
+	// Pass kernel params file flag to GCSFuse iff GCSFuse Kernel Params feature is supported.
+	if s.isGcsFuseKernelParamsFeatureSupported(mounterPodImage, vs) {
+		args.fuseMountOptions = joinMountOptions(args.fuseMountOptions, []string{util.EnableGCSFuseKernelParams + "=true"})
+	}
+
 	// Make the staging path.
 	klog.Infof("NodeStageVolume attempting mkdir for staging path %q", stagingPath)
 	if err := os.MkdirAll(stagingPath, 0750); err != nil {
@@ -886,16 +938,17 @@ func (s *nodeServer) executeNodeStageVolume(ctx context.Context, req *csi.NodeSt
 	}
 
 	// Wait for the mounter pod grpc server to be ready.
-	if err := waitForMounterServer(ctx, clientset, podNamespace, podName, string(pod.UID), s.driver.config.FeatureOptions.SharedMountOptions.EmptyDirBasePath); err != nil {
+	if err := waitForMounterServer(ctx, clientset, podNamespace, podName, podUID, s.driver.config.FeatureOptions.SharedMountOptions.EmptyDirBasePath); err != nil {
 		return nil, err
 	}
-
-	podUID := string(pod.UID)
 
 	// Send GRPC to mounter pod to start GCSFuse.
 	if err := s.mountToNode(ctx, podUID, stagingPath, volumeID, args.fuseMountOptions); err != nil {
 		return nil, err
 	}
+
+	// Start monitoring goroutine for new shared mounts.
+	s.startGcsFuseKernelParamsMonitoring(stagingPath, emptyDirBasePath, podUID, pvName, mounterPodImage, vs)
 
 	klog.Infof("Mounter pod %s/%s is running and staging path %s is mounted", podNamespace, podName, stagingPath)
 
@@ -991,6 +1044,14 @@ func (s *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstage
 }
 
 func (s *nodeServer) cleanupStagingPath(stagingPath string) error {
+	// Stop GCSFuse Kernel Params monitoring.
+	if vs, ok := s.volumeStateStore.Load(stagingPath); ok && vs != nil {
+		if vs.GCSFuseKernelMonitorState.CancelFunc != nil {
+			vs.GCSFuseKernelMonitorState.CancelFunc()
+		}
+		s.volumeStateStore.Delete(stagingPath)
+	}
+
 	// Unmount staging path.
 	mounted, err := s.isDirMounted(stagingPath)
 	if err != nil {

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -327,6 +327,9 @@ func TestExecuteNodeStageVolume(t *testing.T) {
 			req: &csi.NodeStageVolumeRequest{
 				VolumeId:          volID,
 				StagingTargetPath: stagingPath,
+				VolumeContext: map[string]string{
+					util.VolumeContextKeyPVName: volID,
+				},
 				PublishContext: map[string]string{
 					PublishContextKeyMounterPodNamespace: podNamespace,
 					PublishContextKeyMounterPodName:      podName,
@@ -340,6 +343,9 @@ func TestExecuteNodeStageVolume(t *testing.T) {
 			req: &csi.NodeStageVolumeRequest{
 				VolumeId:          volID,
 				StagingTargetPath: stagingPath,
+				VolumeContext: map[string]string{
+					util.VolumeContextKeyPVName: volID,
+				},
 				PublishContext: map[string]string{
 					PublishContextKeyMounterPodNamespace: podNamespace,
 					PublishContextKeyMounterPodName:      podName,
@@ -359,9 +365,9 @@ func TestExecuteNodeStageVolume(t *testing.T) {
 			if tc.podExists {
 				fakeClientSet = clientset.NewFakeClientset()
 				fakeClientSet.CreatePod(clientset.FakePodConfig{
-
-					UID:       types.UID(podName),
-					PodStatus: &corev1.PodStatus{Phase: corev1.PodRunning},
+					UID:          types.UID(podName),
+					PodStatus:    &corev1.PodStatus{Phase: corev1.PodRunning},
+					IsMounterPod: true,
 				})
 			} else {
 				fakeClientSet = clientset.NewFakeClientset()
@@ -1268,6 +1274,24 @@ func TestMountToNode(t *testing.T) {
 	}
 }
 
+func validateMountOptions(t *testing.T, actualOpts []string, expectedOpts []string, unexpectedOpts []string) {
+	t.Helper()
+	optsMap := make(map[string]bool)
+	for _, opt := range actualOpts {
+		optsMap[opt] = true
+	}
+	for _, expectedOpt := range expectedOpts {
+		if !optsMap[expectedOpt] {
+			t.Errorf("expected option %q not found in actual options %v", expectedOpt, actualOpts)
+		}
+	}
+	for _, unexpectedOpt := range unexpectedOpts {
+		if optsMap[unexpectedOpt] {
+			t.Errorf("unexpected option %q found in actual options %v", unexpectedOpt, actualOpts)
+		}
+	}
+}
+
 func validateMountPoint(t *testing.T, fm *mount.FakeMounter, e *mount.MountPoint, unexpectedOpts []string) {
 	t.Helper()
 	if e == nil {
@@ -1295,23 +1319,7 @@ func validateMountPoint(t *testing.T, fm *mount.FakeMounter, e *mount.MountPoint
 		t.Errorf("got type %q, expected %q", a.Type, e.Type)
 	}
 
-	// Validate expected options are present in actual options.
-	actualOpts := make(map[string]bool)
-	for _, opt := range a.Opts {
-		actualOpts[opt] = true
-	}
-	for _, expectedOpt := range e.Opts {
-		if !actualOpts[expectedOpt] {
-			t.Errorf("expected option %q not found in actual options %v", expectedOpt, a.Opts)
-		}
-	}
-
-	// Validate unexpected options are not present in actual options.
-	for _, unexpectedOpt := range unexpectedOpts {
-		if actualOpts[unexpectedOpt] {
-			t.Errorf("unexpected option %q found in actual options %v", unexpectedOpt, a.Opts)
-		}
-	}
+	validateMountOptions(t, a.Opts, e.Opts, unexpectedOpts)
 }
 
 func TestConcurrentMapWrites(t *testing.T) {
@@ -2497,6 +2505,125 @@ func TestNodePublishVolumeForSharedMount(t *testing.T) {
 					}
 				}
 			}
+		})
+	}
+}
+
+func TestNodeStageVolumeEnableGCSFuseKernelParams(t *testing.T) {
+	nodeID := "test-node"
+	volID := testVolumeID
+	podNamespace := "test-ns"
+	podName := createMounterPodName(nodeID, volID)
+	podUID := types.UID(podName)
+
+	cases := []struct {
+		name                       string
+		enableKernelParamsFileFlag bool
+		assumeGoodSidecarVersion   bool
+		expectedOptions            []string
+		unexpectedOptions          []string
+	}{
+		{
+			name:                       "feature enabled, mounter pod image supported",
+			enableKernelParamsFileFlag: true,
+			assumeGoodSidecarVersion:   true,
+			expectedOptions:            []string{"enable-gcsfuse-kernel-params=true"},
+		},
+		{
+			name:                       "feature enabled, mounter pod image not supported",
+			enableKernelParamsFileFlag: true,
+			assumeGoodSidecarVersion:   false,
+			unexpectedOptions:          []string{"enable-gcsfuse-kernel-params=true"},
+		},
+		{
+			name:                       "feature disabled, mounter pod image supported",
+			enableKernelParamsFileFlag: false,
+			assumeGoodSidecarVersion:   true,
+			unexpectedOptions:          []string{"enable-gcsfuse-kernel-params=true"},
+		},
+		{
+			name:                       "feature disabled, mounter pod image not supported",
+			enableKernelParamsFileFlag: false,
+			assumeGoodSidecarVersion:   false,
+			unexpectedOptions:          []string{"enable-gcsfuse-kernel-params=true"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			testStagingPath, cleanupStaging := setupTestStagingPath(t)
+			defer cleanupStaging()
+
+			// Use a short base dir to avoid hitting the 108-character limit for Unix domain sockets.
+			tmpDir, err := os.MkdirTemp("/tmp", "s")
+			if err != nil {
+				t.Fatalf("failed to create temp dir: %v", err)
+			}
+			t.Cleanup(func() { os.RemoveAll(tmpDir) })
+			socketDir := filepath.Join(tmpDir, "s")
+			emptyDirBasePath := filepath.Join(tmpDir, "e")
+
+			sockFile := filepath.Join(emptyDirBasePath, string(podUID), mounterPodSocketFile)
+			mounterServer := startFakeMounterServer(t, sockFile)
+
+			fc := clientset.NewFakeClientset()
+			fc.CreatePod(clientset.FakePodConfig{
+				Name:         podName,
+				Namespace:    podNamespace,
+				UID:          podUID,
+				PodStatus:    &corev1.PodStatus{Phase: corev1.PodRunning},
+				IsMounterPod: true,
+			})
+
+			fakeMounter := mount.NewFakeMounter([]mount.MountPoint{})
+
+			testEnv := initTestNodeServerWithCustomClientset(t, fc, false)
+			ns, ok := testEnv.ns.(*nodeServer)
+			if !ok {
+				t.Fatalf("Failed to cast NodeServer to *nodeServer")
+			}
+			ns.mounter = fakeMounter
+
+			ns.driver.config.FeatureOptions.EnableGCSFuseKernelParams = tc.enableKernelParamsFileFlag
+			ns.driver.config.AssumeGoodSidecarVersion = tc.assumeGoodSidecarVersion
+			ns.driver.config.FeatureOptions.SharedMountOptions = &SharedMountOptions{
+				Enabled:       true,
+				FuseSocketDir: socketDir,
+				EmptyDirBasePath: func(podUID string) string {
+					return filepath.Join(emptyDirBasePath, podUID)
+				},
+			}
+
+			stageReq := &csi.NodeStageVolumeRequest{
+				VolumeId:          volID,
+				StagingTargetPath: testStagingPath,
+				VolumeCapability:  testVolumeCapability,
+				VolumeContext: map[string]string{
+					VolumeContextSharedNodeMount: "true",
+					util.VolumeContextKeyPVName:  volID,
+				},
+				PublishContext: map[string]string{
+					PublishContextKeyMounterPodName:      podName,
+					PublishContextKeyMounterPodNamespace: podNamespace,
+				},
+			}
+
+			_, err = ns.NodeStageVolume(context.Background(), stageReq)
+			if err != nil {
+				t.Fatalf("NodeStageVolume failed: %v", err)
+			}
+			defer func() {
+				if vs, ok := ns.volumeStateStore.Load(testStagingPath); ok && vs != nil {
+					if vs.GCSFuseKernelMonitorState.CancelFunc != nil {
+						vs.GCSFuseKernelMonitorState.CancelFunc()
+					}
+				}
+			}()
+
+			if mounterServer.req == nil {
+				t.Fatalf("expected mounterServer.req to be non-nil, but got nil")
+			}
+			validateMountOptions(t, mounterServer.req.MountOptions, tc.expectedOptions, tc.unexpectedOptions)
 		})
 	}
 }

--- a/pkg/csi_driver/shared_mount.go
+++ b/pkg/csi_driver/shared_mount.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"context"
@@ -76,6 +77,20 @@ func (driver *GCSDriver) sharedMount(vc map[string]string) bool {
 		return true
 	}
 	return false
+}
+
+// mounterPodImage extracts the container image specified for the mounter pod container
+// with name matching MounterPodNamePrefix from the given Pod.
+func mounterPodImage(pod *corev1.Pod) (string, error) {
+	if pod == nil {
+		return "", fmt.Errorf("pod is nil")
+	}
+	for _, container := range pod.Spec.Containers {
+		if strings.HasPrefix(container.Name, util.MounterPodNamePrefix) {
+			return container.Image, nil
+		}
+	}
+	return "", fmt.Errorf("failed to find mounter container with prefix %q", util.MounterPodNamePrefix)
 }
 
 // createMounterPodName returns a unique name for the mounter pod. The name is composed by

--- a/pkg/csi_driver/shared_mount_test.go
+++ b/pkg/csi_driver/shared_mount_test.go
@@ -251,6 +251,84 @@ func TestCreateMounterPodName(t *testing.T) {
 	}
 }
 
+func TestMounterPodImage(t *testing.T) {
+	testCases := []struct {
+		name        string
+		pod         *corev1.Pod
+		expected    string
+		expectError bool
+	}{
+		{
+			name:        "nil pod returns error",
+			pod:         nil,
+			expected:    "",
+			expectError: true,
+		},
+		{
+			name: "pod without mounter container returns error",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "other-container",
+							Image: "nginx:latest",
+						},
+					},
+				},
+			},
+			expected:    "",
+			expectError: true,
+		},
+		{
+			name: "pod with mounter container returns container image",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  util.MounterPodNamePrefix + "-123",
+							Image: "gcr.io/gke-release/gcsfuse-csi-mounter:v1.0.0",
+						},
+					},
+				},
+			},
+			expected:    "gcr.io/gke-release/gcsfuse-csi-mounter:v1.0.0",
+			expectError: false,
+		},
+		{
+			name: "pod with multiple containers returns correct mounter container image",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "sidecar",
+							Image: "sidecar-image:v1",
+						},
+						{
+							Name:  util.MounterPodNamePrefix + "-abc",
+							Image: "mounter-image:v2",
+						},
+					},
+				},
+			},
+			expected:    "mounter-image:v2",
+			expectError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := mounterPodImage(tc.pod)
+			if (err != nil) != tc.expectError {
+				t.Errorf("mounterPodImage() error = %v, expectError %v", err, tc.expectError)
+				return
+			}
+			if got != tc.expected {
+				t.Errorf("mounterPodImage() = %q, want %q", got, tc.expected)
+			}
+		})
+	}
+}
+
 func sortVolumes(volumes []corev1.Volume) {
 	sort.Slice(volumes, func(i, j int) bool {
 		return volumes[i].Name < volumes[j].Name

--- a/pkg/util/kernel_params_monitoring.go
+++ b/pkg/util/kernel_params_monitoring.go
@@ -130,14 +130,8 @@ func checkAndApplyKernelParams(kernelParamsFilePath string, pathForParam map[Par
 
 // MonitorKernelParamsFile monitors the kernel params file and continously enforces
 // kernel parameter changes at regular interval as requested by GCSFuse.
-func MonitorKernelParamsFile(ctx context.Context, targetPath string, interval time.Duration) {
-	podID, volumeName, err := ParsePodIDVolumeFromTargetpath(targetPath)
-	if err != nil {
-		klog.Warningf("Aborting kernel params monitor. Could not parse Pod ID and Volume Name from target path %q: %v", targetPath, err)
-		return
-	}
-	logPrefix := fmt.Sprintf("Kernel Params Monitor[Pod %v, Volume %v]", podID, volumeName)
-
+func MonitorKernelParamsFile(ctx context.Context, mountPoint, emptyDirBasePath, logPrefix string, interval time.Duration) {
+	kernelParamsFilePath := filepath.Join(emptyDirBasePath, GCSFuseKernelParamsFileName)
 	klog.Infof("%v Starting GCSFuse kernel params monitor", logPrefix)
 
 	var terminationError error
@@ -152,14 +146,7 @@ func MonitorKernelParamsFile(ctx context.Context, targetPath string, interval ti
 		}
 	}()
 
-	emptyDirBasePath, err := PrepareEmptyDir(targetPath, false)
-	if err != nil {
-		terminationError = fmt.Errorf("failed to get emptyDir path: %w", err)
-		return
-	}
-	kernelParamsFilePath := filepath.Join(emptyDirBasePath, GCSFuseKernelParamsFileName)
-
-	major, minor, err := getDeviceMajorMinor(targetPath)
+	major, minor, err := getDeviceMajorMinor(mountPoint)
 	if err != nil {
 		terminationError = fmt.Errorf("failed to get device major/minor: %w", err)
 		return


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Integrates GCSFuse Kernel Parameters support for Shared Node Mount mode (`NodeStageVolume` and `NodeUnstageVolume`):
- Passes `--enable-gcsfuse-kernel-params=true` FUSE mount option in `NodeStageVolume` when the feature flag is enabled and the Mounter Pod image version supports it.
- Refactors `MonitorKernelParamsFile` to support shared node mount.
- Starts asynchronous kernel parameter monitoring in `NodeStageVolume` and cleans up the monitoring goroutine in `NodeUnstageVolume`.
- Adds unit test coverage for helper functions and `NodeStageVolume` for kernel parameter.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
```release-note
NONE