### PR TITLE
Implement NodePublishVolumeWithSharedMount mount logic.

### DIFF
--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -98,6 +98,19 @@ func (s *nodeServer) NodePublishVolumeForSharedMount(_ context.Context, req *csi
 	if len(stagingPath) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "NodePublishVolume Staging Target Path must be provided")
 	}
+	targetPath := req.GetTargetPath()
+	if len(targetPath) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "NodePublishVolume Target Path must be provided")
+	}
+	if len(req.GetVolumeId()) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "NodePublishVolume Volume ID must be provided")
+	}
+	if req.GetVolumeCapability() == nil {
+		return nil, status.Error(codes.InvalidArgument, "NodePublishVolume Volume capability must be provided")
+	}
+	if err := s.driver.validateVolumeCapabilities([]*csi.VolumeCapability{req.GetVolumeCapability()}); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
 	publishContext := req.GetPublishContext()
 	if publishContext == nil {
 		return nil, status.Error(codes.InvalidArgument, "NodePublishVolume Publish Context must be provided")
@@ -110,6 +123,12 @@ func (s *nodeServer) NodePublishVolumeForSharedMount(_ context.Context, req *csi
 	if len(mounterPodName) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "NodePublishVolume Mounter Pod Name must be provided")
 	}
+
+	// Acquire a lock on the target path instead of volumeID, since we do not want to serialize multiple node publish calls on the same volume.
+	if acquired := s.volumeLocks.TryAcquire(targetPath); !acquired {
+		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, targetPath)
+	}
+	defer s.volumeLocks.Release(targetPath)
 
 	// Verify mounter pod exists.
 	mounterPod, err := s.k8sClients.GetPod(mounterPodNamespace, mounterPodName)
@@ -144,7 +163,43 @@ func (s *nodeServer) NodePublishVolumeForSharedMount(_ context.Context, req *csi
 		return nil, status.Errorf(codes.Internal, "mounter pod %s/%s was found with an unexpected status: %+v", mounterPodNamespace, mounterPodName, mounterPod.Status)
 	}
 
-	// TODO(urielguzman): Implement the rest of the NodePublishVolume logic for shared mount.
+	// Verify staging path mounted.
+	mounted, err := s.isDirMounted(stagingPath)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to check if path %q is already mounted: %v", stagingPath, err)
+	}
+	if !mounted {
+		return nil, status.Errorf(codes.Internal, "staging path %s was not found mounted", stagingPath)
+	}
+
+	// Succeed if the target path was already mounted.
+	targetPathMounted, err := s.isDirMounted(targetPath)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to check if path %q is already mounted: %v", targetPath, err)
+	}
+	if targetPathMounted {
+		klog.Infof("NodePublishVolume succeeded on staging path %q to target path %q, mount already exists.", stagingPath, targetPath)
+		return &csi.NodePublishVolumeResponse{}, nil
+	}
+
+	// Create target path dir.
+	klog.Infof("NodePublishVolume attempting mkdir for target path %q", targetPath)
+	if err := os.MkdirAll(targetPath, 0o750); err != nil {
+		return nil, status.Errorf(codes.Internal, "mkdir failed for path %q: %v", targetPath, err)
+	}
+
+	// Prepare mount options specific to the bind mount.
+	bindMountOptions := []string{"bind"}
+	if req.GetReadonly() {
+		bindMountOptions = append(bindMountOptions, "ro")
+	}
+
+	// Bind mount staging path to target path.
+	klog.Infof("NodePublishVolume attempting to bind mount staging path %q to target path %q", stagingPath, targetPath)
+	if err = s.mounter.MountSensitiveWithoutSystemd(stagingPath, targetPath, "", bindMountOptions, nil); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to bind mount staging path %q to target path %q: %v", stagingPath, targetPath, err)
+	}
+
 	return &csi.NodePublishVolumeResponse{}, nil
 }
 

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -2009,22 +2009,92 @@ func TestNodePublishVolumeForSharedMount(t *testing.T) {
 	t.Parallel()
 
 	nodeID := "test-node"
-	volID := testVolumeID
 	podNamespace := "test-ns"
-	podName := createMounterPodName(nodeID, volID)
+	podName := createMounterPodName(nodeID, testVolumeID)
 	podUID := types.UID(podName)
 
 	cases := []struct {
-		name             string
-		reqBuilder       func(t *testing.T, targetPath, stagingPath string) *csi.NodePublishVolumeRequest
-		setupClient      func() *clientset.FakeClientset
-		errorFileContent string
-		expectErrCode    codes.Code
+		name              string
+		reqBuilder        func(t *testing.T, targetPath, stagingPath string) *csi.NodePublishVolumeRequest
+		setupClient       func() *clientset.FakeClientset
+		errorFileContent  string
+		targetPathMounted bool
+		expectErrCode     codes.Code
+		expectedBindOpts  []string
 	}{
+		{
+			name: "invalid volume capability - should return InvalidArgument error",
+			reqBuilder: func(t *testing.T, targetPath, stagingPath string) *csi.NodePublishVolumeRequest {
+				return &csi.NodePublishVolumeRequest{
+					TargetPath:        targetPath,
+					StagingTargetPath: stagingPath,
+					VolumeContext: map[string]string{
+						VolumeContextSharedNodeMount: "true",
+					},
+					PublishContext: map[string]string{
+						PublishContextKeyMounterPodName:      podName,
+						PublishContextKeyMounterPodNamespace: podNamespace,
+					},
+					VolumeId: testVolumeID,
+					VolumeCapability: &csi.VolumeCapability{
+						AccessType: &csi.VolumeCapability_Mount{
+							Mount: &csi.VolumeCapability_MountVolume{},
+						},
+						AccessMode: &csi.VolumeCapability_AccessMode{
+							Mode: csi.VolumeCapability_AccessMode_UNKNOWN, // Invalid
+						},
+					},
+				}
+			},
+			setupClient:   func() *clientset.FakeClientset { return clientset.NewFakeClientset() },
+			expectErrCode: codes.InvalidArgument,
+		},
+		{
+			name: "missing volume capability - should return InvalidArgument error",
+			reqBuilder: func(t *testing.T, targetPath, stagingPath string) *csi.NodePublishVolumeRequest {
+				return &csi.NodePublishVolumeRequest{
+					TargetPath:        targetPath,
+					StagingTargetPath: stagingPath,
+					VolumeContext: map[string]string{
+						VolumeContextSharedNodeMount: "true",
+					},
+					PublishContext: map[string]string{
+						PublishContextKeyMounterPodName:      podName,
+						PublishContextKeyMounterPodNamespace: podNamespace,
+					},
+					VolumeId: testVolumeID,
+					// VolumeCapability: testVolumeCapability, // Missing
+				}
+			},
+			setupClient:   func() *clientset.FakeClientset { return clientset.NewFakeClientset() },
+			expectErrCode: codes.InvalidArgument,
+		},
+		{
+			name: "missing volume id - should return InvalidArgument error",
+			reqBuilder: func(t *testing.T, targetPath, stagingPath string) *csi.NodePublishVolumeRequest {
+				return &csi.NodePublishVolumeRequest{
+					TargetPath:        targetPath,
+					StagingTargetPath: stagingPath,
+					VolumeContext: map[string]string{
+						VolumeContextSharedNodeMount: "true",
+					},
+					PublishContext: map[string]string{
+						PublishContextKeyMounterPodName:      podName,
+						PublishContextKeyMounterPodNamespace: podNamespace,
+					},
+					// VolumeId: "", missing volume ID.
+					VolumeCapability: testVolumeCapability,
+				}
+			},
+			setupClient:   func() *clientset.FakeClientset { return clientset.NewFakeClientset() },
+			expectErrCode: codes.InvalidArgument,
+		},
 		{
 			name: "valid request - should succeed",
 			reqBuilder: func(t *testing.T, targetPath, stagingPath string) *csi.NodePublishVolumeRequest {
 				return &csi.NodePublishVolumeRequest{
+					VolumeId:          testVolumeID,
+					VolumeCapability:  testVolumeCapability,
 					TargetPath:        targetPath,
 					StagingTargetPath: stagingPath,
 					VolumeContext: map[string]string{
@@ -2052,7 +2122,9 @@ func TestNodePublishVolumeForSharedMount(t *testing.T) {
 			name: "missing staging path - should return InvalidArgument error",
 			reqBuilder: func(t *testing.T, targetPath, stagingPath string) *csi.NodePublishVolumeRequest {
 				return &csi.NodePublishVolumeRequest{
-					TargetPath: targetPath,
+					VolumeId:         testVolumeID,
+					VolumeCapability: testVolumeCapability,
+					TargetPath:       targetPath,
 					// StagingTargetPath: "", // Missing
 					VolumeContext: map[string]string{
 						VolumeContextSharedNodeMount: "true",
@@ -2070,6 +2142,8 @@ func TestNodePublishVolumeForSharedMount(t *testing.T) {
 			name: "missing target path - should return InvalidArgument error",
 			reqBuilder: func(t *testing.T, targetPath, stagingPath string) *csi.NodePublishVolumeRequest {
 				return &csi.NodePublishVolumeRequest{
+					VolumeId:         testVolumeID,
+					VolumeCapability: testVolumeCapability,
 					// TargetPath:        "", // Missing
 					StagingTargetPath: stagingPath,
 					VolumeContext: map[string]string{
@@ -2088,6 +2162,8 @@ func TestNodePublishVolumeForSharedMount(t *testing.T) {
 			name: "missing publish context - should return InvalidArgument error",
 			reqBuilder: func(t *testing.T, targetPath, stagingPath string) *csi.NodePublishVolumeRequest {
 				return &csi.NodePublishVolumeRequest{
+					VolumeId:          testVolumeID,
+					VolumeCapability:  testVolumeCapability,
 					TargetPath:        targetPath,
 					StagingTargetPath: stagingPath,
 					VolumeContext: map[string]string{
@@ -2103,6 +2179,8 @@ func TestNodePublishVolumeForSharedMount(t *testing.T) {
 			name: "missing mounter pod namespace - should return InvalidArgument error",
 			reqBuilder: func(t *testing.T, targetPath, stagingPath string) *csi.NodePublishVolumeRequest {
 				return &csi.NodePublishVolumeRequest{
+					VolumeId:          testVolumeID,
+					VolumeCapability:  testVolumeCapability,
 					TargetPath:        targetPath,
 					StagingTargetPath: stagingPath,
 					PublishContext: map[string]string{
@@ -2120,6 +2198,8 @@ func TestNodePublishVolumeForSharedMount(t *testing.T) {
 			name: "missing mounter pod name - should return InvalidArgument error",
 			reqBuilder: func(t *testing.T, targetPath, stagingPath string) *csi.NodePublishVolumeRequest {
 				return &csi.NodePublishVolumeRequest{
+					VolumeId:          testVolumeID,
+					VolumeCapability:  testVolumeCapability,
 					TargetPath:        targetPath,
 					StagingTargetPath: stagingPath,
 					PublishContext: map[string]string{
@@ -2137,6 +2217,8 @@ func TestNodePublishVolumeForSharedMount(t *testing.T) {
 			name: "mounter pod not found - should return FailedPrecondition error",
 			reqBuilder: func(t *testing.T, targetPath, stagingPath string) *csi.NodePublishVolumeRequest {
 				return &csi.NodePublishVolumeRequest{
+					VolumeId:          testVolumeID,
+					VolumeCapability:  testVolumeCapability,
 					TargetPath:        targetPath,
 					StagingTargetPath: stagingPath,
 					PublishContext: map[string]string{
@@ -2159,6 +2241,8 @@ func TestNodePublishVolumeForSharedMount(t *testing.T) {
 			name: "mounter pod not running - should return Internal error",
 			reqBuilder: func(t *testing.T, targetPath, stagingPath string) *csi.NodePublishVolumeRequest {
 				return &csi.NodePublishVolumeRequest{
+					VolumeId:          testVolumeID,
+					VolumeCapability:  testVolumeCapability,
 					TargetPath:        targetPath,
 					StagingTargetPath: stagingPath,
 					PublishContext: map[string]string{
@@ -2186,6 +2270,8 @@ func TestNodePublishVolumeForSharedMount(t *testing.T) {
 			name: "error getting mounter pod - should return Internal error",
 			reqBuilder: func(t *testing.T, targetPath, stagingPath string) *csi.NodePublishVolumeRequest {
 				return &csi.NodePublishVolumeRequest{
+					VolumeId:          testVolumeID,
+					VolumeCapability:  testVolumeCapability,
 					TargetPath:        targetPath,
 					StagingTargetPath: stagingPath,
 					PublishContext: map[string]string{
@@ -2208,6 +2294,8 @@ func TestNodePublishVolumeForSharedMount(t *testing.T) {
 			name: "mounter pod error file exists - should return error from file",
 			reqBuilder: func(t *testing.T, targetPath, stagingPath string) *csi.NodePublishVolumeRequest {
 				return &csi.NodePublishVolumeRequest{
+					VolumeId:          testVolumeID,
+					VolumeCapability:  testVolumeCapability,
 					TargetPath:        targetPath,
 					StagingTargetPath: stagingPath,
 					VolumeContext: map[string]string{
@@ -2231,6 +2319,100 @@ func TestNodePublishVolumeForSharedMount(t *testing.T) {
 			},
 			errorFileContent: "gcsfuse failed with error: bucket doesn't exist",
 			expectErrCode:    codes.NotFound,
+		},
+		{
+			name: "target path already mounted - should return early success",
+			reqBuilder: func(t *testing.T, targetPath, stagingPath string) *csi.NodePublishVolumeRequest {
+				return &csi.NodePublishVolumeRequest{
+					VolumeId:          testVolumeID,
+					VolumeCapability:  testVolumeCapability,
+					TargetPath:        targetPath,
+					StagingTargetPath: stagingPath,
+					VolumeContext: map[string]string{
+						VolumeContextSharedNodeMount: "true",
+					},
+					PublishContext: map[string]string{
+						PublishContextKeyMounterPodName:      podName,
+						PublishContextKeyMounterPodNamespace: podNamespace,
+					},
+				}
+			},
+			setupClient: func() *clientset.FakeClientset {
+				fc := clientset.NewFakeClientset()
+				fc.CreatePod(clientset.FakePodConfig{
+					Name:      podName,
+					Namespace: podNamespace,
+					UID:       podUID,
+					PodStatus: &corev1.PodStatus{Phase: corev1.PodRunning},
+				})
+				return fc
+			},
+			targetPathMounted: true,
+			expectErrCode:     codes.OK,
+		},
+		{
+			name: "target path not mounted - should return successful read-write bind mount",
+			reqBuilder: func(t *testing.T, targetPath, stagingPath string) *csi.NodePublishVolumeRequest {
+				return &csi.NodePublishVolumeRequest{
+					VolumeId:          testVolumeID,
+					VolumeCapability:  testVolumeCapability,
+					TargetPath:        targetPath,
+					StagingTargetPath: stagingPath,
+					Readonly:          false,
+					VolumeContext: map[string]string{
+						VolumeContextSharedNodeMount: "true",
+					},
+					PublishContext: map[string]string{
+						PublishContextKeyMounterPodName:      podName,
+						PublishContextKeyMounterPodNamespace: podNamespace,
+					},
+				}
+			},
+			setupClient: func() *clientset.FakeClientset {
+				fc := clientset.NewFakeClientset()
+				fc.CreatePod(clientset.FakePodConfig{
+					Name:      podName,
+					Namespace: podNamespace,
+					UID:       podUID,
+					PodStatus: &corev1.PodStatus{Phase: corev1.PodRunning},
+				})
+				return fc
+			},
+			targetPathMounted: false,
+			expectErrCode:     codes.OK,
+			expectedBindOpts:  []string{"bind"},
+		},
+		{
+			name: "target path not mounted - should return successful read-only bind mount",
+			reqBuilder: func(t *testing.T, targetPath, stagingPath string) *csi.NodePublishVolumeRequest {
+				return &csi.NodePublishVolumeRequest{
+					VolumeId:          testVolumeID,
+					VolumeCapability:  testVolumeCapability,
+					TargetPath:        targetPath,
+					StagingTargetPath: stagingPath,
+					Readonly:          true,
+					VolumeContext: map[string]string{
+						VolumeContextSharedNodeMount: "true",
+					},
+					PublishContext: map[string]string{
+						PublishContextKeyMounterPodName:      podName,
+						PublishContextKeyMounterPodNamespace: podNamespace,
+					},
+				}
+			},
+			setupClient: func() *clientset.FakeClientset {
+				fc := clientset.NewFakeClientset()
+				fc.CreatePod(clientset.FakePodConfig{
+					Name:      podName,
+					Namespace: podNamespace,
+					UID:       podUID,
+					PodStatus: &corev1.PodStatus{Phase: corev1.PodRunning},
+				})
+				return fc
+			},
+			targetPathMounted: false,
+			expectErrCode:     codes.OK,
+			expectedBindOpts:  []string{"bind", "ro"},
 		},
 	}
 
@@ -2261,10 +2443,16 @@ func TestNodePublishVolumeForSharedMount(t *testing.T) {
 				createErrorFile(t, emptyDirPath, tc.errorFileContent)
 			}
 
+			// Configure existing mount states. Staging must always be reported as mounted for verification checks.
+			initialMounts := []mount.MountPoint{
+				{Path: testStagingPath, Device: "fuse"},
+			}
+			if tc.targetPathMounted {
+				initialMounts = append(initialMounts, mount.MountPoint{Path: testTargetPath, Device: "fuse"})
+			}
+			testEnv.fm.MountPoints = initialMounts
+
 			req := tc.reqBuilder(t, testTargetPath, testStagingPath)
-			// Fields not validated by the current function, but needed for other NodePublishVolume calls
-			req.VolumeId = volID
-			req.VolumeCapability = testVolumeCapability
 
 			_, err := ns.NodePublishVolume(context.TODO(), req)
 
@@ -2282,6 +2470,31 @@ func TestNodePublishVolumeForSharedMount(t *testing.T) {
 			} else {
 				if err != nil {
 					t.Errorf("Got error %q, expected error nil", err)
+				}
+
+				// Verify actual flags captured on the fake mounter match expectations
+				if len(tc.expectedBindOpts) > 0 {
+					var targetBindFound bool
+					for _, mp := range testEnv.fm.MountPoints {
+						if mp.Path == testTargetPath {
+							targetBindFound = true
+							for _, expectedOpt := range tc.expectedBindOpts {
+								hasOpt := false
+								for _, o := range mp.Opts {
+									if o == expectedOpt {
+										hasOpt = true
+										break
+									}
+								}
+								if !hasOpt {
+									t.Errorf("Expected flag %q missing from registered mount context: %v", expectedOpt, mp.Opts)
+								}
+							}
+						}
+					}
+					if !targetBindFound {
+						t.Error("Expected target path to be registered to the mount points map, but none was found")
+					}
 				}
 			}
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**: This PR introduces logic to `NodePublishVolumeForSharedMount` to:
1. Verify if the staging path already is mounted. If it isn't return error.
2. Verify if the target path is already mounted. If it is, return success.
3. Create the target path directory and bind-mount the staging path to the target path, appending `ro` when the mount is read-only.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```