### PR TITLE
Automated cherry pick of #1362: Redact Overly generous logs
#1367: Redact Overly generous logs

### DIFF
--- a/pkg/cloud_provider/auth/token_sources.go
+++ b/pkg/cloud_provider/auth/token_sources.go
@@ -177,7 +177,9 @@ func (ts *GCPTokenSource) FetchIdentityBindingToken(ctx context.Context, k8sSATo
 
 	stsResponse, err := stsService.V1.Token(stsRequest).Do()
 	if err != nil {
-		return nil, fmt.Errorf("IdentityBindingToken exchange error with audience %q: and request %v: error %w", audience, stsRequest, err)
+		// Redact the SubjectToken (k8s service account token) from logs to prevent leakage.
+		stsRequest.SubjectToken = "<REDACTED>"
+		return nil, fmt.Errorf("IdentityBindingToken exchange error with audience %q: request=%v: error %w", audience, stsRequest, err)
 	}
 
 	return &oauth2.Token{

--- a/pkg/profiles/scanner.go
+++ b/pkg/profiles/scanner.go
@@ -347,7 +347,7 @@ func generateTokenSource(ctx context.Context, configFile *ConfigFile) (oauth2.To
 	// If configFile.Global.TokenURL is defined use AltTokenSource
 	if configFile != nil && configFile.Global.TokenURL != "" && configFile.Global.TokenURL != "nil" {
 		tokenSource := auth.NewAltTokenSource(ctx, configFile.Global.TokenURL, configFile.Global.TokenBody)
-		klog.Infof("Using AltTokenSource %#v", tokenSource)
+		klog.Infof("Using AltTokenSource with token url %q", configFile.Global.TokenURL)
 		return tokenSource, nil
 	}
 
@@ -382,8 +382,7 @@ func buildCloudConfig(configPath string) (*ConfigFile, error) {
 	if err := gcfg.FatalOnly(gcfg.ReadInto(cfg, reader)); err != nil {
 		return nil, fmt.Errorf("couldn't read cloud provider configuration at %s: %w", configPath, err)
 	}
-	klog.Infof("Config file read %#v", cfg)
-
+	klog.Infof("Config file read with token url %q", cfg.Global.TokenURL)
 	return cfg, nil
 }
 


### PR DESCRIPTION
Cherry pick of #1362 #1367 on release-1.22.

#1362: Redact Overly generous logs
#1367: Redact Overly generous logs

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```