### PR TITLE
Fix typos and misspellings in documentation

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -234,7 +234,7 @@ The following steps create a pool of Cloud Build workers that run inside your ne
 
 **Part 1: Set up the Private Connection**
 
-These first three steps establish the private "bridge" between your VPC and Google's network. For the offical documentation and more details on setting parameters in the commands below, refer to [setting up a private connection](https://cloud.google.com/build/docs/private-pools/set-up-private-pool-to-use-in-vpc-network#setup-private-connection).
+These first three steps establish the private "bridge" between your VPC and Google's network. For the official documentation and more details on setting parameters in the commands below, refer to [setting up a private connection](https://cloud.google.com/build/docs/private-pools/set-up-private-pool-to-use-in-vpc-network#setup-private-connection).
 
 1.  **Enable the Service Networking API.** This is a one-time setup step that grants your project permission to create private connections to Google services, including Cloud Build.
 
@@ -274,7 +274,7 @@ These first three steps establish the private "bridge" between your VPC and Goog
 
 Now that the network bridge exists, this final step creates the pool of workers. For additional background, refer to the official documentation for [creating a new private pool](https://cloud.google.com/build/docs/private-pools/create-manage-private-pools#creating_a_new_private_pool).
 
-4.  **Create the Private Pool.** This command builds the pool and connects it to your VPC via the peering you just created. We recommend creating the pool in the same region as your Kubernetes cluster to ensure low latency and avoid network data transfer costs. Replace `WORKER_POOL_NAME` with a name for your pool,  `CLUSTER_LOCATION` with the region of your K8s cluster, and `VPC_NAME` with the name of your VPC network. To have permissionsn to create the private pool, ask your administrator to grant you the Cloud Build WorkerPool Owner role (`roles/cloudbuild.workerPoolOwner`).
+4.  **Create the Private Pool.** This command builds the pool and connects it to your VPC via the peering you just created. We recommend creating the pool in the same region as your Kubernetes cluster to ensure low latency and avoid network data transfer costs. Replace `WORKER_POOL_NAME` with a name for your pool,  `CLUSTER_LOCATION` with the region of your K8s cluster, and `VPC_NAME` with the name of your VPC network. To have permissions to create the private pool, ask your administrator to grant you the Cloud Build WorkerPool Owner role (`roles/cloudbuild.workerPoolOwner`).
 
     ```bash
     export WORKER_POOL_NAME=<your pool name>

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -56,7 +56,7 @@ After GKE 1.29, because of the native sidecar container feature, the CSI driver 
 
 ### Solutions
 
-The GCS FUSE SCI Driver now utilizes the [Kubernetes native sidecar container feature](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/753-sidecar-containers), available in GKE versions 1.29.3-gke.1093000 or later.
+The GCS FUSE CSI Driver now utilizes the [Kubernetes native sidecar container feature](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/753-sidecar-containers), available in GKE versions 1.29.3-gke.1093000 or later.
 
 The Kubernetes native sidecar container feature introduces sidecar containers, a new type of init container that starts before other containers but remains running for the full duration of the pod's lifecycle and will not block pod termination.
 
@@ -76,7 +76,7 @@ Here are some of the webhooks that may be affected:
 
 - The webhook `pod-admission-controller.spiffe.gke.io` used by [Managed Workload Identities](https://cloud.google.com/iam/docs/managed-workload-identity).
 - The webhook `istio-inject.webhook.crfa.internal.knative.dev` used by [Cloud Run for Anthos](https://cloud.google.com/anthos/run/archive/docs).
-- The webhook `gtoken.doit-intl.com` bused by [gtoken](https://github.com/doitintl/gtoken/tree/master).
+- The webhook `gtoken.doit-intl.com` used by [gtoken](https://github.com/doitintl/gtoken/tree/master).
 - The webhook `k8s-image-swapper.github.io` used by [k8s-image-swapper](https://github.com/estahn/k8s-image-swapper), with version smaller than `v1.5.10`.
 - The webhook `logsidecar-injector.logging.kubesphere.io` used by [logsidecar-injector](https://github.com/kubesphere/logsidecar-injector).
 

--- a/docs/sidecar-manual-injection.md
+++ b/docs/sidecar-manual-injection.md
@@ -25,7 +25,7 @@ This document explains how to manually inject the GCSFuse sidecar container to y
 
 1. Modify your workload spec
 
-    Add the `gke-gcsfuse-sidecar` container to your workload as a regular container, and also add three auxiliary volumes. Make sure the container `gke-gcsfuse-sidecar` is before your workload contianer. Meanwhile, remove the annotation `gke-gcsfuse/volumes: "true"`.
+    Add the `gke-gcsfuse-sidecar` container to your workload as a regular container, and also add three auxiliary volumes. Make sure the container `gke-gcsfuse-sidecar` is before your workload container. Meanwhile, remove the annotation `gke-gcsfuse/volumes: "true"`.
 
     Below is an example. Replace the image signature `xxx` with the value copied in the previous step.
 

--- a/docs/sub-directory-mounts.md
+++ b/docs/sub-directory-mounts.md
@@ -20,7 +20,7 @@ limitations under the License.
 1. Create a bucket
 
     ```bash
-    gcloud create bucket gs://<your-bucket-name> --uniform-bucket-level-access
+    gcloud storage buckets create gs://<your-bucket-name> --uniform-bucket-level-access
     ```
 
 1. Create a namespace `test`

--- a/examples/README.md
+++ b/examples/README.md
@@ -43,16 +43,16 @@ kubectl delete -f ./examples/ephemeral/deployment-two-vols.yaml
 # replace <bucket-name> with your pre-provisioned GCS bucket name
 GCS_BUCKET_NAME=your-bucket-name
 sed -i "s/<bucket-name>/$GCS_BUCKET_NAME/g" ./examples/static/pv-pvc-deployment.yaml
-sed -i "s/<bucket-name>/$GCS_BUCKET_NAME/g" ./examples/static/pv-pvc-deploymen-non-root.yaml
+sed -i "s/<bucket-name>/$GCS_BUCKET_NAME/g" ./examples/static/pv-pvc-deployment-non-root.yaml
 
 # install PV/PVC and a Deployment
 kubectl apply -f ./examples/static/pv-pvc-deployment.yaml
-kubectl apply -f ./examples/static/pv-pvc-deploymen-non-root.yaml
+kubectl apply -f ./examples/static/pv-pvc-deployment-non-root.yaml
 
 # clean up
 # the PV deletion will not delete your GCS bucket
 kubectl delete -f ./examples/static/pv-pvc-deployment.yaml
-kubectl delete -f ./examples/static/pv-pvc-deploymen-non-root.yaml
+kubectl delete -f ./examples/static/pv-pvc-deployment-non-root.yaml
 ```
 
 ## Batch Job Example
@@ -115,11 +115,11 @@ following (the exact ranges used will depend on your specifics). The router
 commands are necessary to expose the network externally, so it can reach GCS
 endpoints. The parameters used are not critical and depend on your setup as
 well. The network and subnet names are only used for node pool creation and are
-not critcal for your pod configuration.
+not critical for your pod configuration.
 
 ```bash
 gcloud compute networks create additional
-gcloud compute networks subnests create alt \
+gcloud compute networks subnets create alt \
   --range=10.144.16.0/20 \
   --network=additional \
   --secondary-range=alt=10.144.32.0/20


### PR DESCRIPTION
## What type of PR is this?

/kind documentation

## What this PR does / why we need it

Fixes typos and misspellings across multiple documentation files:

- Fix `gcloud create bucket` → `gcloud storage buckets create` in `docs/sub-directory-mounts.md`
- Fix `pv-pvc-deploymen-non-root` → `pv-pvc-deployment-non-root` in `examples/README.md`
- Fix `subnests` → `subnets` in `examples/README.md`
- Fix `not critcal` → `not critical` in `examples/README.md`
- Fix `permissionsn` → `permissions` in `docs/installation.md`
- Fix `offical` → `official` in `docs/installation.md`
- Fix `SCI Driver` → `CSI Driver` in `docs/known-issues.md`
- Fix `bused by` → `used by` in `docs/known-issues.md`
- Fix `contianer` → `container` in `docs/sidecar-manual-injection.md`

## Does this PR introduce a user-facing change?

No.