### PR TITLE
Block eviction request for mounter pod in webhook

### DIFF
--- a/deploy/base/webhook/mutatingwebhook.yaml
+++ b/deploy/base/webhook/mutatingwebhook.yaml
@@ -24,7 +24,7 @@ webhooks:
       - apiGroups: [""]
         apiVersions: ["v1"]
         operations: ["CREATE"]
-        resources: ["pods"]
+        resources: ["pods", "pods/eviction"]
         scope: "Namespaced"
       - apiGroups: [""]
         apiVersions: ["v1"]

--- a/pkg/webhook/mutatingwebhook.go
+++ b/pkg/webhook/mutatingwebhook.go
@@ -86,6 +86,14 @@ type SidecarInjector struct {
 
 // Handle injects a gcsfuse sidecar container and a emptyDir to incoming qualified pods.
 func (si *SidecarInjector) Handle(ctx context.Context, req admission.Request) admission.Response {
+	if req.Kind.Kind == "Eviction" {
+		if strings.HasPrefix(req.Name, util.MounterPodNamePrefix) {
+			klog.Infof("Blocking eviction request for Mounter Pod: %q in namespace %q", req.Name, req.Namespace)
+			return admission.Denied("Eviction of Mounter Pod is not allowed")
+		}
+		return admission.Allowed(fmt.Sprintf("Eviction allowed for non-Mounter Pod: %q", req.Name))
+	}
+
 	if req.Kind.Kind == "PersistentVolume" {
 		pv := &corev1.PersistentVolume{}
 		if err := si.Decoder.Decode(req, pv); err != nil {

--- a/pkg/webhook/mutatingwebhook_test.go
+++ b/pkg/webhook/mutatingwebhook_test.go
@@ -2625,3 +2625,60 @@ func modifySpecWithExecutableWorkloadIdentity(newPod corev1.Pod, configMapName s
 
 	return &newPod
 }
+
+func TestHandleEviction(t *testing.T) {
+	t.Parallel()
+
+	si := SidecarInjector{
+		Decoder: admission.NewDecoder(runtime.NewScheme()),
+	}
+
+	testCases := []struct {
+		name        string
+		podName     string
+		namespace   string
+		wantAllowed bool
+		wantMessage string
+	}{
+		{
+			name:        "Block eviction for mounter pod",
+			podName:     util.MounterPodNamePrefix + "-12345",
+			namespace:   "default",
+			wantAllowed: false,
+			wantMessage: "Eviction of Mounter Pod is not allowed",
+		},
+		{
+			name:        "Allow eviction for non-mounter pod",
+			podName:     "regular-pod-54321",
+			namespace:   "default",
+			wantAllowed: true,
+			wantMessage: "Eviction allowed for non-Mounter Pod: \"regular-pod-54321\"",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			request := admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Kind: metav1.GroupVersionKind{
+						Group:   "policy",
+						Version: "v1",
+						Kind:    "Eviction",
+					},
+					Name:      tc.podName,
+					Namespace: tc.namespace,
+					Operation: admissionv1.Create,
+				},
+			}
+
+			response := si.Handle(context.Background(), request)
+
+			if response.Allowed != tc.wantAllowed {
+				t.Errorf("expected allowed: %v, got: %v", tc.wantAllowed, response.Allowed)
+			}
+			if tc.wantMessage != "" && !strings.Contains(response.Result.Message, tc.wantMessage) {
+				t.Errorf("expected message to contain %q, got %q", tc.wantMessage, response.Result.Message)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
During node drain operations or Cluster Autoscaler scale-down events, the Mounter Pods in Shared Node Mount mode could be evicted. Blocking these eviction requests prevents unexpected unmounts and ensures mount stability for workload pods sharing the mount on the node.

**What changes are included in this PR**:
1. **Webhook Configuration**: Updated `MutatingWebhookConfiguration` rules to intercept `CREATE` operations on the `pods/eviction` subresource.
2. **Eviction Handler Logic**: Added logic in `pkg/webhook/mutatingwebhook.go` to inspect incoming admission requests for `Kind == "Eviction"`. If the target pod matches the Mounter Pod naming prefix (`gcsfusecsi-mount-`), the webhook rejects the eviction request with an explicit denial message.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
- Verified manually that during node pool upgrades and node pool deletions, Kubernetes only evicts pods with controller/owner references. 
- Confirmed that the Eviction API request verb triggered during node drains matches exactly with the rules added in the mutating webhook configuration.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note