### PR TITLE
feat: add support for tuning host FUSE max_pages_limit during file descriptor mounting

### DIFF
--- a/cmd/sidecar_mounter/gcsfuse_binary
+++ b/cmd/sidecar_mounter/gcsfuse_binary
@@ -1,1 +1,1 @@
-gs://gke-release-staging/gcsfuse/v3.10.0-gke.0/gcsfuse_bin
+gs://gke-release-staging/gcsfuse/v3.11.1-gke.0/gcsfuse_bin

--- a/deploy/base/node/node.yaml
+++ b/deploy/base/node/node.yaml
@@ -112,6 +112,9 @@ spec:
               mountPath: /sys
             - name: host-iproute
               mountPath: /etc/iproute2
+            - name: host-proc-sys-fs-fuse
+              mountPath: /host-proc-sys-fs-fuse
+
             - name: tmp
               mountPath: /tmp
         - name: csi-driver-registrar
@@ -168,6 +171,10 @@ spec:
         - name: host-iproute
           hostPath:
             path: /etc/iproute2
+            type: Directory
+        - name: host-proc-sys-fs-fuse
+          hostPath:
+            path: /proc/sys/fs/fuse
             type: Directory
         - name: tmp
           emptyDir:

--- a/pkg/cloud_provider/storage/storage_test.go
+++ b/pkg/cloud_provider/storage/storage_test.go
@@ -38,13 +38,13 @@ func TestCompareBuckets(t *testing.T) {
 				Name:      "name",
 				Project:   "project",
 				Location:  "location",
-				SizeBytes: 10 * util.Mb,
+				SizeBytes: 10 * util.MiB,
 			},
 			b: &ServiceBucket{
 				Name:      "name",
 				Project:   "project",
 				Location:  "location",
-				SizeBytes: 10 * util.Mb,
+				SizeBytes: 10 * util.MiB,
 			},
 		},
 		{
@@ -53,13 +53,13 @@ func TestCompareBuckets(t *testing.T) {
 				Name:      "name1",
 				Project:   "project1",
 				Location:  "location1",
-				SizeBytes: 10 * util.Mb,
+				SizeBytes: 10 * util.MiB,
 			},
 			b: &ServiceBucket{
 				Name:      "name2",
 				Project:   "project2",
 				Location:  "location2",
-				SizeBytes: 20 * util.Mb,
+				SizeBytes: 20 * util.MiB,
 			},
 			expectedMismatches: []string{
 				"bucket name",

--- a/pkg/csi_driver/controller.go
+++ b/pkg/csi_driver/controller.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	MinimumVolumeSizeInBytes int64 = 1 * util.Mb
+	MinimumVolumeSizeInBytes int64 = 1 * util.MiB
 )
 
 // CreateVolume parameters.

--- a/pkg/csi_driver/controller_test.go
+++ b/pkg/csi_driver/controller_test.go
@@ -155,7 +155,7 @@ func TestCreateVolume(t *testing.T) {
 			},
 			resp: &csi.CreateVolumeResponse{
 				Volume: &csi.Volume{
-					CapacityBytes: 1 * util.Mb,
+					CapacityBytes: 1 * util.MiB,
 					VolumeId:      testVolumeID,
 				},
 			},

--- a/pkg/csi_mounter/csi_mounter.go
+++ b/pkg/csi_mounter/csi_mounter.go
@@ -43,12 +43,24 @@ import (
 )
 
 const (
+	// Note: All variables here are in KiB instead of KB but they are added like this to ensure consistency in codebase.
 	socketName                       = "socket"
 	readAheadKBMountFlagRegexPattern = "^read_ahead_kb=(.+)$"
 	readAheadKBMountFlag             = "read_ahead_kb"
+	// Hidden CSI flag never to be passed to gcsfuse
+	nodeFuseMaxRequestLimitKBMountFlag             = "node_fuse_max_request_limit_kb"
+	nodeFuseMaxRequestLimitKBMountFlagRegexPattern = "^" + nodeFuseMaxRequestLimitKBMountFlag + "=(.+)$"
+	defaultNodeFuseMaxRequestLimitKB               = 16 * util.MiB / util.KiB // 16 MiB Request Size
+	// minPageSizeKB defines the minimum page size (4 KiB) to use as a fallback.
+	minPageSizeKB = 4
+	// maxFuseMaxPagesLimit defines the maximum pages limit supported by the Linux FUSE kernel (2^16 - 1).
+	maxFuseMaxPagesLimit = 65535
 )
 
-var readAheadKBMountFlagRegex = regexp.MustCompile(readAheadKBMountFlagRegexPattern)
+var (
+	readAheadKBMountFlagRegex               = regexp.MustCompile(readAheadKBMountFlagRegexPattern)
+	nodeFuseMaxRequestLimitKBMountFlagRegex = regexp.MustCompile(nodeFuseMaxRequestLimitKBMountFlagRegexPattern)
+)
 
 // Mounter provides the Cloud Storage FUSE CSI implementation of mount.Interface
 // for the linux platform.
@@ -78,7 +90,7 @@ func (m *Mounter) Mount(source string, target string, fstype string, options []s
 	m.mux.Lock()
 	defer m.mux.Unlock()
 
-	csiMountOptions, sidecarMountOptions, sysfsBDI, err := prepareMountOptions(options)
+	csiMountOptions, sidecarMountOptions, sysfsBDI, fuseMaxPagesLimit, err := prepareMountOptions(options)
 	if err != nil {
 		return err
 	}
@@ -104,8 +116,18 @@ func (m *Mounter) Mount(source string, target string, fstype string, options []s
 	}
 	csiMountOptions = append(csiMountOptions, fmt.Sprintf("fd=%v", fd))
 
-	klog.V(4).Infof("%v mounting the fuse filesystem", logPrefix)
-	err = m.MountSensitiveWithoutSystemdWithMountFlags(source, target, fstype, csiMountOptions, nil, []string{"--internal-only"})
+	mountFn := func() error {
+		klog.V(4).Infof("%v mounting the fuse filesystem", logPrefix)
+		return m.MountSensitiveWithoutSystemdWithMountFlags(source, target, fstype, csiMountOptions, nil, []string{"--internal-only"})
+	}
+	// TODO(mohitkyadav): Remove this check when kernel reader is enabled by default for Regional Buckets.
+	isKernelReaderEnabled := checkForKernelReader(options)
+	shouldMountUsingElevatedFuseMaxPagesLimit := util.FuseMaxMaxPagesUpdateSupported() && fuseMaxPagesLimit > 0 && isKernelReaderEnabled
+	if shouldMountUsingElevatedFuseMaxPagesLimit {
+		err = util.MountUsingElevatedFuseMaxPagesLimit(fuseMaxPagesLimit, logPrefix, mountFn)
+	} else {
+		err = mountFn()
+	}
 	if err != nil {
 		klog.Errorf("MountSensitiveWithoutSystemdWithMountFlags failed with error %v", err)
 		return fmt.Errorf("failed to mount the fuse filesystem: %w", err)
@@ -357,7 +379,7 @@ func startAcceptConn(l net.Listener, logPrefix string, msg []byte, fd int, cance
 	klog.V(4).Infof("%v exiting the listener goroutine.", logPrefix)
 }
 
-func prepareMountOptions(options []string) ([]string, []string, map[string]int64, error) {
+func prepareMountOptions(options []string) ([]string, []string, map[string]int64, int64, error) {
 	allowedOptions := map[string]bool{
 		"exec":    true,
 		"noexec":  true,
@@ -390,6 +412,11 @@ func prepareMountOptions(options []string) ([]string, []string, map[string]int64
 	}
 
 	sysfsBDI := make(map[string]int64)
+	pageSizeKB := max(minPageSizeKB, int64(os.Getpagesize()/util.KiB))
+	// Calculate default FUSE max pages limit. We use integer ceiling division to ensure we round
+	// up to the next page if the default size 16MB is not a perfect multiple of the page size on the machine.
+	fuseMaxPagesLimit := util.CeilDiv64(defaultNodeFuseMaxRequestLimitKB, pageSizeKB)
+
 	for _, o := range optionSet.List() {
 		if strings.HasPrefix(o, "o=") {
 			v := o[2:]
@@ -406,15 +433,44 @@ func prepareMountOptions(options []string) ([]string, []string, map[string]int64
 			// If found, it will be at index 1
 			readAheadKBInt, err := strconv.ParseInt(readAheadKB[1], 10, 0)
 			if err != nil {
-				return nil, nil, nil, fmt.Errorf("invalid read_ahead_kb mount flag %q: %w", o, err)
+				return nil, nil, nil, 0, fmt.Errorf("invalid read_ahead_kb mount flag %q: %w", o, err)
 			}
 			if readAheadKBInt < 0 {
-				return nil, nil, nil, fmt.Errorf("invalid negative value for read_ahead_kb mount flag: %q", o)
+				return nil, nil, nil, 0, fmt.Errorf("invalid negative value for read_ahead_kb mount flag: %q", o)
 			}
 			sysfsBDI[readAheadKBMountFlag] = readAheadKBInt
 			optionSet.Delete(o)
 		}
+
+		if maxReqSize := nodeFuseMaxRequestLimitKBMountFlagRegex.FindStringSubmatch(o); len(maxReqSize) == 2 {
+			nodeFuseMaxRequestLimitKB, err := strconv.ParseInt(maxReqSize[1], 10, 0)
+			if err != nil {
+				return nil, nil, nil, 0, fmt.Errorf("invalid %s mount flag %q: %w", nodeFuseMaxRequestLimitKBMountFlag, o, err)
+			}
+			if nodeFuseMaxRequestLimitKB < 0 {
+				return nil, nil, nil, 0, fmt.Errorf("invalid negative value for %s mount flag: %q", nodeFuseMaxRequestLimitKBMountFlag, o)
+			}
+			maxAllowedSizeKB := maxFuseMaxPagesLimit * pageSizeKB
+			if nodeFuseMaxRequestLimitKB > maxAllowedSizeKB {
+				return nil, nil, nil, 0, fmt.Errorf("invalid value for %s mount flag %q: exceeds maximum allowed limit of %d KiB on this host", nodeFuseMaxRequestLimitKBMountFlag, o, maxAllowedSizeKB)
+			}
+			// Convert the requested size in KB to pages. We use integer ceiling division
+			// to round up to the next page if the requested size is not a multiple of the
+			// page size. This ensures we can accommodate the full requested buffer size in
+			// a single fuse request.
+			fuseMaxPagesLimit = util.CeilDiv64(nodeFuseMaxRequestLimitKB, pageSizeKB)
+			optionSet.Delete(o)
+		}
 	}
 
-	return csiMountOptions, optionSet.List(), sysfsBDI, nil
+	return csiMountOptions, optionSet.List(), sysfsBDI, fuseMaxPagesLimit, nil
+}
+
+func checkForKernelReader(options []string) bool {
+	for _, o := range options {
+		if o == "enable-kernel-reader" || o == "enable-kernel-reader=true" || o == "file-system:enable-kernel-reader:true" {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/csi_mounter/csi_mounter_test.go
+++ b/pkg/csi_mounter/csi_mounter_test.go
@@ -22,6 +22,8 @@ import (
 	"os"
 	"reflect"
 	"testing"
+
+	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util"
 )
 
 var defaultCsiMountOptions = []string{
@@ -37,48 +39,51 @@ var defaultCsiMountOptions = []string{
 func TestPrepareMountArgs(t *testing.T) {
 	t.Parallel()
 
+	pageSizeKB := max(minPageSizeKB, int64(os.Getpagesize()/util.KiB))
+
 	testCases := []struct {
-		name                       string
-		inputMountOptions          []string
-		expecteCsiMountOptions     []string
-		expecteSidecarMountOptions []string
-		expectedSysfsBDI           map[string]int64
-		expectErr                  bool
+		name                        string
+		inputMountOptions           []string
+		expectedCsiMountOptions     []string
+		expectedSidecarMountOptions []string
+		expectedSysfsBDI            map[string]int64
+		expectedFuseMaxPagesLimit   *int64
+		expectErr                   bool
 	}{
 		{
-			name:                       "should return valid options correctly with empty input",
-			inputMountOptions:          []string{},
-			expecteCsiMountOptions:     defaultCsiMountOptions,
-			expecteSidecarMountOptions: []string{},
-			expectedSysfsBDI:           map[string]int64{},
+			name:                        "should return valid options correctly with empty input",
+			inputMountOptions:           []string{},
+			expectedCsiMountOptions:     defaultCsiMountOptions,
+			expectedSidecarMountOptions: []string{},
+			expectedSysfsBDI:            map[string]int64{},
 		},
 		{
-			name:                       "should return valid options correctly with CSI mount options only",
-			inputMountOptions:          []string{"ro", "o=noexec", "o=noatime", "o=invalid"},
-			expecteCsiMountOptions:     append(defaultCsiMountOptions, "ro", "noexec", "noatime"),
-			expecteSidecarMountOptions: []string{},
-			expectedSysfsBDI:           map[string]int64{},
+			name:                        "should return valid options correctly with CSI mount options only",
+			inputMountOptions:           []string{"ro", "o=noexec", "o=noatime", "o=invalid"},
+			expectedCsiMountOptions:     append(defaultCsiMountOptions, "ro", "noexec", "noatime"),
+			expectedSidecarMountOptions: []string{},
+			expectedSysfsBDI:            map[string]int64{},
 		},
 		{
-			name:                       "should return valid options correctly with sidecar mount options only",
-			inputMountOptions:          []string{"implicit-dirs", "max-conns-per-host=10"},
-			expecteCsiMountOptions:     defaultCsiMountOptions,
-			expecteSidecarMountOptions: []string{"implicit-dirs", "max-conns-per-host=10"},
-			expectedSysfsBDI:           map[string]int64{},
+			name:                        "should return valid options correctly with sidecar mount options only",
+			inputMountOptions:           []string{"implicit-dirs", "max-conns-per-host=10"},
+			expectedCsiMountOptions:     defaultCsiMountOptions,
+			expectedSidecarMountOptions: []string{"implicit-dirs", "max-conns-per-host=10"},
+			expectedSysfsBDI:            map[string]int64{},
 		},
 		{
-			name:                       "should return valid options correctly with CSI and sidecar mount options",
-			inputMountOptions:          []string{"ro", "implicit-dirs", "max-conns-per-host=10", "o=noexec", "o=noatime", "o=invalid"},
-			expecteCsiMountOptions:     append(defaultCsiMountOptions, "ro", "noexec", "noatime"),
-			expecteSidecarMountOptions: []string{"implicit-dirs", "max-conns-per-host=10"},
-			expectedSysfsBDI:           map[string]int64{},
+			name:                        "should return valid options correctly with CSI and sidecar mount options",
+			inputMountOptions:           []string{"ro", "implicit-dirs", "max-conns-per-host=10", "o=noexec", "o=noatime", "o=invalid"},
+			expectedCsiMountOptions:     append(defaultCsiMountOptions, "ro", "noexec", "noatime"),
+			expectedSidecarMountOptions: []string{"implicit-dirs", "max-conns-per-host=10"},
+			expectedSysfsBDI:            map[string]int64{},
 		},
 		{
-			name:                       "should return valid options correctly with CSI and sidecar mount options with read ahead configs",
-			inputMountOptions:          []string{"ro", "implicit-dirs", "max-conns-per-host=10", "o=noexec", "o=noatime", "o=invalid", "read_ahead_kb=4096"},
-			expecteCsiMountOptions:     append(defaultCsiMountOptions, "ro", "noexec", "noatime"),
-			expecteSidecarMountOptions: []string{"implicit-dirs", "max-conns-per-host=10"},
-			expectedSysfsBDI:           map[string]int64{"read_ahead_kb": 4096},
+			name:                        "should return valid options correctly with CSI and sidecar mount options with read ahead configs",
+			inputMountOptions:           []string{"ro", "implicit-dirs", "max-conns-per-host=10", "o=noexec", "o=noatime", "o=invalid", "read_ahead_kb=4096"},
+			expectedCsiMountOptions:     append(defaultCsiMountOptions, "ro", "noexec", "noatime"),
+			expectedSidecarMountOptions: []string{"implicit-dirs", "max-conns-per-host=10"},
+			expectedSysfsBDI:            map[string]int64{"read_ahead_kb": 4096},
 		},
 		{
 			name:              "invalid read ahead - not int",
@@ -90,6 +95,53 @@ func TestPrepareMountArgs(t *testing.T) {
 			inputMountOptions: append(defaultCsiMountOptions, "read_ahead_kb=-1"),
 			expectErr:         true,
 		},
+		{
+			name:                        "should return valid options correctly with node_fuse_max_request_limit_kb",
+			inputMountOptions:           []string{"ro", "implicit-dirs", "node_fuse_max_request_limit_kb=8192"},
+			expectedCsiMountOptions:     append(defaultCsiMountOptions, "ro"),
+			expectedSidecarMountOptions: []string{"implicit-dirs"},
+			expectedSysfsBDI:            map[string]int64{},
+			expectedFuseMaxPagesLimit:   ptr(8192 / pageSizeKB),
+		},
+		{
+			name:              "invalid node_fuse_max_request_limit_kb - not int",
+			inputMountOptions: []string{"node_fuse_max_request_limit_kb=abc"},
+			expectErr:         true,
+		},
+		{
+			name:              "invalid node_fuse_max_request_limit_kb - negative",
+			inputMountOptions: []string{"node_fuse_max_request_limit_kb=-100"},
+			expectErr:         true,
+		},
+		{
+			name:                        "should return valid options correctly with node_fuse_max_request_limit_kb - not multiple of page size (ceil up)",
+			inputMountOptions:           []string{"node_fuse_max_request_limit_kb=8193"},
+			expectedCsiMountOptions:     defaultCsiMountOptions,
+			expectedSidecarMountOptions: []string{},
+			expectedSysfsBDI:            map[string]int64{},
+			expectedFuseMaxPagesLimit:   ptr(util.CeilDiv64(8193, pageSizeKB)),
+		},
+		{
+			name:                        "should return valid options correctly with node_fuse_max_request_limit_kb at maximum allowed limit",
+			inputMountOptions:           []string{fmt.Sprintf("node_fuse_max_request_limit_kb=%d", maxFuseMaxPagesLimit*pageSizeKB)},
+			expectedCsiMountOptions:     defaultCsiMountOptions,
+			expectedSidecarMountOptions: []string{},
+			expectedSysfsBDI:            map[string]int64{},
+			expectedFuseMaxPagesLimit:   ptr(int64(maxFuseMaxPagesLimit)),
+		},
+		{
+			name:              "invalid node_fuse_max_request_limit_kb - exceeds max limit",
+			inputMountOptions: []string{fmt.Sprintf("node_fuse_max_request_limit_kb=%d", maxFuseMaxPagesLimit*pageSizeKB+1)},
+			expectErr:         true,
+		},
+		{
+			name:                        "should return valid options correctly with node_fuse_max_request_limit_kb=0",
+			inputMountOptions:           []string{"node_fuse_max_request_limit_kb=0"},
+			expectedCsiMountOptions:     defaultCsiMountOptions,
+			expectedSidecarMountOptions: []string{},
+			expectedSysfsBDI:            map[string]int64{},
+			expectedFuseMaxPagesLimit:   ptr(int64(0)),
+		},
 	}
 
 	for _, tc := range testCases {
@@ -97,7 +149,7 @@ func TestPrepareMountArgs(t *testing.T) {
 			t.Parallel()
 			t.Logf("test case: %s", tc.name)
 
-			c, s, sysfsBDI, err := prepareMountOptions(tc.inputMountOptions)
+			c, s, sysfsBDI, fuseMaxPagesLimit, err := prepareMountOptions(tc.inputMountOptions)
 
 			if tc.expectErr && err == nil {
 				t.Errorf("test %q failed: expected an error, but got nil", tc.name)
@@ -113,16 +165,24 @@ func TestPrepareMountArgs(t *testing.T) {
 				return
 			}
 
-			if !reflect.DeepEqual(countOptionOccurrence(c), countOptionOccurrence(tc.expecteCsiMountOptions)) {
-				t.Errorf("Got options %v, but expected %v", c, tc.expecteCsiMountOptions)
+			if !reflect.DeepEqual(countOptionOccurrence(c), countOptionOccurrence(tc.expectedCsiMountOptions)) {
+				t.Errorf("Got options %v, but expected %v", c, tc.expectedCsiMountOptions)
 			}
 
-			if !reflect.DeepEqual(countOptionOccurrence(s), countOptionOccurrence(tc.expecteSidecarMountOptions)) {
-				t.Errorf("Got options %v, but expected %v", s, tc.expecteSidecarMountOptions)
+			if !reflect.DeepEqual(countOptionOccurrence(s), countOptionOccurrence(tc.expectedSidecarMountOptions)) {
+				t.Errorf("Got options %v, but expected %v", s, tc.expectedSidecarMountOptions)
 			}
 
 			if !reflect.DeepEqual(sysfsBDI, tc.expectedSysfsBDI) {
 				t.Errorf("Got sysfsBDI %v, expected %v", sysfsBDI, tc.expectedSysfsBDI)
+			}
+
+			expectedPages := util.CeilDiv64(defaultNodeFuseMaxRequestLimitKB, pageSizeKB)
+			if tc.expectedFuseMaxPagesLimit != nil {
+				expectedPages = *tc.expectedFuseMaxPagesLimit
+			}
+			if fuseMaxPagesLimit != expectedPages {
+				t.Errorf("Got fuseMaxPagesLimit %d, expected %d", fuseMaxPagesLimit, expectedPages)
 			}
 		})
 	}
@@ -135,4 +195,69 @@ func countOptionOccurrence(options []string) map[string]int {
 	}
 
 	return dict
+}
+
+func TestCheckForKernelReader(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		options  []string
+		expected bool
+	}{
+		{
+			name:     "empty options",
+			options:  []string{},
+			expected: false,
+		},
+		{
+			name:     "unrelated options",
+			options:  []string{"ro", "implicit-dirs", "node_fuse_max_request_limit_kb=8192"},
+			expected: false,
+		},
+		{
+			name:     "enable-kernel-reader flag only",
+			options:  []string{"enable-kernel-reader"},
+			expected: true,
+		},
+		{
+			name:     "enable-kernel-reader=true flag",
+			options:  []string{"enable-kernel-reader=true"},
+			expected: true,
+		},
+		{
+			name:     "enable-kernel-reader=false flag",
+			options:  []string{"enable-kernel-reader=false"},
+			expected: false,
+		},
+		{
+			name:     "file-system:enable-kernel-reader:true config",
+			options:  []string{"file-system:enable-kernel-reader:true"},
+			expected: true,
+		},
+		{
+			name:     "file-system:enable-kernel-reader:false config",
+			options:  []string{"file-system:enable-kernel-reader:false"},
+			expected: false,
+		},
+		{
+			name:     "multiple options with enable-kernel-reader",
+			options:  []string{"ro", "implicit-dirs", "enable-kernel-reader=true", "node_fuse_max_request_limit_kb=8192"},
+			expected: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := checkForKernelReader(tc.options)
+			if got != tc.expected {
+				t.Errorf("checkForKernelReader() = %v, expected %v", got, tc.expected)
+			}
+		})
+	}
+}
+
+func ptr[T any](v T) *T {
+	return &v
 }

--- a/pkg/profiles/recommender.go
+++ b/pkg/profiles/recommender.go
@@ -1037,7 +1037,7 @@ func bytesToMiB(a int64) int64 {
 	if a == -1 {
 		return -1
 	}
-	return ceilDiv64(a, mib)
+	return util.CeilDiv64(a, mib)
 }
 
 // mibToBytes converts mebibytes (MiB) to a byte count.
@@ -1046,11 +1046,6 @@ func mibToBytes(a int64) int64 {
 		return -1
 	}
 	return a * mib
-}
-
-// ceilDiv64 performs integer division of 'a' by 'b', rounding the result up.
-func ceilDiv64(a, b int64) int64 {
-	return (a + b - 1) / b
 }
 
 // isValidMountOption checks if a mount option string follows the allowed formats.

--- a/pkg/util/kernel_params_monitoring.go
+++ b/pkg/util/kernel_params_monitoring.go
@@ -24,12 +24,40 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
 	"golang.org/x/sys/unix"
 	"k8s.io/klog/v2"
 )
+
+var (
+	// fuseMaxMaxPagesMu serializes concurrent updates to the host's FUSE max_pages_limit.
+	fuseMaxMaxPagesMu sync.Mutex
+	// procSysFsFuseMaxPagesLimitPath is the host FUSE max_pages_limit path (overridable for unit testing).
+	procSysFsFuseMaxPagesLimitPath = "/host-proc-sys-fs-fuse/max_pages_limit"
+)
+
+// FuseMaxMaxPagesUpdateSupported returns true if the host supports FUSE max_pages_limit tuning.
+func FuseMaxMaxPagesUpdateSupported() bool {
+	_, err := os.Lstat(procSysFsFuseMaxPagesLimitPath)
+	return err == nil
+}
+
+// ReadFuseMaxPagesLimit reads the host's current FUSE max_pages_limit.
+func ReadFuseMaxPagesLimit() (int64, error) {
+	bytes, err := os.ReadFile(procSysFsFuseMaxPagesLimitPath)
+	if err != nil {
+		return 0, err
+	}
+	return strconv.ParseInt(strings.TrimSpace(string(bytes)), 10, 64)
+}
+
+// SetFuseMaxPagesLimit writes the target limit to the host's FUSE max_pages_limit file.
+func SetFuseMaxPagesLimit(target int64) error {
+	return os.WriteFile(procSysFsFuseMaxPagesLimitPath, []byte(strconv.FormatInt(target, 10)+"\n"), 0o644)
+}
 
 // getDeviceMajorMinor returns the major and minor device numbers
 // for the filesystem mounted at the given targetPath.
@@ -182,4 +210,39 @@ func MonitorKernelParamsFile(ctx context.Context, mountPoint, emptyDirBasePath, 
 			}
 		}
 	}
+}
+
+// MountUsingElevatedFuseMaxPagesLimit temporarily increases the host's FUSE max_pages_limit if the current limit is lower,
+// executes the provided function, and then restores the original limit.
+func MountUsingElevatedFuseMaxPagesLimit(targetLimit int64, logPrefix string, fn func() error) error {
+	fuseMaxMaxPagesMu.Lock()
+	defer fuseMaxMaxPagesMu.Unlock()
+
+	origLimit, err := ReadFuseMaxPagesLimit()
+	if err != nil {
+		klog.Warningf("%v Failed to read host FUSE max_pages_limit: %v. Proceeding with default kernel limit.", logPrefix, err)
+		return fn()
+	}
+
+	if origLimit >= targetLimit {
+		return fn()
+	}
+
+	klog.Infof("%v Temporarily increasing host FUSE max_pages_limit from %d to %d for mount", logPrefix, origLimit, targetLimit)
+	if err := SetFuseMaxPagesLimit(targetLimit); err != nil {
+		klog.Warningf("%v Failed to set host FUSE max_pages_limit to %d: %v. Proceeding with default kernel limit.", logPrefix, targetLimit, err)
+		return fn()
+	}
+
+	// TODO(mohit): This approach for restoration suffers from TOCTOU problem and needs to be re-visited before default ON enablement
+	// of kernel reader feature in GCSFuse. This restore can overwrite any changes between time when the limit was checked vs the time
+	// when limit was restored.
+	defer func() {
+		klog.Infof("%v Restoring host FUSE max_pages_limit back to %d", logPrefix, origLimit)
+		if err := SetFuseMaxPagesLimit(origLimit); err != nil {
+			klog.Errorf("%v Failed to restore host FUSE max_pages_limit to %d: %v", logPrefix, origLimit, err)
+		}
+	}()
+
+	return fn()
 }

--- a/pkg/util/kernel_params_monitoring_test.go
+++ b/pkg/util/kernel_params_monitoring_test.go
@@ -18,6 +18,8 @@ limitations under the License.
 package util
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -379,5 +381,295 @@ func TestValidateParamValue(t *testing.T) {
 				t.Errorf("validateParamValue(%q, %q): unexpected error: %v", tc.paramName, tc.paramValue, err)
 			}
 		})
+	}
+}
+
+func TestFuseMaxMaxPagesUpdateSupported(t *testing.T) {
+	origPath := procSysFsFuseMaxPagesLimitPath
+	t.Cleanup(func() {
+		procSysFsFuseMaxPagesLimitPath = origPath
+	})
+
+	testCases := []struct {
+		name           string
+		setup          func(t *testing.T, tempDir string) string
+		expectedResult bool
+	}{
+		{
+			name: "FileDoesNotExist",
+			setup: func(t *testing.T, tempDir string) string {
+				return filepath.Join(tempDir, "missing_file")
+			},
+			expectedResult: false,
+		},
+		{
+			name: "FileExists",
+			setup: func(t *testing.T, tempDir string) string {
+				path := filepath.Join(tempDir, "existing_file")
+				if err := os.WriteFile(path, []byte("16\n"), 0644); err != nil {
+					t.Fatalf("failed to write temp file: %v", err)
+				}
+				return path
+			},
+			expectedResult: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			procSysFsFuseMaxPagesLimitPath = tc.setup(t, tempDir)
+			result := FuseMaxMaxPagesUpdateSupported()
+			if result != tc.expectedResult {
+				t.Errorf("Expected %v, got %v", tc.expectedResult, result)
+			}
+		})
+	}
+}
+
+func TestReadFuseMaxPagesLimit(t *testing.T) {
+	origPath := procSysFsFuseMaxPagesLimitPath
+	t.Cleanup(func() {
+		procSysFsFuseMaxPagesLimitPath = origPath
+	})
+
+	testCases := []struct {
+		name          string
+		setup         func(t *testing.T, tempDir string) string
+		expectedValue int64
+		expectError   bool
+	}{
+		{
+			name: "FileDoesNotExist",
+			setup: func(t *testing.T, tempDir string) string {
+				return filepath.Join(tempDir, "missing_file")
+			},
+			expectedValue: 0,
+			expectError:   true,
+		},
+		{
+			name: "ValidContent",
+			setup: func(t *testing.T, tempDir string) string {
+				path := filepath.Join(tempDir, "valid_file")
+				if err := os.WriteFile(path, []byte("  256\n"), 0644); err != nil {
+					t.Fatalf("failed to write temp file: %v", err)
+				}
+				return path
+			},
+			expectedValue: 256,
+			expectError:   false,
+		},
+		{
+			name: "InvalidContent",
+			setup: func(t *testing.T, tempDir string) string {
+				path := filepath.Join(tempDir, "invalid_file")
+				if err := os.WriteFile(path, []byte("abc\n"), 0644); err != nil {
+					t.Fatalf("failed to write temp file: %v", err)
+				}
+				return path
+			},
+			expectedValue: 0,
+			expectError:   true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			procSysFsFuseMaxPagesLimitPath = tc.setup(t, tempDir)
+			val, err := ReadFuseMaxPagesLimit()
+			if tc.expectError {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				if val != tc.expectedValue {
+					t.Errorf("Expected %d, got %d", tc.expectedValue, val)
+				}
+			}
+		})
+	}
+}
+
+func TestSetFuseMaxPagesLimit(t *testing.T) {
+	origPath := procSysFsFuseMaxPagesLimitPath
+	t.Cleanup(func() {
+		procSysFsFuseMaxPagesLimitPath = origPath
+	})
+
+	testCases := []struct {
+		name            string
+		inputLimit      int64
+		expectedContent string
+	}{
+		{
+			name:            "WritePositive",
+			inputLimit:      512,
+			expectedContent: "512\n",
+		},
+		{
+			name:            "WriteZero",
+			inputLimit:      0,
+			expectedContent: "0\n",
+		},
+		{
+			name:            "WriteNegative",
+			inputLimit:      -1,
+			expectedContent: "-1\n",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			tempFile := filepath.Join(tempDir, "max_pages_limit")
+			procSysFsFuseMaxPagesLimitPath = tempFile
+
+			if err := SetFuseMaxPagesLimit(tc.inputLimit); err != nil {
+				t.Fatalf("SetFuseMaxPagesLimit failed: %v", err)
+			}
+
+			bytes, err := os.ReadFile(tempFile)
+			if err != nil {
+				t.Fatalf("failed to read temp file: %v", err)
+			}
+			if string(bytes) != tc.expectedContent {
+				t.Errorf("Expected file content %q, got %q", tc.expectedContent, string(bytes))
+			}
+		})
+	}
+}
+
+func TestMountUsingElevatedFuseMaxPagesLimit(t *testing.T) {
+	origPath := procSysFsFuseMaxPagesLimitPath
+	t.Cleanup(func() {
+		procSysFsFuseMaxPagesLimitPath = origPath
+	})
+
+	testCases := []struct {
+		name                 string
+		initialLimit         int64
+		targetLimit          int64
+		fn                   func(tempFile string) func() error
+		expectedMountError   bool
+		expectedLimitInMount int64
+		expectedFinalLimit   int64
+		expectPanic          bool
+	}{
+		{
+			name:         "should temporarily increase limit and restore it",
+			initialLimit: 256,
+			targetLimit:  512,
+			fn: func(tempFile string) func() error {
+				return func() error {
+					// Inside the mount function, the limit should be increased to 512
+					limit, err := ReadFuseMaxPagesLimit()
+					if err != nil {
+						return err
+					}
+					if limit != 512 {
+						return fmt.Errorf("expected limit during mount to be 512, got %d", limit)
+					}
+					return nil
+				}
+			},
+			expectedFinalLimit: 256,
+		},
+		{
+			name:         "should not change limit if target is smaller or equal",
+			initialLimit: 256,
+			targetLimit:  128,
+			fn: func(tempFile string) func() error {
+				return func() error {
+					limit, err := ReadFuseMaxPagesLimit()
+					if err != nil {
+						return err
+					}
+					if limit != 256 {
+						return fmt.Errorf("expected limit during mount to remain 256, got %d", limit)
+					}
+					return nil
+				}
+			},
+			expectedFinalLimit: 256,
+		},
+		{
+			name:         "should propagate error and still restore limit",
+			initialLimit: 256,
+			targetLimit:  512,
+			fn: func(tempFile string) func() error {
+				return func() error {
+					return errors.New("mount failed")
+				}
+			},
+			expectedMountError: true,
+			expectedFinalLimit: 256,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			tempFile := filepath.Join(tempDir, "max_pages_limit")
+			procSysFsFuseMaxPagesLimitPath = tempFile
+
+			if err := SetFuseMaxPagesLimit(tc.initialLimit); err != nil {
+				t.Fatalf("SetFuseMaxPagesLimit failed: %v", err)
+			}
+
+			err := MountUsingElevatedFuseMaxPagesLimit(tc.targetLimit, "test", tc.fn(tempFile))
+			if tc.expectedMountError && err == nil {
+				t.Errorf("Expected mount error, got nil")
+			}
+			if !tc.expectedMountError && err != nil {
+				t.Errorf("Unexpected mount error: %v", err)
+			}
+
+			finalLimit, err := ReadFuseMaxPagesLimit()
+			if err != nil {
+				t.Fatalf("failed to read final limit: %v", err)
+			}
+			if finalLimit != tc.expectedFinalLimit {
+				t.Errorf("Expected final limit to be %d, got %d", tc.expectedFinalLimit, finalLimit)
+			}
+		})
+	}
+}
+
+func TestMountUsingElevatedFuseMaxPagesLimitPanic(t *testing.T) {
+	origPath := procSysFsFuseMaxPagesLimitPath
+	t.Cleanup(func() {
+		procSysFsFuseMaxPagesLimitPath = origPath
+	})
+
+	tempDir := t.TempDir()
+	tempFile := filepath.Join(tempDir, "max_pages_limit")
+	procSysFsFuseMaxPagesLimitPath = tempFile
+
+	if err := SetFuseMaxPagesLimit(256); err != nil {
+		t.Fatalf("SetFuseMaxPagesLimit failed: %v", err)
+	}
+
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Errorf("Expected panic, did not panic")
+			}
+		}()
+
+		_ = MountUsingElevatedFuseMaxPagesLimit(512, "test", func() error {
+			panic("mount panic")
+		})
+	}()
+
+	finalLimit, err := ReadFuseMaxPagesLimit()
+	if err != nil {
+		t.Fatalf("failed to read final limit: %v", err)
+	}
+	if finalLimit != 256 {
+		t.Errorf("Expected final limit to be restored to 256, got %d", finalLimit)
 	}
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -36,7 +36,8 @@ import (
 )
 
 const (
-	Mb = 1024 * 1024
+	KiB = 1024
+	MiB = 1024 * KiB
 
 	TrueStr  = "true"
 	FalseStr = "false"
@@ -338,4 +339,9 @@ func CheckNotSymlink(path string) error {
 		return fmt.Errorf("security error: path %q is a symlink", path)
 	}
 	return nil
+}
+
+// CeilDiv64 performs integer division of 'a' by 'b', rounding the result up.
+func CeilDiv64(a, b int64) int64 {
+	return (a + b - 1) / b
 }

--- a/test/e2e/specs/specs.go
+++ b/test/e2e/specs/specs.go
@@ -1145,6 +1145,11 @@ func (t *TestPod) VerifyDefaultingFlagsArePassed(namespace string, expectedMachi
 		"Should find MachineType flag string %q in stdout", expectedMachineTypeFlagString)
 }
 
+func (t *TestPod) GetSidecarLogs() (string, error) {
+	stdout, _, err := runKubectlWithFullOutputWithRetry(t.namespace.Name, "logs", t.pod.Name, "-c", "gke-gcsfuse-sidecar")
+	return stdout, err
+}
+
 func (t *TestPod) VerifyProfileFlagsArePassed(namespace string, expectedProfileFlag string, expectedProfile bool) {
 	stdout, stderr, err := runKubectlWithFullOutputWithRetry(namespace, "logs", t.pod.Name, "-c", "gke-gcsfuse-sidecar")
 	framework.ExpectNoError(err,

--- a/test/e2e/testsuites/kernel_params.go
+++ b/test/e2e/testsuites/kernel_params.go
@@ -19,15 +19,19 @@ package testsuites
 import (
 	"context"
 	"fmt"
+	"os"
 	"regexp"
+	"strconv"
 	"strings"
 
+	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util"
 	"local/test/e2e/specs"
 	"local/test/e2e/utils"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -40,15 +44,21 @@ import (
 type ParamName string
 
 const (
-	MaxReadAheadKb               ParamName = "max-read-ahead-kb"
-	MaxBackgroundRequests        ParamName = "fuse-max-background-requests"
-	CongestionWindowThreshold    ParamName = "fuse-congestion-window-threshold"
-	CustomCSIReadAhead3MB                  = "3072"
-	CustomGCSFuseMaxReadAhead6MB           = "6144"
-	CustomGCSFuseMaxReadAhead8MB           = "8192"
-	CustomMaxBackground                    = "999"
-	CustomCongestionThreshold              = "666"
-	tmpMountPath                           = "/gcsfuse-tmp"
+	MaxReadAheadKb                ParamName = "max-read-ahead-kb"
+	MaxBackgroundRequests         ParamName = "fuse-max-background-requests"
+	CongestionWindowThreshold     ParamName = "fuse-congestion-window-threshold"
+	CustomCSIReadAhead3MiB                  = "3072"
+	CustomGCSFuseMaxReadAhead6MiB           = "6144"
+	CustomGCSFuseMaxReadAhead8MiB           = "8192"
+	CustomMaxBackground                     = "999"
+	CustomCongestionThreshold               = "666"
+	tmpMountPath                            = "/gcsfuse-tmp"
+
+	testFileSizeMiB       = 16
+	testFileSize32MiB     = 32
+	requestSize32MiBInKiB = 32 * util.KiB
+	chunkSize1MiBBytes    = 1 * util.MiB
+	expectedChunkCount    = 16
 )
 
 type gcsFuseCSIKernelParamsTestSuite struct {
@@ -137,6 +147,19 @@ func skipIfKernelParamsNotSupported() {
 	// Kernel parameters were introduced in v3.7.0-gke.0.
 	if !gcsfuseVersion.AtLeast(version.MustParseSemantic(utils.MinGCSFuseKernelParamsVersion)) {
 		e2eskipper.Skipf("skip kernel params test for unsupported gcsfuse version %s", gcsfuseVersion.String())
+	}
+}
+
+func skipIfFuseMaxRequestSizeNotSupported() {
+	gcsfuseVersion, branch := specs.GCSFuseVersionAndBranch()
+
+	// Running since we are on master branch.
+	if branch == utils.MasterBranchName {
+		return
+	}
+	// fuse-max-request-size-kb was introduced in v3.11.1-gke.0.
+	if !gcsfuseVersion.AtLeast(version.MustParseSemantic(utils.MinGCSFuseFuseMaxRequestSizeVersion)) {
+		e2eskipper.Skipf("skip fuse max request size test for unsupported gcsfuse version %s", gcsfuseVersion.String())
 	}
 }
 
@@ -242,7 +265,7 @@ func (t *gcsFuseCSIKernelParamsTestSuite) DefineTests(driver storageframework.Te
 
 		ginkgo.By("Configuring and setting up test pod")
 		// This read_ahead_kb will be overwritten by GCSFuse default readAheadKb in config file.
-		tPod := setupAndDeployTestPod(ctx, f, l.volumeResource, false /* needsFuseConnections */, fmt.Sprintf("read_ahead_kb=%s", CustomCSIReadAhead3MB))
+		tPod := setupAndDeployTestPod(ctx, f, l.volumeResource, false /* needsFuseConnections */, fmt.Sprintf("read_ahead_kb=%s", CustomCSIReadAhead3MiB))
 
 		ginkgo.By("Verifying read_ahead_kb is eventually overwritten by GCSFuse default value")
 		expectedValue := kernelParamValueFromConfigFile(f, tPod, volumeName, MaxReadAheadKb)
@@ -252,7 +275,7 @@ func (t *gcsFuseCSIKernelParamsTestSuite) DefineTests(driver storageframework.Te
 
 		ginkgo.By("Verify actual value of ReadAheadKb is not equal to CSI read_ahead_kb value")
 		actualValue := KernelParamValueFromMount(f, tPod, MaxReadAheadKb)
-		gomega.Expect(actualValue).ShouldNot(gomega.Equal(CustomCSIReadAhead3MB))
+		gomega.Expect(actualValue).ShouldNot(gomega.Equal(CustomCSIReadAhead3MiB))
 
 		ginkgo.By("Deleting the pod")
 		tPod.Cleanup(ctx)
@@ -267,11 +290,11 @@ func (t *gcsFuseCSIKernelParamsTestSuite) DefineTests(driver storageframework.Te
 
 		ginkgo.By("Configuring and setting up test pod")
 		// This read_ahead_kb will be overwritten by user provided GCSFuse max-read-ahead-kb in config file.
-		tPod := setupAndDeployTestPod(ctx, f, l.volumeResource, false /* needsFuseConnections */, fmt.Sprintf("read_ahead_kb=%s,file-system:max-read-ahead-kb:%s", CustomCSIReadAhead3MB, CustomGCSFuseMaxReadAhead6MB))
+		tPod := setupAndDeployTestPod(ctx, f, l.volumeResource, false /* needsFuseConnections */, fmt.Sprintf("read_ahead_kb=%s,file-system:max-read-ahead-kb:%s", CustomCSIReadAhead3MiB, CustomGCSFuseMaxReadAhead6MiB))
 
 		ginkgo.By("Verifying ReadAheadkb is eventually overwritten by user provided value of GCSFuse max-read-ahead-kb")
 		expectedValue := kernelParamValueFromConfigFile(f, tPod, volumeName, MaxReadAheadKb)
-		gomega.Expect(CustomGCSFuseMaxReadAhead6MB).Should(gomega.Equal(expectedValue))
+		gomega.Expect(CustomGCSFuseMaxReadAhead6MiB).Should(gomega.Equal(expectedValue))
 		gomega.Eventually(func() string {
 			return KernelParamValueFromMount(f, tPod, MaxReadAheadKb)
 		}, retryTimeout, retryPolling).Should(gomega.Equal(expectedValue))
@@ -360,7 +383,7 @@ func (t *gcsFuseCSIKernelParamsTestSuite) DefineTests(driver storageframework.Te
 			ginkgo.By("Deleting the pod")
 			tPod.Cleanup(ctx)
 		},
-		ginkgo.Entry("for read-ahead-kb", MaxReadAheadKb, CustomGCSFuseMaxReadAhead8MB, false),
+		ginkgo.Entry("for read-ahead-kb", MaxReadAheadKb, CustomGCSFuseMaxReadAhead8MiB, false),
 		ginkgo.Entry("for max-background", MaxBackgroundRequests, CustomMaxBackground, true),
 		ginkgo.Entry("for congestion-threshold", CongestionWindowThreshold, CustomCongestionThreshold, true),
 	)
@@ -381,4 +404,235 @@ func (t *gcsFuseCSIKernelParamsTestSuite) DefineTests(driver storageframework.Te
 		ginkgo.By("Deleting the pod")
 		tPod.Cleanup(ctx)
 	})
+
+	ginkgo.It("should verify node_fuse_max_request_limit_kb=0 disables higher file I/O", func() {
+		if driver, ok := driver.(*specs.GCSFuseCSITestDriver); ok && driver.EnableZB {
+			e2eskipper.Skipf("skip for zonal bucket")
+		}
+		init(specs.EnableKernelParamsPrefix)
+		skipIfFuseMaxRequestSizeNotSupported()
+		defer cleanup()
+
+		ginkgo.By("Configuring and setting up test pod with trace logging")
+		tPod := setupAndDeployTestPod(ctx, f, l.volumeResource, false /* needsFuseConnections */, "enable-kernel-reader=true,node_fuse_max_request_limit_kb=0,logging:severity:trace")
+		defer tPod.Cleanup(ctx)
+
+		// We use direct-io=true to bypass the page cache, allowing us to verify file I/O correctly.
+		ginkgo.By("Write a 16MB file in single block and read in single block")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("dd if=/dev/zero of=%s/testfile bs=%dM count=1 oflag=direct", mountPath, testFileSizeMiB))
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("dd if=%s/testfile of=/dev/null bs=%dM count=1 iflag=direct", mountPath, testFileSizeMiB))
+
+		bucketName := l.volumeResource.VolSource.CSI.VolumeAttributes["bucketName"]
+		ginkgo.By("Verifying write I/O is present in sidecar logs in 1MiB blocks")
+		assertFuseIO(tPod, "write", chunkSize1MiBBytes, expectedChunkCount, bucketName)
+
+		ginkgo.By("Verifying read I/O is present in sidecar logs in 1MiB blocks")
+		assertFuseIO(tPod, "read", chunkSize1MiBBytes, expectedChunkCount, bucketName)
+	})
+
+	ginkgo.It("should verify enabling kernel reader results in 16MiB readFile I/O", func() {
+		if driver, ok := driver.(*specs.GCSFuseCSITestDriver); ok && driver.EnableZB {
+			e2eskipper.Skipf("skip for zonal bucket")
+		}
+		init(specs.EnableKernelParamsPrefix)
+		defer cleanup()
+
+		ginkgo.By("Configuring and setting up test pod with trace logging")
+		tPod := setupAndDeployTestPod(ctx, f, l.volumeResource, false /* needsFuseConnections */, "enable-kernel-reader=true,logging:severity:trace")
+		defer tPod.Cleanup(ctx)
+
+		// We use direct-io=true to bypass the page cache, allowing us to verify file I/O correctly.
+		ginkgo.By("Write a 16MB file in a single block and read in a single block")
+		targetSize := int64(testFileSizeMiB * chunkSize1MiBBytes)
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("dd if=/dev/zero of=%s/testfile bs=%d count=1 oflag=direct", mountPath, targetSize))
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("dd if=%s/testfile of=/dev/null bs=%d count=1 iflag=direct", mountPath, targetSize))
+
+		bucketName := l.volumeResource.VolSource.CSI.VolumeAttributes["bucketName"]
+		ginkgo.By("Verifying write I/O is present in sidecar logs in 1MiB blocks")
+		assertFuseIO(tPod, "write", chunkSize1MiBBytes, expectedChunkCount, bucketName)
+
+		ginkgo.By("Verifying read I/O is present in sidecar logs in a single 16MiB block")
+		assertFuseIO(tPod, "read", targetSize, 1, bucketName)
+	})
+
+	ginkgo.It("should verify enabling kernel reader with non-default setting results in 32MiB read and write file I/O", func() {
+		if driver, ok := driver.(*specs.GCSFuseCSITestDriver); ok && driver.EnableZB {
+			e2eskipper.Skipf("skip for zonal bucket")
+		}
+		init(specs.EnableKernelParamsPrefix)
+		skipIfFuseMaxRequestSizeNotSupported()
+		defer cleanup()
+
+		ginkgo.By("Configuring and deploying test pod with 32MiB limits and trace logging")
+		tPod := specs.NewTestPod(f.ClientSet, f.Namespace)
+		tPod.SetupVolume(l.volumeResource, volumeName, mountPath, false,
+			fmt.Sprintf("enable-kernel-reader=true,node_fuse_max_request_limit_kb=%d,file-system:fuse-max-request-size-kb:%d,logging:severity:trace", requestSize32MiBInKiB, requestSize32MiBInKiB))
+		tPod.SetupTmpVolumeMount(tmpMountPath)
+		tPod.SetResource("100m", "50Mi", "100Mi")
+		defer tPod.Cleanup(ctx)
+
+		tPod.Create(ctx)
+		tPod.WaitForRunning(ctx)
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("mountpoint %q", mountPath))
+
+		// We use direct-io=true to bypass the page cache, allowing us to verify file I/O correctly.
+		ginkgo.By("Write a 32MB file in a single block and read in a single block")
+		targetSize := int64(testFileSize32MiB * chunkSize1MiBBytes)
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("dd if=/dev/zero of=%s/testfile bs=%d count=1 oflag=direct", mountPath, targetSize))
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("dd if=%s/testfile of=/dev/null bs=%d count=1 iflag=direct", mountPath, targetSize))
+
+		bucketName := l.volumeResource.VolSource.CSI.VolumeAttributes["bucketName"]
+		ginkgo.By("Verifying write I/O is present in sidecar logs in 1MiB blocks")
+		assertFuseIO(tPod, "write", chunkSize1MiBBytes, testFileSize32MiB, bucketName)
+
+		ginkgo.By("Verifying read I/O is present in sidecar logs in a single 32MiB block")
+		assertFuseIO(tPod, "read", targetSize, 1, bucketName)
+	})
+
+	ginkgo.It("should verify enabling kernel reader on multiple volumes inside a single pod yields independent 16MiB and 32MiB block file I/O", func() {
+		if driver, ok := driver.(*specs.GCSFuseCSITestDriver); ok && driver.EnableZB {
+			e2eskipper.Skipf("skip for zonal bucket")
+		}
+		init(specs.EnableKernelParamsPrefix)
+		skipIfFuseMaxRequestSizeNotSupported()
+		defer cleanup()
+
+		ginkgo.By("Creating the second volume resource (second bucket)")
+		l.config.Prefix = specs.EnableKernelParamsPrefix
+		volumeResource2 := storageframework.CreateVolumeResource(ctx, driver, l.config, pattern, e2evolume.SizeRange{})
+		defer func() {
+			if volumeResource2 != nil {
+				framework.ExpectNoError(volumeResource2.CleanupResource(ctx))
+			}
+		}()
+
+		ginkgo.By("Configuring and deploying a multi-volume test pod")
+		tPod := specs.NewTestPod(f.ClientSet, f.Namespace)
+		tPod.SetupVolume(l.volumeResource, "vol-16mib", "/mnt/test-16mib", false,
+			"enable-kernel-reader=true,logging:severity:trace")
+		tPod.SetupVolume(volumeResource2, "vol-32mib", "/mnt/test-32mib", false,
+			fmt.Sprintf("enable-kernel-reader=true,node_fuse_max_request_limit_kb=%d,file-system:fuse-max-request-size-kb:%d,logging:severity:trace", requestSize32MiBInKiB, requestSize32MiBInKiB))
+		tPod.SetupTmpVolumeMount(tmpMountPath)
+		tPod.SetResource("100m", "50Mi", "100Mi")
+		defer tPod.Cleanup(ctx)
+
+		tPod.Create(ctx)
+		tPod.WaitForRunning(ctx)
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, "mountpoint '/mnt/test-16mib'")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, "mountpoint '/mnt/test-32mib'")
+
+		// We use direct-io=true to bypass the page cache, allowing us to verify file I/O correctly.
+		ginkgo.By("Write 16MiB to Volume 1 (vol-16mib) and verify write and read logs")
+		targetSize16 := int64(testFileSizeMiB * chunkSize1MiBBytes)
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("dd if=/dev/zero of=/mnt/test-16mib/testfile bs=%d count=1 oflag=direct", targetSize16))
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("dd if=/mnt/test-16mib/testfile of=/dev/null bs=%d count=1 iflag=direct", targetSize16))
+
+		ginkgo.By("Write 32MiB to Volume 2 (vol-32mib) and verify write and read logs")
+		targetSize32 := int64(testFileSize32MiB * chunkSize1MiBBytes)
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("dd if=/dev/zero of=/mnt/test-32mib/testfile bs=%d count=1 oflag=direct", targetSize32))
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("dd if=/mnt/test-32mib/testfile of=/dev/null bs=%d count=1 iflag=direct", targetSize32))
+
+		bucketName16 := l.volumeResource.VolSource.CSI.VolumeAttributes["bucketName"]
+		bucketName32 := volumeResource2.VolSource.CSI.VolumeAttributes["bucketName"]
+
+		ginkgo.By("Verifying Volume 1 (16MiB) I/O traces in sidecar logs")
+		assertFuseIO(tPod, "write", chunkSize1MiBBytes, expectedChunkCount, bucketName16)
+		assertFuseIO(tPod, "read", targetSize16, 1, bucketName16)
+
+		ginkgo.By("Verifying Volume 2 (32MiB) I/O traces in sidecar logs")
+		assertFuseIO(tPod, "write", chunkSize1MiBBytes, testFileSize32MiB, bucketName32)
+		assertFuseIO(tPod, "read", targetSize32, 1, bucketName32)
+	})
+
+	ginkgo.It("should verify that once the GCSFuse mount is done the FUSE max_pages_limit on the host is reverted back to its original default value", func() {
+		if driver, ok := driver.(*specs.GCSFuseCSITestDriver); ok && driver.EnableZB {
+			e2eskipper.Skipf("skip for zonal bucket")
+		}
+		init(specs.EnableKernelParamsPrefix)
+		defer cleanup()
+
+		driverNamespace := "gcs-fuse-csi-driver"
+		if os.Getenv(specs.IsOSSEnvVar) != "true" {
+			driverNamespace = "kube-system"
+		}
+
+		ginkgo.By("Listing CSI driver pods to select a node")
+		pods, err := f.ClientSet.CoreV1().Pods(driverNamespace).List(ctx, metav1.ListOptions{
+			LabelSelector: "k8s-app=gcs-fuse-csi-driver",
+		})
+		framework.ExpectNoError(err)
+		gomega.Expect(pods.Items).ToNot(gomega.BeEmpty())
+
+		// Pick the first driver pod to pin our test pods to its node
+		driverPod := pods.Items[0]
+		nodeName := driverPod.Spec.NodeName
+
+		ginkgo.By("Configuring a host-reader helper pod pinned to the selected node")
+		helperPod := specs.NewTestPod(f.ClientSet, f.Namespace)
+		hostFuseVol := &storageframework.VolumeResource{
+			VolSource: &corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: "/proc/sys/fs/fuse",
+				},
+			},
+		}
+		helperPod.SetupVolume(hostFuseVol, "host-fuse", "/host-proc-sys-fs-fuse", false)
+		helperPod.SetNodeAffinity(nodeName, true)
+
+		ginkgo.By("Deploying the host-reader helper pod")
+		helperPod.Create(ctx)
+		defer helperPod.Cleanup(ctx)
+		helperPod.WaitForRunning(ctx)
+
+		ginkgo.By("Reading the initial FUSE max_pages_limit on the host via the helper pod")
+		limitStr := helperPod.VerifyExecInPodSucceedWithOutput(f, specs.TesterContainerName, "cat /host-proc-sys-fs-fuse/max_pages_limit")
+		initialLimit, err := strconv.ParseInt(strings.TrimSpace(limitStr), 10, 64)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Configuring the GCSFuse test pod with GCSFuse volume and node affinity")
+		tPod := specs.NewTestPod(f.ClientSet, f.Namespace)
+		tPod.SetupVolume(l.volumeResource, volumeName, mountPath, false, "enable-kernel-reader=true")
+		tPod.SetupTmpVolumeMount(tmpMountPath)
+		tPod.SetNodeAffinity(nodeName, true)
+
+		ginkgo.By("Deploying the GCSFuse test pod")
+		tPod.Create(ctx)
+		defer tPod.Cleanup(ctx)
+		tPod.WaitForRunning(ctx)
+
+		ginkgo.By("Checking that the GCSFuse mount is active")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("mountpoint %q", mountPath))
+
+		ginkgo.By("Reading the FUSE max_pages_limit on the host again via the helper pod")
+		limitStr = helperPod.VerifyExecInPodSucceedWithOutput(f, specs.TesterContainerName, "cat /host-proc-sys-fs-fuse/max_pages_limit")
+		currentLimit, err := strconv.ParseInt(strings.TrimSpace(limitStr), 10, 64)
+		framework.ExpectNoError(err)
+
+		gomega.Expect(currentLimit).To(gomega.Equal(initialLimit), "host max_pages_limit (%d) should be reverted back to its initial value (%d)", currentLimit, initialLimit)
+	})
+}
+
+func countWriteSizes(stdout string, targetSize int64, bucketName string) int {
+	re := regexp.MustCompile(fmt.Sprintf(`<- WriteFile \([^)]*?, (%d) bytes\).*?"mount-id":"%s-`, targetSize, regexp.QuoteMeta(bucketName)))
+	matches := re.FindAllStringSubmatch(stdout, -1)
+	return len(matches)
+}
+
+func countReadSizes(stdout string, targetSize int64, bucketName string) int {
+	re := regexp.MustCompile(fmt.Sprintf(`<- ReadFile \([^)]*?, (%d) bytes\).*?"mount-id":"%s-`, targetSize, regexp.QuoteMeta(bucketName)))
+	matches := re.FindAllStringSubmatch(stdout, -1)
+	return len(matches)
+}
+
+func assertFuseIO(tPod *specs.TestPod, opType string, targetSize int64, expectedCount int, bucketName string) {
+	gomega.Eventually(func() int {
+		stdout, err := tPod.GetSidecarLogs()
+		if err != nil {
+			return 0
+		}
+		if opType == "write" {
+			return countWriteSizes(stdout, targetSize, bucketName)
+		}
+		return countReadSizes(stdout, targetSize, bucketName)
+	}, retryTimeout, retryPolling).Should(gomega.Equal(expectedCount))
 }

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -48,6 +48,7 @@ const (
 	MinGCSFuseTestConfigVersion              = "v3.7.0-gke.0"
 	MinGCSFuseMetricsCardinalityFixesVersion = "v3.7.2-gke.0" // The minimum version where we stop exporting metrics if a pod has more than 10 GCSFuse volumes
 	MinGCSFuseGrpcMetricsVersion             = "v3.8.0-gke.0"
+	MinGCSFuseFuseMaxRequestSizeVersion      = "v3.11.1-gke.0"
 
 	GcsfuseVersionVarName = "gcsfuse-version"
 

--- a/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/clientset/clientset.go
+++ b/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/clientset/clientset.go
@@ -55,6 +55,7 @@ type Interface interface {
 	ConfigurePVCLister(ctx context.Context)
 	ConfigureSCLister(ctx context.Context)
 	ConfigurePodTemplateLister(ctx context.Context)
+	ConfigureConfigMapLister(ctx context.Context, namespace string)
 	GetPod(namespace, name string) (*corev1.Pod, error)
 	GetMounterPod(namespace, name string) (*corev1.Pod, error)
 	GetMounterPodsByName(name string) ([]*corev1.Pod, error)
@@ -63,6 +64,7 @@ type Interface interface {
 	GetPVC(namespace string, name string) (*corev1.PersistentVolumeClaim, error)
 	GetSC(name string) (*storagev1.StorageClass, error)
 	GetPodTemplate(namespace, name string) (*corev1.PodTemplate, error)
+	GetConfigMap(namespace, name string) (*corev1.ConfigMap, error)
 	CreateServiceAccountToken(ctx context.Context, namespace, name string, tokenRequest *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error)
 	GetGCPServiceAccountName(ctx context.Context, namespace, name string) (string, error)
 }
@@ -82,6 +84,7 @@ type Clientset struct {
 	pvcLister                 listersv1.PersistentVolumeClaimLister
 	scLister                  storagelisters.StorageClassLister
 	podTemplateLister         listersv1.PodTemplateLister
+	configMapLister           listersv1.ConfigMapLister
 	informerResyncDurationSec int
 	runController             bool
 	enableGCSFuseProfiles     bool
@@ -294,6 +297,9 @@ func (c *Clientset) ConfigurePVCLister(ctx context.Context) {
 }
 
 func (c *Clientset) ConfigureSCLister(ctx context.Context) {
+	labelsToKeep := map[string]bool{
+		profilesutil.LabelProfile: true,
+	}
 	trim := func(obj any) (any, error) {
 		scObj, ok := obj.(*storagev1.StorageClass)
 		if !ok || scObj == nil {
@@ -302,7 +308,7 @@ func (c *Clientset) ConfigureSCLister(ctx context.Context) {
 		return &storagev1.StorageClass{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:   scObj.ObjectMeta.Name,
-				Labels: scObj.ObjectMeta.Labels, // Required by the gcsfuse profiles feature to know if the StorageClass is a profile.
+				Labels: trimMap(scObj.ObjectMeta.Labels, labelsToKeep), // Required by the gcsfuse profiles feature to know if the StorageClass is a profile.
 			},
 			MountOptions: scObj.MountOptions, // Required by the gcsfuse profiles feature to apply pre-bundled mount options.
 			Parameters:   scObj.Parameters,   // Required by the gcsfuse profiles feature to get profile configs.
@@ -313,6 +319,9 @@ func (c *Clientset) ConfigureSCLister(ctx context.Context) {
 		c.k8sClients,
 		time.Duration(c.informerResyncDurationSec)*time.Second,
 		informers.WithTransform(trim),
+		informers.WithTweakListOptions(func(options *metav1.ListOptions) {
+			options.LabelSelector = fmt.Sprintf("%s=%s", profilesutil.LabelProfile, util.TrueStr)
+		}),
 	)
 	scLister := informerFactory.Storage().V1().StorageClasses().Lister()
 
@@ -350,6 +359,38 @@ func (c *Clientset) ConfigurePodTemplateLister(ctx context.Context) {
 	informerFactory.WaitForCacheSync(ctx.Done())
 
 	c.podTemplateLister = podTemplateLister
+}
+
+func (c *Clientset) ConfigureConfigMapLister(ctx context.Context, namespace string) {
+	trim := func(obj any) (any, error) {
+		cmObj, ok := obj.(*corev1.ConfigMap)
+		if !ok || cmObj == nil {
+			return obj, nil
+		}
+		return &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      cmObj.ObjectMeta.Name,
+				Namespace: cmObj.ObjectMeta.Namespace,
+			},
+			Data: cmObj.Data,
+		}, nil
+	}
+
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(
+		c.k8sClients,
+		time.Duration(c.informerResyncDurationSec)*time.Second,
+		informers.WithNamespace(namespace),
+		informers.WithTweakListOptions(func(options *metav1.ListOptions) {
+			options.FieldSelector = fmt.Sprintf("metadata.name=%s", util.SidecarImageConfigMapName)
+		}),
+		informers.WithTransform(trim),
+	)
+	configMapLister := informerFactory.Core().V1().ConfigMaps().Lister()
+
+	informerFactory.Start(ctx.Done())
+	informerFactory.WaitForCacheSync(ctx.Done())
+
+	c.configMapLister = configMapLister
 }
 
 func New(kubeconfigPath string, informerResyncDurationSec int, runController bool, kubeAPIBurst int, kubeAPIQPS float64, enableGCSFuseProfiles, enableSharedMount bool) (Interface, error) {
@@ -446,9 +487,11 @@ func (c *Clientset) configureControllerPodLister(ctx context.Context, nodeName s
 				klog.Fatalf("Failed to add indexers: %v", err)
 			}
 		}
+		podLister := factory.Core().V1().Pods().Lister()
+		podInformer := factory.Core().V1().Pods().Informer()
 		factory.Start(ctx.Done())
 		factory.WaitForCacheSync(ctx.Done())
-		return factory.Core().V1().Pods().Lister(), factory.Core().V1().Pods().Informer()
+		return podLister, podInformer
 	}
 
 	if c.enableGCSFuseProfiles {
@@ -541,9 +584,12 @@ func (c *Clientset) ConfigurePodLister(ctx context.Context, nodeName string, eve
 		informers.WithTransform(trim),
 	)
 
+	podLister := informerFactory.Core().V1().Pods().Lister()
+
 	informerFactory.Start(ctx.Done())
 	informerFactory.WaitForCacheSync(ctx.Done())
-	c.podLister = informerFactory.Core().V1().Pods().Lister()
+
+	c.podLister = podLister
 }
 
 // GetMounterPodsByName retrieves all mounter pods with the given name across all namespaces.
@@ -641,6 +687,14 @@ func (c *Clientset) GetPodTemplate(namespace, name string) (*corev1.PodTemplate,
 	}
 
 	return c.podTemplateLister.PodTemplates(namespace).Get(name)
+}
+
+func (c *Clientset) GetConfigMap(namespace, name string) (*corev1.ConfigMap, error) {
+	if c.configMapLister == nil {
+		return nil, errors.New("configmap informer is not ready")
+	}
+
+	return c.configMapLister.ConfigMaps(namespace).Get(name)
 }
 
 func (c *Clientset) CreateServiceAccountToken(ctx context.Context, namespace, name string, tokenRequest *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error) {

--- a/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/clientset/fake.go
+++ b/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/clientset/fake.go
@@ -80,6 +80,12 @@ type FakePodTemplateConfig struct {
 	Template  corev1.PodTemplateSpec
 }
 
+type FakeConfigMapConfig struct {
+	Name      string
+	Namespace string
+	Data      map[string]string
+}
+
 type FakeClientset struct {
 	Client            kubernetes.Interface
 	fakePod           *corev1.Pod
@@ -87,8 +93,9 @@ type FakeClientset struct {
 	fakePVs           map[string]*corev1.PersistentVolume
 	fakePVCs          map[string]*corev1.PersistentVolumeClaim
 	fakeSCs           map[string]*storagev1.StorageClass
-	fakePods          []*corev1.Pod
 	fakePodTemplates  map[string]*corev1.PodTemplate
+	fakeConfigMaps    map[string]*corev1.ConfigMap
+	fakePods          []*corev1.Pod
 	ListPodErr        error
 	GetPodErr         error
 	GetPodTemplateErr error
@@ -102,6 +109,7 @@ func NewFakeClientset() *FakeClientset {
 		fakePVCs:         make(map[string]*corev1.PersistentVolumeClaim),
 		fakeSCs:          make(map[string]*storagev1.StorageClass),
 		fakePodTemplates: make(map[string]*corev1.PodTemplate),
+		fakeConfigMaps:   make(map[string]*corev1.ConfigMap),
 		fakePods:         []*corev1.Pod{},
 	}
 	// Default setting for most unit tests is pod doesn't use host network & workload identity is enabled on the node
@@ -111,6 +119,7 @@ func NewFakeClientset() *FakeClientset {
 	fakeClientSet.CreatePVC(FakePVCConfig{})
 	fakeClientSet.CreateSC(FakeSCConfig{})
 	fakeClientSet.CreatePodTemplate(FakePodTemplateConfig{})
+	fakeClientSet.CreateConfigMap(FakeConfigMapConfig{})
 
 	return fakeClientSet
 }
@@ -347,6 +356,27 @@ func (c *FakeClientset) GetPodTemplate(namespace, name string) (*corev1.PodTempl
 	}
 
 	return c.fakePodTemplates[""], nil
+}
+
+func (c *FakeClientset) ConfigureConfigMapLister(_ context.Context, _ string) {}
+
+func (c *FakeClientset) GetConfigMap(namespace, name string) (*corev1.ConfigMap, error) {
+	if cm, ok := c.fakeConfigMaps[name]; ok {
+		return cm, nil
+	}
+	return c.fakeConfigMaps[""], nil
+}
+
+func (c *FakeClientset) CreateConfigMap(cmConfig FakeConfigMapConfig) {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cmConfig.Name,
+			Namespace: cmConfig.Namespace,
+		},
+		Data: cmConfig.Data,
+	}
+
+	c.fakeConfigMaps[cmConfig.Name] = cm
 }
 
 func (c *FakeClientset) CreateServiceAccountToken(_ context.Context, _, _ string, _ *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error) {

--- a/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/csi_driver/controller.go
+++ b/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/csi_driver/controller.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	MinimumVolumeSizeInBytes int64 = 1 * util.Mb
+	MinimumVolumeSizeInBytes int64 = 1 * util.MiB
 )
 
 // CreateVolume parameters.
@@ -150,7 +150,6 @@ func (s *controllerServer) ControllerPublishVolume(ctx context.Context, req *csi
 	if !s.driver.sharedMount(vc) {
 		return &csi.ControllerPublishVolumeResponse{}, nil
 	}
-
 	// Find the workload namespace where the mounter pod should be created by identifying the PVC
 	// bound to this volume's PV.
 	clientset := s.driver.config.K8sClients
@@ -196,9 +195,28 @@ func (s *controllerServer) ControllerPublishVolume(ctx context.Context, req *csi
 	// Extract overrides specifically from the container named "gcsfusecsi-mount".
 	var containerResources *corev1.ResourceRequirements
 	var containerImage string
-	if s.features != nil && s.features.SharedMountOptions != nil {
-		containerImage = s.features.SharedMountOptions.MounterPodImage
+
+	// Retrieve the mounter pod image from the ConfigMap.
+	if s.features == nil || s.features.SharedMountOptions == nil {
+		return nil, status.Error(codes.Internal, "shared mount options can't be nil")
 	}
+	driverNamespace := s.features.SharedMountOptions.DriverNamespace
+	if driverNamespace == "" {
+		return nil, status.Error(codes.Internal, "driver namespace can't be empty")
+	}
+	configMap, err := clientset.GetConfigMap(driverNamespace, util.SidecarImageConfigMapName)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to get image configmap %s/%s: %v", driverNamespace, util.SidecarImageConfigMapName, err)
+	}
+	if configMap == nil || configMap.Data == nil {
+		return nil, status.Errorf(codes.Internal, "%s/%s ConfigMap data can't be empty", driverNamespace, util.SidecarImageConfigMapName)
+	}
+	var ok bool
+	containerImage, ok = configMap.Data[util.SidecarImageConfigMapKey]
+	if !ok || containerImage == "" {
+		return nil, status.Errorf(codes.Internal, "%s/%s ConfigMap is missing key %q or it is empty", driverNamespace, util.SidecarImageConfigMapName, util.SidecarImageConfigMapKey)
+	}
+
 	for i := range podTemplate.Template.Spec.Containers {
 		container := &podTemplate.Template.Spec.Containers[i]
 		if container.Name != util.MounterPodNamePrefix {

--- a/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/csi_driver/gcs_fuse_driver.go
+++ b/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/csi_driver/gcs_fuse_driver.go
@@ -53,8 +53,8 @@ type GoMemLimitOptions struct {
 
 type SharedMountOptions struct {
 	Enabled         bool
-	MounterPodImage string
 	FuseSocketDir   string
+	DriverNamespace string
 	// Needed to override the mounter pods emptydir base path, otherwise tests will try to write to var/lib/kubelet which it won't have access to.
 	EmptyDirBasePath func(podUID string) string
 }

--- a/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/profiles/recommender.go
+++ b/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/profiles/recommender.go
@@ -1037,7 +1037,7 @@ func bytesToMiB(a int64) int64 {
 	if a == -1 {
 		return -1
 	}
-	return ceilDiv64(a, mib)
+	return util.CeilDiv64(a, mib)
 }
 
 // mibToBytes converts mebibytes (MiB) to a byte count.
@@ -1046,11 +1046,6 @@ func mibToBytes(a int64) int64 {
 		return -1
 	}
 	return a * mib
-}
-
-// ceilDiv64 performs integer division of 'a' by 'b', rounding the result up.
-func ceilDiv64(a, b int64) int64 {
-	return (a + b - 1) / b
 }
 
 // isValidMountOption checks if a mount option string follows the allowed formats.

--- a/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/profiles/scanner.go
+++ b/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/profiles/scanner.go
@@ -45,8 +45,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/informers"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
@@ -77,8 +75,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	typedv1 "k8s.io/client-go/kubernetes/typed/core/v1"
-	v1listers "k8s.io/client-go/listers/core/v1"
-	storagelisters "k8s.io/client-go/listers/storage/v1"
 )
 
 const (
@@ -193,10 +189,6 @@ type DatafluxConfig struct {
 // ScannerConfig holds the configuration for the Scanner.
 type ScannerConfig struct {
 	K8SClients                       clientset.Interface // Kubernetes clientset.
-	KubeAPIQPS                       float64             // QPS limit for Kubernetes API client.
-	KubeAPIBurst                     int                 // Burst limit for Kubernetes API client.
-	ResyncPeriod                     time.Duration       // Resync period for informers.
-	KubeConfigPath                   string              // Optional: Path to kubeconfig file. If empty, InClusterConfig is used.
 	CloudConfigPath                  string
 	RateLimiter                      workqueue.TypedRateLimiter[string]
 	DatafluxConfig                   *DatafluxConfig
@@ -241,12 +233,6 @@ type EventInfo struct {
 
 // Scanner is the main controller structure.
 type Scanner struct {
-	kubeClient           kubernetes.Interface
-	pvcLister            v1listers.PersistentVolumeClaimLister
-	scLister             storagelisters.StorageClassLister
-	pvcSynced            cache.InformerSynced
-	scSynced             cache.InformerSynced
-	factory              informers.SharedInformerFactory
 	queue                workqueue.TypedRateLimitingInterface[string]
 	eventRecorder        record.EventRecorder
 	datafluxConfig       *DatafluxConfig
@@ -355,9 +341,11 @@ func buildCloudConfig(configPath string) (*ConfigFile, error) {
 
 // NewScanner creates a new Scanner instance.
 func NewScanner(config *ScannerConfig) (*Scanner, error) {
-	kubeconfig, err := buildKubeConfig(config.KubeConfigPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to build kubeconfig: %w", err)
+	if config == nil {
+		return nil, errors.New("config must not be nil")
+	}
+	if config.K8SClients == nil {
+		return nil, errors.New("K8SClients must be provided in ScannerConfig")
 	}
 
 	// Add a uniquifier so that two processes on the same host don't accidentally both become active.
@@ -368,40 +356,18 @@ func NewScanner(config *ScannerConfig) (*Scanner, error) {
 	}
 	id := hostname + "_" + string(uuid.NewUUID())
 
-	kubeconfig.QPS = float32(config.KubeAPIQPS)
-	kubeconfig.Burst = config.KubeAPIBurst
-	klog.Infof("KubeClient QPS: %f, Burst: %d", kubeconfig.QPS, kubeconfig.Burst)
-	kubeClient, err := kubernetes.NewForConfig(kubeconfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create kubernetes client: %w", err)
-	}
-
 	rateLimiter := config.RateLimiter
 	if rateLimiter == nil {
 		rateLimiter = workqueue.DefaultTypedControllerRateLimiter[string]()
 	}
 
-	// Factory for PV, PVC and SC informers
-	if config.K8SClients == nil {
-		return nil, errors.New("K8SClients must be provided in ScannerConfig")
-	}
-	factory := informers.NewSharedInformerFactory(kubeClient, config.ResyncPeriod)
-	pvcInformer := factory.Core().V1().PersistentVolumeClaims()
-	scInformer := factory.Storage().V1().StorageClasses()
-
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartStructuredLogging(0)
-	eventBroadcaster.StartRecordingToSink(&typedv1.EventSinkImpl{Interface: kubeClient.CoreV1().Events("")})
+	eventBroadcaster.StartRecordingToSink(&typedv1.EventSinkImpl{Interface: config.K8SClients.K8sClient().CoreV1().Events("")})
 	eventRecorder := eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: scannerComponentName})
 	mux := http.NewServeMux()
 
 	scanner := &Scanner{
-		kubeClient:     kubeClient,
-		factory:        factory,
-		pvcLister:      pvcInformer.Lister(),
-		scLister:       scInformer.Lister(),
-		pvcSynced:      pvcInformer.Informer().HasSynced,
-		scSynced:       scInformer.Informer().HasSynced,
 		queue:          workqueue.NewTypedRateLimitingQueue(rateLimiter),
 		trackedPVs:     make(map[string]syncInfo),
 		eventRecorder:  eventRecorder,
@@ -480,16 +446,6 @@ func (s *Scanner) run(ctx context.Context) {
 
 	stopCh := ctx.Done()
 
-	klog.Info("Starting informers")
-	s.factory.Start(stopCh)
-
-	klog.Info("Waiting for informer caches to sync")
-	if !cache.WaitForCacheSync(stopCh, s.pvcSynced, s.scSynced) {
-		klog.Error("Failed to wait for caches to sync")
-		return
-	}
-	klog.Info("Informer caches synced successfully")
-
 	klog.Info("Starting worker")
 	go wait.Until(func() { s.runWorker(ctx) }, time.Second, ctx.Done())
 
@@ -529,7 +485,7 @@ func (s *Scanner) runWithLeaderElection(ctx context.Context, cancel context.Canc
 		s.config.LeaderElectionNamespace,
 		leaseName,
 		nil,
-		s.kubeClient.CoordinationV1(),
+		s.config.K8SClients.K8sClient().CoordinationV1(),
 		resourcelock.ResourceLockConfig{
 			Identity: s.id,
 		})
@@ -698,7 +654,7 @@ func (s *Scanner) syncPod(ctx context.Context, key string) error {
 		}
 
 		pvcName := vol.PersistentVolumeClaim.ClaimName
-		pvc, err := s.pvcLister.PersistentVolumeClaims(namespace).Get(pvcName)
+		pvc, err := s.config.K8SClients.GetPVC(namespace, pvcName)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				klog.Warningf("PVC %q/%q for Pod %q not found, will recheck Pod later", namespace, pvcName, key)
@@ -796,7 +752,7 @@ func (s *Scanner) removeSchedulingGate(ctx context.Context, pod *v1.Pod) error {
 		return fmt.Errorf("failed to marshal patch data for Pod %q/%q: %w", pod.Namespace, pod.Name, err)
 	}
 
-	_, err = s.kubeClient.CoreV1().Pods(pod.Namespace).Patch(ctx, pod.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+	_, err = s.config.K8SClients.K8sClient().CoreV1().Pods(pod.Namespace).Patch(ctx, pod.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			klog.Warningf("Failed to patch Pod %q/%q because it was not found", pod.Namespace, pod.Name)
@@ -1498,7 +1454,7 @@ func (s *Scanner) ensurePVTrackingLabel(ctx context.Context, pv *v1.PersistentVo
 		return status.Errorf(codes.Internal, "failed to marshal label patch data for PV %q: %v", pv.Name, marshalErr)
 	}
 	klog.V(6).Infof("PV %q is missing the tracking label. Patching it with: %q", pv.Name, string(patchBytes))
-	_, patchErr := s.kubeClient.CoreV1().PersistentVolumes().Patch(ctx, pv.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+	_, patchErr := s.config.K8SClients.K8sClient().CoreV1().PersistentVolumes().Patch(ctx, pv.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
 	if patchErr != nil {
 		if apierrors.IsNotFound(patchErr) {
 			klog.Warningf("Failed to patch PV %q because it was not found", pv.Name)
@@ -1525,7 +1481,7 @@ func (s *Scanner) patchPVAnnotations(ctx context.Context, pvName string, annotat
 		return status.Errorf(codes.Internal, "failed to marshal annotation patch data for PV %q: %v", pvName, err)
 	}
 	klog.V(6).Infof("Patching PV %q annotations with: %q", pvName, string(patchBytes))
-	_, err = s.kubeClient.CoreV1().PersistentVolumes().Patch(ctx, pvName, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+	_, err = s.config.K8SClients.K8sClient().CoreV1().PersistentVolumes().Patch(ctx, pvName, types.MergePatchType, patchBytes, metav1.PatchOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			klog.Warningf("Failed to patch PV %q because it was not found", pvName)
@@ -1870,7 +1826,7 @@ func (s *Scanner) getStorageClass(pv *v1.PersistentVolume) (*storagev1.StorageCl
 	if scName == "" {
 		return nil, nil
 	}
-	sc, err := s.scLister.Get(scName)
+	sc, err := s.config.K8SClients.GetSC(scName)
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
 			return nil, fmt.Errorf("failed to get StorageClass %q: %w", scName, err)

--- a/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util/kernel_params_monitoring.go
+++ b/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util/kernel_params_monitoring.go
@@ -24,12 +24,40 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
 	"golang.org/x/sys/unix"
 	"k8s.io/klog/v2"
 )
+
+var (
+	// fuseMaxMaxPagesMu serializes concurrent updates to the host's FUSE max_pages_limit.
+	fuseMaxMaxPagesMu sync.Mutex
+	// procSysFsFuseMaxPagesLimitPath is the host FUSE max_pages_limit path (overridable for unit testing).
+	procSysFsFuseMaxPagesLimitPath = "/host-proc-sys-fs-fuse/max_pages_limit"
+)
+
+// FuseMaxMaxPagesUpdateSupported returns true if the host supports FUSE max_pages_limit tuning.
+func FuseMaxMaxPagesUpdateSupported() bool {
+	_, err := os.Lstat(procSysFsFuseMaxPagesLimitPath)
+	return err == nil
+}
+
+// ReadFuseMaxPagesLimit reads the host's current FUSE max_pages_limit.
+func ReadFuseMaxPagesLimit() (int64, error) {
+	bytes, err := os.ReadFile(procSysFsFuseMaxPagesLimitPath)
+	if err != nil {
+		return 0, err
+	}
+	return strconv.ParseInt(strings.TrimSpace(string(bytes)), 10, 64)
+}
+
+// SetFuseMaxPagesLimit writes the target limit to the host's FUSE max_pages_limit file.
+func SetFuseMaxPagesLimit(target int64) error {
+	return os.WriteFile(procSysFsFuseMaxPagesLimitPath, []byte(strconv.FormatInt(target, 10)+"\n"), 0o644)
+}
 
 // getDeviceMajorMinor returns the major and minor device numbers
 // for the filesystem mounted at the given targetPath.
@@ -182,4 +210,36 @@ func MonitorKernelParamsFile(ctx context.Context, mountPoint, emptyDirBasePath, 
 			}
 		}
 	}
+}
+
+// MountUsingElevatedFuseMaxPagesLimit temporarily increases the host's FUSE max_pages_limit if the current limit is lower,
+// executes the provided function, and then restores the original limit.
+func MountUsingElevatedFuseMaxPagesLimit(targetLimit int64, logPrefix string, fn func() error) error {
+	fuseMaxMaxPagesMu.Lock()
+	defer fuseMaxMaxPagesMu.Unlock()
+
+	origLimit, err := ReadFuseMaxPagesLimit()
+	if err != nil {
+		klog.Warningf("%v Failed to read host FUSE max_pages_limit: %v. Proceeding with default kernel limit.", logPrefix, err)
+		return fn()
+	}
+
+	if origLimit >= targetLimit {
+		return fn()
+	}
+
+	klog.Infof("%v Temporarily increasing host FUSE max_pages_limit from %d to %d for mount", logPrefix, origLimit, targetLimit)
+	if err := SetFuseMaxPagesLimit(targetLimit); err != nil {
+		klog.Warningf("%v Failed to set host FUSE max_pages_limit to %d: %v. Proceeding with default kernel limit.", logPrefix, targetLimit, err)
+		return fn()
+	}
+
+	defer func() {
+		klog.Infof("%v Restoring host FUSE max_pages_limit back to %d", logPrefix, origLimit)
+		if err := SetFuseMaxPagesLimit(origLimit); err != nil {
+			klog.Errorf("%v Failed to restore host FUSE max_pages_limit to %d: %v", logPrefix, origLimit, err)
+		}
+	}()
+
+	return fn()
 }

--- a/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util/util.go
+++ b/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util/util.go
@@ -36,7 +36,8 @@ import (
 )
 
 const (
-	Mb = 1024 * 1024
+	KiB = 1024
+	MiB = 1024 * KiB
 
 	TrueStr  = "true"
 	FalseStr = "false"
@@ -75,6 +76,8 @@ const (
 	KubeletPluginsGCSFuseDir            = "/var/lib/kubelet/plugins/kubernetes.io/csi/gcsfuse.csi.storage.gke.io"
 	VolumeContextKeyPVName              = "csi.storage.k8s.io/pv/name"
 	MounterPodNamePrefix                = "gcsfusecsi-mount"
+	SidecarImageConfigMapName           = "gcsfusecsi-image-config"
+	SidecarImageConfigMapKey            = "sidecar-image"
 )
 
 var (
@@ -336,4 +339,9 @@ func CheckNotSymlink(path string) error {
 		return fmt.Errorf("security error: path %q is a symlink", path)
 	}
 	return nil
+}
+
+// CeilDiv64 performs integer division of 'a' by 'b', rounding the result up.
+func CeilDiv64(a, b int64) int64 {
+	return (a + b - 1) / b
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:
This PR adds support for dynamically tuning the host's FUSE `max_pages_limit` during the volume mount operation, the CSI driver:
1. Calculates the required page limit (based on the host's page size).
2. Acquires a lock to prevent concurrent modifications.
3. Temporarily raises the host's `/proc/sys/fs/fuse/max_pages_limit` (if the current value is lower).
4. Executes the FUSE mount.
5. Restores the host's original `max_pages_limit`.
This enables support for larger FUSE request sizes (e.g. up to 16 MiB), which can significantly improve throughput/performance.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
b/526496388

**Special notes for your reviewer**:
* The new CSI option `node_fuse_max_request_limit_kb` is a "hidden" option: it is parsed and stripped by the CSI driver and not passed down to the `gcsfuse` binary.
* Concurrent mount operations on the same node are serialized during the limit adjustment and mount execution using a global lock (`util.FuseMaxMaxPagesMu`).
* Unit tests have been added to verify reading, setting, and checking support for `max_pages_limit` under `pkg/util/kernel_params_monitoring_test.go` and the parsing logic in `pkg/csi_mounter/csi_mounter_test.go`.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```