### PR TITLE
Stop logging false-positive Error for missing GCS Fuse cache/buffer dir

### DIFF
--- a/pkg/sidecar_mounter/sidecar_mounter.go
+++ b/pkg/sidecar_mounter/sidecar_mounter.go
@@ -324,10 +324,14 @@ func logVolumeTotalSize(dirPath string) {
 		return nil
 	})
 
-	if err != nil {
-		klog.Errorf("failed to calculate volume total size for %q: %v", dirPath, err)
-	} else {
+	switch {
+	case err == nil:
 		klog.Infof("total volume size of %v: %v bytes", dirPath, totalSize)
+	case os.IsNotExist(err):
+		// The cache/buffer dir may not exist when caching is not in use for this volume, which is expected and not an error.
+		klog.V(4).Infof("skipping volume total size calculation for %q: %v", dirPath, err)
+	default:
+		klog.Errorf("failed to calculate volume total size for %q: %v", dirPath, err)
 	}
 }
 

--- a/pkg/sidecar_mounter/sidecar_mounter_test.go
+++ b/pkg/sidecar_mounter/sidecar_mounter_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+Copyright 2024 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sidecarmounter
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// captureKlogOutput redirects klog output to a buffer for the duration of fn,
+// then restores klog to logging to stderr.
+func captureKlogOutput(t *testing.T, fn func()) string {
+	t.Helper()
+
+	var buf bytes.Buffer
+	klog.SetOutput(&buf)
+	klog.LogToStderr(false)
+
+	defer func() {
+		klog.LogToStderr(true)
+		klog.SetOutput(os.Stderr)
+	}()
+
+	fn()
+	klog.Flush()
+
+	return buf.String()
+}
+
+func hasErrorLine(output string) bool {
+	for _, line := range strings.Split(output, "\n") {
+		if strings.HasPrefix(line, "E") {
+			return true
+		}
+	}
+
+	return false
+}
+
+func hasInfoLine(output string) bool {
+	for _, line := range strings.Split(output, "\n") {
+		if strings.HasPrefix(line, "I") {
+			return true
+		}
+	}
+
+	return false
+}
+
+func TestLogVolumeTotalSize_MissingDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	missingDir := filepath.Join(tmpDir, "does-not-exist")
+
+	output := captureKlogOutput(t, func() {
+		logVolumeTotalSize(missingDir)
+	})
+
+	if hasErrorLine(output) {
+		t.Errorf("expected no Error-level klog line for a missing directory, got output: %q", output)
+	}
+}
+
+func TestLogVolumeTotalSize_ExistingDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmpDir, "file.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	output := captureKlogOutput(t, func() {
+		logVolumeTotalSize(tmpDir)
+	})
+
+	if hasErrorLine(output) {
+		t.Errorf("expected no Error-level klog line for an existing directory, got output: %q", output)
+	}
+	if !hasInfoLine(output) || !strings.Contains(output, "total volume size of") {
+		t.Errorf("expected an Infof total-size log line for an existing directory, got output: %q", output)
+	}
+}
+
+func TestLogVolumeTotalSize_PermissionDenied(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits behave differently on windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("running as root, permission checks are bypassed")
+	}
+
+	tmpDir := t.TempDir()
+	restrictedDir := filepath.Join(tmpDir, "restricted")
+	if err := os.Mkdir(restrictedDir, 0o755); err != nil {
+		t.Fatalf("failed to create test dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(restrictedDir, "file.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+	if err := os.Chmod(restrictedDir, 0o000); err != nil {
+		t.Fatalf("failed to chmod test dir: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chmod(restrictedDir, 0o755)
+	})
+
+	output := captureKlogOutput(t, func() {
+		logVolumeTotalSize(restrictedDir)
+	})
+
+	if !hasErrorLine(output) {
+		t.Errorf("expected an Error-level klog line for a permission-denied error, got output: %q", output)
+	}
+}


### PR DESCRIPTION
What type of PR is this?

/kind bug

What this PR does / why we need it:

The `gke-gcsfuse-sidecar` container polls buffer/cache dirs every 30s via
`logVolumeTotalSize` and logs any `filepath.Walk` failure at Error level.
When a volume has no file-cache configured, its cache dir legitimately
doesn't exist — but this benign case still logged `lstat ...: no such file
or directory` as `klog.Errorf`, every cycle, for the pod's lifetime.

In production this generates hundreds of Error logs per workload per day
(~4,419/day across 42 pods in one report) despite every volume mounting and
working correctly, inflating log costs and triggering false Error alerts.

Fix: distinguish `os.IsNotExist(err)` from genuine errors. Missing dirs now
log at `klog.V(4)` instead of `klog.Errorf`; real errors (permission
denied, I/O errors) still log at Error level, unchanged. Added test
coverage for all three cases and verified live on a GKE cluster that the
Error log disappears post-fix while the success-path log is unaffected.

Files changed:

- `pkg/sidecar_mounter/sidecar_mounter.go` — modified `logVolumeTotalSize`
  to branch on `os.IsNotExist(err)` instead of unconditionally logging at
  Error level.
- `pkg/sidecar_mounter/sidecar_mounter_test.go` — new file (no test file
  previously covered this function); adds `TestLogVolumeTotalSize_MissingDir`,
  `TestLogVolumeTotalSize_ExistingDir`, and
  `TestLogVolumeTotalSize_PermissionDenied`.

Which issue(s) this PR fixes:

Fixes #1013

Does this PR introduce a user-facing change?

Reduces log noise: the `gke-gcsfuse-sidecar` container no longer logs a
spurious Error-level message every 30 seconds when a volume has no
file-cache configured. This eliminates false-positive Error-based alerts
that were previously triggered despite the volume mounting and working
correctly.
