### PR TITLE
Keep dir-mode/file-mode as quoted octal strings in gcsfuse config YAML

### DIFF
--- a/pkg/sidecar_mounter/sidecar_mounter_config.go
+++ b/pkg/sidecar_mounter/sidecar_mounter_config.go
@@ -43,6 +43,17 @@ const (
 	KernelParamsFileConfigFlag = "file-system:kernel-params-file"
 )
 
+// octalStringConfigFlags are gcsfuse config-file leaf keys whose values must
+// remain quoted YAML strings (e.g. "777"), not be coerced to YAML integers,
+// since gcsfuse parses them as octal permission bits
+// (see https://cloud.google.com/storage/docs/cloud-storage-fuse/config-file).
+// A bare YAML integer like 777 is decimal, not octal, and gets rejected by
+// gcsfuse with "illegal file perms".
+var octalStringConfigFlags = map[string]bool{
+	"dir-mode":  true,
+	"file-mode": true,
+}
+
 // MountConfig contains the information gcsfuse needs.
 type MountConfig struct {
 	FileDescriptor                 int                   `json:"-"`
@@ -429,12 +440,17 @@ func (mc *MountConfig) prepareConfigFile() error {
 					return fmt.Errorf("invalid config file flag: %q", f)
 				}
 
-				if intVal, err := strconv.ParseInt(v, 10, 64); err == nil {
-					curLevel[t] = intVal
-				} else if boolVal, err := strconv.ParseBool(v); err == nil {
-					curLevel[t] = boolVal
-				} else {
+				switch {
+				case octalStringConfigFlags[t]:
 					curLevel[t] = v
+				default:
+					if intVal, err := strconv.ParseInt(v, 10, 64); err == nil {
+						curLevel[t] = intVal
+					} else if boolVal, err := strconv.ParseBool(v); err == nil {
+						curLevel[t] = boolVal
+					} else {
+						curLevel[t] = v
+					}
 				}
 
 				break

--- a/pkg/sidecar_mounter/sidecar_mounter_config_test.go
+++ b/pkg/sidecar_mounter/sidecar_mounter_config_test.go
@@ -772,6 +772,22 @@ func TestPrepareConfigFile(t *testing.T) {
 			},
 			expectedErr: true,
 		},
+		{
+			name: "should keep dir-mode and file-mode as quoted octal strings, not YAML ints",
+			mc: &MountConfig{
+				ConfigFile: "./test-config-file.yaml",
+				ConfigFileFlagMap: map[string]string{
+					"file-system:dir-mode":  "777",
+					"file-system:file-mode": "666",
+				},
+			},
+			expectedConfig: map[string]interface{}{
+				"file-system": map[string]interface{}{
+					"dir-mode":  "777",
+					"file-mode": "666",
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
What type of PR is this?

/kind bug

What this PR does / why we need it:

`prepareConfigFile` in `sidecar_mounter_config.go` opportunistically parses
every config-file mount option value with `strconv.ParseInt` before falling
back to a string. Values like `dir-mode:777`/`file-mode:666` parse cleanly
as decimal ints, so they were marshaled into the gcsfuse config YAML as bare
integers (`dir-mode: 777`) instead of the quoted octal strings gcsfuse
expects (`dir-mode: "777"`). gcsfuse then rejects the mount with
`illegal file perms`, even though the user followed the documented format.

Fix: added an `octalStringConfigFlags` set (`dir-mode`, `file-mode`)
checked before the numeric-coercion logic, so these two keys are always
kept as strings. Verified `yaml.v3` auto-quotes numeric-looking strings on
marshal, producing the correct `dir-mode: "777"` gcsfuse expects.

Added a test case to `TestPrepareConfigFile` asserting `dir-mode`/`file-mode`
round-trip as strings. Verified live on a GKE cluster: pre-fix image fails
to mount with `illegal file perms: --w--wx-w-`; post-fix image mounts
successfully with `ls -la` showing the requested `-rw-rw-rw-` (666) bits.

Which issue(s) this PR fixes:

Fixes #871

Does this PR introduce a user-facing change?

Fixes mounting with `dir-mode`/`file-mode` mount options (e.g.
`file-system:dir-mode:777,file-system:file-mode:666`) — these were
previously always rejected with `illegal file perms` regardless of the
values passed.
