### PR TITLE
Implement Host NetWork Integration in CPV and NSV

### DIFF
--- a/pkg/csi_driver/controller.go
+++ b/pkg/csi_driver/controller.go
@@ -237,6 +237,16 @@ func (s *controllerServer) ControllerPublishVolume(ctx context.Context, req *csi
 		}
 	}
 
+	hostNetworkEnabled := vc[VolumeContextKeyHostNetworkPodKSA] == util.TrueStr
+	identityProvider := vc[VolumeContextKeyIdentityProvider]
+
+	var tokenAudience string
+	if util.IsGKEIdentityProvider(identityProvider) || identityProvider == "" {
+		tokenAudience = s.driver.config.TokenManager.GetIdentityPool()
+	} else {
+		tokenAudience = identityProvider
+	}
+
 	// Prepare mounter pod config.
 	podName := createMounterPodName(nodeID, volumeID)
 	podConfig := &mounterPodConfig{
@@ -248,6 +258,9 @@ func (s *controllerServer) ControllerPublishVolume(ctx context.Context, req *csi
 		image:              containerImage,
 		volumes:            podTemplate.Template.Spec.Volumes,
 		profilesEnabled:    profilesEnabled,
+		hostNetworkEnabled: hostNetworkEnabled,
+		tokenAudience:      tokenAudience,
+		dnsPolicy:          podTemplate.Template.Spec.DNSPolicy,
 	}
 
 	if err := createMounterPod(clientset, ctx, podConfig); err != nil {

--- a/pkg/csi_driver/controller_test.go
+++ b/pkg/csi_driver/controller_test.go
@@ -506,6 +506,144 @@ func TestControllerPublishVolume(t *testing.T) {
 			},
 		},
 		{
+			name: "sharedMount true - mounter pod with dnsPolicy override - should create pod with overridden dnsPolicy",
+			req: &csi.ControllerPublishVolumeRequest{
+				VolumeId:         testVolumeID,
+				NodeId:           testNodeID,
+				VolumeCapability: testVolumeCapability,
+				VolumeContext: map[string]string{
+					"sharedMount":               "true",
+					util.VolumeContextKeyPVName: testPV,
+				},
+			},
+			setupFake: func() *clientset.FakeClientset {
+				cfg := getDefaultFakeClientsetConfig()
+				cfg.ptConfig.Template.Spec.DNSPolicy = corev1.DNSClusterFirstWithHostNet
+				return setupFakeBase(cfg)
+			},
+			wantPublishContext: map[string]string{
+				PublishContextKeyMounterPodNamespace: testNamespace,
+				PublishContextKeyMounterPodName:      createMounterPodName(testNodeID, testVolumeID),
+			},
+			expectErr: false,
+			verifyCreatedPod: func(t *testing.T, pod *corev1.Pod) {
+				if pod.Spec.DNSPolicy != corev1.DNSClusterFirstWithHostNet {
+					t.Errorf("Expected DNSPolicy %q, got %q", corev1.DNSClusterFirstWithHostNet, pod.Spec.DNSPolicy)
+				}
+			},
+		},
+		{
+			name: "sharedMount true - hostNetwork true with GKE IDP - should set SA token volume with identity pool audience",
+			req: &csi.ControllerPublishVolumeRequest{
+				VolumeId:         testVolumeID,
+				NodeId:           testNodeID,
+				VolumeCapability: testVolumeCapability,
+				VolumeContext: map[string]string{
+					"sharedMount":                     "true",
+					util.VolumeContextKeyPVName:       testPV,
+					VolumeContextKeyHostNetworkPodKSA: "true",
+					VolumeContextKeyIdentityProvider:  "https://container.googleapis.com/v1/projects/my-proj/locations/us-central1/clusters/my-cluster",
+				},
+			},
+			setupFake: func() *clientset.FakeClientset {
+				return setupFakeBase(getDefaultFakeClientsetConfig())
+			},
+			wantPublishContext: map[string]string{
+				PublishContextKeyMounterPodNamespace: testNamespace,
+				PublishContextKeyMounterPodName:      createMounterPodName(testNodeID, testVolumeID),
+			},
+			expectErr: false,
+			verifyCreatedPod: func(t *testing.T, pod *corev1.Pod) {
+				wantVolume := webhook.GetSATokenVolume("fake.identity.pool")
+				found := false
+				for _, v := range pod.Spec.Volumes {
+					if v.Name == wantVolume.Name {
+						found = true
+						if !reflect.DeepEqual(v, wantVolume) {
+							t.Errorf("SA token volume mismatch.\nGot: %+v\nWant: %+v", v, wantVolume)
+						}
+					}
+				}
+				if !found {
+					t.Errorf("SA token volume %q not found in pod volumes", wantVolume.Name)
+				}
+			},
+		},
+		{
+			name: "sharedMount true - hostNetwork true with custom IDP - should set SA token volume with custom IDP audience",
+			req: &csi.ControllerPublishVolumeRequest{
+				VolumeId:         testVolumeID,
+				NodeId:           testNodeID,
+				VolumeCapability: testVolumeCapability,
+				VolumeContext: map[string]string{
+					"sharedMount":                     "true",
+					util.VolumeContextKeyPVName:       testPV,
+					VolumeContextKeyHostNetworkPodKSA: "true",
+					VolumeContextKeyIdentityProvider:  "https://custom.identity.provider",
+				},
+			},
+			setupFake: func() *clientset.FakeClientset {
+				return setupFakeBase(getDefaultFakeClientsetConfig())
+			},
+			wantPublishContext: map[string]string{
+				PublishContextKeyMounterPodNamespace: testNamespace,
+				PublishContextKeyMounterPodName:      createMounterPodName(testNodeID, testVolumeID),
+			},
+			expectErr: false,
+			verifyCreatedPod: func(t *testing.T, pod *corev1.Pod) {
+				wantVolume := webhook.GetSATokenVolume("https://custom.identity.provider")
+				found := false
+				for _, v := range pod.Spec.Volumes {
+					if v.Name == wantVolume.Name {
+						found = true
+						if !reflect.DeepEqual(v, wantVolume) {
+							t.Errorf("SA token volume mismatch.\nGot: %+v\nWant: %+v", v, wantVolume)
+						}
+					}
+				}
+				if !found {
+					t.Errorf("SA token volume %q not found in pod volumes", wantVolume.Name)
+				}
+			},
+		},
+		{
+			name: "sharedMount true - hostNetwork true with empty IDP - should default SA token volume with identity pool audience",
+			req: &csi.ControllerPublishVolumeRequest{
+				VolumeId:         testVolumeID,
+				NodeId:           testNodeID,
+				VolumeCapability: testVolumeCapability,
+				VolumeContext: map[string]string{
+					"sharedMount":                     "true",
+					util.VolumeContextKeyPVName:       testPV,
+					VolumeContextKeyHostNetworkPodKSA: "true",
+				},
+			},
+			setupFake: func() *clientset.FakeClientset {
+				return setupFakeBase(getDefaultFakeClientsetConfig())
+			},
+			wantPublishContext: map[string]string{
+				PublishContextKeyMounterPodNamespace: testNamespace,
+				PublishContextKeyMounterPodName:      createMounterPodName(testNodeID, testVolumeID),
+			},
+			expectErr: false,
+			verifyCreatedPod: func(t *testing.T, pod *corev1.Pod) {
+				wantVolume := webhook.GetSATokenVolume("fake.identity.pool")
+				found := false
+				for _, v := range pod.Spec.Volumes {
+					if v.Name == wantVolume.Name {
+						found = true
+						if !reflect.DeepEqual(v, wantVolume) {
+							t.Errorf("SA token volume mismatch.\nGot: %+v\nWant: %+v", v, wantVolume)
+						}
+					}
+				}
+				if !found {
+					t.Errorf("SA token volume %q not found in pod volumes", wantVolume.Name)
+				}
+			},
+		},
+
+		{
 			name: "sharedMount true - missing mounter pod template annotation - should return error",
 			req: &csi.ControllerPublishVolumeRequest{
 				VolumeId:         testVolumeID,

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -302,38 +302,7 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 		}
 	}
 
-	sidecarCheckVal := getInternalMountOptionValue(args.fuseMountOptions, util.EnableSidecarBucketAccessCheckConst)
-	userExplicitlyEnabled := sidecarCheckVal == util.TrueStr
-	userExplicitlyDisabled := sidecarCheckVal == util.FalseStr
-	enableSidecarBucketAccessCheckForSidecarVersion := s.driver.isSidecarVersionSupportedForGivenFeature(gcsFuseSidecarImage, SidecarBucketAccessCheckMinVersion) &&
-		(userExplicitlyEnabled || (s.driver.config.EnableSidecarBucketAccessCheck && !userExplicitlyDisabled))
-	identityProvider := ""
-	if s.shouldPopulateIdentityProvider(pod, args.optInHostnetworkKSA, args.userSpecifiedIdentityProvider != "") {
-		if args.userSpecifiedIdentityProvider != "" {
-			identityProvider = args.userSpecifiedIdentityProvider
-		} else {
-			identityProvider = s.driver.config.TokenManager.GetIdentityProvider()
-		}
-		klog.V(6).Infof("NodePublishVolume populating identity provider %q in mount options", identityProvider)
-		args.fuseMountOptions = joinMountOptions(args.fuseMountOptions, []string{util.OptInHnw + "=true", util.TokenServerIdentityProviderConst + "=" + identityProvider})
-	} else if enableSidecarBucketAccessCheckForSidecarVersion && !userExplicitlyEnabled {
-		//Enable sidecar bucket access check only for Workload Identity workloads. This feature consumes additional quota for Host Network pods as we do not have token caching.
-		args.fuseMountOptions = joinMountOptions(args.fuseMountOptions, []string{util.EnableSidecarBucketAccessCheckConst + "=true"})
-	}
-
-	if enableSidecarBucketAccessCheckForSidecarVersion {
-		if identityProvider == "" {
-			identityProvider = s.driver.config.TokenManager.GetIdentityProvider()
-			args.fuseMountOptions = joinMountOptions(args.fuseMountOptions, []string{util.TokenServerIdentityProviderConst + "=" + identityProvider})
-		}
-		klog.Infof("Got identity provider %s", identityProvider)
-
-		identityPool := s.driver.config.TokenManager.GetIdentityPool()
-		args.fuseMountOptions = joinMountOptions(args.fuseMountOptions, []string{
-			util.PodNamespaceConst + "=" + vc[VolumeContextKeyPodNamespace],
-			util.ServiceAccountNameConst + "=" + vc[VolumeContextKeyServiceAccountName],
-			util.TokenServerIdentityPoolConst + "=" + identityPool})
-	}
+	s.populateTokenAndBucketAccessCheckOptions(pod, gcsFuseSidecarImage, vc, &args, vc[VolumeContextKeyPodNamespace], vc[VolumeContextKeyServiceAccountName])
 
 	if args.enableCloudProfilerForSidecar && s.driver.isSidecarVersionSupportedForGivenFeature(gcsFuseSidecarImage, SidecarCloudProfilerMinVersion) {
 		args.fuseMountOptions = joinMountOptions(args.fuseMountOptions, []string{
@@ -714,8 +683,56 @@ func (s *nodeServer) shouldPopulateIdentityProvider(pod *corev1.Pod, optInHnwKSA
 			break
 		}
 	}
+	for _, container := range pod.Spec.Containers {
+		if strings.HasPrefix(container.Name, util.MounterPodNamePrefix) {
+			sidecarVersionSupported = s.driver.isSidecarVersionSupportedForGivenFeature(container.Image, TokenServerSidecarMinVersion)
+
+			break
+		}
+	}
 
 	return tokenVolumeInjected && (sidecarVersionSupported || userInput)
+}
+
+// populateTokenAndBucketAccessCheckOptions populates fuseMountOptions with token server identity provider
+// for host network workloads and bucket access check parameters for both sidecar and shared mount modes.
+func (s *nodeServer) populateTokenAndBucketAccessCheckOptions(pod *corev1.Pod, image string, vc map[string]string, args *requestArgs, podNamespace, serviceAccountName string) {
+	sidecarCheckVal := getInternalMountOptionValue(args.fuseMountOptions, util.EnableSidecarBucketAccessCheckConst)
+	userExplicitlyEnabled := sidecarCheckVal == util.TrueStr
+	userExplicitlyDisabled := sidecarCheckVal == util.FalseStr
+	enableBucketAccessCheckForVersion := s.driver.isSidecarVersionSupportedForGivenFeature(image, SidecarBucketAccessCheckMinVersion) &&
+		(userExplicitlyEnabled || (s.driver.config.EnableSidecarBucketAccessCheck && !userExplicitlyDisabled))
+	identityProvider := ""
+	userSpecifiedIDP := args.userSpecifiedIdentityProvider
+	if userSpecifiedIDP == "" {
+		userSpecifiedIDP = vc[util.TokenServerIdentityProviderConst]
+	}
+	if s.shouldPopulateIdentityProvider(pod, args.optInHostnetworkKSA, userSpecifiedIDP != "") {
+		if userSpecifiedIDP != "" {
+			identityProvider = userSpecifiedIDP
+		} else {
+			identityProvider = s.driver.config.TokenManager.GetIdentityProvider()
+		}
+		klog.V(6).Infof("Populating identity provider %q in mount options", identityProvider)
+		args.fuseMountOptions = joinMountOptions(args.fuseMountOptions, []string{util.OptInHnw + "=true", util.TokenServerIdentityProviderConst + "=" + identityProvider})
+	} else if enableBucketAccessCheckForVersion && !userExplicitlyEnabled {
+		// Enable sidecar bucket access check only for Workload Identity workloads. This feature consumes additional quota for Host Network pods as we do not have token caching.
+		args.fuseMountOptions = joinMountOptions(args.fuseMountOptions, []string{util.EnableSidecarBucketAccessCheckConst + "=true"})
+	}
+
+	if enableBucketAccessCheckForVersion {
+		if identityProvider == "" {
+			identityProvider = s.driver.config.TokenManager.GetIdentityProvider()
+			args.fuseMountOptions = joinMountOptions(args.fuseMountOptions, []string{util.TokenServerIdentityProviderConst + "=" + identityProvider})
+		}
+		klog.Infof("Got identity provider %s", identityProvider)
+
+		identityPool := s.driver.config.TokenManager.GetIdentityPool()
+		args.fuseMountOptions = joinMountOptions(args.fuseMountOptions, []string{
+			util.PodNamespaceConst + "=" + podNamespace,
+			util.ServiceAccountNameConst + "=" + serviceAccountName,
+			util.TokenServerIdentityPoolConst + "=" + identityPool})
+	}
 }
 
 func gcsFuseSidecarContainerImage(pod *corev1.Pod) string {
@@ -895,6 +912,13 @@ func (s *nodeServer) executeNodeStageVolume(ctx context.Context, req *csi.NodeSt
 		}
 	}
 
+	podImage, err := mounterPodImage(pod)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to get image of mounter pod %s/%s: %v", podNamespace, podName, err)
+	}
+
+	s.populateTokenAndBucketAccessCheckOptions(pod, podImage, vc, &args, podNamespace, pod.Spec.ServiceAccountName)
+
 	// We initialize volumeState if bucket name is NOT "_", I.e. It's not a dynamic mount.
 	var vs *util.VolumeState
 	if args.bucketName != "_" {
@@ -903,11 +927,6 @@ func (s *nodeServer) executeNodeStageVolume(ctx context.Context, req *csi.NodeSt
 			vs = &util.VolumeState{}
 			s.volumeStateStore.Store(stagingPath, vs)
 		}
-	}
-
-	mounterPodImage, err := mounterPodImage(pod)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to get image of mounter pod %s/%s: %v", podNamespace, podName, err)
 	}
 
 	podUID := string(pod.UID)
@@ -920,14 +939,14 @@ func (s *nodeServer) executeNodeStageVolume(ctx context.Context, req *csi.NodeSt
 	}
 	if mounted {
 		// Restart monitoring goroutine if the driver restarts for existing mounts.
-		s.startGcsFuseKernelParamsMonitoring(stagingPath, emptyDirBasePath, podUID, pvName, mounterPodImage, vs)
+		s.startGcsFuseKernelParamsMonitoring(stagingPath, emptyDirBasePath, podUID, pvName, podImage, vs)
 
 		klog.Infof("NodeStageVolume succeeded on staging path %q for volume %q, mount already exists.", stagingPath, req.GetVolumeId())
 		return &csi.NodeStageVolumeResponse{}, nil
 	}
 
 	// Pass kernel params file flag to GCSFuse iff GCSFuse Kernel Params feature is supported.
-	if s.isGcsFuseKernelParamsFeatureSupported(mounterPodImage, vs) {
+	if s.isGcsFuseKernelParamsFeatureSupported(podImage, vs) {
 		args.fuseMountOptions = joinMountOptions(args.fuseMountOptions, []string{util.EnableGCSFuseKernelParams + "=true"})
 	}
 
@@ -948,7 +967,7 @@ func (s *nodeServer) executeNodeStageVolume(ctx context.Context, req *csi.NodeSt
 	}
 
 	// Start monitoring goroutine for new shared mounts.
-	s.startGcsFuseKernelParamsMonitoring(stagingPath, emptyDirBasePath, podUID, pvName, mounterPodImage, vs)
+	s.startGcsFuseKernelParamsMonitoring(stagingPath, emptyDirBasePath, podUID, pvName, podImage, vs)
 
 	klog.Infof("Mounter pod %s/%s is running and staging path %s is mounted", podNamespace, podName, stagingPath)
 

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/storage"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/metrics"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util"
+	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/webhook"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -2624,6 +2625,123 @@ func TestNodeStageVolumeEnableGCSFuseKernelParams(t *testing.T) {
 				t.Fatalf("expected mounterServer.req to be non-nil, but got nil")
 			}
 			validateMountOptions(t, mounterServer.req.MountOptions, tc.expectedOptions, tc.unexpectedOptions)
+		})
+	}
+}
+
+func TestNodeStageVolumeHostNetwork(t *testing.T) {
+	cases := []struct {
+		name             string
+		userSpecifiedIDP string
+		expectedOptions  []string
+	}{
+		{
+			name:             "mounter pod on host network with ksa opt-in and user-specified identity provider",
+			userSpecifiedIDP: "https://container.googleapis.com/v1/projects/test/locations/test/clusters/test",
+			expectedOptions: []string{
+				"hnw-ksa=true",
+				"token-server-identity-provider=https://container.googleapis.com/v1/projects/test/locations/test/clusters/test",
+			},
+		},
+		{
+			name:             "mounter pod on host network with ksa opt-in and default token manager identity provider",
+			userSpecifiedIDP: "",
+			expectedOptions: []string{
+				"hnw-ksa=true",
+				"token-server-identity-provider=fake.identity.provider",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			nodeID := "test-node"
+			volID := testVolumeID
+			podNamespace := "test-ns"
+			podName := createMounterPodName(nodeID, volID)
+			podUID := types.UID(podName)
+
+			testStagingPath, cleanupStaging := setupTestStagingPath(t)
+			defer cleanupStaging()
+
+			tmpDir, err := os.MkdirTemp("/tmp", "s_hnw")
+			if err != nil {
+				t.Fatalf("failed to create temp dir: %v", err)
+			}
+			t.Cleanup(func() { os.RemoveAll(tmpDir) })
+			socketDir := filepath.Join(tmpDir, "s")
+			emptyDirBasePath := filepath.Join(tmpDir, "e")
+
+			sockFile := filepath.Join(emptyDirBasePath, string(podUID), mounterPodSocketFile)
+			mounterServer := startFakeMounterServer(t, sockFile)
+
+			fc := clientset.NewFakeClientset()
+			fc.CreatePod(clientset.FakePodConfig{
+				Name:               podName,
+				Namespace:          podNamespace,
+				UID:                podUID,
+				PodStatus:          &corev1.PodStatus{Phase: corev1.PodRunning},
+				IsMounterPod:       true,
+				HostNetworkEnabled: true,
+			})
+			fc.AddPodVolumes([]corev1.Volume{
+				{Name: webhook.SidecarContainerSATokenVolumeName},
+			})
+
+			fakeMounter := mount.NewFakeMounter([]mount.MountPoint{})
+
+			testEnv := initTestNodeServerWithCustomClientset(t, fc, false)
+			ns, ok := testEnv.ns.(*nodeServer)
+			if !ok {
+				t.Fatalf("Failed to cast NodeServer to *nodeServer")
+			}
+			ns.mounter = fakeMounter
+
+			ns.driver.config.AssumeGoodSidecarVersion = true
+			ns.driver.config.FeatureOptions.SharedMountOptions = &SharedMountOptions{
+				Enabled:       true,
+				FuseSocketDir: socketDir,
+				EmptyDirBasePath: func(podUID string) string {
+					return filepath.Join(emptyDirBasePath, podUID)
+				},
+			}
+
+			volContext := map[string]string{
+				VolumeContextSharedNodeMount:      "true",
+				VolumeContextKeyHostNetworkPodKSA: "true",
+				util.VolumeContextKeyPVName:       volID,
+			}
+			if tc.userSpecifiedIDP != "" {
+				volContext[VolumeContextKeyIdentityProvider] = tc.userSpecifiedIDP
+			}
+
+			stageReq := &csi.NodeStageVolumeRequest{
+				VolumeId:          volID,
+				StagingTargetPath: testStagingPath,
+				VolumeCapability:  testVolumeCapability,
+				VolumeContext:     volContext,
+				PublishContext: map[string]string{
+					PublishContextKeyMounterPodName:      podName,
+					PublishContextKeyMounterPodNamespace: podNamespace,
+				},
+			}
+
+			_, err = ns.NodeStageVolume(context.Background(), stageReq)
+			if err != nil {
+				t.Fatalf("NodeStageVolume failed: %v", err)
+			}
+			defer func() {
+				if vs, ok := ns.volumeStateStore.Load(testStagingPath); ok && vs != nil {
+					if vs.GCSFuseKernelMonitorState.CancelFunc != nil {
+						vs.GCSFuseKernelMonitorState.CancelFunc()
+					}
+				}
+			}()
+
+			if mounterServer.req == nil {
+				t.Fatalf("expected mounterServer.req to be non-nil, but got nil")
+			}
+			validateMountOptions(t, mounterServer.req.MountOptions, tc.expectedOptions, nil)
 		})
 	}
 }

--- a/pkg/csi_driver/shared_mount.go
+++ b/pkg/csi_driver/shared_mount.go
@@ -63,6 +63,9 @@ type mounterPodConfig struct {
 	resources          *corev1.ResourceRequirements // The resource requirements for the mounter pod container.
 	volumes            []corev1.Volume              // The volumes for the mounter pod.
 	profilesEnabled    bool                         // Whether the profiles feature is enabled.
+	hostNetworkEnabled bool                         // Whether hostNetwork is enabled for the mounter pod.
+	tokenAudience      string                       // Token audience for projected service account volume.
+	dnsPolicy          corev1.DNSPolicy             // The DNS policy for the mounter pod.
 }
 
 // sharedMount checks if the VolumeContext enables the shared node mount feature
@@ -177,6 +180,10 @@ func createMounterPodSpec(config *mounterPodConfig) *corev1.Pod {
 		}
 	}
 
+	if config.hostNetworkEnabled {
+		volumeMounts = append(volumeMounts, webhook.SATokenVolumeMount)
+	}
+
 	labels := map[string]string{
 		webhook.SharedMountLabel: util.TrueStr,
 	}
@@ -198,6 +205,7 @@ func createMounterPodSpec(config *mounterPodConfig) *corev1.Pod {
 				"kubernetes.io/os":       "linux",
 			},
 			PriorityClassName: mounterPodPriorityClass,
+			HostNetwork:       config.hostNetworkEnabled,
 			Containers: []corev1.Container{
 				{
 					Name:            util.MounterPodNamePrefix,
@@ -223,6 +231,10 @@ func createMounterPodSpec(config *mounterPodConfig) *corev1.Pod {
 
 	if config.serviceAccountName != "" {
 		spec.Spec.ServiceAccountName = config.serviceAccountName
+	}
+
+	if config.dnsPolicy != "" {
+		spec.Spec.DNSPolicy = config.dnsPolicy
 	}
 
 	spec.Spec.Containers[0].Resources = *mounterPodResources(config)
@@ -394,8 +406,10 @@ func mounterPodVolumes(config *mounterPodConfig) []corev1.Volume {
 			},
 		}})
 
-	// TODO(urielguzman): Add host network volumes when those features are implemented for
-	// shared mount.
+	if config.hostNetworkEnabled {
+		volumes = append(volumes, webhook.GetSATokenVolume(config.tokenAudience))
+	}
+
 	if config.profilesEnabled {
 		if !webhook.VolumeExists(volumes, webhook.SidecarContainerFileCacheEphemeralDiskVolumeName) {
 			volumes = append(volumes, webhook.EphemeralFileCacheVolume)

--- a/pkg/csi_driver/shared_mount_test.go
+++ b/pkg/csi_driver/shared_mount_test.go
@@ -654,6 +654,106 @@ func TestCreateMounterPodSpec(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "hostNetworkEnabled true - should set hostNetwork, saToken volume and volumeMount",
+			config: &mounterPodConfig{
+				podName:            "my-mounter-pod",
+				namespace:          "my-namespace",
+				serviceAccountName: "my-ksa",
+				nodeID:             "node-123",
+				image:              "gcr.io/my-project/my-image:v1.0.0",
+				hostNetworkEnabled: true,
+				tokenAudience:      "test-audience",
+			},
+			want: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-mounter-pod",
+					Namespace: "my-namespace",
+					Labels: map[string]string{
+						"gke-gcsfuse/shared-mount": "true",
+					},
+				},
+				Spec: corev1.PodSpec{
+					NodeSelector: map[string]string{
+						"kubernetes.io/hostname": "node-123",
+						"kubernetes.io/os":       "linux",
+					},
+					ServiceAccountName: "my-ksa",
+					PriorityClassName:  mounterPodPriorityClass,
+					HostNetwork:        true,
+					Containers: []corev1.Container{
+						{
+							Name:            util.MounterPodNamePrefix,
+							Image:           "gcr.io/my-project/my-image:v1.0.0",
+							ImagePullPolicy: corev1.PullAlways,
+							SecurityContext: &corev1.SecurityContext{
+								Privileged: ptr.To(true),
+							},
+							Resources: defaultResources,
+							VolumeMounts: append(expectedVolumeMounts,
+								webhook.SATokenVolumeMount,
+							),
+						},
+					},
+					Volumes: []corev1.Volume{
+						testBuffVolume,
+						testCacheVolume,
+						testTmpVolume,
+						kubeletHostPathVolume,
+						webhook.GetSATokenVolume("test-audience"),
+					},
+					Tolerations: []corev1.Toleration{{Operator: corev1.TolerationOpExists}},
+				},
+			},
+		},
+		{
+			name: "custom dnsPolicy specified in config - should set DNSPolicy on pod spec",
+			config: &mounterPodConfig{
+				podName:            "my-mounter-pod",
+				namespace:          "my-namespace",
+				serviceAccountName: "my-ksa",
+				nodeID:             "node-123",
+				image:              "gcr.io/my-project/my-image:v1.0.0",
+				dnsPolicy:          corev1.DNSClusterFirstWithHostNet,
+			},
+			want: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-mounter-pod",
+					Namespace: "my-namespace",
+					Labels: map[string]string{
+						"gke-gcsfuse/shared-mount": "true",
+					},
+				},
+				Spec: corev1.PodSpec{
+					NodeSelector: map[string]string{
+						"kubernetes.io/hostname": "node-123",
+						"kubernetes.io/os":       "linux",
+					},
+					ServiceAccountName: "my-ksa",
+					PriorityClassName:  mounterPodPriorityClass,
+					DNSPolicy:          corev1.DNSClusterFirstWithHostNet,
+					Containers: []corev1.Container{
+						{
+							Name:            util.MounterPodNamePrefix,
+							Image:           "gcr.io/my-project/my-image:v1.0.0",
+							ImagePullPolicy: corev1.PullAlways,
+							SecurityContext: &corev1.SecurityContext{
+								Privileged: ptr.To(true),
+							},
+							Resources:    defaultResources,
+							VolumeMounts: expectedVolumeMounts,
+						},
+					},
+					Volumes: []corev1.Volume{
+						testBuffVolume,
+						testCacheVolume,
+						testTmpVolume,
+						kubeletHostPathVolume,
+					},
+					Tolerations: []corev1.Toleration{{Operator: corev1.TolerationOpExists}},
+				},
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/webhook/sidecar_spec.go
+++ b/pkg/webhook/sidecar_spec.go
@@ -103,7 +103,7 @@ var (
 		MountPath: SidecarContainerCacheVolumeMountPath,
 	}
 
-	saTokenVolumeMount = corev1.VolumeMount{
+	SATokenVolumeMount = corev1.VolumeMount{
 		Name:      SidecarContainerSATokenVolumeName,
 		MountPath: SidecarContainerSATokenVolumeMountPath,
 	}
@@ -154,7 +154,7 @@ func GetSidecarContainerSpec(c *Config, credentialConfig *SidecarContainerCreden
 	volumeMounts := []corev1.VolumeMount{TmpVolumeMount, buffVolumeMount, cacheVolumeMount}
 	// Inject SA token only for Host Network pods
 	if c.PodHostNetworkSetting && c.ShouldInjectSAVolume {
-		volumeMounts = append(volumeMounts, saTokenVolumeMount)
+		volumeMounts = append(volumeMounts, SATokenVolumeMount)
 	}
 
 	container := corev1.Container{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR implements Host NetWork Integration in CPV and NSV. Once `mountToNode` is completed, a separate PR will implement the UDS token handler.


1. **ControllerPublishVolume (CPV) & Mounter Pod Spec**:
   - Extracts `hostNetworkEnabled` and `identityProvider` from volume context and configures `HostNetwork` and SA Token Volume mounts on the created Mounter Pod.
   - Allows users to explicitly configure `DNSPolicy` in `PodTemplate`  for mounter pod
2. **NodeStageVolume (NSV) & NodePublishVolume (NPV)**:
   - Refactors token server and sidecar bucket access check configuration into a unified `populateTokenAndBucketAccessCheckOptions` helper method.
   - Integrates token server parameter population into `executeNodeStageVolume` for Mounter Pods, ensuring identity provider, identity pool, namespace, and KSA options are correctly passed for Shared Mounts and Host Network workloads.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:


**Does this PR introduce a user-facing change?**:
```release-note