### PR TITLE
[Shared Mount] Create and register mounter server, fix kubelet path

### DIFF
--- a/cmd/sidecar_mounter/main.go
+++ b/cmd/sidecar_mounter/main.go
@@ -49,10 +49,47 @@ var (
 	storageServiceAndBucketAccessFactor   = flag.Float64("storage-service-check-retry-factor", 2.0, "storage service creation and bucket access check exponential retry factor")
 	storageServiceAndBucketAccessJitter   = flag.Float64("storage-service-check-retry-jitter", 0.1, "storage service creation and bucket access check exponential retry jitter")
 	storageServiceAndBucketAccessDuration = flag.Duration("storage-service-check-retry-duration", 5*time.Second, "storage service creation and bucket access check exponential retry initial duration")
+	enableSharedMount                     = flag.Bool("enable-shared-mount", false, "whether to run gcsfuse in a mounter pod")
 
 	// This is set at compile time.
 	version = "unknown"
 )
+
+func runNodeMounter(ctx context.Context, cancel context.CancelFunc, mounter *sidecarmounter.Mounter) {
+	klog.Infof("Running node mounter...")
+	s := driver.NewNonBlockingGRPCServer()
+	ms := sidecarmounter.NewMounterServer(mounter)
+
+	socketFile := filepath.Join(webhook.SidecarContainerTmpVolumeMountPath, driver.MounterPodSocketFile)
+
+	if err := os.Remove(socketFile); err != nil && !os.IsNotExist(err) {
+		klog.Warningf("failed to remove stale socket file %q: %v", socketFile, err)
+	}
+	defer func() {
+		if err := os.Remove(socketFile); err != nil && !os.IsNotExist(err) {
+			klog.Warningf("failed to remove socket file %q on exit: %v", socketFile, err)
+		}
+	}()
+	socketPath := fmt.Sprintf("unix:%s", socketFile)
+
+	s.Start(socketPath, nil, nil, nil, ms)
+
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, syscall.SIGTERM, syscall.SIGINT)
+	klog.Info("Waiting for SIGTERM signal or context cancellation...")
+	select {
+	case <-c:
+		klog.Info("Received SIGTERM signal, waiting for the gcsfuse process to exit...")
+	case <-ctx.Done():
+		klog.Info("Context cancelled, waiting for the gcsfuse process to exit...")
+	}
+
+	cancel()
+	s.Stop()
+	mounter.WaitGroup.Wait()
+	s.Wait()
+	klog.Info("Exiting node mounter...")
+}
 
 func main() {
 	klog.InitFlags(nil)
@@ -60,13 +97,19 @@ func main() {
 
 	klog.Infof("Running Google Cloud Storage FUSE CSI driver sidecar mounter version %v", version)
 
+	mounter := sidecarmounter.New(*gcsfusePath)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	if *enableSharedMount {
+		runNodeMounter(ctx, cancel, mounter)
+		return
+	}
+
 	socketPathPattern := *volumeBasePath + "/*/socket"
 	socketPaths, err := filepath.Glob(socketPathPattern)
 	if err != nil {
 		klog.Fatalf("failed to look up socket paths: %v", err)
 	}
-	mounter := sidecarmounter.New(*gcsfusePath)
-	ctx, cancel := context.WithCancel(context.Background())
 	flagsFromDriver := map[string]string{}
 	defaultingFlagFilePath := *volumeBasePath + "/" + driver.FlagFileForDefaultingPath
 	klog.Infof("Checking if defaulting-flag file %q exists", defaultingFlagFilePath)

--- a/deploy/base/node/node.yaml
+++ b/deploy/base/node/node.yaml
@@ -98,8 +98,11 @@ spec:
                   name: gcsfusecsi-node-config
                   key: universe-domain
           volumeMounts:
-            - name: kubelet-dir
+            - name: kubelet-pods-dir
               mountPath: /var/lib/kubelet/pods
+              mountPropagation: "Bidirectional"
+            - name: kubelet-plugins-dir
+              mountPath: /var/lib/kubelet/plugins/kubernetes.io/csi/gcsfuse.csi.storage.gke.io
               mountPropagation: "Bidirectional"
             - name: socket-dir
               mountPath: /csi
@@ -144,10 +147,14 @@ spec:
           hostPath:
             path: /var/lib/kubelet/plugins_registry/
             type: Directory
-        - name: kubelet-dir
+        - name: kubelet-pods-dir
           hostPath:
             path: /var/lib/kubelet/pods/
             type: Directory
+        - name: kubelet-plugins-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/kubernetes.io/csi/gcsfuse.csi.storage.gke.io/
+            type: DirectoryOrCreate
         - name: socket-dir
           hostPath:
             path: /var/lib/kubelet/plugins/gcsfuse.csi.storage.gke.io/

--- a/pkg/csi_driver/gcs_fuse_driver.go
+++ b/pkg/csi_driver/gcs_fuse_driver.go
@@ -255,7 +255,7 @@ func (driver *GCSDriver) Run(ctx context.Context, cancel context.CancelFunc, end
 	klog.Infof("Running driver: %v", driver.config.Name)
 
 	s := NewNonBlockingGRPCServer()
-	s.Start(endpoint, driver.ids, driver.cs, driver.ns)
+	s.Start(endpoint, driver.ids, driver.cs, driver.ns, nil)
 
 	if driver.config.RunController && driver.config.FeatureOptions.FeatureGCSFuseProfiles.Enabled {
 		// Start the scanner in a separate goroutine, respecting the parent context.

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -937,7 +937,7 @@ func (s *nodeServer) executeNodeStageVolume(ctx context.Context, req *csi.NodeSt
 	if profilesEnabled {
 		klog.V(4).Infof("NodeStageVolume gcsfuse profiles feature is enabled for mounter pod %s/%s", podNamespace, podName)
 		profile, err = profiles.BuildProfileConfig(&profiles.BuildProfileConfigParams{
-			VolumeName:          vc[util.VolumeContextKeyPVName],
+			VolumeName:          pvName,
 			Clientset:           s.k8sClients,
 			ContainerName:       util.MounterPodNamePrefix,
 			VolumeAttributeKeys: transformKeysToSet(volumeAttributesToMountOptionsMapping),
@@ -1039,7 +1039,7 @@ func (s *nodeServer) mountToNode(ctx context.Context, podUID, stagingPath, volum
 		return status.Errorf(codes.Internal, "empty dir base path must be provided for shared mount")
 	}
 	emptyDirBasePath := s.driver.config.FeatureOptions.SharedMountOptions.EmptyDirBasePath(podUID)
-	socketFile := filepath.Join(emptyDirBasePath, mounterPodSocketFile)
+	socketFile := filepath.Join(emptyDirBasePath, MounterPodSocketFile)
 
 	// Create a symlink to bypass the 108-character limit for Unix domain sockets
 	// when dialing the connection from the Node Server.

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -331,7 +331,7 @@ func TestExecuteNodeStageVolume(t *testing.T) {
 	if err := os.MkdirAll(mounterSocketDirValid, 0755); err != nil {
 		t.Fatalf("failed to create temp dir: %v", err)
 	}
-	validSocketFile := filepath.Join(mounterSocketDirValid, mounterPodSocketFile)
+	validSocketFile := filepath.Join(mounterSocketDirValid, MounterPodSocketFile)
 
 	_ = startFakeMounterServer(t, validSocketFile)
 
@@ -1027,7 +1027,7 @@ func TestNodeStageVolume(t *testing.T) {
 	if err := os.MkdirAll(mounterSocketDirValid, 0755); err != nil {
 		t.Fatalf("failed to create temp dir: %v", err)
 	}
-	validSocketFile := filepath.Join(mounterSocketDirValid, mounterPodSocketFile)
+	validSocketFile := filepath.Join(mounterSocketDirValid, MounterPodSocketFile)
 
 	fakeServer := startFakeMounterServer(t, validSocketFile)
 
@@ -1413,7 +1413,7 @@ func TestMountToNode(t *testing.T) {
 				return emptyDirBasePath
 			}
 
-			socketFile := filepath.Join(emptyDirBasePath, mounterPodSocketFile)
+			socketFile := filepath.Join(emptyDirBasePath, MounterPodSocketFile)
 
 			startFakeMounterServer(t, socketFile)
 
@@ -2720,7 +2720,7 @@ func TestNodeStageVolumeEnableGCSFuseKernelParams(t *testing.T) {
 			socketDir := filepath.Join(tmpDir, "s")
 			emptyDirBasePath := filepath.Join(tmpDir, "e")
 
-			sockFile := filepath.Join(emptyDirBasePath, string(podUID), mounterPodSocketFile)
+			sockFile := filepath.Join(emptyDirBasePath, string(podUID), MounterPodSocketFile)
 			mounterServer := startFakeMounterServer(t, sockFile)
 
 			fc := clientset.NewFakeClientset()
@@ -2828,7 +2828,7 @@ func TestNodeStageVolumeHostNetwork(t *testing.T) {
 			socketDir := filepath.Join(tmpDir, "s")
 			emptyDirBasePath := filepath.Join(tmpDir, "e")
 
-			sockFile := filepath.Join(emptyDirBasePath, string(podUID), mounterPodSocketFile)
+			sockFile := filepath.Join(emptyDirBasePath, string(podUID), MounterPodSocketFile)
 			mounterServer := startFakeMounterServer(t, sockFile)
 
 			fc := clientset.NewFakeClientset()

--- a/pkg/csi_driver/server.go
+++ b/pkg/csi_driver/server.go
@@ -23,6 +23,7 @@ import (
 
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util"
+	"github.com/googlecloudplatform/gcs-fuse-csi-driver/proto/mounter"
 	"google.golang.org/grpc"
 	"k8s.io/klog/v2"
 )
@@ -30,7 +31,7 @@ import (
 // Defines Non blocking GRPC server interfaces.
 type NonBlockingGRPCServer interface {
 	// Start services at the endpoint
-	Start(endpoint string, ids csi.IdentityServer, cs csi.ControllerServer, ns csi.NodeServer)
+	Start(endpoint string, ids csi.IdentityServer, cs csi.ControllerServer, ns csi.NodeServer, ms mounter.MounterServer)
 	// Waits for the service to stop
 	Wait()
 	// Stops the service gracefully
@@ -49,10 +50,10 @@ type nonBlockingGRPCServer struct {
 	server *grpc.Server
 }
 
-func (s *nonBlockingGRPCServer) Start(endpoint string, ids csi.IdentityServer, cs csi.ControllerServer, ns csi.NodeServer) {
+func (s *nonBlockingGRPCServer) Start(endpoint string, ids csi.IdentityServer, cs csi.ControllerServer, ns csi.NodeServer, ms mounter.MounterServer) {
 	s.wg.Add(1)
 
-	go s.serve(endpoint, ids, cs, ns)
+	go s.serve(endpoint, ids, cs, ns, ms)
 }
 
 func (s *nonBlockingGRPCServer) Wait() {
@@ -67,7 +68,7 @@ func (s *nonBlockingGRPCServer) ForceStop() {
 	s.server.Stop()
 }
 
-func (s *nonBlockingGRPCServer) serve(endpoint string, ids csi.IdentityServer, cs csi.ControllerServer, ns csi.NodeServer) {
+func (s *nonBlockingGRPCServer) serve(endpoint string, ids csi.IdentityServer, cs csi.ControllerServer, ns csi.NodeServer, ms mounter.MounterServer) {
 	scheme, addr, err := util.ParseEndpoint(endpoint, true)
 	if err != nil {
 		klog.Fatalf("failed to parse endpoint %v", err)
@@ -93,6 +94,9 @@ func (s *nonBlockingGRPCServer) serve(endpoint string, ids csi.IdentityServer, c
 	}
 	if ns != nil {
 		csi.RegisterNodeServer(server, ns)
+	}
+	if ms != nil {
+		mounter.RegisterMounterServer(server, ms)
 	}
 
 	klog.Infof("Listening for connections on address: %#v", listener.Addr())

--- a/pkg/csi_driver/shared_mount.go
+++ b/pkg/csi_driver/shared_mount.go
@@ -44,7 +44,7 @@ import (
 const (
 	mounterPodPriorityClass       = "gcsfusecsi-mount-priority"
 	mounterPodMountDir            = "mount-dir"
-	mounterPodSocketFile          = "mounter.sock"
+	MounterPodSocketFile          = "mounter.sock"
 	mounterPodManagedImageKeyword = "managed"
 	mounterPodSocketDir           = "mount-socket"
 )
@@ -155,12 +155,12 @@ func createMounterPodSpec(config *mounterPodConfig) *corev1.Pod {
 	volumeMounts := []corev1.VolumeMount{
 		{
 			Name:             mounterPodMountDir,
-			MountPath:        util.KubeletDir,
+			MountPath:        util.KubeletPluginsGCSFuseDir,
 			MountPropagation: ptr.To(corev1.MountPropagationBidirectional),
 		},
 		{
 			Name:      util.SidecarContainerTmpVolumeName,
-			MountPath: util.SidecarContainerTmpVolumePath,
+			MountPath: webhook.SidecarContainerTmpVolumeMountPath,
 		},
 		{
 			Name:      webhook.SidecarContainerBufferVolumeName,
@@ -211,6 +211,7 @@ func createMounterPodSpec(config *mounterPodConfig) *corev1.Pod {
 					Name:            util.MounterPodNamePrefix,
 					Image:           config.image,
 					ImagePullPolicy: corev1.PullAlways,
+					Args:            []string{"--enable-shared-mount"},
 					SecurityContext: &corev1.SecurityContext{
 						Privileged: ptr.To(true),
 					},
@@ -399,9 +400,7 @@ func mounterPodVolumes(config *mounterPodConfig) []corev1.Volume {
 	volumes = append(volumes, corev1.Volume{Name: mounterPodMountDir,
 		VolumeSource: corev1.VolumeSource{
 			HostPath: &corev1.HostPathVolumeSource{
-				// TODO(urielguzman): Check if we can use /var/lib/kubelet/plugins/gcsfuse.csi.storage.gke.io/
-				// instead, to decrease the host path scope.
-				Path: util.KubeletDir,
+				Path: util.KubeletPluginsGCSFuseDir,
 				Type: ptr.To(corev1.HostPathDirectoryOrCreate),
 			},
 		}})
@@ -455,7 +454,7 @@ func waitForMounterServer(ctx context.Context, clientset clientset.Interface, mo
 	}
 
 	// Construct the mounter socket file path.
-	mounterSocketFilePath := filepath.Join(emptyDirBasePath(podUID), mounterPodSocketFile)
+	mounterSocketFilePath := filepath.Join(emptyDirBasePath(podUID), MounterPodSocketFile)
 	var pod *corev1.Pod
 	var err error
 

--- a/pkg/csi_driver/shared_mount_test.go
+++ b/pkg/csi_driver/shared_mount_test.go
@@ -119,7 +119,7 @@ func TestWaitForMounterServer(t *testing.T) {
 		t.Fatalf("failed to create temp dir: %v", err)
 	}
 
-	validSocketFile := filepath.Join(mounterSocketDirValid, mounterPodSocketFile)
+	validSocketFile := filepath.Join(mounterSocketDirValid, MounterPodSocketFile)
 	if file, err := os.Create(validSocketFile); err != nil {
 		t.Fatalf("failed to create socket file: %v", err)
 	} else {
@@ -350,12 +350,12 @@ func TestCreateMounterPodSpec(t *testing.T) {
 	expectedVolumeMounts := []corev1.VolumeMount{
 		{
 			Name:             mounterPodMountDir,
-			MountPath:        util.KubeletDir,
+			MountPath:        util.KubeletPluginsGCSFuseDir,
 			MountPropagation: ptr.To(corev1.MountPropagationBidirectional),
 		},
 		{
 			Name:      util.SidecarContainerTmpVolumeName,
-			MountPath: util.SidecarContainerTmpVolumePath,
+			MountPath: webhook.SidecarContainerTmpVolumeMountPath,
 		},
 		{
 			Name:      webhook.SidecarContainerBufferVolumeName,
@@ -372,7 +372,7 @@ func TestCreateMounterPodSpec(t *testing.T) {
 		Name: mounterPodMountDir,
 		VolumeSource: corev1.VolumeSource{
 			HostPath: &corev1.HostPathVolumeSource{
-				Path: util.KubeletDir,
+				Path: util.KubeletPluginsGCSFuseDir,
 				Type: ptr.To(corev1.HostPathDirectoryOrCreate),
 			},
 		},
@@ -426,6 +426,7 @@ func TestCreateMounterPodSpec(t *testing.T) {
 							Name:            util.MounterPodNamePrefix,
 							Image:           "gcr.io/my-project/my-image:v1.0.0",
 							ImagePullPolicy: corev1.PullAlways,
+							Args:            []string{"--enable-shared-mount"},
 							SecurityContext: &corev1.SecurityContext{
 								Privileged: ptr.To(true),
 							},
@@ -481,6 +482,7 @@ func TestCreateMounterPodSpec(t *testing.T) {
 							Name:            util.MounterPodNamePrefix,
 							Image:           "gcr.io/my-project/my-image:v1.0.0",
 							ImagePullPolicy: corev1.PullAlways,
+							Args:            []string{"--enable-shared-mount"},
 							SecurityContext: &corev1.SecurityContext{
 								Privileged: ptr.To(true),
 							},
@@ -537,6 +539,7 @@ func TestCreateMounterPodSpec(t *testing.T) {
 							Name:            util.MounterPodNamePrefix,
 							Image:           "gcr.io/my-project/my-image:v1.0.0",
 							ImagePullPolicy: corev1.PullAlways,
+							Args:            []string{"--enable-shared-mount"},
 							SecurityContext: &corev1.SecurityContext{
 								Privileged: ptr.To(true),
 							},
@@ -585,6 +588,7 @@ func TestCreateMounterPodSpec(t *testing.T) {
 							Name:            util.MounterPodNamePrefix,
 							Image:           "gcr.io/my-project/my-image:v1.0.0",
 							ImagePullPolicy: corev1.PullAlways,
+							Args:            []string{"--enable-shared-mount"},
 							SecurityContext: &corev1.SecurityContext{
 								Privileged: ptr.To(true),
 							},
@@ -632,6 +636,7 @@ func TestCreateMounterPodSpec(t *testing.T) {
 							Name:            util.MounterPodNamePrefix,
 							Image:           "gcr.io/my-project/my-image:v1.0.0",
 							ImagePullPolicy: corev1.PullAlways,
+							Args:            []string{"--enable-shared-mount"},
 							SecurityContext: &corev1.SecurityContext{
 								Privileged: ptr.To(true),
 							},
@@ -686,6 +691,7 @@ func TestCreateMounterPodSpec(t *testing.T) {
 							Name:            util.MounterPodNamePrefix,
 							Image:           "gcr.io/my-project/my-image:v1.0.0",
 							ImagePullPolicy: corev1.PullAlways,
+							Args:            []string{"--enable-shared-mount"},
 							SecurityContext: &corev1.SecurityContext{
 								Privileged: ptr.To(true),
 							},
@@ -737,6 +743,7 @@ func TestCreateMounterPodSpec(t *testing.T) {
 							Name:            util.MounterPodNamePrefix,
 							Image:           "gcr.io/my-project/my-image:v1.0.0",
 							ImagePullPolicy: corev1.PullAlways,
+							Args:            []string{"--enable-shared-mount"},
 							SecurityContext: &corev1.SecurityContext{
 								Privileged: ptr.To(true),
 							},
@@ -1484,7 +1491,7 @@ func TestMounterPodVolumes(t *testing.T) {
 		Name: mounterPodMountDir,
 		VolumeSource: corev1.VolumeSource{
 			HostPath: &corev1.HostPathVolumeSource{
-				Path: util.KubeletDir,
+				Path: util.KubeletPluginsGCSFuseDir,
 				Type: ptr.To(corev1.HostPathDirectoryOrCreate),
 			},
 		},

--- a/pkg/sidecar_mounter/mounter_server.go
+++ b/pkg/sidecar_mounter/mounter_server.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sidecarmounter
+
+import (
+	"context"
+
+	"github.com/googlecloudplatform/gcs-fuse-csi-driver/proto/mounter"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type MounterServer struct {
+	mounter.UnimplementedMounterServer
+	Mounter *Mounter
+}
+
+func NewMounterServer(mounter *Mounter) *MounterServer {
+	return &MounterServer{
+		Mounter: mounter,
+	}
+}
+
+func (ms *MounterServer) Mount(ctx context.Context, req *mounter.MountRequest) (*mounter.MountResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Mount not implemented")
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -60,7 +60,6 @@ const (
 	EnableCloudProfilerForSidecarConst  = "enable-cloud-profiler-for-sidecar"
 	EnableCloudProfilerConst            = "enable-cloud-profiler"
 	SidecarContainerTmpVolumeName       = "gke-gcsfuse-tmp"
-	SidecarContainerTmpVolumePath       = "/gke-gcsfuse-tmp"
 	SidecarBucketAccessCheckErrorPrefix = "sidecar bucket access check error"
 	StorageServiceErrorStr              = "failed to setup storage service"
 	GCSFuseCsiDriverName                = "gcsfuse.csi.storage.gke.io"
@@ -73,6 +72,7 @@ const (
 	GoMemLimitCgroupPercentage          = 0.95
 	StorageEndpointInternal             = "storage-endpoint-internal"
 	KubeletDir                          = "/var/lib/kubelet"
+	KubeletPluginsGCSFuseDir            = "/var/lib/kubelet/plugins/kubernetes.io/csi/gcsfuse.csi.storage.gke.io"
 	VolumeContextKeyPVName              = "csi.storage.k8s.io/pv/name"
 	MounterPodNamePrefix                = "gcsfusecsi-mount"
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:
This PR adds the following:
*Adds the mounter pods proto buff, defining the mounter pods server requests and response
* Adds the kublet plugs dir "kubelet-plugins-dir" to the node, allowing it to create the staging path during node stage volume
* Corrects the mounter pods expected staging path to specify the one we added "kubelet-plugins-dir"
* Registers the server in server.go
* Starts the server in sidecarmounter/main.go
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
NONE
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```