### PR TITLE
Automated cherry pick of #1497: Retry NodeUnpublishVolume upon failure

### DIFF
--- a/pkg/csi_driver/gcs_fuse_driver_test.go
+++ b/pkg/csi_driver/gcs_fuse_driver_test.go
@@ -29,7 +29,7 @@ import (
 	mount "k8s.io/mount-utils"
 )
 
-func initTestDriver(t *testing.T, fm mount.Interface, clientset clientset.Interface) *GCSDriver {
+func initTestDriver(t *testing.T, fm *mount.FakeMounter, clientset clientset.Interface) *GCSDriver {
 	t.Helper()
 	config := &GCSDriverConfig{
 		Name:                  "test-driver",
@@ -57,7 +57,7 @@ func initTestDriver(t *testing.T, fm mount.Interface, clientset clientset.Interf
 }
 
 // Helper function for creating node server with a custom FakeClientset
-func initTestDriverWithCustomNodeServer(t *testing.T, fm mount.Interface, clientSet *clientset.FakeClientset, wiNodeLabelCheck bool) *GCSDriver {
+func initTestDriverWithCustomNodeServer(t *testing.T, fm *mount.FakeMounter, clientSet *clientset.FakeClientset, wiNodeLabelCheck bool) *GCSDriver {
 	t.Helper()
 	config := &GCSDriverConfig{
 		Name:                     "test-driver",

--- a/pkg/csi_driver/gcs_fuse_driver_test.go
+++ b/pkg/csi_driver/gcs_fuse_driver_test.go
@@ -29,7 +29,7 @@ import (
 	mount "k8s.io/mount-utils"
 )
 
-func initTestDriver(t *testing.T, fm *mount.FakeMounter, clientset clientset.Interface) *GCSDriver {
+func initTestDriver(t *testing.T, fm *mount.FakeMounter) *GCSDriver {
 	t.Helper()
 	config := &GCSDriverConfig{
 		Name:                  "test-driver",

--- a/pkg/csi_driver/gcs_fuse_driver_test.go
+++ b/pkg/csi_driver/gcs_fuse_driver_test.go
@@ -29,7 +29,7 @@ import (
 	mount "k8s.io/mount-utils"
 )
 
-func initTestDriver(t *testing.T, fm *mount.FakeMounter) *GCSDriver {
+func initTestDriver(t *testing.T, fm mount.Interface, clientset clientset.Interface) *GCSDriver {
 	t.Helper()
 	config := &GCSDriverConfig{
 		Name:                  "test-driver",
@@ -57,7 +57,7 @@ func initTestDriver(t *testing.T, fm *mount.FakeMounter) *GCSDriver {
 }
 
 // Helper function for creating node server with a custom FakeClientset
-func initTestDriverWithCustomNodeServer(t *testing.T, fm *mount.FakeMounter, clientSet *clientset.FakeClientset, wiNodeLabelCheck bool) *GCSDriver {
+func initTestDriverWithCustomNodeServer(t *testing.T, fm mount.Interface, clientSet *clientset.FakeClientset, wiNodeLabelCheck bool) *GCSDriver {
 	t.Helper()
 	config := &GCSDriverConfig{
 		Name:                     "test-driver",

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -52,6 +52,8 @@ const (
 	unmountRetryJitter                  = 0.1
 	standardUnmountRetryTimeout         = 2 * time.Second
 	standardUnmountRetrySteps           = 5
+	// Non-force unmount takes 5s to timeout (as defined in vendor/k8s.io/mount-utils/mount_linux.go);
+	// we then retry force unmounting for 2s.
 	forceUnmountRetryTimeout            = 7 * time.Second
 	forceUnmountRetrySteps              = 6
 )

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -47,6 +47,8 @@ const (
 	GCSFuseKernelParamsFilePollInterval = time.Second * 5
 	FuseMountType                       = "fuse"
 	maxGCSFuseVolumesForMetrics         = 10
+	UnmountRetryInterval                = 100 * time.Millisecond
+	UnmountRetryTimeout                 = 2 * time.Second
 )
 
 // nodeServer handles mounting and unmounting of GCS FUSE volumes on a node.
@@ -506,7 +508,7 @@ func (s *nodeServer) isDirMounted(targetPath string) (bool, error) {
 func (s *nodeServer) forceUnmountWithRetry(ctx context.Context, targetPath string, forceUnmounter mount.MounterForceUnmounter) error {
 	var lastErr error
 
-	pollErr := wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 2*time.Second, true, func(ctx context.Context) (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(ctx, UnmountRetryInterval, UnmountRetryTimeout, true, func(ctx context.Context) (bool, error) {
 		lastErr = forceUnmounter.UnmountWithForce(targetPath, UmountTimeout)
 		if lastErr == nil {
 			return true, nil
@@ -527,7 +529,7 @@ func (s *nodeServer) forceUnmountWithRetry(ctx context.Context, targetPath strin
 func (s *nodeServer) unmountWithRetry(ctx context.Context, targetPath string) error {
 	var lastErr error
 
-	pollErr := wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 2*time.Second, true, func(ctx context.Context) (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(ctx, UnmountRetryInterval, UnmountRetryTimeout, true, func(ctx context.Context) (bool, error) {
 		lastErr = s.mounter.Unmount(targetPath)
 		if lastErr == nil {
 			return true, nil

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -47,8 +47,8 @@ const (
 	GCSFuseKernelParamsFilePollInterval = time.Second * 5
 	FuseMountType                       = "fuse"
 	maxGCSFuseVolumesForMetrics         = 10
-	UnmountRetryInterval                = 100 * time.Millisecond
-	UnmountRetryTimeout                 = 2 * time.Second
+	unmountRetryInterval                = 100 * time.Millisecond
+	unmountRetryTimeout                 = 2 * time.Second
 )
 
 // nodeServer handles mounting and unmounting of GCS FUSE volumes on a node.
@@ -508,7 +508,7 @@ func (s *nodeServer) isDirMounted(targetPath string) (bool, error) {
 func (s *nodeServer) forceUnmountWithRetry(ctx context.Context, targetPath string, forceUnmounter mount.MounterForceUnmounter) error {
 	var lastErr error
 
-	pollErr := wait.PollUntilContextTimeout(ctx, UnmountRetryInterval, UnmountRetryTimeout, true, func(ctx context.Context) (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(ctx, unmountRetryInterval, unmountRetryTimeout, true, func(ctx context.Context) (bool, error) {
 		lastErr = forceUnmounter.UnmountWithForce(targetPath, UmountTimeout)
 		if lastErr == nil {
 			return true, nil
@@ -529,7 +529,7 @@ func (s *nodeServer) forceUnmountWithRetry(ctx context.Context, targetPath strin
 func (s *nodeServer) unmountWithRetry(ctx context.Context, targetPath string) error {
 	var lastErr error
 
-	pollErr := wait.PollUntilContextTimeout(ctx, UnmountRetryInterval, UnmountRetryTimeout, true, func(ctx context.Context) (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(ctx, unmountRetryInterval, unmountRetryTimeout, true, func(ctx context.Context) (bool, error) {
 		lastErr = s.mounter.Unmount(targetPath)
 		if lastErr == nil {
 			return true, nil

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -50,12 +50,15 @@ const (
 	unmountRetryInterval                = 100 * time.Millisecond
 	unmountRetryBackoffFactor           = 2.0
 	unmountRetryJitter                  = 0.1
-	standardUnmountRetryTimeout         = 2 * time.Second
-	standardUnmountRetrySteps           = 5
-	// Non-force unmount takes 5s to timeout (as defined in vendor/k8s.io/mount-utils/mount_linux.go);
-	// we then retry force unmounting for 2s.
-	forceUnmountRetryTimeout            = 7 * time.Second
-	forceUnmountRetrySteps              = 6
+	// Standard unmount has no built-in timeout, so we use a short timeout to fail fast.
+	standardUnmountRetryTimeout = 2 * time.Second
+	standardUnmountRetrySteps   = 5
+	// Force unmount attempts include an initial non-force unmount with a
+	// 5 second timeout (as defined in vendor/k8s.io/mount-utils/mount_linux.go).
+	// We then retry force unmounting for 2 seconds.
+	// Thus the full timeout is 7 seconds.
+	forceUnmountRetryTimeout = 7 * time.Second
+	forceUnmountRetrySteps   = 6
 )
 
 // nodeServer handles mounting and unmounting of GCS FUSE volumes on a node.
@@ -516,6 +519,13 @@ func (s *nodeServer) isDirMounted(targetPath string) (bool, error) {
 	return false, nil
 }
 
+// unmountWithRetry retries the unmount operation using exponential backoff.
+// It uses a child context with a timeout to limit the total retry duration,
+// in addition to being limited to the defined number of steps.
+//
+// If the OS unmount system call itself hangs, this function will block
+// on the hung call. It won't be able to interrupt the hung call until the Kubelet cancels the parent
+// context (NodeUnpublishVolume context) and retries the entire operation.
 func (s *nodeServer) unmountWithRetry(ctx context.Context, targetPath string, timeout time.Duration, steps int, unmountFn func() error) error {
 	var lastErr error
 	childCtx, cancel := context.WithTimeout(ctx, timeout)

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -430,7 +430,7 @@ func (s *nodeServer) isGcsFuseKernelParamsFeatureSupported(gcsFuseSidecarImage s
 		s.driver.isSidecarVersionSupportedForGivenFeature(gcsFuseSidecarImage, GCSFuseKernelParamsMinVersion)
 }
 
-func (s *nodeServer) NodeUnpublishVolume(_ context.Context, req *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
+func (s *nodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
 	// Validate arguments
 	targetPath := req.GetTargetPath()
 	if len(targetPath) == 0 {
@@ -467,12 +467,12 @@ func (s *nodeServer) NodeUnpublishVolume(_ context.Context, req *csi.NodeUnpubli
 		// mount.CleanupMountPoint() call will hang.
 		forceUnmounter, ok := s.mounter.(mount.MounterForceUnmounter)
 		if ok {
-			if err = s.forceUnmountWithRetry(targetPath, forceUnmounter); err != nil {
+			if err = s.forceUnmountWithRetry(ctx, targetPath, forceUnmounter); err != nil {
 				return nil, status.Errorf(codes.Internal, "failed to force unmount target path %q: %v", targetPath, err)
 			}
 		} else {
 			klog.Warningf("failed to cast the mounter to a forceUnmounter, proceed with the default mounter Unmount")
-			if err = s.unmountWithRetry(targetPath); err != nil {
+			if err = s.unmountWithRetry(ctx, targetPath); err != nil {
 				return nil, status.Errorf(codes.Internal, "failed to unmount target path %q: %v", targetPath, err)
 			}
 		}
@@ -503,10 +503,10 @@ func (s *nodeServer) isDirMounted(targetPath string) (bool, error) {
 	return false, nil
 }
 
-func (s *nodeServer) forceUnmountWithRetry(targetPath string, forceUnmounter mount.MounterForceUnmounter) error {
+func (s *nodeServer) forceUnmountWithRetry(ctx context.Context, targetPath string, forceUnmounter mount.MounterForceUnmounter) error {
 	var lastErr error
 
-	pollErr := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 500*time.Millisecond, true, func(ctx context.Context) (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {
 		lastErr = forceUnmounter.UnmountWithForce(targetPath, UmountTimeout)
 		if lastErr == nil {
 			return true, nil
@@ -524,10 +524,10 @@ func (s *nodeServer) forceUnmountWithRetry(targetPath string, forceUnmounter mou
 	return nil
 }
 
-func (s *nodeServer) unmountWithRetry(targetPath string) error {
+func (s *nodeServer) unmountWithRetry(ctx context.Context, targetPath string) error {
 	var lastErr error
 
-	pollErr := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 500*time.Millisecond, true, func(ctx context.Context) (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {
 		lastErr = s.mounter.Unmount(targetPath)
 		if lastErr == nil {
 			return true, nil

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -471,12 +471,16 @@ func (s *nodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpub
 		// mount.CleanupMountPoint() call will hang.
 		forceUnmounter, ok := s.mounter.(mount.MounterForceUnmounter)
 		if ok {
-			if err = s.forceUnmountWithRetry(ctx, targetPath, forceUnmounter); err != nil {
+			if err = s.unmountWithRetry(ctx, targetPath, func() error {
+				return forceUnmounter.UnmountWithForce(targetPath, UmountTimeout)
+			}); err != nil {
 				return nil, status.Errorf(codes.Internal, "failed to force unmount target path %q: %v", targetPath, err)
 			}
 		} else {
 			klog.Warningf("failed to cast the mounter to a forceUnmounter, proceed with the default mounter Unmount")
-			if err = s.unmountWithRetry(ctx, targetPath); err != nil {
+			if err = s.unmountWithRetry(ctx, targetPath, func() error {
+				return s.mounter.Unmount(targetPath)
+			}); err != nil {
 				return nil, status.Errorf(codes.Internal, "failed to unmount target path %q: %v", targetPath, err)
 			}
 		}
@@ -507,32 +511,11 @@ func (s *nodeServer) isDirMounted(targetPath string) (bool, error) {
 	return false, nil
 }
 
-func (s *nodeServer) forceUnmountWithRetry(ctx context.Context, targetPath string, forceUnmounter mount.MounterForceUnmounter) error {
+func (s *nodeServer) unmountWithRetry(ctx context.Context, targetPath string, unmountFn func() error) error {
 	var lastErr error
 
 	pollErr := wait.PollUntilContextTimeout(ctx, unmountRetryInterval, unmountRetryTimeout, true, func(ctx context.Context) (bool, error) {
-		lastErr = forceUnmounter.UnmountWithForce(targetPath, UmountTimeout)
-		if lastErr == nil {
-			return true, nil
-		}
-		klog.Warningf("Failed to force unmount %q: %v. Retrying...", targetPath, lastErr)
-		return false, nil
-	})
-
-	if pollErr != nil {
-		if lastErr != nil {
-			return lastErr
-		}
-		return pollErr
-	}
-	return nil
-}
-
-func (s *nodeServer) unmountWithRetry(ctx context.Context, targetPath string) error {
-	var lastErr error
-
-	pollErr := wait.PollUntilContextTimeout(ctx, unmountRetryInterval, unmountRetryTimeout, true, func(ctx context.Context) (bool, error) {
-		lastErr = s.mounter.Unmount(targetPath)
+		lastErr = unmountFn()
 		if lastErr == nil {
 			return true, nil
 		}

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -506,7 +506,7 @@ func (s *nodeServer) isDirMounted(targetPath string) (bool, error) {
 func (s *nodeServer) forceUnmountWithRetry(ctx context.Context, targetPath string, forceUnmounter mount.MounterForceUnmounter) error {
 	var lastErr error
 
-	pollErr := wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 2*time.Second, true, func(ctx context.Context) (bool, error) {
 		lastErr = forceUnmounter.UnmountWithForce(targetPath, UmountTimeout)
 		if lastErr == nil {
 			return true, nil
@@ -527,7 +527,7 @@ func (s *nodeServer) forceUnmountWithRetry(ctx context.Context, targetPath strin
 func (s *nodeServer) unmountWithRetry(ctx context.Context, targetPath string) error {
 	var lastErr error
 
-	pollErr := wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 2*time.Second, true, func(ctx context.Context) (bool, error) {
 		lastErr = s.mounter.Unmount(targetPath)
 		if lastErr == nil {
 			return true, nil

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -35,6 +35,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	mount "k8s.io/mount-utils"
 )
@@ -466,12 +467,12 @@ func (s *nodeServer) NodeUnpublishVolume(_ context.Context, req *csi.NodeUnpubli
 		// mount.CleanupMountPoint() call will hang.
 		forceUnmounter, ok := s.mounter.(mount.MounterForceUnmounter)
 		if ok {
-			if err = forceUnmounter.UnmountWithForce(targetPath, UmountTimeout); err != nil {
+			if err = s.forceUnmountWithRetry(targetPath, forceUnmounter); err != nil {
 				return nil, status.Errorf(codes.Internal, "failed to force unmount target path %q: %v", targetPath, err)
 			}
 		} else {
 			klog.Warningf("failed to cast the mounter to a forceUnmounter, proceed with the default mounter Unmount")
-			if err = s.mounter.Unmount(targetPath); err != nil {
+			if err = s.unmountWithRetry(targetPath); err != nil {
 				return nil, status.Errorf(codes.Internal, "failed to unmount target path %q: %v", targetPath, err)
 			}
 		}
@@ -500,6 +501,48 @@ func (s *nodeServer) isDirMounted(targetPath string) (bool, error) {
 	}
 
 	return false, nil
+}
+
+func (s *nodeServer) forceUnmountWithRetry(targetPath string, forceUnmounter mount.MounterForceUnmounter) error {
+	var lastErr error
+
+	pollErr := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 500*time.Millisecond, true, func(ctx context.Context) (bool, error) {
+		lastErr = forceUnmounter.UnmountWithForce(targetPath, UmountTimeout)
+		if lastErr == nil {
+			return true, nil
+		}
+		klog.Warningf("Failed to force unmount %q: %v. Retrying...", targetPath, lastErr)
+		return false, nil
+	})
+
+	if pollErr != nil {
+		if lastErr != nil {
+			return lastErr
+		}
+		return pollErr
+	}
+	return nil
+}
+
+func (s *nodeServer) unmountWithRetry(targetPath string) error {
+	var lastErr error
+
+	pollErr := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 500*time.Millisecond, true, func(ctx context.Context) (bool, error) {
+		lastErr = s.mounter.Unmount(targetPath)
+		if lastErr == nil {
+			return true, nil
+		}
+		klog.Warningf("Failed to unmount %q: %v. Retrying...", targetPath, lastErr)
+		return false, nil
+	})
+
+	if pollErr != nil {
+		if lastErr != nil {
+			return lastErr
+		}
+		return pollErr
+	}
+	return nil
 }
 
 // setupMultiNIC updates args with options for multi NIC configuration.

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -48,7 +48,9 @@ const (
 	FuseMountType                       = "fuse"
 	maxGCSFuseVolumesForMetrics         = 10
 	unmountRetryInterval                = 100 * time.Millisecond
-	unmountRetryTimeout                 = 2 * time.Second
+	// Non-force unmount takes 5s to timeout (as defined in vendor/k8s.io/mount-utils/mount_linux.go);
+	// we then retry force unmounting for 2s.
+	unmountRetryTimeout = 7 * time.Second
 )
 
 // nodeServer handles mounting and unmounting of GCS FUSE volumes on a node.

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -48,9 +48,12 @@ const (
 	FuseMountType                       = "fuse"
 	maxGCSFuseVolumesForMetrics         = 10
 	unmountRetryInterval                = 100 * time.Millisecond
-	// Non-force unmount takes 5s to timeout (as defined in vendor/k8s.io/mount-utils/mount_linux.go);
-	// we then retry force unmounting for 2s.
-	unmountRetryTimeout = 7 * time.Second
+	unmountRetryBackoffFactor           = 2.0
+	unmountRetryJitter                  = 0.1
+	standardUnmountRetryTimeout         = 2 * time.Second
+	standardUnmountRetrySteps           = 5
+	forceUnmountRetryTimeout            = 7 * time.Second
+	forceUnmountRetrySteps              = 6
 )
 
 // nodeServer handles mounting and unmounting of GCS FUSE volumes on a node.
@@ -471,14 +474,14 @@ func (s *nodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpub
 		// mount.CleanupMountPoint() call will hang.
 		forceUnmounter, ok := s.mounter.(mount.MounterForceUnmounter)
 		if ok {
-			if err = s.unmountWithRetry(ctx, targetPath, func() error {
+			if err = s.unmountWithRetry(ctx, targetPath, forceUnmountRetryTimeout, forceUnmountRetrySteps, func() error {
 				return forceUnmounter.UnmountWithForce(targetPath, UmountTimeout)
 			}); err != nil {
 				return nil, status.Errorf(codes.Internal, "failed to force unmount target path %q: %v", targetPath, err)
 			}
 		} else {
 			klog.Warningf("failed to cast the mounter to a forceUnmounter, proceed with the default mounter Unmount")
-			if err = s.unmountWithRetry(ctx, targetPath, func() error {
+			if err = s.unmountWithRetry(ctx, targetPath, standardUnmountRetryTimeout, standardUnmountRetrySteps, func() error {
 				return s.mounter.Unmount(targetPath)
 			}); err != nil {
 				return nil, status.Errorf(codes.Internal, "failed to unmount target path %q: %v", targetPath, err)
@@ -511,10 +514,19 @@ func (s *nodeServer) isDirMounted(targetPath string) (bool, error) {
 	return false, nil
 }
 
-func (s *nodeServer) unmountWithRetry(ctx context.Context, targetPath string, unmountFn func() error) error {
+func (s *nodeServer) unmountWithRetry(ctx context.Context, targetPath string, timeout time.Duration, steps int, unmountFn func() error) error {
 	var lastErr error
+	childCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
 
-	pollErr := wait.PollUntilContextTimeout(ctx, unmountRetryInterval, unmountRetryTimeout, true, func(ctx context.Context) (bool, error) {
+	backoff := wait.Backoff{
+		Duration: unmountRetryInterval,
+		Factor:   unmountRetryBackoffFactor,
+		Jitter:   unmountRetryJitter,
+		Steps:    steps,
+	}
+
+	pollErr := wait.ExponentialBackoffWithContext(childCtx, backoff, func(ctx context.Context) (bool, error) {
 		lastErr = unmountFn()
 		if lastErr == nil {
 			return true, nil

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -695,7 +695,7 @@ func TestNodeUnpublishVolume(t *testing.T) {
 				ctx, _ := context.WithTimeout(context.Background(), 500*time.Millisecond)
 				return ctx
 			}(),
-			expectErr:     status.Errorf(codes.Internal, "failed to unmount target path %q: umount: %s: target is busy", testTargetPath, testTargetPath),
+			expectErr: status.Errorf(codes.Internal, "failed to unmount target path %q: umount: %s: target is busy", testTargetPath, testTargetPath),
 		},
 	}
 
@@ -774,7 +774,7 @@ func TestNodeUnpublishVolumeForceUnmount(t *testing.T) {
 				ctx, _ := context.WithTimeout(context.Background(), 500*time.Millisecond)
 				return ctx
 			}(),
-			expectErr:     status.Errorf(codes.Internal, "failed to force unmount target path %q: umount: %s: target is busy", testTargetPath, testTargetPath),
+			expectErr: status.Errorf(codes.Internal, "failed to force unmount target path %q: umount: %s: target is busy", testTargetPath, testTargetPath),
 		},
 	}
 

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -19,6 +19,7 @@ package driver
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -26,6 +27,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/clientset"
@@ -85,6 +87,53 @@ func initTestNodeServerWithCustomClientset(t *testing.T, clientSet *clientset.Fa
 		fm:    mounter,
 		nwMgr: driver.config.NetworkManager.(*fakeNetworkManager),
 	}
+}
+
+type fakeForceUnmounter struct {
+	*mount.FakeMounter
+	unmountWithForceFunc func(target string, umountTimeout time.Duration) error
+}
+
+func (f *fakeForceUnmounter) UnmountWithForce(target string, umountTimeout time.Duration) error {
+	if f.unmountWithForceFunc != nil {
+		return f.unmountWithForceFunc(target, umountTimeout)
+	}
+	return f.FakeMounter.Unmount(target)
+}
+
+func initTestNodeServerWithForceMounter(t *testing.T) (*nodeServerTestEnv, *fakeForceUnmounter) {
+	t.Helper()
+	fakeMounter := mount.NewFakeMounter([]mount.MountPoint{})
+	mounter := &fakeForceUnmounter{
+		FakeMounter: fakeMounter,
+	}
+	podName := createMounterPodName("test-node", testVolumeID)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: "test-ns",
+		},
+	}
+	fakeClient := clientset.NewFakeClientset(pod)
+	fakeClient.CreatePV(clientset.FakePVConfig{
+		Name:         "test-pv",
+		VolumeHandle: testVolumeID,
+		ClaimRef: &corev1.ObjectReference{
+			Namespace: "test-ns",
+			Name:      "test-pvc",
+		},
+	})
+	driver := initTestDriver(t, mounter, fakeClient)
+	s, _ := driver.config.StorageServiceManager.SetupService(context.TODO(), nil, "")
+	if _, err := s.CreateBucket(context.Background(), &storage.ServiceBucket{Name: testVolumeID}); err != nil {
+		t.Fatalf("failed to create the fake bucket: %v", err)
+	}
+
+	return &nodeServerTestEnv{
+		ns:    newNodeServer(driver, mounter),
+		fm:    fakeMounter,
+		nwMgr: driver.config.NetworkManager.(*fakeNetworkManager),
+	}, mounter
 }
 
 func setupMountTarget(t *testing.T) (string, func()) {
@@ -580,6 +629,7 @@ func TestNodeUnpublishVolume(t *testing.T) {
 		mounts        []mount.MountPoint // already existing mounts
 		req           *csi.NodeUnpublishVolumeRequest
 		actions       []mount.FakeAction
+		unmountFunc   func(path string) error
 		expectedMount *mount.MountPoint
 		expectErr     error
 	}{
@@ -612,6 +662,37 @@ func TestNodeUnpublishVolume(t *testing.T) {
 				TargetPath: testTargetPath,
 			},
 		},
+		{
+			name:   "retry unmount succeeds eventually",
+			mounts: []mount.MountPoint{{Device: testVolumeID, Path: testTargetPath}},
+			req: &csi.NodeUnpublishVolumeRequest{
+				VolumeId:   testVolumeID,
+				TargetPath: testTargetPath,
+			},
+			unmountFunc: func() func(path string) error {
+				calls := 0
+				return func(path string) error {
+					calls++
+					if calls < 3 {
+						return fmt.Errorf("umount: %s: target is busy", path)
+					}
+					return nil
+				}
+			}(),
+		},
+		{
+			name:   "retry unmount fails after max retries",
+			mounts: []mount.MountPoint{{Device: testVolumeID, Path: testTargetPath}},
+			req: &csi.NodeUnpublishVolumeRequest{
+				VolumeId:   testVolumeID,
+				TargetPath: testTargetPath,
+			},
+			unmountFunc: func(path string) error {
+				return fmt.Errorf("umount: %s: target is busy", path)
+			},
+			expectedMount: &mount.MountPoint{Device: testVolumeID, Path: testTargetPath},
+			expectErr:     status.Errorf(codes.Internal, "failed to unmount target path %q: umount: %s: target is busy", testTargetPath, testTargetPath),
+		},
 	}
 
 	for _, test := range cases {
@@ -619,6 +700,78 @@ func TestNodeUnpublishVolume(t *testing.T) {
 			testEnv := initTestNodeServer(t)
 			if test.mounts != nil {
 				testEnv.fm.MountPoints = test.mounts
+			}
+			if test.unmountFunc != nil {
+				testEnv.fm.UnmountFunc = test.unmountFunc
+			}
+
+			_, err := testEnv.ns.NodeUnpublishVolume(context.TODO(), test.req)
+			if test.expectErr == nil && err != nil {
+				t.Errorf("got error %q, expected error nil", err)
+			}
+			if test.expectErr != nil && !errors.Is(err, test.expectErr) {
+				t.Errorf("got error %q, expected error %q", err, test.expectErr)
+			}
+
+			validateMountPoint(t, testEnv.fm, test.expectedMount, nil)
+		})
+	}
+}
+
+func TestNodeUnpublishVolumeForceUnmount(t *testing.T) {
+	t.Parallel()
+	testTargetPath, cleanup := setupMountTarget(t)
+	defer cleanup()
+
+	cases := []struct {
+		name                 string
+		mounts               []mount.MountPoint
+		req                  *csi.NodeUnpublishVolumeRequest
+		unmountWithForceFunc func(target string, umountTimeout time.Duration) error
+		expectedMount        *mount.MountPoint
+		expectErr            error
+	}{
+		{
+			name:   "retry force unmount succeeds eventually",
+			mounts: []mount.MountPoint{{Device: testVolumeID, Path: testTargetPath}},
+			req: &csi.NodeUnpublishVolumeRequest{
+				VolumeId:   testVolumeID,
+				TargetPath: testTargetPath,
+			},
+			unmountWithForceFunc: func() func(target string, umountTimeout time.Duration) error {
+				calls := 0
+				return func(target string, umountTimeout time.Duration) error {
+					calls++
+					if calls < 3 {
+						return fmt.Errorf("umount: %s: target is busy", target)
+					}
+					return nil
+				}
+			}(),
+		},
+		{
+			name:   "retry force unmount fails after max retries",
+			mounts: []mount.MountPoint{{Device: testVolumeID, Path: testTargetPath}},
+			req: &csi.NodeUnpublishVolumeRequest{
+				VolumeId:   testVolumeID,
+				TargetPath: testTargetPath,
+			},
+			unmountWithForceFunc: func(target string, umountTimeout time.Duration) error {
+				return fmt.Errorf("umount: %s: target is busy", target)
+			},
+			expectedMount: &mount.MountPoint{Device: testVolumeID, Path: testTargetPath},
+			expectErr:     status.Errorf(codes.Internal, "failed to force unmount target path %q: umount: %s: target is busy", testTargetPath, testTargetPath),
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			testEnv, forceMounter := initTestNodeServerWithForceMounter(t)
+			if test.mounts != nil {
+				testEnv.fm.MountPoints = test.mounts
+			}
+			if test.unmountWithForceFunc != nil {
+				forceMounter.unmountWithForceFunc = test.unmountWithForceFunc
 			}
 
 			_, err := testEnv.ns.NodeUnpublishVolume(context.TODO(), test.req)

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -115,17 +115,17 @@ func initTestNodeServerWithMounter(t *testing.T, mounter mount.Interface) *nodeS
 			Name:      "test-pvc",
 		},
 	})
-	driver := initTestDriver(t, mounter, fakeClient)
-	s, _ := driver.config.StorageServiceManager.SetupService(context.TODO(), nil, "")
-	if _, err := s.CreateBucket(context.Background(), &storage.ServiceBucket{Name: testVolumeID}); err != nil {
-		t.Fatalf("failed to create the fake bucket: %v", err)
-	}
-
 	var fakeMounter *mount.FakeMounter
 	if fm, ok := mounter.(*mount.FakeMounter); ok {
 		fakeMounter = fm
 	} else if ffm, ok := mounter.(*fakeForceUnmounter); ok {
 		fakeMounter = ffm.FakeMounter
+	}
+
+	driver := initTestDriver(t, fakeMounter, fakeClient)
+	s, _ := driver.config.StorageServiceManager.SetupService(context.TODO(), nil, "")
+	if _, err := s.CreateBucket(context.Background(), &storage.ServiceBucket{Name: testVolumeID}); err != nil {
+		t.Fatalf("failed to create the fake bucket: %v", err)
 	}
 
 	return &nodeServerTestEnv{

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -630,6 +630,7 @@ func TestNodeUnpublishVolume(t *testing.T) {
 		actions       []mount.FakeAction
 		unmountFunc   func(path string) error
 		expectedMount *mount.MountPoint
+		ctx           context.Context
 		expectErr     error
 	}{
 		{
@@ -690,6 +691,10 @@ func TestNodeUnpublishVolume(t *testing.T) {
 				return fmt.Errorf("umount: %s: target is busy", path)
 			},
 			expectedMount: &mount.MountPoint{Device: testVolumeID, Path: testTargetPath},
+			ctx: func() context.Context {
+				ctx, _ := context.WithTimeout(context.Background(), 500*time.Millisecond)
+				return ctx
+			}(),
 			expectErr:     status.Errorf(codes.Internal, "failed to unmount target path %q: umount: %s: target is busy", testTargetPath, testTargetPath),
 		},
 	}
@@ -704,7 +709,12 @@ func TestNodeUnpublishVolume(t *testing.T) {
 				testEnv.fm.UnmountFunc = test.unmountFunc
 			}
 
-			_, err := testEnv.ns.NodeUnpublishVolume(context.TODO(), test.req)
+			ctx := context.TODO()
+			if test.ctx != nil {
+				ctx = test.ctx
+			}
+
+			_, err := testEnv.ns.NodeUnpublishVolume(ctx, test.req)
 			if test.expectErr == nil && err != nil {
 				t.Errorf("got error %q, expected error nil", err)
 			}
@@ -728,6 +738,7 @@ func TestNodeUnpublishVolumeForceUnmount(t *testing.T) {
 		req                  *csi.NodeUnpublishVolumeRequest
 		unmountWithForceFunc func(target string, umountTimeout time.Duration) error
 		expectedMount        *mount.MountPoint
+		ctx                  context.Context
 		expectErr            error
 	}{
 		{
@@ -759,6 +770,10 @@ func TestNodeUnpublishVolumeForceUnmount(t *testing.T) {
 				return fmt.Errorf("umount: %s: target is busy", target)
 			},
 			expectedMount: &mount.MountPoint{Device: testVolumeID, Path: testTargetPath},
+			ctx: func() context.Context {
+				ctx, _ := context.WithTimeout(context.Background(), 500*time.Millisecond)
+				return ctx
+			}(),
 			expectErr:     status.Errorf(codes.Internal, "failed to force unmount target path %q: umount: %s: target is busy", testTargetPath, testTargetPath),
 		},
 	}
@@ -773,7 +788,12 @@ func TestNodeUnpublishVolumeForceUnmount(t *testing.T) {
 				forceMounter.unmountWithForceFunc = test.unmountWithForceFunc
 			}
 
-			_, err := testEnv.ns.NodeUnpublishVolume(context.TODO(), test.req)
+			ctx := context.TODO()
+			if test.ctx != nil {
+				ctx = test.ctx
+			}
+
+			_, err := testEnv.ns.NodeUnpublishVolume(ctx, test.req)
 			if test.expectErr == nil && err != nil {
 				t.Errorf("got error %q, expected error nil", err)
 			}

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -58,19 +58,7 @@ type nodeServerTestEnv struct {
 }
 
 func initTestNodeServer(t *testing.T) *nodeServerTestEnv {
-	t.Helper()
-	mounter := mount.NewFakeMounter([]mount.MountPoint{})
-	driver := initTestDriver(t, mounter)
-	s, _ := driver.config.StorageServiceManager.SetupService(context.TODO(), nil, "")
-	if _, err := s.CreateBucket(context.Background(), &storage.ServiceBucket{Name: testVolumeID}); err != nil {
-		t.Fatalf("failed to create the fake bucket: %v", err)
-	}
-
-	return &nodeServerTestEnv{
-		ns:    newNodeServer(driver, mounter),
-		fm:    mounter,
-		nwMgr: driver.config.NetworkManager.(*fakeNetworkManager),
-	}
+	return initTestNodeServerWithMounter(t, mount.NewFakeMounter([]mount.MountPoint{}))
 }
 
 func initTestNodeServerWithCustomClientset(t *testing.T, clientSet *clientset.FakeClientset, wiNodeLabelCheck bool) *nodeServerTestEnv {
@@ -102,11 +90,15 @@ func (f *fakeForceUnmounter) UnmountWithForce(target string, umountTimeout time.
 }
 
 func initTestNodeServerWithForceMounter(t *testing.T) (*nodeServerTestEnv, *fakeForceUnmounter) {
-	t.Helper()
 	fakeMounter := mount.NewFakeMounter([]mount.MountPoint{})
 	mounter := &fakeForceUnmounter{
 		FakeMounter: fakeMounter,
 	}
+	return initTestNodeServerWithMounter(t, mounter), mounter
+}
+
+func initTestNodeServerWithMounter(t *testing.T, mounter mount.Interface) *nodeServerTestEnv {
+	t.Helper()
 	podName := createMounterPodName("test-node", testVolumeID)
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -129,11 +121,18 @@ func initTestNodeServerWithForceMounter(t *testing.T) (*nodeServerTestEnv, *fake
 		t.Fatalf("failed to create the fake bucket: %v", err)
 	}
 
+	var fakeMounter *mount.FakeMounter
+	if fm, ok := mounter.(*mount.FakeMounter); ok {
+		fakeMounter = fm
+	} else if ffm, ok := mounter.(*fakeForceUnmounter); ok {
+		fakeMounter = ffm.FakeMounter
+	}
+
 	return &nodeServerTestEnv{
 		ns:    newNodeServer(driver, mounter),
 		fm:    fakeMounter,
 		nwMgr: driver.config.NetworkManager.(*fakeNetworkManager),
-	}, mounter
+	}
 }
 
 func setupMountTarget(t *testing.T) (string, func()) {

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -99,22 +99,6 @@ func initTestNodeServerWithForceMounter(t *testing.T) (*nodeServerTestEnv, *fake
 
 func initTestNodeServerWithMounter(t *testing.T, mounter mount.Interface) *nodeServerTestEnv {
 	t.Helper()
-	podName := createMounterPodName("test-node", testVolumeID)
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      podName,
-			Namespace: "test-ns",
-		},
-	}
-	fakeClient := clientset.NewFakeClientset(pod)
-	fakeClient.CreatePV(clientset.FakePVConfig{
-		Name:         "test-pv",
-		VolumeHandle: testVolumeID,
-		ClaimRef: &corev1.ObjectReference{
-			Namespace: "test-ns",
-			Name:      "test-pvc",
-		},
-	})
 	var fakeMounter *mount.FakeMounter
 	if fm, ok := mounter.(*mount.FakeMounter); ok {
 		fakeMounter = fm
@@ -122,7 +106,7 @@ func initTestNodeServerWithMounter(t *testing.T, mounter mount.Interface) *nodeS
 		fakeMounter = ffm.FakeMounter
 	}
 
-	driver := initTestDriver(t, fakeMounter, fakeClient)
+	driver := initTestDriver(t, fakeMounter)
 	s, _ := driver.config.StorageServiceManager.SetupService(context.TODO(), nil, "")
 	if _, err := s.CreateBucket(context.Background(), &storage.ServiceBucket{Name: testVolumeID}); err != nil {
 		t.Fatalf("failed to create the fake bucket: %v", err)
@@ -729,7 +713,7 @@ func TestNodeUnpublishVolume(t *testing.T) {
 
 func TestNodeUnpublishVolumeForceUnmount(t *testing.T) {
 	t.Parallel()
-	testTargetPath, cleanup := setupTestTargetPath(t)
+	testTargetPath, cleanup := setupMountTarget(t)
 	defer cleanup()
 
 	cases := []struct {

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -729,7 +729,7 @@ func TestNodeUnpublishVolume(t *testing.T) {
 
 func TestNodeUnpublishVolumeForceUnmount(t *testing.T) {
 	t.Parallel()
-	testTargetPath, cleanup := setupMountTarget(t)
+	testTargetPath, cleanup := setupTestTargetPath(t)
 	defer cleanup()
 
 	cases := []struct {


### PR DESCRIPTION
Cherry pick of #1497 on release-1.23.

#1497: Retry NodeUnpublishVolume upon failure

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```