### PR TITLE
test: update PV listing in clientset tests to use pvLister directly with labels

### DIFF
--- a/pkg/cloud_provider/clientset/clientset_test.go
+++ b/pkg/cloud_provider/clientset/clientset_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/webhook"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
@@ -86,7 +87,7 @@ func TestConfigurePVLister(t *testing.T) {
 
 	c.ConfigurePVLister(t.Context())
 
-	pvs, err := c.ListPVs()
+	pvs, err := c.pvLister.List(labels.Everything())
 	if err != nil {
 		t.Fatalf("ListPVs() unexpected error: %v", err)
 	}


### PR DESCRIPTION
Use pvLister directly in TestConfigurePVLister

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR updates the `TestConfigurePVLister` unit test in `clientset_test.go` to verify the configured `pvLister` directly rather than calling the wrapper method `ListPVs()`. 

This allows us to more cleanly cherry-pick PR #1512 onto release-1.23 which does not have the `ListPVs()` method.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
This is a straightforward test-only change to ensure direct validation of the initialized lister.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```