### PR TITLE
Redact DefaultTokenSource credential exposure in klog

### DIFF
--- a/pkg/profiles/scanner.go
+++ b/pkg/profiles/scanner.go
@@ -362,7 +362,7 @@ func generateTokenSource(ctx context.Context, configFile *ConfigFile) (oauth2.To
 	} else {
 		klog.Warningf("GOOGLE_APPLICATION_CREDENTIALS env var not set")
 	}
-	klog.Infof("Using DefaultTokenSource %#v", tokenSource)
+	klog.Info("Using DefaultTokenSource")
 
 	return tokenSource, err
 }


### PR DESCRIPTION
## Summary

The earlier fix (d4157225 "Redact Overly generous logs") addressed
`AltTokenSource` logging at line 347 but missed a second instance at
line 364: `klog.Infof("Using DefaultTokenSource %#v", tokenSource)`.

The `%#v` verb recursively prints all struct fields including
sensitive credentials (token body, client secrets). This change
redacts the log to `klog.Info("Using DefaultTokenSource")`.

Bug: b/512256960

## Test plan

- [x] Verified the log line no longer prints struct contents
- [x] No behavioral change — only log output affected