### PR TITLE
[Shared Mount] Implement Mounter Pod Mount

### DIFF
--- a/cmd/sidecar_mounter/main.go
+++ b/cmd/sidecar_mounter/main.go
@@ -58,7 +58,7 @@ var (
 func runNodeMounter(ctx context.Context, cancel context.CancelFunc, mounter *sidecarmounter.Mounter) {
 	klog.Infof("Running node mounter...")
 	s := driver.NewNonBlockingGRPCServer()
-	ms := sidecarmounter.NewMounterServer(mounter)
+	ms := sidecarmounter.NewMounterServer(ctx, mounter)
 
 	socketFile := filepath.Join(webhook.SidecarContainerTmpVolumeMountPath, driver.MounterPodSocketFile)
 

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -954,7 +954,7 @@ func (s *nodeServer) executeNodeStageVolume(ctx context.Context, req *csi.NodeSt
 	}
 
 	// Validate arguments
-	args, err := parseRequestArguments(volumeID, false, req.GetVolumeCapability(), vc)
+	args, err := parseRequestArguments(volumeID, false /* readOnly */, req.GetVolumeCapability(), vc)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "failed to parse request arguments: %v", err)
 	}

--- a/pkg/sidecar_mounter/mounter_server.go
+++ b/pkg/sidecar_mounter/mounter_server.go
@@ -18,23 +18,72 @@ package sidecarmounter
 
 import (
 	"context"
+	"path/filepath"
 
+	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util"
+	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/webhook"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/proto/mounter"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"k8s.io/klog/v2"
 )
 
 type MounterServer struct {
 	mounter.UnimplementedMounterServer
-	Mounter *Mounter
+	mounter   *Mounter
+	serverCtx context.Context
 }
 
-func NewMounterServer(mounter *Mounter) *MounterServer {
+func NewMounterServer(ctx context.Context, mounter *Mounter) *MounterServer {
 	return &MounterServer{
-		Mounter: mounter,
+		mounter:   mounter,
+		serverCtx: ctx,
 	}
 }
 
 func (ms *MounterServer) Mount(ctx context.Context, req *mounter.MountRequest) (*mounter.MountResponse, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method Mount not implemented")
+	if req == nil {
+		return nil, status.Error(codes.Internal, "mount request cannot be nil")
+	}
+	if req.GetVolumeId() == "" {
+		return nil, status.Error(codes.Internal, "volume id cannot be empty")
+	}
+	if req.GetMountPoint() == "" {
+		return nil, status.Error(codes.Internal, "mount point cannot be empty")
+	}
+
+	mc := MountConfig{
+		VolumeName:       req.GetVolumeId(), // Set VolumeName to VolumeId for logging purposes.
+		BucketName:       util.ParseVolumeID(req.GetVolumeId()),
+		Options:          req.GetMountOptions(),
+		SharedMountPoint: req.GetMountPoint(),
+		TempDir:          webhook.SidecarContainerTmpVolumeMountPath,
+		ErrWriter:        NewErrorWriter(filepath.Join(webhook.SidecarContainerTmpVolumeMountPath, util.ErrorFileName)),
+		BufferDir:        webhook.SidecarContainerBufferVolumeMountPath,
+		CacheDir:         webhook.SidecarContainerCacheVolumeMountPath,
+		ConfigFile:       filepath.Join(webhook.SidecarContainerTmpVolumeMountPath, "config.yaml"),
+		// TODO(FUECHR): Implement Auto Go Mem Limit.
+	}
+
+	// TODO(FUECHR): Implement defaultingFlagFileParsing.
+
+	mc.prepareMountArgs()
+
+	// TODO(FUECHR): Call mergeFlags(mc.ConfigFileFlagMap, flagMapFromDriver) (to be done with flag defaulting).
+
+	// TODO(FUECHR) SetupTokenAndStorageManager for bucket access check.
+	// TODO(FUECHR) Implement cloud profiler hook.
+	// TODO(FUECHR) Clean errors in preparation for mount.
+
+	if err := mc.prepareConfigFile(); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to prepare config file: %v", err)
+	}
+
+	klog.Infof("Start mounting bucket %q to %q for volume %q", mc.BucketName, mc.SharedMountPoint, mc.VolumeName)
+
+	// Use the mounter servers long running ctx to prevent the one from NodeStageVolume from killing the gcsfuse process.
+	if err := ms.mounter.MountToNode(ctx, ms.serverCtx, &mc); err != nil {
+		return nil, err
+	}
+	return &mounter.MountResponse{}, nil
 }

--- a/pkg/sidecar_mounter/sidecar_mounter.go
+++ b/pkg/sidecar_mounter/sidecar_mounter.go
@@ -131,66 +131,10 @@ func (m *Mounter) Mount(ctx context.Context, mc *MountConfig) error {
 	// the /dev/fuse is passed as ExtraFiles below, and will always be FD 3
 	args = append(args, "/dev/fd/3")
 
-	cmdName := m.mounterPath
-	if mc.GcsFuseNumaNode >= 0 && numactlAllowed(ctx, mc.GcsFuseNumaNode) {
-		// A nonnegative numa node has been calculated by the csi driver by looking at network
-		// interface numa information. So we are confident enough to pass it directly to numactl
-		// without further checking.
-		klog.Infof("binding gcsfuse to numa node %d", mc.GcsFuseNumaNode)
-		numactlArgs := []string{
-			fmt.Sprintf("--cpunodebind=%d", mc.GcsFuseNumaNode),
-			fmt.Sprintf("--membind=%d", mc.GcsFuseNumaNode),
-			m.mounterPath,
-		}
-		args = append(numactlArgs, args...)
-		cmdName = "numactl"
-	}
-
-	//nolint: gosec
-	klog.Infof("gcsfuse mounting with %s %v...", cmdName, args)
-	cmd := exec.CommandContext(ctx, cmdName, args...)
-
-	if mc.EnableAutoGoMemLimit {
-		//  Set for the sidecar mounter process
-		appliedLimit, err := memlimit.SetGoMemLimitWithOpts(
-			memlimit.WithRatio(mc.AutoGoMemLimitRatio),
-			memlimit.WithProvider(memlimit.FromCgroup),
-		)
-		if err != nil {
-			klog.V(4).Infof("GOMEMLIMIT not set (expected if gke-gcsfuse-sidecar memory limit is unset): %v", err)
-		} else if appliedLimit > 0 {
-			// Export GOMEMLIMIT for the gcsfuse child process.
-			// If appliedLimit is 0, it means GOMEMLIMIT was already set in
-			// the environment or there is no memory limit; in both cases we
-			// should not override.
-			cmd.Env = append(os.Environ(), fmt.Sprintf("GOMEMLIMIT=%d", appliedLimit))
-			klog.Infof("Successfully set GOMEMLIMIT=%d for gcsfuse and sidecar_mounter", appliedLimit)
-		}
-	}
-
+	cmd := m.prepareMountCommand(ctx, mc, args)
 	cmd.ExtraFiles = []*os.File{os.NewFile(uintptr(mc.FileDescriptor), "/dev/fuse")}
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = io.MultiWriter(os.Stderr, mc.ErrWriter)
-	cmd.Cancel = func() error {
-		klog.V(4).Infof("sending SIGTERM to gcsfuse process: %v", cmd)
 
-		return cmd.Process.Signal(syscall.SIGTERM)
-	}
-
-	// when the ctx.Done() is closed,
-	// the main workload containers have exited,
-	// so it is safe to force kill the gcsfuse process.
-	go func(cmd *exec.Cmd) {
-		<-ctx.Done()
-		klog.V(4).Infof("context marked as done, sleep for 5 seconds, to evaluate gcsfuse process %d exit state", cmd.Process.Pid)
-		time.Sleep(time.Second * 5)
-		if cmd.ProcessState == nil || !cmd.ProcessState.Exited() {
-			klog.Warningf("after 5 seconds, process with id %v has not exited, force kill the process", cmd.Process.Pid)
-			if err := cmd.Process.Kill(); err != nil {
-				klog.Warningf("failed to force kill process with id %v", cmd.Process.Pid)
-			}
-		}
-	}(cmd)
+	startCleanupMonitor(ctx, cmd)
 
 	m.WaitGroup.Add(1)
 	go func() {
@@ -233,6 +177,80 @@ func (m *Mounter) Mount(ctx context.Context, mc *MountConfig) error {
 	}()
 
 	return nil
+}
+
+// MountToNode uses the mount config to initialize the GCSFuse process for a share node mount architecture.
+// gcsfuseContext is the long running context from the sidecar, this prevents the gcsfuse process from being killed when the NodeStageVolume context (the ctx variable) is canceled.
+func (m *Mounter) MountToNode(ctx context.Context, gcsfuseContext context.Context, mc *MountConfig) error {
+	return status.Errorf(codes.Unimplemented, "method MountToNode not implemented")
+}
+
+func startCleanupMonitor(ctx context.Context, cmd *exec.Cmd) {
+	// when the ctx.Done() is closed,
+	// the main workload containers have exited,
+	// so it is safe to force kill the gcsfuse process.
+	go func(cmd *exec.Cmd) {
+		<-ctx.Done()
+
+		klog.V(4).Infof("context marked as done, sleep for 5 seconds, to evaluate gcsfuse process %d exit state", cmd.Process.Pid)
+		time.Sleep(time.Second * 5)
+
+		if cmd.ProcessState == nil || !cmd.ProcessState.Exited() {
+			klog.Warningf("after 5 seconds, process with id %v has not exited, force kill the process", cmd.Process.Pid)
+			if err := cmd.Process.Kill(); err != nil {
+				klog.Warningf("failed to force kill process with id %v", cmd.Process.Pid)
+			}
+		}
+	}(cmd)
+}
+
+// prepareMountCommand prepares the exec.Cmd with optional NUMA node binding using numactl.
+func (m *Mounter) prepareMountCommand(ctx context.Context, mc *MountConfig, args []string) *exec.Cmd {
+	cmdName := m.mounterPath
+	if mc.GcsFuseNumaNode >= 0 && numactlAllowed(ctx, mc.GcsFuseNumaNode) {
+		// A nonnegative numa node has been calculated by the csi driver by looking at network
+		// interface numa information. So we are confident enough to pass it directly to numactl
+		// without further checking.
+		klog.Infof("binding gcsfuse to numa node %d", mc.GcsFuseNumaNode)
+		numactlArgs := []string{
+			fmt.Sprintf("--cpunodebind=%d", mc.GcsFuseNumaNode),
+			fmt.Sprintf("--membind=%d", mc.GcsFuseNumaNode),
+			m.mounterPath,
+		}
+		args = append(numactlArgs, args...)
+		cmdName = "numactl"
+	}
+
+	//nolint: gosec
+	klog.Infof("gcsfuse mounting with %s %v...", cmdName, args)
+	cmd := exec.CommandContext(ctx, cmdName, args...)
+
+	if mc.EnableAutoGoMemLimit {
+		//  Set for the sidecar mounter process
+		appliedLimit, err := memlimit.SetGoMemLimitWithOpts(
+			memlimit.WithRatio(mc.AutoGoMemLimitRatio),
+			memlimit.WithProvider(memlimit.FromCgroup),
+		)
+		if err != nil {
+			klog.V(4).Infof("GOMEMLIMIT not set (expected if gke-gcsfuse-sidecar memory limit is unset): %v", err)
+		} else if appliedLimit > 0 {
+			// Export GOMEMLIMIT for the gcsfuse child process.
+			// If appliedLimit is 0, it means GOMEMLIMIT was already set in
+			// the environment or there is no memory limit; in both cases we
+			// should not override.
+			cmd.Env = append(os.Environ(), fmt.Sprintf("GOMEMLIMIT=%d", appliedLimit))
+			klog.Infof("Successfully set GOMEMLIMIT=%d for gcsfuse and sidecar_mounter", appliedLimit)
+		}
+	}
+
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = io.MultiWriter(os.Stderr, mc.ErrWriter)
+	cmd.Cancel = func() error {
+		klog.V(4).Infof("sending SIGTERM to gcsfuse process: %v", cmd)
+		return cmd.Process.Signal(syscall.SIGTERM)
+	}
+
+	return cmd
 }
 
 func (m *Mounter) fetchTokenSource(saNamespace, saName string, audience string) (oauth2.TokenSource, error) {

--- a/pkg/sidecar_mounter/sidecar_mounter_config.go
+++ b/pkg/sidecar_mounter/sidecar_mounter_config.go
@@ -73,6 +73,7 @@ type MountConfig struct {
 	EnableAutoGoMemLimit           bool                  `json:"-"`
 	AutoGoMemLimitRatio            float64               `json:"-"`
 	StorageEndpoint                string                `json:"-"`
+	SharedMountPoint               string                `json:"-"`
 }
 
 // EnsureErrWriter safely initializes ErrWriter to the correct writer if it is nil.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:
This PR implements the mounter serves mount method which prepares gcsfuse configurations and mount arguments calling a unimplemented mount to node method. It also restructures GCSFuse Mount code for reuse in Mount To Node in a future pr. This separation of changes is to prevent context overload on reviewers since modifying existing code and adding new ones on the same lines can be difficult to review**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
none
```