### PR TITLE
Automated cherry pick of #1524: Redact DefaultTokenSource credential exposure in klog

### DIFF
--- a/pkg/profiles/scanner.go
+++ b/pkg/profiles/scanner.go
@@ -362,7 +362,7 @@ func generateTokenSource(ctx context.Context, configFile *ConfigFile) (oauth2.To
 	} else {
 		klog.Warningf("GOOGLE_APPLICATION_CREDENTIALS env var not set")
 	}
-	klog.Infof("Using DefaultTokenSource %#v", tokenSource)
+	klog.Info("Using DefaultTokenSource")
 
 	return tokenSource, err
 }


### PR DESCRIPTION
Cherry pick of #1524 on release-1.23.

#1524: Redact DefaultTokenSource credential exposure in klog

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```