### PR TITLE
Share pod clientset in scanner.go and controller.go

### DIFF
--- a/cmd/csi_driver/main.go
+++ b/cmd/csi_driver/main.go
@@ -195,7 +195,7 @@ func main() {
 		}()
 	}
 
-	clientset, err := clientset.New(*kubeconfigPath, *informerResyncDurationSec, *runController, *kubeAPIBurst, *kubeAPIQPS)
+	clientset, err := clientset.New(*kubeconfigPath, *informerResyncDurationSec, *runController, *kubeAPIBurst, *kubeAPIQPS, *enableGCSFuseProfiles, *enableSharedMount)
 	if err != nil {
 		klog.Fatalf("Failed to configure k8s client: %v", err)
 	}
@@ -274,7 +274,7 @@ func main() {
 			klog.Fatalf("NodeID cannot be empty for node service")
 		}
 
-		clientset.ConfigurePodLister(ctx, *nodeID)
+		clientset.ConfigurePodLister(ctx, *nodeID, nil)
 		clientset.ConfigureNodeLister(ctx, *nodeID)
 
 		if *enableGCSFuseProfiles {
@@ -292,6 +292,7 @@ func main() {
 		}
 	} else if *runController {
 		var pvEventHandlerFuncs *cache.ResourceEventHandlerFuncs
+		var podEventHandlerFuncs *cache.ResourceEventHandlerFuncs
 		if *enableGCSFuseProfiles {
 			s, err := profiles.NewScanner(featureOptions.FeatureGCSFuseProfiles.ScannerConfig)
 			if err != nil {
@@ -301,15 +302,19 @@ func main() {
 				AddFunc:    s.AddPV,
 				DeleteFunc: s.DeletePV,
 			}
+			podEventHandlerFuncs = &cache.ResourceEventHandlerFuncs{
+				AddFunc:    s.AddPod,
+				DeleteFunc: s.DeletePod,
+			}
 			featureOptions.FeatureGCSFuseProfiles.Scanner = s
 		}
 		if *enableSharedMount || *enableGCSFuseProfiles {
 			clientset.ConfigurePVLister(ctx, pvEventHandlerFuncs)
+			clientset.ConfigurePodLister(ctx, "", podEventHandlerFuncs)
 		}
 		if *enableSharedMount {
 			clientset.ConfigurePVCLister(ctx)
 			clientset.ConfigurePodTemplateLister(ctx)
-			clientset.ConfigurePodLister(ctx, "")
 		}
 	}
 

--- a/pkg/cloud_provider/clientset/clientset.go
+++ b/pkg/cloud_provider/clientset/clientset.go
@@ -49,14 +49,15 @@ const (
 
 type Interface interface {
 	K8sClient() kubernetes.Interface
-	ConfigurePodLister(ctx context.Context, nodeName string)
+	ConfigurePodLister(ctx context.Context, nodeName string, eventHandlerFuncs *cache.ResourceEventHandlerFuncs)
 	ConfigureNodeLister(ctx context.Context, nodeName string)
 	ConfigurePVLister(ctx context.Context, eventHandlerFuncs *cache.ResourceEventHandlerFuncs)
 	ConfigurePVCLister(ctx context.Context)
 	ConfigureSCLister(ctx context.Context)
 	ConfigurePodTemplateLister(ctx context.Context)
 	GetPod(namespace, name string) (*corev1.Pod, error)
-	GetPodsByName(name string) ([]*corev1.Pod, error)
+	GetMounterPod(namespace, name string) (*corev1.Pod, error)
+	GetMounterPodsByName(name string) ([]*corev1.Pod, error)
 	GetNode(name string) (*corev1.Node, error)
 	GetPV(name string) (*corev1.PersistentVolume, error)
 	GetPVC(namespace string, name string) (*corev1.PersistentVolumeClaim, error)
@@ -74,7 +75,8 @@ type PodInfo struct {
 type Clientset struct {
 	k8sClients                kubernetes.Interface
 	podLister                 listersv1.PodLister
-	podInformer               cache.SharedIndexInformer
+	mounterPodLister          listersv1.PodLister
+	mounterPodInformer        cache.SharedIndexInformer
 	nodeLister                listersv1.NodeLister
 	pvLister                  listersv1.PersistentVolumeLister
 	pvcLister                 listersv1.PersistentVolumeClaimLister
@@ -82,6 +84,8 @@ type Clientset struct {
 	podTemplateLister         listersv1.PodTemplateLister
 	informerResyncDurationSec int
 	runController             bool
+	enableGCSFuseProfiles     bool
+	enableSharedMount         bool
 }
 
 const (
@@ -348,7 +352,7 @@ func (c *Clientset) ConfigurePodTemplateLister(ctx context.Context) {
 	c.podTemplateLister = podTemplateLister
 }
 
-func New(kubeconfigPath string, informerResyncDurationSec int, runController bool, kubeAPIBurst int, kubeAPIQPS float64) (Interface, error) {
+func New(kubeconfigPath string, informerResyncDurationSec int, runController bool, kubeAPIBurst int, kubeAPIQPS float64, enableGCSFuseProfiles, enableSharedMount bool) (Interface, error) {
 	var err error
 	var rc *rest.Config
 	if kubeconfigPath != "" {
@@ -374,7 +378,12 @@ func New(kubeconfigPath string, informerResyncDurationSec int, runController boo
 		return nil, fmt.Errorf("failed to configure k8s client: %w", err)
 	}
 
-	return &Clientset{k8sClients: clientset, informerResyncDurationSec: informerResyncDurationSec, runController: runController}, nil
+	return &Clientset{
+		k8sClients:                clientset,
+		informerResyncDurationSec: informerResyncDurationSec,
+		runController:             runController,
+		enableGCSFuseProfiles:     enableGCSFuseProfiles,
+		enableSharedMount:         enableSharedMount}, nil
 }
 
 // PodNameIndexFunc is an IndexFunc that indexes pods by their name.
@@ -386,7 +395,83 @@ func PodNameIndexFunc(obj interface{}) ([]string, error) {
 	return []string{pod.Name}, nil
 }
 
-func (c *Clientset) ConfigurePodLister(ctx context.Context, nodeName string) {
+func (c *Clientset) configureControllerPodLister(ctx context.Context, nodeName string, eventHandlerFuncs *cache.ResourceEventHandlerFuncs) {
+	// podListerForLabel creates a SharedInformerFactory that filters pods by the given label key.
+	// This is the most memory efficient way to filter pods with different labels on the server side, since Kubernetes
+	// doesn't support label selector OR statements.
+	podListerForLabel := func(ctx context.Context, labelKey string, eventHandlerFuncs *cache.ResourceEventHandlerFuncs, indexers cache.Indexers) (listersv1.PodLister, cache.SharedIndexInformer) {
+		trim := func(obj interface{}) (interface{}, error) {
+			if accessor, err := meta.Accessor(obj); err == nil {
+				if accessor.GetManagedFields() != nil {
+					accessor.SetManagedFields(nil)
+				}
+			}
+
+			// We are filtering only for relevant PodSpec info to optimize memory usage.
+			// Relevant info is for NodePublishVolume calls:
+			// https://github.com/GoogleCloudPlatform/gcs-fuse-csi-driver/blob/547cab9a9aea4cdbda581885880020fb9266dc03/pkg/csi_driver/node.go#L85
+			podObj, ok := obj.(*corev1.Pod)
+			if !ok || podObj == nil {
+				return obj, nil
+			}
+
+			return &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              podObj.ObjectMeta.Name,
+					Namespace:         podObj.ObjectMeta.Namespace,
+					DeletionTimestamp: podObj.DeletionTimestamp, // Needed by shared mount to check if the pod is being deleted.
+				},
+				Spec: corev1.PodSpec{
+					Volumes:         podObj.Spec.Volumes,         // Needed by profiles to check PVs requiring scans.
+					SchedulingGates: podObj.Spec.SchedulingGates, // Needed by profiles to remove scheduling gates.
+					NodeName:        podObj.Spec.NodeName,        // Needed by shared mount to check if the pod is scheduled.
+				},
+				Status: podObj.Status, // Needed by shared mount to check if the pod scheduled.
+			}, nil
+		}
+
+		factory := informers.NewSharedInformerFactoryWithOptions(
+			c.k8sClients,
+			time.Duration(c.informerResyncDurationSec)*time.Second,
+			informers.WithTweakListOptions(func(options *metav1.ListOptions) {
+				options.LabelSelector = fmt.Sprintf("%s=%s", labelKey, util.TrueStr)
+			}),
+			informers.WithTransform(trim),
+		)
+		if eventHandlerFuncs != nil {
+			factory.Core().V1().Pods().Informer().AddEventHandler(eventHandlerFuncs)
+		}
+		if indexers != nil {
+			if err := factory.Core().V1().Pods().Informer().AddIndexers(indexers); err != nil {
+				klog.Fatalf("Failed to add indexers: %v", err)
+			}
+		}
+		podLister := factory.Core().V1().Pods().Lister()
+		podInformer := factory.Core().V1().Pods().Informer()
+		factory.Start(ctx.Done())
+		factory.WaitForCacheSync(ctx.Done())
+		return podLister, podInformer
+	}
+
+	if c.enableGCSFuseProfiles {
+		c.podLister, _ = podListerForLabel(ctx, webhook.GcsfuseProfilesManagedLabel, eventHandlerFuncs, nil)
+	}
+	if c.enableSharedMount {
+		c.mounterPodLister, c.mounterPodInformer = podListerForLabel(ctx, webhook.SharedMountLabel, nil, cache.Indexers{
+			// Add an indexer to allow efficient lookup of pods by name across all namespaces.
+			// This is used by the controller to quickly find specific pods (e.g., mounter pods)
+			// by their known name without needing to iterate through all pods or know the namespace.
+			PodNameIndex: PodNameIndexFunc,
+		})
+	}
+}
+
+func (c *Clientset) ConfigurePodLister(ctx context.Context, nodeName string, eventHandlerFuncs *cache.ResourceEventHandlerFuncs) {
+	if c.runController {
+		c.configureControllerPodLister(ctx, nodeName, eventHandlerFuncs)
+		return
+	}
+
 	trim := func(obj interface{}) (interface{}, error) {
 		if accessor, err := meta.Accessor(obj); err == nil {
 			if accessor.GetManagedFields() != nil {
@@ -398,11 +483,7 @@ func (c *Clientset) ConfigurePodLister(ctx context.Context, nodeName string) {
 		// Relevant info is for NodePublishVolume calls:
 		// https://github.com/GoogleCloudPlatform/gcs-fuse-csi-driver/blob/547cab9a9aea4cdbda581885880020fb9266dc03/pkg/csi_driver/node.go#L85
 		podObj, ok := obj.(*corev1.Pod)
-		if !ok {
-			return obj, nil
-		}
-
-		if c.runController {
+		if !ok || podObj == nil {
 			return obj, nil
 		}
 
@@ -458,29 +539,11 @@ func (c *Clientset) ConfigurePodLister(ctx context.Context, nodeName string) {
 			if nodeName != "" {
 				options.FieldSelector = "spec.nodeName=" + nodeName
 			}
-			if c.runController {
-				// Only track mounter pods when the Pod informer is configured in the controller.
-				options.LabelSelector = fmt.Sprintf("%s=%s", webhook.SharedMountLabel, util.TrueStr)
-			}
 		}),
 		informers.WithTransform(trim),
 	)
+
 	podLister := informerFactory.Core().V1().Pods().Lister()
-
-	if c.runController {
-		podInformer := informerFactory.Core().V1().Pods().Informer()
-		// Add an indexer to allow efficient lookup of pods by name across all namespaces.
-		// This is used by the controller to quickly find specific pods (e.g., mounter pods)
-		// by their known name without needing to iterate through all pods or know the namespace.
-		err := podInformer.AddIndexers(cache.Indexers{
-			PodNameIndex: PodNameIndexFunc,
-		})
-		if err != nil {
-			klog.Fatalf("Failed to add podName indexer: %v", err)
-		}
-
-		c.podInformer = podInformer
-	}
 
 	informerFactory.Start(ctx.Done())
 	informerFactory.WaitForCacheSync(ctx.Done())
@@ -488,13 +551,18 @@ func (c *Clientset) ConfigurePodLister(ctx context.Context, nodeName string) {
 	c.podLister = podLister
 }
 
-func (c *Clientset) GetPodsByName(podName string) ([]*corev1.Pod, error) {
-	if c.podInformer == nil {
-		return nil, fmt.Errorf("podInformer is not initialized")
+// GetMounterPodsByName retrieves all mounter pods with the given name across all namespaces.
+// This function is used to find mounter pods that are labeled with the shared mount label.
+// It is important to note that this function only retrieves pods that are labeled with the shared mount label,
+// and is currently only initialized in the controller. When getting the mounter pod from the node driver, call GetPod instead, which tracks
+// all pods, including the mounter pods.
+func (c *Clientset) GetMounterPodsByName(podName string) ([]*corev1.Pod, error) {
+	if c.mounterPodInformer == nil {
+		return nil, fmt.Errorf("mounterPodInformer is not initialized")
 	}
 
 	// objs is a slice of interface{}, each element is a *corev1.Pod
-	objs, err := c.podInformer.GetIndexer().ByIndex(PodNameIndex, podName)
+	objs, err := c.mounterPodInformer.GetIndexer().ByIndex(PodNameIndex, podName)
 	if err != nil {
 		return nil, err
 	}
@@ -519,6 +587,19 @@ func (c *Clientset) GetPod(namespace, name string) (*corev1.Pod, error) {
 	}
 
 	return c.podLister.Pods(namespace).Get(name)
+}
+
+// GetMounterPod retrieves a mounter pod from the informer cache by namespace and name.
+// This function is used to check if a mounter pod exists and its status.
+// It is important to note that this function only retrieves pods that are labeled with the shared mount label,
+// and is currently only initialized in the controller. When getting the mounter pod from the node driver, call GetPod instead, which tracks
+// all pods, including the mounter pods.
+func (c *Clientset) GetMounterPod(namespace, name string) (*corev1.Pod, error) {
+	if c.mounterPodLister == nil {
+		return nil, errors.New("mounter pod informer is not ready")
+	}
+
+	return c.mounterPodLister.Pods(namespace).Get(name)
 }
 
 func (c *Clientset) GetNode(name string) (*corev1.Node, error) {

--- a/pkg/cloud_provider/clientset/fake.go
+++ b/pkg/cloud_provider/clientset/fake.go
@@ -27,7 +27,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
@@ -95,8 +94,8 @@ type FakeClientset struct {
 	GetPodTemplateErr error
 }
 
-func NewFakeClientset(objects ...runtime.Object) *FakeClientset {
-	fakeK8sClient := fake.NewSimpleClientset(objects...)
+func NewFakeClientset() *FakeClientset {
+	fakeK8sClient := fake.NewSimpleClientset()
 	fakeClientSet := &FakeClientset{
 		Client:           fakeK8sClient,
 		fakePVs:          make(map[string]*corev1.PersistentVolume),
@@ -120,7 +119,8 @@ func (c *FakeClientset) K8sClient() kubernetes.Interface {
 	return c.Client
 }
 
-func (c *FakeClientset) ConfigurePodLister(_ context.Context, _ string) {}
+func (c *FakeClientset) ConfigurePodLister(_ context.Context, _ string, _ *cache.ResourceEventHandlerFuncs) {
+}
 
 func (c *FakeClientset) ConfigureNodeLister(_ context.Context, _ string) {}
 
@@ -291,6 +291,10 @@ func (c *FakeClientset) GetPod(namespace, name string) (*corev1.Pod, error) {
 	return c.fakePod, nil
 }
 
+func (c *FakeClientset) GetMounterPod(namespace, name string) (*corev1.Pod, error) {
+	return c.GetPod(namespace, name)
+}
+
 func (c *FakeClientset) GetNode(name string) (*corev1.Node, error) {
 	c.fakeNode.ObjectMeta.Name = name
 
@@ -305,7 +309,7 @@ func (c *FakeClientset) GetPV(name string) (*corev1.PersistentVolume, error) {
 	return c.fakePVs[""], nil
 }
 
-func (c *FakeClientset) GetPodsByName(podName string) ([]*corev1.Pod, error) {
+func (c *FakeClientset) GetMounterPodsByName(podName string) ([]*corev1.Pod, error) {
 	if c.ListPodErr != nil {
 		return nil, c.ListPodErr
 	}

--- a/pkg/csi_driver/controller.go
+++ b/pkg/csi_driver/controller.go
@@ -301,7 +301,7 @@ func (s *controllerServer) ControllerUnpublishVolume(ctx context.Context, req *c
 
 	// Delete the mounter pod, if it exists.
 	podName := createMounterPodName(nodeID, volumeID)
-	mounterPods, err := s.driver.config.K8sClients.GetPodsByName(podName)
+	mounterPods, err := s.driver.config.K8sClients.GetMounterPodsByName(podName)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to list pods: %v", err)
 	}

--- a/pkg/csi_driver/controller_test.go
+++ b/pkg/csi_driver/controller_test.go
@@ -63,16 +63,15 @@ func initTestController(t *testing.T, clientset clientset.Interface) csi.Control
 }
 
 type fakeClientsetConfig struct {
-	existingObjects []runtime.Object
-	pvConfig        *clientset.FakePVConfig
-	pvcConfig       *clientset.FakePVCConfig
-	ptConfig        *clientset.FakePodTemplateConfig
-	podConfig       *clientset.FakePodConfig
-	scConfig        *clientset.FakeSCConfig
+	pvConfig  *clientset.FakePVConfig
+	pvcConfig *clientset.FakePVCConfig
+	ptConfig  *clientset.FakePodTemplateConfig
+	podConfig *clientset.FakePodConfig
+	scConfig  *clientset.FakeSCConfig
 }
 
 func setupFakeBase(cfg fakeClientsetConfig) *clientset.FakeClientset {
-	fc := clientset.NewFakeClientset(cfg.existingObjects...)
+	fc := clientset.NewFakeClientset()
 	if cfg.pvConfig != nil {
 		fc.CreatePV(*cfg.pvConfig)
 	}
@@ -242,23 +241,6 @@ func TestControllerPublishVolume(t *testing.T) {
 	mounterPodPollInterval = 10 * time.Millisecond
 	defer func() { mounterPodPollInterval = oldInterval }()
 
-	timeNow := metav1.Now()
-
-	// Helper to create a mounter pod for initial state
-	makeMounterPod := func(config *mounterPodConfig, deletionTimestamp *metav1.Time) *corev1.Pod {
-		p := createMounterPodSpec(config)
-		p.ObjectMeta.DeletionTimestamp = deletionTimestamp
-		p.ResourceVersion = "1"
-		return p
-	}
-
-	defaultMounterPodConfig := &mounterPodConfig{
-		podName:   createMounterPodName(testNodeID, testVolumeID),
-		namespace: testNamespace,
-		nodeID:    testNodeID,
-		image:     testImage,
-	}
-
 	cases := []struct {
 		name               string
 		req                *csi.ControllerPublishVolumeRequest
@@ -382,6 +364,7 @@ func TestControllerPublishVolume(t *testing.T) {
 				PublishContextKeyMounterPodNamespace: testNamespace,
 				PublishContextKeyMounterPodName:      createMounterPodName(testNodeID, testVolumeID),
 			},
+			podGetErr: apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "pods"}, ""),
 			expectErr: false,
 		},
 		{
@@ -424,6 +407,7 @@ func TestControllerPublishVolume(t *testing.T) {
 				PublishContextKeyMounterPodNamespace: testNamespace,
 				PublishContextKeyMounterPodName:      createMounterPodName(testNodeID, testVolumeID),
 			},
+			podGetErr: apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "pods"}, ""),
 			expectErr: false,
 			verifyCreatedPod: func(t *testing.T, pod *corev1.Pod) {
 				if len(pod.Spec.Containers) != 1 {
@@ -488,6 +472,7 @@ func TestControllerPublishVolume(t *testing.T) {
 				PublishContextKeyMounterPodNamespace: testNamespace,
 				PublishContextKeyMounterPodName:      createMounterPodName(testNodeID, testVolumeID),
 			},
+			podGetErr: apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "pods"}, ""),
 			expectErr: false,
 			verifyCreatedPod: func(t *testing.T, pod *corev1.Pod) {
 				if len(pod.Spec.Containers) != 1 {
@@ -525,6 +510,7 @@ func TestControllerPublishVolume(t *testing.T) {
 				PublishContextKeyMounterPodNamespace: testNamespace,
 				PublishContextKeyMounterPodName:      createMounterPodName(testNodeID, testVolumeID),
 			},
+			podGetErr: apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "pods"}, ""),
 			expectErr: false,
 			verifyCreatedPod: func(t *testing.T, pod *corev1.Pod) {
 				if pod.Spec.DNSPolicy != corev1.DNSClusterFirstWithHostNet {
@@ -552,6 +538,7 @@ func TestControllerPublishVolume(t *testing.T) {
 				PublishContextKeyMounterPodNamespace: testNamespace,
 				PublishContextKeyMounterPodName:      createMounterPodName(testNodeID, testVolumeID),
 			},
+			podGetErr: apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "pods"}, ""),
 			expectErr: false,
 			verifyCreatedPod: func(t *testing.T, pod *corev1.Pod) {
 				wantVolume := webhook.GetSATokenVolume("fake.identity.pool")
@@ -589,6 +576,7 @@ func TestControllerPublishVolume(t *testing.T) {
 				PublishContextKeyMounterPodNamespace: testNamespace,
 				PublishContextKeyMounterPodName:      createMounterPodName(testNodeID, testVolumeID),
 			},
+			podGetErr: apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "pods"}, ""),
 			expectErr: false,
 			verifyCreatedPod: func(t *testing.T, pod *corev1.Pod) {
 				wantVolume := webhook.GetSATokenVolume("https://custom.identity.provider")
@@ -625,6 +613,7 @@ func TestControllerPublishVolume(t *testing.T) {
 				PublishContextKeyMounterPodNamespace: testNamespace,
 				PublishContextKeyMounterPodName:      createMounterPodName(testNodeID, testVolumeID),
 			},
+			podGetErr: apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "pods"}, ""),
 			expectErr: false,
 			verifyCreatedPod: func(t *testing.T, pod *corev1.Pod) {
 				wantVolume := webhook.GetSATokenVolume("fake.identity.pool")
@@ -714,9 +703,7 @@ func TestControllerPublishVolume(t *testing.T) {
 				},
 			},
 			setupFake: func() *clientset.FakeClientset {
-				existingPod := makeMounterPod(defaultMounterPodConfig, nil)
 				cfg := getDefaultFakeClientsetConfig()
-				cfg.existingObjects = []runtime.Object{existingPod}
 				cfg.podConfig = &clientset.FakePodConfig{
 					NodeName: testNodeID,
 					PodStatus: &corev1.PodStatus{
@@ -748,9 +735,19 @@ func TestControllerPublishVolume(t *testing.T) {
 				},
 			},
 			setupFake: func() *clientset.FakeClientset {
-				existingPod := makeMounterPod(defaultMounterPodConfig, &timeNow)
 				cfg := getDefaultFakeClientsetConfig()
-				cfg.existingObjects = []runtime.Object{existingPod}
+				cfg.podConfig = &clientset.FakePodConfig{
+					NodeName: testNodeID,
+					PodStatus: &corev1.PodStatus{
+						Conditions: []corev1.PodCondition{
+							{
+								Type:   corev1.PodScheduled,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+					DeletionTimestamp: &metav1.Time{},
+				}
 				return setupFakeBase(cfg)
 			},
 			expectErr:     true,
@@ -788,6 +785,7 @@ func TestControllerPublishVolume(t *testing.T) {
 			setupFake: func() *clientset.FakeClientset {
 				return setupFakeBase(getDefaultFakeClientsetConfig())
 			},
+			podGetErr:     apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "pods"}, ""),
 			podCreateErr:  errors.New("simulated create error"),
 			expectErr:     true,
 			expectErrCode: codes.Internal,
@@ -831,6 +829,7 @@ func TestControllerPublishVolume(t *testing.T) {
 				PublishContextKeyMounterPodNamespace: testNamespace,
 				PublishContextKeyMounterPodName:      createMounterPodName(testNodeID, testVolumeID),
 			},
+			podGetErr: apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "pods"}, ""),
 			expectErr: false,
 			verifyCreatedPod: func(t *testing.T, pod *corev1.Pod) {
 				// The profile volumes must be injected if profilesEnabled was true
@@ -857,9 +856,7 @@ func TestControllerPublishVolume(t *testing.T) {
 			var createdPod *corev1.Pod
 
 			if test.podGetErr != nil {
-				fakeK8sClient.PrependReactor("get", "pods", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
-					return true, nil, test.podGetErr
-				})
+				fc.GetPodErr = test.podGetErr
 			}
 			if test.podCreateErr != nil {
 				fakeK8sClient.Fake.PrependReactor("create", "pods", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
@@ -887,6 +884,9 @@ func TestControllerPublishVolume(t *testing.T) {
 						PodStatus: &pod.Status,
 					})
 
+					if apierrors.IsNotFound(fc.GetPodErr) {
+						fc.GetPodErr = nil // Clear any previous GetPodErr to simulate successful retrieval after creation
+					}
 					return false, pod, nil // Return false to allow default fake client handling to store the object
 				})
 			}

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -44,7 +44,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	mount "k8s.io/mount-utils"
@@ -145,14 +144,7 @@ func initTestNodeServerWithForceMounter(t *testing.T) (*nodeServerTestEnv, *fake
 
 func initTestNodeServerWithMounter(t *testing.T, mounter mount.Interface) *nodeServerTestEnv {
 	t.Helper()
-	podName := createMounterPodName("test-node", testVolumeID)
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      podName,
-			Namespace: "test-ns",
-		},
-	}
-	fakeClient := clientset.NewFakeClientset(pod)
+	fakeClient := clientset.NewFakeClientset()
 	fakeClient.CreatePV(clientset.FakePVConfig{
 		Name:         "test-pv",
 		VolumeHandle: testVolumeID,

--- a/pkg/csi_driver/shared_mount.go
+++ b/pkg/csi_driver/shared_mount.go
@@ -116,9 +116,8 @@ func createMounterPod(clientset clientset.Interface, ctx context.Context, config
 	if config == nil {
 		return status.Error(codes.Internal, "mounter pod config cannot be nil")
 	}
-	// Check if the mounter pod already exists, but was marked for deletion.
-	// This requires calling the API server directly to retrieve the most up-to-date pod status.
-	pod, err := clientset.K8sClient().CoreV1().Pods(config.namespace).Get(ctx, config.podName, metav1.GetOptions{})
+	// Check if the mounter pod already exists.
+	pod, err := clientset.GetMounterPod(config.namespace, config.podName)
 	if err != nil && !errors.IsNotFound(err) {
 		return status.Errorf(codes.Internal, "failed to get mounter pod %s/%s: %v", config.namespace, config.podName, err)
 	}
@@ -250,7 +249,7 @@ func waitForMounterPodScheduled(clientset clientset.Interface, ctx context.Conte
 	}
 
 	checkIfScheduled := func() (bool, error) {
-		pod, err := clientset.GetPod(namespace, podName)
+		pod, err := clientset.GetMounterPod(namespace, podName)
 		if err != nil {
 			if errors.IsNotFound(err) {
 				return false, nil
@@ -348,7 +347,7 @@ func deleteMounterPod(ctx context.Context, clientset clientset.Interface, podNam
 			}
 			return status.Errorf(code, "timed out waiting for mounter pod %s/%s to be deleted", podNamespace, podName)
 		case <-ticker.C:
-			if _, err := clientset.GetPod(podNamespace, podName); err != nil {
+			if _, err := clientset.GetMounterPod(podNamespace, podName); err != nil {
 				if errors.IsNotFound(err) {
 					klog.Infof("Mounter pod %s/%s was successfully deleted.", podNamespace, podName)
 					return nil

--- a/pkg/csi_driver/shared_mount_test.go
+++ b/pkg/csi_driver/shared_mount_test.go
@@ -790,42 +790,43 @@ func TestCreateMounterPod(t *testing.T) {
 		image:     testImage,
 	}
 
-	timeNow := metav1.Now()
-
-	makePod := func(deletionTimestamp *metav1.Time) *corev1.Pod {
-		p := createMounterPodSpec(baseConfig)
-		p.ObjectMeta.DeletionTimestamp = deletionTimestamp
-		p.ResourceVersion = "1" // Needed for some fake client operations
-		return p
-	}
-
 	tests := []struct {
-		name         string
-		initialState []runtime.Object
-		getErr       error
-		createErr    error
-		wantErr      bool
-		wantCode     codes.Code
-		wantCreates  int
+		name        string
+		getErr      error
+		createErr   error
+		wantErr     bool
+		wantCode    codes.Code
+		wantCreates int
+		setupFake   func() *clientset.FakeClientset
 	}{
 		{
-			name:         "pod does not exist - create pod successfully",
-			initialState: []runtime.Object{},
-			wantErr:      false,
-			wantCreates:  1,
+			name:        "pod does not exist - create pod successfully",
+			wantErr:     false,
+			wantCreates: 1,
+			getErr:      k8serrors.NewNotFound(schema.GroupResource{Group: "", Resource: "pods"}, ""),
 		},
 		{
-			name: "pod exists - no-op success",
-			initialState: []runtime.Object{
-				makePod(nil),
-			},
+			name:        "pod exists - no-op success",
 			wantErr:     false,
 			wantCreates: 0,
 		},
 		{
 			name: "pod exists with deletion timestamp - return error",
-			initialState: []runtime.Object{
-				makePod(&timeNow),
+			setupFake: func() *clientset.FakeClientset {
+				cfg := getDefaultFakeClientsetConfig()
+				cfg.podConfig = &clientset.FakePodConfig{
+					NodeName: testNodeID,
+					PodStatus: &corev1.PodStatus{
+						Conditions: []corev1.PodCondition{
+							{
+								Type:   corev1.PodScheduled,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+					DeletionTimestamp: &metav1.Time{},
+				}
+				return setupFakeBase(cfg)
 			},
 			wantErr:     true,
 			wantCode:    codes.Aborted,
@@ -841,24 +842,30 @@ func TestCreateMounterPod(t *testing.T) {
 			name:        "pod create fails with error - return error",
 			createErr:   errors.New("simulated create failed"),
 			wantErr:     true,
+			getErr:      k8serrors.NewNotFound(schema.GroupResource{Group: "", Resource: "pods"}, ""),
 			wantCreates: 1, // Create was attempted
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			// NewFakeClientset now initializes the standard fake client
-			testClientset := clientset.NewFakeClientset(tc.initialState...)
+			var testClientset *clientset.FakeClientset
+			if tc.setupFake != nil {
+				testClientset = tc.setupFake()
+			} else {
+				testClientset = clientset.NewFakeClientset()
+			}
 			fakeK8sClient := testClientset.K8sClient().(*fake.Clientset)
 
 			// Inject errors using reactors on the standard fake client
 			if tc.getErr != nil {
-				fakeK8sClient.PrependReactor("get", "pods", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
-					return true, nil, tc.getErr
-				})
+				testClientset.GetPodErr = tc.getErr
 			}
 			if tc.createErr != nil {
 				fakeK8sClient.PrependReactor("create", "pods", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+					if k8serrors.IsNotFound(testClientset.GetPodErr) {
+						testClientset.GetPodErr = nil // Clear any previous GetPodErr to simulate successful retrieval after creation
+					}
 					return true, nil, tc.createErr
 				})
 			}
@@ -1270,7 +1277,7 @@ func TestDeleteMounterPod(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond) // Short timeout for testing
 			defer cancel()
 
-			testClientset := clientset.NewFakeClientset(tc.initialObjects...)
+			testClientset := clientset.NewFakeClientset()
 			fakeK8sClient := testClientset.K8sClient().(*fake.Clientset)
 
 			deleteCalled := false

--- a/pkg/profiles/scanner.go
+++ b/pkg/profiles/scanner.go
@@ -42,7 +42,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"gopkg.in/gcfg.v1"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -245,12 +244,9 @@ type Scanner struct {
 	kubeClient           kubernetes.Interface
 	pvcLister            v1listers.PersistentVolumeClaimLister
 	scLister             storagelisters.StorageClassLister
-	podLister            v1listers.PodLister
 	pvcSynced            cache.InformerSynced
 	scSynced             cache.InformerSynced
-	podSynced            cache.InformerSynced
 	factory              informers.SharedInformerFactory
-	podFactory           informers.SharedInformerFactory
 	queue                workqueue.TypedRateLimitingInterface[string]
 	eventRecorder        record.EventRecorder
 	datafluxConfig       *DatafluxConfig
@@ -312,35 +308,6 @@ func buildKubeConfig(kubeconfigPath string) (*rest.Config, error) {
 	}
 	klog.Info("Using In-Cluster Kubeconfig")
 	return cfg, nil
-}
-
-// trimPodObject is a transform function for the Pod informer to reduce memory usage.
-// It keeps only the fields relevant to the scanner logic.
-func trimPodObject(obj any) (any, error) {
-	if accessor, err := meta.Accessor(obj); err == nil {
-		accessor.SetManagedFields(nil)
-	} else {
-		klog.Warningf("Failed to get meta accessor for object: %v", err)
-	}
-
-	podObj, ok := obj.(*v1.Pod)
-	if !ok {
-		return obj, nil
-	}
-
-	// Create a new Pod object with only the fields we need.
-	trimmedPod := &v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      podObj.ObjectMeta.Name,      // Needed for workqueue key.
-			Namespace: podObj.ObjectMeta.Namespace, // Needed for workqueue key.
-		},
-		Spec: v1.PodSpec{
-			Volumes:         podObj.Spec.Volumes,         // Needed to check PVs requiring scans.
-			SchedulingGates: podObj.Spec.SchedulingGates, // Needed to remove scheduling gates.
-		},
-	}
-
-	return trimmedPod, nil
 }
 
 func generateTokenSource(ctx context.Context, configFile *ConfigFile) (oauth2.TokenSource, error) {
@@ -422,21 +389,6 @@ func NewScanner(config *ScannerConfig) (*Scanner, error) {
 	pvcInformer := factory.Core().V1().PersistentVolumeClaims()
 	scInformer := factory.Storage().V1().StorageClasses()
 
-	// Factory for Pod informer with label selector and transform
-	// The label is patched by the mutating webhook.
-	podLabelSelector := fmt.Sprintf("%s=%s", profileManagedLabelKey, profileManagedLabelValue)
-	tweakFunc := func(options *metav1.ListOptions) {
-		options.LabelSelector = podLabelSelector
-	}
-	podFactory := informers.NewSharedInformerFactoryWithOptions(
-		kubeClient,
-		config.ResyncPeriod,
-		informers.WithTweakListOptions(tweakFunc),
-		informers.WithTransform(trimPodObject),
-	)
-	podInformer := podFactory.Core().V1().Pods()
-	klog.Infof("Pod informer configured with label selector: %q and a transform function", podLabelSelector)
-
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartStructuredLogging(0)
 	eventBroadcaster.StartRecordingToSink(&typedv1.EventSinkImpl{Interface: kubeClient.CoreV1().Events("")})
@@ -446,13 +398,10 @@ func NewScanner(config *ScannerConfig) (*Scanner, error) {
 	scanner := &Scanner{
 		kubeClient:     kubeClient,
 		factory:        factory,
-		podFactory:     podFactory,
 		pvcLister:      pvcInformer.Lister(),
 		scLister:       scInformer.Lister(),
-		podLister:      podInformer.Lister(),
 		pvcSynced:      pvcInformer.Informer().HasSynced,
 		scSynced:       scInformer.Informer().HasSynced,
-		podSynced:      podInformer.Informer().HasSynced,
 		queue:          workqueue.NewTypedRateLimitingQueue(rateLimiter),
 		trackedPVs:     make(map[string]syncInfo),
 		eventRecorder:  eventRecorder,
@@ -463,12 +412,6 @@ func NewScanner(config *ScannerConfig) (*Scanner, error) {
 		metricManager:  metrics.NewPrometheusMetricManager(config.HTTPEndpoint, mux),
 		mux:            mux,
 	}
-
-	klog.Info("Setting up event handlers for Pods")
-	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    scanner.addPod,
-		DeleteFunc: scanner.deletePod,
-	})
 
 	return scanner, nil
 }
@@ -539,10 +482,9 @@ func (s *Scanner) run(ctx context.Context) {
 
 	klog.Info("Starting informers")
 	s.factory.Start(stopCh)
-	s.podFactory.Start(stopCh)
 
 	klog.Info("Waiting for informer caches to sync")
-	if !cache.WaitForCacheSync(stopCh, s.pvcSynced, s.scSynced, s.podSynced) {
+	if !cache.WaitForCacheSync(stopCh, s.pvcSynced, s.scSynced) {
 		klog.Error("Failed to wait for caches to sync")
 		return
 	}
@@ -735,7 +677,7 @@ func (s *Scanner) syncPod(ctx context.Context, key string) error {
 		return status.Errorf(codes.Internal, "failed to split meta namespace key %q: %v", key, err)
 	}
 
-	pod, err := s.podLister.Pods(namespace).Get(name)
+	pod, err := s.config.K8SClients.GetPod(namespace, name)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			klog.Infof("Pod %q in namespace %q has been deleted", name, namespace)
@@ -1870,9 +1812,9 @@ func (s *Scanner) enqueueTrackedPVs() {
 }
 
 // addPod is the add event handler for Pods.
-func (s *Scanner) addPod(obj any) {
+func (s *Scanner) AddPod(obj any) {
 	pod, ok := obj.(*v1.Pod)
-	if !ok {
+	if !ok || pod == nil {
 		klog.Errorf("AddFunc Pod: Expected Pod but got %T", obj)
 		return
 	}
@@ -1881,9 +1823,9 @@ func (s *Scanner) addPod(obj any) {
 }
 
 // deletePod is the event handler for Pod Delete events.
-func (s *Scanner) deletePod(obj any) {
+func (s *Scanner) DeletePod(obj any) {
 	pod, ok := obj.(*v1.Pod)
-	if !ok {
+	if !ok || pod == nil {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
 			klog.Errorf("DeleteFunc Pod: Expected Pod or Tombstone but got %T", obj)

--- a/pkg/profiles/scanner_test.go
+++ b/pkg/profiles/scanner_test.go
@@ -162,11 +162,16 @@ func (f *fakeScanBucketImplFunc) Scan(scanner *Scanner, ctx context.Context, buc
 
 type fakeK8sClients struct {
 	clientset.Interface
-	pvLister corelisters.PersistentVolumeLister
+	pvLister  corelisters.PersistentVolumeLister
+	podLister corelisters.PodLister
 }
 
 func (f *fakeK8sClients) GetPV(name string) (*v1.PersistentVolume, error) {
 	return f.pvLister.Get(name)
+}
+
+func (f *fakeK8sClients) GetPod(namespace, name string) (*v1.Pod, error) {
+	return f.podLister.Pods(namespace).Get(name)
 }
 
 // testFixture holds the necessary components for testing the Scanner.
@@ -195,19 +200,7 @@ func newTestFixture(t *testing.T, initialObjects ...runtime.Object) *testFixture
 	pvInformer := factory.Core().V1().PersistentVolumes()
 	pvcInformer := factory.Core().V1().PersistentVolumeClaims()
 	scInformer := factory.Storage().V1().StorageClasses()
-
-	// Factory for Pod informer
-	podLabelSelector := fmt.Sprintf("%s=%s", profileManagedLabelKey, profileManagedLabelValue)
-	tweakFunc := func(options *metav1.ListOptions) {
-		options.LabelSelector = podLabelSelector
-	}
-	podFactory := informers.NewSharedInformerFactoryWithOptions(
-		kubeClient,
-		0, // No resync period for tests
-		informers.WithTweakListOptions(tweakFunc),
-		informers.WithTransform(trimPodObject),
-	)
-	podInformer := podFactory.Core().V1().Pods()
+	podInformer := factory.Core().V1().Pods()
 
 	// Manually add initial objects to the informer indexers to ensure they are available in listers.
 	for _, obj := range initialObjects {
@@ -225,12 +218,7 @@ func newTestFixture(t *testing.T, initialObjects ...runtime.Object) *testFixture
 				t.Fatalf("Failed to add SC to indexer: %v", err)
 			}
 		case *v1.Pod:
-			// Must apply transform before adding to indexer to mimic real behavior
-			trimmedObj, err := trimPodObject(obj)
-			if err != nil {
-				t.Fatalf("Failed to transform Pod: %v", err)
-			}
-			if err := podInformer.Informer().GetIndexer().Add(trimmedObj); err != nil {
+			if err := podInformer.Informer().GetIndexer().Add(obj); err != nil {
 				t.Fatalf("Failed to add Pod to indexer: %v", err)
 			}
 		}
@@ -254,12 +242,9 @@ func newTestFixture(t *testing.T, initialObjects ...runtime.Object) *testFixture
 		kubeClient:     kubeClient,
 		pvcLister:      pvcInformer.Lister(),
 		scLister:       scInformer.Lister(),
-		podLister:      podInformer.Lister(),
 		pvcSynced:      pvcInformer.Informer().HasSynced,
 		scSynced:       scInformer.Informer().HasSynced,
-		podSynced:      podInformer.Informer().HasSynced,
 		factory:        factory,
-		podFactory:     podFactory,
 		queue:          workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()),
 		eventRecorder:  recorder,
 		trackedPVs:     make(map[string]syncInfo),
@@ -268,14 +253,14 @@ func newTestFixture(t *testing.T, initialObjects ...runtime.Object) *testFixture
 		metricManager:  metrics.NewFakePrometheusMetricsManager(),
 		config: &ScannerConfig{
 			K8SClients: &fakeK8sClients{
-				pvLister: pvInformer.Lister(),
+				pvLister:  pvInformer.Lister(),
+				podLister: podInformer.Lister(),
 			},
 		},
 	}
 
 	factory.Start(stopCh)
-	podFactory.Start(stopCh)
-	if !cache.WaitForCacheSync(stopCh, pvInformer.Informer().HasSynced, s.pvcSynced, s.scSynced, s.podSynced) {
+	if !cache.WaitForCacheSync(stopCh, pvInformer.Informer().HasSynced, s.pvcSynced, s.scSynced, podInformer.Informer().HasSynced) {
 		t.Fatalf("Failed to sync caches")
 	}
 
@@ -1233,7 +1218,7 @@ func TestAddPod(t *testing.T) {
 	pod := createPod(testPodName, testNamespace, nil, podLabels, false)
 	f := newTestFixture(t, pod)
 
-	f.scanner.addPod(pod)
+	f.scanner.AddPod(pod)
 
 	if f.scanner.queue.Len() != 1 {
 		t.Errorf("Queue length: got %d, want 1", f.scanner.queue.Len())
@@ -1253,7 +1238,7 @@ func TestDeletePod(t *testing.T) {
 	f.scanner.queue.AddRateLimited(queueKey)
 	// NumRequeues check can be flaky with fake rate limiters, so we don't assert on it.
 
-	f.scanner.deletePod(pod)
+	f.scanner.DeletePod(pod)
 
 	// After deletePod, the key should be "forgotten", resetting its rate limiting.
 	if f.scanner.queue.NumRequeues(queueKey) != 0 {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -68,7 +68,7 @@ var _ = func() bool {
 	testsuites.PDStorageClass = *pdStorageClass
 	framework.AfterReadingAllFlags(&framework.TestContext)
 
-	c, err = clientset.New(framework.TestContext.KubeConfig, 0, false, 0, 0)
+	c, err = clientset.New(framework.TestContext.KubeConfig, 0, false, 0, 0, *profilesFlag, false)
 	if err != nil {
 		klog.Fatalf("Failed to configure k8s client: %v", err)
 	}

--- a/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/clientset/clientset.go
+++ b/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/clientset/clientset.go
@@ -49,14 +49,15 @@ const (
 
 type Interface interface {
 	K8sClient() kubernetes.Interface
-	ConfigurePodLister(ctx context.Context, nodeName string)
+	ConfigurePodLister(ctx context.Context, nodeName string, eventHandlerFuncs *cache.ResourceEventHandlerFuncs)
 	ConfigureNodeLister(ctx context.Context, nodeName string)
 	ConfigurePVLister(ctx context.Context, eventHandlerFuncs *cache.ResourceEventHandlerFuncs)
 	ConfigurePVCLister(ctx context.Context)
 	ConfigureSCLister(ctx context.Context)
 	ConfigurePodTemplateLister(ctx context.Context)
 	GetPod(namespace, name string) (*corev1.Pod, error)
-	GetPodsByName(name string) ([]*corev1.Pod, error)
+	GetMounterPod(namespace, name string) (*corev1.Pod, error)
+	GetMounterPodsByName(name string) ([]*corev1.Pod, error)
 	GetNode(name string) (*corev1.Node, error)
 	GetPV(name string) (*corev1.PersistentVolume, error)
 	GetPVC(namespace string, name string) (*corev1.PersistentVolumeClaim, error)
@@ -74,7 +75,8 @@ type PodInfo struct {
 type Clientset struct {
 	k8sClients                kubernetes.Interface
 	podLister                 listersv1.PodLister
-	podInformer               cache.SharedIndexInformer
+	mounterPodLister          listersv1.PodLister
+	mounterPodInformer        cache.SharedIndexInformer
 	nodeLister                listersv1.NodeLister
 	pvLister                  listersv1.PersistentVolumeLister
 	pvcLister                 listersv1.PersistentVolumeClaimLister
@@ -82,6 +84,8 @@ type Clientset struct {
 	podTemplateLister         listersv1.PodTemplateLister
 	informerResyncDurationSec int
 	runController             bool
+	enableGCSFuseProfiles     bool
+	enableSharedMount         bool
 }
 
 const (
@@ -348,7 +352,7 @@ func (c *Clientset) ConfigurePodTemplateLister(ctx context.Context) {
 	c.podTemplateLister = podTemplateLister
 }
 
-func New(kubeconfigPath string, informerResyncDurationSec int, runController bool, kubeAPIBurst int, kubeAPIQPS float64) (Interface, error) {
+func New(kubeconfigPath string, informerResyncDurationSec int, runController bool, kubeAPIBurst int, kubeAPIQPS float64, enableGCSFuseProfiles, enableSharedMount bool) (Interface, error) {
 	var err error
 	var rc *rest.Config
 	if kubeconfigPath != "" {
@@ -374,7 +378,12 @@ func New(kubeconfigPath string, informerResyncDurationSec int, runController boo
 		return nil, fmt.Errorf("failed to configure k8s client: %w", err)
 	}
 
-	return &Clientset{k8sClients: clientset, informerResyncDurationSec: informerResyncDurationSec, runController: runController}, nil
+	return &Clientset{
+		k8sClients:                clientset,
+		informerResyncDurationSec: informerResyncDurationSec,
+		runController:             runController,
+		enableGCSFuseProfiles:     enableGCSFuseProfiles,
+		enableSharedMount:         enableSharedMount}, nil
 }
 
 // PodNameIndexFunc is an IndexFunc that indexes pods by their name.
@@ -386,7 +395,81 @@ func PodNameIndexFunc(obj interface{}) ([]string, error) {
 	return []string{pod.Name}, nil
 }
 
-func (c *Clientset) ConfigurePodLister(ctx context.Context, nodeName string) {
+func (c *Clientset) configureControllerPodLister(ctx context.Context, nodeName string, eventHandlerFuncs *cache.ResourceEventHandlerFuncs) {
+	// podListerForLabel creates a SharedInformerFactory that filters pods by the given label key.
+	// This is the most memory efficient way to filter pods with different labels on the server side, since Kubernetes
+	// doesn't support label selector OR statements.
+	podListerForLabel := func(ctx context.Context, labelKey string, eventHandlerFuncs *cache.ResourceEventHandlerFuncs, indexers cache.Indexers) (listersv1.PodLister, cache.SharedIndexInformer) {
+		trim := func(obj interface{}) (interface{}, error) {
+			if accessor, err := meta.Accessor(obj); err == nil {
+				if accessor.GetManagedFields() != nil {
+					accessor.SetManagedFields(nil)
+				}
+			}
+
+			// We are filtering only for relevant PodSpec info to optimize memory usage.
+			// Relevant info is for NodePublishVolume calls:
+			// https://github.com/GoogleCloudPlatform/gcs-fuse-csi-driver/blob/547cab9a9aea4cdbda581885880020fb9266dc03/pkg/csi_driver/node.go#L85
+			podObj, ok := obj.(*corev1.Pod)
+			if !ok || podObj == nil {
+				return obj, nil
+			}
+
+			return &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              podObj.ObjectMeta.Name,
+					Namespace:         podObj.ObjectMeta.Namespace,
+					DeletionTimestamp: podObj.DeletionTimestamp, // Needed by shared mount to check if the pod is being deleted.
+				},
+				Spec: corev1.PodSpec{
+					Volumes:         podObj.Spec.Volumes,         // Needed by profiles to check PVs requiring scans.
+					SchedulingGates: podObj.Spec.SchedulingGates, // Needed by profiles to remove scheduling gates.
+					NodeName:        podObj.Spec.NodeName,        // Needed by shared mount to check if the pod is scheduled.
+				},
+				Status: podObj.Status, // Needed by shared mount to check if the pod scheduled.
+			}, nil
+		}
+
+		factory := informers.NewSharedInformerFactoryWithOptions(
+			c.k8sClients,
+			time.Duration(c.informerResyncDurationSec)*time.Second,
+			informers.WithTweakListOptions(func(options *metav1.ListOptions) {
+				options.LabelSelector = fmt.Sprintf("%s=%s", labelKey, util.TrueStr)
+			}),
+			informers.WithTransform(trim),
+		)
+		if eventHandlerFuncs != nil {
+			factory.Core().V1().Pods().Informer().AddEventHandler(eventHandlerFuncs)
+		}
+		if indexers != nil {
+			if err := factory.Core().V1().Pods().Informer().AddIndexers(indexers); err != nil {
+				klog.Fatalf("Failed to add indexers: %v", err)
+			}
+		}
+		factory.Start(ctx.Done())
+		factory.WaitForCacheSync(ctx.Done())
+		return factory.Core().V1().Pods().Lister(), factory.Core().V1().Pods().Informer()
+	}
+
+	if c.enableGCSFuseProfiles {
+		c.podLister, _ = podListerForLabel(ctx, webhook.GcsfuseProfilesManagedLabel, eventHandlerFuncs, nil)
+	}
+	if c.enableSharedMount {
+		c.mounterPodLister, c.mounterPodInformer = podListerForLabel(ctx, webhook.SharedMountLabel, nil, cache.Indexers{
+			// Add an indexer to allow efficient lookup of pods by name across all namespaces.
+			// This is used by the controller to quickly find specific pods (e.g., mounter pods)
+			// by their known name without needing to iterate through all pods or know the namespace.
+			PodNameIndex: PodNameIndexFunc,
+		})
+	}
+}
+
+func (c *Clientset) ConfigurePodLister(ctx context.Context, nodeName string, eventHandlerFuncs *cache.ResourceEventHandlerFuncs) {
+	if c.runController {
+		c.configureControllerPodLister(ctx, nodeName, eventHandlerFuncs)
+		return
+	}
+
 	trim := func(obj interface{}) (interface{}, error) {
 		if accessor, err := meta.Accessor(obj); err == nil {
 			if accessor.GetManagedFields() != nil {
@@ -398,11 +481,7 @@ func (c *Clientset) ConfigurePodLister(ctx context.Context, nodeName string) {
 		// Relevant info is for NodePublishVolume calls:
 		// https://github.com/GoogleCloudPlatform/gcs-fuse-csi-driver/blob/547cab9a9aea4cdbda581885880020fb9266dc03/pkg/csi_driver/node.go#L85
 		podObj, ok := obj.(*corev1.Pod)
-		if !ok {
-			return obj, nil
-		}
-
-		if c.runController {
+		if !ok || podObj == nil {
 			return obj, nil
 		}
 
@@ -458,43 +537,27 @@ func (c *Clientset) ConfigurePodLister(ctx context.Context, nodeName string) {
 			if nodeName != "" {
 				options.FieldSelector = "spec.nodeName=" + nodeName
 			}
-			if c.runController {
-				// Only track mounter pods when the Pod informer is configured in the controller.
-				options.LabelSelector = fmt.Sprintf("%s=%s", webhook.SharedMountLabel, util.TrueStr)
-			}
 		}),
 		informers.WithTransform(trim),
 	)
-	podLister := informerFactory.Core().V1().Pods().Lister()
-
-	if c.runController {
-		podInformer := informerFactory.Core().V1().Pods().Informer()
-		// Add an indexer to allow efficient lookup of pods by name across all namespaces.
-		// This is used by the controller to quickly find specific pods (e.g., mounter pods)
-		// by their known name without needing to iterate through all pods or know the namespace.
-		err := podInformer.AddIndexers(cache.Indexers{
-			PodNameIndex: PodNameIndexFunc,
-		})
-		if err != nil {
-			klog.Fatalf("Failed to add podName indexer: %v", err)
-		}
-
-		c.podInformer = podInformer
-	}
 
 	informerFactory.Start(ctx.Done())
 	informerFactory.WaitForCacheSync(ctx.Done())
-
-	c.podLister = podLister
+	c.podLister = informerFactory.Core().V1().Pods().Lister()
 }
 
-func (c *Clientset) GetPodsByName(podName string) ([]*corev1.Pod, error) {
-	if c.podInformer == nil {
-		return nil, fmt.Errorf("podInformer is not initialized")
+// GetMounterPodsByName retrieves all mounter pods with the given name across all namespaces.
+// This function is used to find mounter pods that are labeled with the shared mount label.
+// It is important to note that this function only retrieves pods that are labeled with the shared mount label,
+// and is currently only initialized in the controller. When getting the mounter pod from the node driver, call GetPod instead, which tracks
+// all pods, including the mounter pods.
+func (c *Clientset) GetMounterPodsByName(podName string) ([]*corev1.Pod, error) {
+	if c.mounterPodInformer == nil {
+		return nil, fmt.Errorf("mounterPodInformer is not initialized")
 	}
 
 	// objs is a slice of interface{}, each element is a *corev1.Pod
-	objs, err := c.podInformer.GetIndexer().ByIndex(PodNameIndex, podName)
+	objs, err := c.mounterPodInformer.GetIndexer().ByIndex(PodNameIndex, podName)
 	if err != nil {
 		return nil, err
 	}
@@ -519,6 +582,19 @@ func (c *Clientset) GetPod(namespace, name string) (*corev1.Pod, error) {
 	}
 
 	return c.podLister.Pods(namespace).Get(name)
+}
+
+// GetMounterPod retrieves a mounter pod from the informer cache by namespace and name.
+// This function is used to check if a mounter pod exists and its status.
+// It is important to note that this function only retrieves pods that are labeled with the shared mount label,
+// and is currently only initialized in the controller. When getting the mounter pod from the node driver, call GetPod instead, which tracks
+// all pods, including the mounter pods.
+func (c *Clientset) GetMounterPod(namespace, name string) (*corev1.Pod, error) {
+	if c.mounterPodLister == nil {
+		return nil, errors.New("mounter pod informer is not ready")
+	}
+
+	return c.mounterPodLister.Pods(namespace).Get(name)
 }
 
 func (c *Clientset) GetNode(name string) (*corev1.Node, error) {

--- a/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/clientset/fake.go
+++ b/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/clientset/fake.go
@@ -27,7 +27,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
@@ -95,8 +94,8 @@ type FakeClientset struct {
 	GetPodTemplateErr error
 }
 
-func NewFakeClientset(objects ...runtime.Object) *FakeClientset {
-	fakeK8sClient := fake.NewSimpleClientset(objects...)
+func NewFakeClientset() *FakeClientset {
+	fakeK8sClient := fake.NewSimpleClientset()
 	fakeClientSet := &FakeClientset{
 		Client:           fakeK8sClient,
 		fakePVs:          make(map[string]*corev1.PersistentVolume),
@@ -120,7 +119,8 @@ func (c *FakeClientset) K8sClient() kubernetes.Interface {
 	return c.Client
 }
 
-func (c *FakeClientset) ConfigurePodLister(_ context.Context, _ string) {}
+func (c *FakeClientset) ConfigurePodLister(_ context.Context, _ string, _ *cache.ResourceEventHandlerFuncs) {
+}
 
 func (c *FakeClientset) ConfigureNodeLister(_ context.Context, _ string) {}
 
@@ -291,6 +291,10 @@ func (c *FakeClientset) GetPod(namespace, name string) (*corev1.Pod, error) {
 	return c.fakePod, nil
 }
 
+func (c *FakeClientset) GetMounterPod(namespace, name string) (*corev1.Pod, error) {
+	return c.GetPod(namespace, name)
+}
+
 func (c *FakeClientset) GetNode(name string) (*corev1.Node, error) {
 	c.fakeNode.ObjectMeta.Name = name
 
@@ -305,7 +309,7 @@ func (c *FakeClientset) GetPV(name string) (*corev1.PersistentVolume, error) {
 	return c.fakePVs[""], nil
 }
 
-func (c *FakeClientset) GetPodsByName(podName string) ([]*corev1.Pod, error) {
+func (c *FakeClientset) GetMounterPodsByName(podName string) ([]*corev1.Pod, error) {
 	if c.ListPodErr != nil {
 		return nil, c.ListPodErr
 	}

--- a/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/csi_driver/controller.go
+++ b/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/csi_driver/controller.go
@@ -230,6 +230,16 @@ func (s *controllerServer) ControllerPublishVolume(ctx context.Context, req *csi
 		}
 	}
 
+	hostNetworkEnabled := vc[VolumeContextKeyHostNetworkPodKSA] == util.TrueStr
+	identityProvider := vc[VolumeContextKeyIdentityProvider]
+
+	var tokenAudience string
+	if util.IsGKEIdentityProvider(identityProvider) || identityProvider == "" {
+		tokenAudience = s.driver.config.TokenManager.GetIdentityPool()
+	} else {
+		tokenAudience = identityProvider
+	}
+
 	// Prepare mounter pod config.
 	podName := createMounterPodName(nodeID, volumeID)
 	podConfig := &mounterPodConfig{
@@ -241,6 +251,9 @@ func (s *controllerServer) ControllerPublishVolume(ctx context.Context, req *csi
 		image:              containerImage,
 		volumes:            podTemplate.Template.Spec.Volumes,
 		profilesEnabled:    profilesEnabled,
+		hostNetworkEnabled: hostNetworkEnabled,
+		tokenAudience:      tokenAudience,
+		dnsPolicy:          podTemplate.Template.Spec.DNSPolicy,
 	}
 
 	if err := createMounterPod(clientset, ctx, podConfig); err != nil {
@@ -288,7 +301,7 @@ func (s *controllerServer) ControllerUnpublishVolume(ctx context.Context, req *c
 
 	// Delete the mounter pod, if it exists.
 	podName := createMounterPodName(nodeID, volumeID)
-	mounterPods, err := s.driver.config.K8sClients.GetPodsByName(podName)
+	mounterPods, err := s.driver.config.K8sClients.GetMounterPodsByName(podName)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to list pods: %v", err)
 	}

--- a/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/csi_driver/gcs_fuse_driver.go
+++ b/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/csi_driver/gcs_fuse_driver.go
@@ -256,7 +256,7 @@ func (driver *GCSDriver) Run(ctx context.Context, cancel context.CancelFunc, end
 	klog.Infof("Running driver: %v", driver.config.Name)
 
 	s := NewNonBlockingGRPCServer()
-	s.Start(endpoint, driver.ids, driver.cs, driver.ns)
+	s.Start(endpoint, driver.ids, driver.cs, driver.ns, nil)
 
 	if driver.config.RunController &&
 		driver.config.FeatureOptions != nil &&

--- a/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/csi_driver/node.go
+++ b/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/csi_driver/node.go
@@ -315,38 +315,7 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 		}
 	}
 
-	sidecarCheckVal := getInternalMountOptionValue(args.fuseMountOptions, util.EnableSidecarBucketAccessCheckConst)
-	userExplicitlyEnabled := sidecarCheckVal == util.TrueStr
-	userExplicitlyDisabled := sidecarCheckVal == util.FalseStr
-	enableSidecarBucketAccessCheckForSidecarVersion := s.driver.isSidecarVersionSupportedForGivenFeature(gcsFuseSidecarImage, SidecarBucketAccessCheckMinVersion) &&
-		(userExplicitlyEnabled || (s.driver.config.EnableSidecarBucketAccessCheck && !userExplicitlyDisabled))
-	identityProvider := ""
-	if s.shouldPopulateIdentityProvider(pod, args.optInHostnetworkKSA, args.userSpecifiedIdentityProvider != "") {
-		if args.userSpecifiedIdentityProvider != "" {
-			identityProvider = args.userSpecifiedIdentityProvider
-		} else {
-			identityProvider = s.driver.config.TokenManager.GetIdentityProvider()
-		}
-		klog.V(6).Infof("NodePublishVolume populating identity provider %q in mount options", identityProvider)
-		args.fuseMountOptions = joinMountOptions(args.fuseMountOptions, []string{util.OptInHnw + "=true", util.TokenServerIdentityProviderConst + "=" + identityProvider})
-	} else if enableSidecarBucketAccessCheckForSidecarVersion && !userExplicitlyEnabled {
-		//Enable sidecar bucket access check only for Workload Identity workloads. This feature consumes additional quota for Host Network pods as we do not have token caching.
-		args.fuseMountOptions = joinMountOptions(args.fuseMountOptions, []string{util.EnableSidecarBucketAccessCheckConst + "=true"})
-	}
-
-	if enableSidecarBucketAccessCheckForSidecarVersion {
-		if identityProvider == "" {
-			identityProvider = s.driver.config.TokenManager.GetIdentityProvider()
-			args.fuseMountOptions = joinMountOptions(args.fuseMountOptions, []string{util.TokenServerIdentityProviderConst + "=" + identityProvider})
-		}
-		klog.Infof("Got identity provider %s", identityProvider)
-
-		identityPool := s.driver.config.TokenManager.GetIdentityPool()
-		args.fuseMountOptions = joinMountOptions(args.fuseMountOptions, []string{
-			util.PodNamespaceConst + "=" + vc[VolumeContextKeyPodNamespace],
-			util.ServiceAccountNameConst + "=" + vc[VolumeContextKeyServiceAccountName],
-			util.TokenServerIdentityPoolConst + "=" + identityPool})
-	}
+	s.populateTokenAndBucketAccessCheckOptions(pod, gcsFuseSidecarImage, vc, &args, vc[VolumeContextKeyPodNamespace], vc[VolumeContextKeyServiceAccountName])
 
 	if args.enableCloudProfilerForSidecar && s.driver.isSidecarVersionSupportedForGivenFeature(gcsFuseSidecarImage, SidecarCloudProfilerMinVersion) {
 		args.fuseMountOptions = joinMountOptions(args.fuseMountOptions, []string{
@@ -768,8 +737,56 @@ func (s *nodeServer) shouldPopulateIdentityProvider(pod *corev1.Pod, optInHnwKSA
 			break
 		}
 	}
+	for _, container := range pod.Spec.Containers {
+		if strings.HasPrefix(container.Name, util.MounterPodNamePrefix) {
+			sidecarVersionSupported = s.driver.isSidecarVersionSupportedForGivenFeature(container.Image, TokenServerSidecarMinVersion)
+
+			break
+		}
+	}
 
 	return tokenVolumeInjected && (sidecarVersionSupported || userInput)
+}
+
+// populateTokenAndBucketAccessCheckOptions populates fuseMountOptions with token server identity provider
+// for host network workloads and bucket access check parameters for both sidecar and shared mount modes.
+func (s *nodeServer) populateTokenAndBucketAccessCheckOptions(pod *corev1.Pod, image string, vc map[string]string, args *requestArgs, podNamespace, serviceAccountName string) {
+	sidecarCheckVal := getInternalMountOptionValue(args.fuseMountOptions, util.EnableSidecarBucketAccessCheckConst)
+	userExplicitlyEnabled := sidecarCheckVal == util.TrueStr
+	userExplicitlyDisabled := sidecarCheckVal == util.FalseStr
+	enableBucketAccessCheckForVersion := s.driver.isSidecarVersionSupportedForGivenFeature(image, SidecarBucketAccessCheckMinVersion) &&
+		(userExplicitlyEnabled || (s.driver.config.EnableSidecarBucketAccessCheck && !userExplicitlyDisabled))
+	identityProvider := ""
+	userSpecifiedIDP := args.userSpecifiedIdentityProvider
+	if userSpecifiedIDP == "" {
+		userSpecifiedIDP = vc[util.TokenServerIdentityProviderConst]
+	}
+	if s.shouldPopulateIdentityProvider(pod, args.optInHostnetworkKSA, userSpecifiedIDP != "") {
+		if userSpecifiedIDP != "" {
+			identityProvider = userSpecifiedIDP
+		} else {
+			identityProvider = s.driver.config.TokenManager.GetIdentityProvider()
+		}
+		klog.V(6).Infof("Populating identity provider %q in mount options", identityProvider)
+		args.fuseMountOptions = joinMountOptions(args.fuseMountOptions, []string{util.OptInHnw + "=true", util.TokenServerIdentityProviderConst + "=" + identityProvider})
+	} else if enableBucketAccessCheckForVersion && !userExplicitlyEnabled {
+		// Enable sidecar bucket access check only for Workload Identity workloads. This feature consumes additional quota for Host Network pods as we do not have token caching.
+		args.fuseMountOptions = joinMountOptions(args.fuseMountOptions, []string{util.EnableSidecarBucketAccessCheckConst + "=true"})
+	}
+
+	if enableBucketAccessCheckForVersion {
+		if identityProvider == "" {
+			identityProvider = s.driver.config.TokenManager.GetIdentityProvider()
+			args.fuseMountOptions = joinMountOptions(args.fuseMountOptions, []string{util.TokenServerIdentityProviderConst + "=" + identityProvider})
+		}
+		klog.Infof("Got identity provider %s", identityProvider)
+
+		identityPool := s.driver.config.TokenManager.GetIdentityPool()
+		args.fuseMountOptions = joinMountOptions(args.fuseMountOptions, []string{
+			util.PodNamespaceConst + "=" + podNamespace,
+			util.ServiceAccountNameConst + "=" + serviceAccountName,
+			util.TokenServerIdentityPoolConst + "=" + identityPool})
+	}
 }
 
 func gcsFuseSidecarContainerImage(pod *corev1.Pod) string {
@@ -920,7 +937,7 @@ func (s *nodeServer) executeNodeStageVolume(ctx context.Context, req *csi.NodeSt
 	if profilesEnabled {
 		klog.V(4).Infof("NodeStageVolume gcsfuse profiles feature is enabled for mounter pod %s/%s", podNamespace, podName)
 		profile, err = profiles.BuildProfileConfig(&profiles.BuildProfileConfigParams{
-			VolumeName:          vc[util.VolumeContextKeyPVName],
+			VolumeName:          pvName,
 			Clientset:           s.k8sClients,
 			ContainerName:       util.MounterPodNamePrefix,
 			VolumeAttributeKeys: transformKeysToSet(volumeAttributesToMountOptionsMapping),
@@ -937,7 +954,7 @@ func (s *nodeServer) executeNodeStageVolume(ctx context.Context, req *csi.NodeSt
 	}
 
 	// Validate arguments
-	args, err := parseRequestArguments(volumeID, false, req.GetVolumeCapability(), vc)
+	args, err := parseRequestArguments(volumeID, false /* readOnly */, req.GetVolumeCapability(), vc)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "failed to parse request arguments: %v", err)
 	}
@@ -949,6 +966,13 @@ func (s *nodeServer) executeNodeStageVolume(ctx context.Context, req *csi.NodeSt
 		}
 	}
 
+	podImage, err := mounterPodImage(pod)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to get image of mounter pod %s/%s: %v", podNamespace, podName, err)
+	}
+
+	s.populateTokenAndBucketAccessCheckOptions(pod, podImage, vc, &args, podNamespace, pod.Spec.ServiceAccountName)
+
 	// We initialize volumeState if bucket name is NOT "_", I.e. It's not a dynamic mount.
 	var vs *util.VolumeState
 	if args.bucketName != "_" {
@@ -957,11 +981,6 @@ func (s *nodeServer) executeNodeStageVolume(ctx context.Context, req *csi.NodeSt
 			vs = &util.VolumeState{}
 			s.volumeStateStore.Store(stagingPath, vs)
 		}
-	}
-
-	mounterPodImage, err := mounterPodImage(pod)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to get image of mounter pod %s/%s: %v", podNamespace, podName, err)
 	}
 
 	podUID := string(pod.UID)
@@ -974,14 +993,14 @@ func (s *nodeServer) executeNodeStageVolume(ctx context.Context, req *csi.NodeSt
 	}
 	if mounted {
 		// Restart monitoring goroutine if the driver restarts for existing mounts.
-		s.startGcsFuseKernelParamsMonitoring(stagingPath, emptyDirBasePath, podUID, pvName, mounterPodImage, vs)
+		s.startGcsFuseKernelParamsMonitoring(stagingPath, emptyDirBasePath, podUID, pvName, podImage, vs)
 
 		klog.Infof("NodeStageVolume succeeded on staging path %q for volume %q, mount already exists.", stagingPath, req.GetVolumeId())
 		return &csi.NodeStageVolumeResponse{}, nil
 	}
 
 	// Pass kernel params file flag to GCSFuse iff GCSFuse Kernel Params feature is supported.
-	if s.isGcsFuseKernelParamsFeatureSupported(mounterPodImage, vs) {
+	if s.isGcsFuseKernelParamsFeatureSupported(podImage, vs) {
 		args.fuseMountOptions = joinMountOptions(args.fuseMountOptions, []string{util.EnableGCSFuseKernelParams + "=true"})
 	}
 
@@ -1002,7 +1021,7 @@ func (s *nodeServer) executeNodeStageVolume(ctx context.Context, req *csi.NodeSt
 	}
 
 	// Start monitoring goroutine for new shared mounts.
-	s.startGcsFuseKernelParamsMonitoring(stagingPath, emptyDirBasePath, podUID, pvName, mounterPodImage, vs)
+	s.startGcsFuseKernelParamsMonitoring(stagingPath, emptyDirBasePath, podUID, pvName, podImage, vs)
 
 	klog.Infof("Mounter pod %s/%s is running and staging path %s is mounted", podNamespace, podName, stagingPath)
 
@@ -1020,7 +1039,7 @@ func (s *nodeServer) mountToNode(ctx context.Context, podUID, stagingPath, volum
 		return status.Errorf(codes.Internal, "empty dir base path must be provided for shared mount")
 	}
 	emptyDirBasePath := s.driver.config.FeatureOptions.SharedMountOptions.EmptyDirBasePath(podUID)
-	socketFile := filepath.Join(emptyDirBasePath, mounterPodSocketFile)
+	socketFile := filepath.Join(emptyDirBasePath, MounterPodSocketFile)
 
 	// Create a symlink to bypass the 108-character limit for Unix domain sockets
 	// when dialing the connection from the Node Server.

--- a/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/csi_driver/server.go
+++ b/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/csi_driver/server.go
@@ -23,6 +23,7 @@ import (
 
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util"
+	"github.com/googlecloudplatform/gcs-fuse-csi-driver/proto/mounter"
 	"google.golang.org/grpc"
 	"k8s.io/klog/v2"
 )
@@ -30,7 +31,7 @@ import (
 // Defines Non blocking GRPC server interfaces.
 type NonBlockingGRPCServer interface {
 	// Start services at the endpoint
-	Start(endpoint string, ids csi.IdentityServer, cs csi.ControllerServer, ns csi.NodeServer)
+	Start(endpoint string, ids csi.IdentityServer, cs csi.ControllerServer, ns csi.NodeServer, ms mounter.MounterServer)
 	// Waits for the service to stop
 	Wait()
 	// Stops the service gracefully
@@ -49,10 +50,10 @@ type nonBlockingGRPCServer struct {
 	server *grpc.Server
 }
 
-func (s *nonBlockingGRPCServer) Start(endpoint string, ids csi.IdentityServer, cs csi.ControllerServer, ns csi.NodeServer) {
+func (s *nonBlockingGRPCServer) Start(endpoint string, ids csi.IdentityServer, cs csi.ControllerServer, ns csi.NodeServer, ms mounter.MounterServer) {
 	s.wg.Add(1)
 
-	go s.serve(endpoint, ids, cs, ns)
+	go s.serve(endpoint, ids, cs, ns, ms)
 }
 
 func (s *nonBlockingGRPCServer) Wait() {
@@ -67,7 +68,7 @@ func (s *nonBlockingGRPCServer) ForceStop() {
 	s.server.Stop()
 }
 
-func (s *nonBlockingGRPCServer) serve(endpoint string, ids csi.IdentityServer, cs csi.ControllerServer, ns csi.NodeServer) {
+func (s *nonBlockingGRPCServer) serve(endpoint string, ids csi.IdentityServer, cs csi.ControllerServer, ns csi.NodeServer, ms mounter.MounterServer) {
 	scheme, addr, err := util.ParseEndpoint(endpoint, true)
 	if err != nil {
 		klog.Fatalf("failed to parse endpoint %v", err)
@@ -93,6 +94,9 @@ func (s *nonBlockingGRPCServer) serve(endpoint string, ids csi.IdentityServer, c
 	}
 	if ns != nil {
 		csi.RegisterNodeServer(server, ns)
+	}
+	if ms != nil {
+		mounter.RegisterMounterServer(server, ms)
 	}
 
 	klog.Infof("Listening for connections on address: %#v", listener.Addr())

--- a/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/csi_driver/shared_mount.go
+++ b/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/csi_driver/shared_mount.go
@@ -44,7 +44,7 @@ import (
 const (
 	mounterPodPriorityClass       = "gcsfusecsi-mount-priority"
 	mounterPodMountDir            = "mount-dir"
-	mounterPodSocketFile          = "mounter.sock"
+	MounterPodSocketFile          = "mounter.sock"
 	mounterPodManagedImageKeyword = "managed"
 	mounterPodSocketDir           = "mount-socket"
 )
@@ -63,6 +63,9 @@ type mounterPodConfig struct {
 	resources          *corev1.ResourceRequirements // The resource requirements for the mounter pod container.
 	volumes            []corev1.Volume              // The volumes for the mounter pod.
 	profilesEnabled    bool                         // Whether the profiles feature is enabled.
+	hostNetworkEnabled bool                         // Whether hostNetwork is enabled for the mounter pod.
+	tokenAudience      string                       // Token audience for projected service account volume.
+	dnsPolicy          corev1.DNSPolicy             // The DNS policy for the mounter pod.
 }
 
 // sharedMount checks if the VolumeContext enables the shared node mount feature
@@ -113,9 +116,8 @@ func createMounterPod(clientset clientset.Interface, ctx context.Context, config
 	if config == nil {
 		return status.Error(codes.Internal, "mounter pod config cannot be nil")
 	}
-	// Check if the mounter pod already exists, but was marked for deletion.
-	// This requires calling the API server directly to retrieve the most up-to-date pod status.
-	pod, err := clientset.K8sClient().CoreV1().Pods(config.namespace).Get(ctx, config.podName, metav1.GetOptions{})
+	// Check if the mounter pod already exists.
+	pod, err := clientset.GetMounterPod(config.namespace, config.podName)
 	if err != nil && !errors.IsNotFound(err) {
 		return status.Errorf(codes.Internal, "failed to get mounter pod %s/%s: %v", config.namespace, config.podName, err)
 	}
@@ -152,12 +154,12 @@ func createMounterPodSpec(config *mounterPodConfig) *corev1.Pod {
 	volumeMounts := []corev1.VolumeMount{
 		{
 			Name:             mounterPodMountDir,
-			MountPath:        util.KubeletDir,
+			MountPath:        util.KubeletPluginsGCSFuseDir,
 			MountPropagation: ptr.To(corev1.MountPropagationBidirectional),
 		},
 		{
 			Name:      util.SidecarContainerTmpVolumeName,
-			MountPath: util.SidecarContainerTmpVolumePath,
+			MountPath: webhook.SidecarContainerTmpVolumeMountPath,
 		},
 		{
 			Name:      webhook.SidecarContainerBufferVolumeName,
@@ -175,6 +177,10 @@ func createMounterPodSpec(config *mounterPodConfig) *corev1.Pod {
 		if !webhook.VolumeMountExists(volumeMounts, webhook.SidecarContainerFileCacheRamDiskVolumeName) {
 			volumeMounts = append(volumeMounts, webhook.RamFileCacheVolumeMount)
 		}
+	}
+
+	if config.hostNetworkEnabled {
+		volumeMounts = append(volumeMounts, webhook.SATokenVolumeMount)
 	}
 
 	labels := map[string]string{
@@ -198,11 +204,13 @@ func createMounterPodSpec(config *mounterPodConfig) *corev1.Pod {
 				"kubernetes.io/os":       "linux",
 			},
 			PriorityClassName: mounterPodPriorityClass,
+			HostNetwork:       config.hostNetworkEnabled,
 			Containers: []corev1.Container{
 				{
 					Name:            util.MounterPodNamePrefix,
 					Image:           config.image,
 					ImagePullPolicy: corev1.PullAlways,
+					Args:            []string{"--enable-shared-mount"},
 					SecurityContext: &corev1.SecurityContext{
 						Privileged: ptr.To(true),
 					},
@@ -225,6 +233,10 @@ func createMounterPodSpec(config *mounterPodConfig) *corev1.Pod {
 		spec.Spec.ServiceAccountName = config.serviceAccountName
 	}
 
+	if config.dnsPolicy != "" {
+		spec.Spec.DNSPolicy = config.dnsPolicy
+	}
+
 	spec.Spec.Containers[0].Resources = *mounterPodResources(config)
 
 	return spec
@@ -237,7 +249,7 @@ func waitForMounterPodScheduled(clientset clientset.Interface, ctx context.Conte
 	}
 
 	checkIfScheduled := func() (bool, error) {
-		pod, err := clientset.GetPod(namespace, podName)
+		pod, err := clientset.GetMounterPod(namespace, podName)
 		if err != nil {
 			if errors.IsNotFound(err) {
 				return false, nil
@@ -335,7 +347,7 @@ func deleteMounterPod(ctx context.Context, clientset clientset.Interface, podNam
 			}
 			return status.Errorf(code, "timed out waiting for mounter pod %s/%s to be deleted", podNamespace, podName)
 		case <-ticker.C:
-			if _, err := clientset.GetPod(podNamespace, podName); err != nil {
+			if _, err := clientset.GetMounterPod(podNamespace, podName); err != nil {
 				if errors.IsNotFound(err) {
 					klog.Infof("Mounter pod %s/%s was successfully deleted.", podNamespace, podName)
 					return nil
@@ -387,15 +399,15 @@ func mounterPodVolumes(config *mounterPodConfig) []corev1.Volume {
 	volumes = append(volumes, corev1.Volume{Name: mounterPodMountDir,
 		VolumeSource: corev1.VolumeSource{
 			HostPath: &corev1.HostPathVolumeSource{
-				// TODO(urielguzman): Check if we can use /var/lib/kubelet/plugins/gcsfuse.csi.storage.gke.io/
-				// instead, to decrease the host path scope.
-				Path: util.KubeletDir,
+				Path: util.KubeletPluginsGCSFuseDir,
 				Type: ptr.To(corev1.HostPathDirectoryOrCreate),
 			},
 		}})
 
-	// TODO(urielguzman): Add host network volumes when those features are implemented for
-	// shared mount.
+	if config.hostNetworkEnabled {
+		volumes = append(volumes, webhook.GetSATokenVolume(config.tokenAudience))
+	}
+
 	if config.profilesEnabled {
 		if !webhook.VolumeExists(volumes, webhook.SidecarContainerFileCacheEphemeralDiskVolumeName) {
 			volumes = append(volumes, webhook.EphemeralFileCacheVolume)
@@ -441,7 +453,7 @@ func waitForMounterServer(ctx context.Context, clientset clientset.Interface, mo
 	}
 
 	// Construct the mounter socket file path.
-	mounterSocketFilePath := filepath.Join(emptyDirBasePath(podUID), mounterPodSocketFile)
+	mounterSocketFilePath := filepath.Join(emptyDirBasePath(podUID), MounterPodSocketFile)
 	var pod *corev1.Pod
 	var err error
 

--- a/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/profiles/scanner.go
+++ b/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/profiles/scanner.go
@@ -42,7 +42,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"gopkg.in/gcfg.v1"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -245,12 +244,9 @@ type Scanner struct {
 	kubeClient           kubernetes.Interface
 	pvcLister            v1listers.PersistentVolumeClaimLister
 	scLister             storagelisters.StorageClassLister
-	podLister            v1listers.PodLister
 	pvcSynced            cache.InformerSynced
 	scSynced             cache.InformerSynced
-	podSynced            cache.InformerSynced
 	factory              informers.SharedInformerFactory
-	podFactory           informers.SharedInformerFactory
 	queue                workqueue.TypedRateLimitingInterface[string]
 	eventRecorder        record.EventRecorder
 	datafluxConfig       *DatafluxConfig
@@ -314,35 +310,6 @@ func buildKubeConfig(kubeconfigPath string) (*rest.Config, error) {
 	return cfg, nil
 }
 
-// trimPodObject is a transform function for the Pod informer to reduce memory usage.
-// It keeps only the fields relevant to the scanner logic.
-func trimPodObject(obj any) (any, error) {
-	if accessor, err := meta.Accessor(obj); err == nil {
-		accessor.SetManagedFields(nil)
-	} else {
-		klog.Warningf("Failed to get meta accessor for object: %v", err)
-	}
-
-	podObj, ok := obj.(*v1.Pod)
-	if !ok {
-		return obj, nil
-	}
-
-	// Create a new Pod object with only the fields we need.
-	trimmedPod := &v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      podObj.ObjectMeta.Name,      // Needed for workqueue key.
-			Namespace: podObj.ObjectMeta.Namespace, // Needed for workqueue key.
-		},
-		Spec: v1.PodSpec{
-			Volumes:         podObj.Spec.Volumes,         // Needed to check PVs requiring scans.
-			SchedulingGates: podObj.Spec.SchedulingGates, // Needed to remove scheduling gates.
-		},
-	}
-
-	return trimmedPod, nil
-}
-
 func generateTokenSource(ctx context.Context, configFile *ConfigFile) (oauth2.TokenSource, error) {
 	// If configFile.Global.TokenURL is defined use AltTokenSource
 	if configFile != nil && configFile.Global.TokenURL != "" && configFile.Global.TokenURL != "nil" {
@@ -362,7 +329,7 @@ func generateTokenSource(ctx context.Context, configFile *ConfigFile) (oauth2.To
 	} else {
 		klog.Warningf("GOOGLE_APPLICATION_CREDENTIALS env var not set")
 	}
-	klog.Infof("Using DefaultTokenSource %#v", tokenSource)
+	klog.Info("Using DefaultTokenSource")
 
 	return tokenSource, err
 }
@@ -422,21 +389,6 @@ func NewScanner(config *ScannerConfig) (*Scanner, error) {
 	pvcInformer := factory.Core().V1().PersistentVolumeClaims()
 	scInformer := factory.Storage().V1().StorageClasses()
 
-	// Factory for Pod informer with label selector and transform
-	// The label is patched by the mutating webhook.
-	podLabelSelector := fmt.Sprintf("%s=%s", profileManagedLabelKey, profileManagedLabelValue)
-	tweakFunc := func(options *metav1.ListOptions) {
-		options.LabelSelector = podLabelSelector
-	}
-	podFactory := informers.NewSharedInformerFactoryWithOptions(
-		kubeClient,
-		config.ResyncPeriod,
-		informers.WithTweakListOptions(tweakFunc),
-		informers.WithTransform(trimPodObject),
-	)
-	podInformer := podFactory.Core().V1().Pods()
-	klog.Infof("Pod informer configured with label selector: %q and a transform function", podLabelSelector)
-
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartStructuredLogging(0)
 	eventBroadcaster.StartRecordingToSink(&typedv1.EventSinkImpl{Interface: kubeClient.CoreV1().Events("")})
@@ -446,13 +398,10 @@ func NewScanner(config *ScannerConfig) (*Scanner, error) {
 	scanner := &Scanner{
 		kubeClient:     kubeClient,
 		factory:        factory,
-		podFactory:     podFactory,
 		pvcLister:      pvcInformer.Lister(),
 		scLister:       scInformer.Lister(),
-		podLister:      podInformer.Lister(),
 		pvcSynced:      pvcInformer.Informer().HasSynced,
 		scSynced:       scInformer.Informer().HasSynced,
-		podSynced:      podInformer.Informer().HasSynced,
 		queue:          workqueue.NewTypedRateLimitingQueue(rateLimiter),
 		trackedPVs:     make(map[string]syncInfo),
 		eventRecorder:  eventRecorder,
@@ -463,12 +412,6 @@ func NewScanner(config *ScannerConfig) (*Scanner, error) {
 		metricManager:  metrics.NewPrometheusMetricManager(config.HTTPEndpoint, mux),
 		mux:            mux,
 	}
-
-	klog.Info("Setting up event handlers for Pods")
-	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    scanner.addPod,
-		DeleteFunc: scanner.deletePod,
-	})
 
 	return scanner, nil
 }
@@ -539,10 +482,9 @@ func (s *Scanner) run(ctx context.Context) {
 
 	klog.Info("Starting informers")
 	s.factory.Start(stopCh)
-	s.podFactory.Start(stopCh)
 
 	klog.Info("Waiting for informer caches to sync")
-	if !cache.WaitForCacheSync(stopCh, s.pvcSynced, s.scSynced, s.podSynced) {
+	if !cache.WaitForCacheSync(stopCh, s.pvcSynced, s.scSynced) {
 		klog.Error("Failed to wait for caches to sync")
 		return
 	}
@@ -735,7 +677,7 @@ func (s *Scanner) syncPod(ctx context.Context, key string) error {
 		return status.Errorf(codes.Internal, "failed to split meta namespace key %q: %v", key, err)
 	}
 
-	pod, err := s.podLister.Pods(namespace).Get(name)
+	pod, err := s.config.K8SClients.GetPod(namespace, name)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			klog.Infof("Pod %q in namespace %q has been deleted", name, namespace)
@@ -1870,9 +1812,9 @@ func (s *Scanner) enqueueTrackedPVs() {
 }
 
 // addPod is the add event handler for Pods.
-func (s *Scanner) addPod(obj any) {
+func (s *Scanner) AddPod(obj any) {
 	pod, ok := obj.(*v1.Pod)
-	if !ok {
+	if !ok || pod == nil {
 		klog.Errorf("AddFunc Pod: Expected Pod but got %T", obj)
 		return
 	}
@@ -1881,9 +1823,9 @@ func (s *Scanner) addPod(obj any) {
 }
 
 // deletePod is the event handler for Pod Delete events.
-func (s *Scanner) deletePod(obj any) {
+func (s *Scanner) DeletePod(obj any) {
 	pod, ok := obj.(*v1.Pod)
-	if !ok {
+	if !ok || pod == nil {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
 			klog.Errorf("DeleteFunc Pod: Expected Pod or Tombstone but got %T", obj)

--- a/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/sidecar_mounter/mounter_server.go
+++ b/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/sidecar_mounter/mounter_server.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sidecarmounter
+
+import (
+	"context"
+	"path/filepath"
+
+	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util"
+	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/webhook"
+	"github.com/googlecloudplatform/gcs-fuse-csi-driver/proto/mounter"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"k8s.io/klog/v2"
+)
+
+type MounterServer struct {
+	mounter.UnimplementedMounterServer
+	mounter   *Mounter
+	serverCtx context.Context
+}
+
+func NewMounterServer(ctx context.Context, mounter *Mounter) *MounterServer {
+	return &MounterServer{
+		mounter:   mounter,
+		serverCtx: ctx,
+	}
+}
+
+func (ms *MounterServer) Mount(ctx context.Context, req *mounter.MountRequest) (*mounter.MountResponse, error) {
+	if req == nil {
+		return nil, status.Error(codes.Internal, "mount request cannot be nil")
+	}
+	if req.GetVolumeId() == "" {
+		return nil, status.Error(codes.Internal, "volume id cannot be empty")
+	}
+	if req.GetMountPoint() == "" {
+		return nil, status.Error(codes.Internal, "mount point cannot be empty")
+	}
+
+	mc := MountConfig{
+		VolumeName:       req.GetVolumeId(), // Set VolumeName to VolumeId for logging purposes.
+		BucketName:       util.ParseVolumeID(req.GetVolumeId()),
+		Options:          req.GetMountOptions(),
+		SharedMountPoint: req.GetMountPoint(),
+		TempDir:          webhook.SidecarContainerTmpVolumeMountPath,
+		ErrWriter:        NewErrorWriter(filepath.Join(webhook.SidecarContainerTmpVolumeMountPath, util.ErrorFileName)),
+		BufferDir:        webhook.SidecarContainerBufferVolumeMountPath,
+		CacheDir:         webhook.SidecarContainerCacheVolumeMountPath,
+		ConfigFile:       filepath.Join(webhook.SidecarContainerTmpVolumeMountPath, "config.yaml"),
+		// TODO(FUECHR): Implement Auto Go Mem Limit.
+	}
+
+	// TODO(FUECHR): Implement defaultingFlagFileParsing.
+
+	mc.prepareMountArgs()
+
+	// TODO(FUECHR): Call mergeFlags(mc.ConfigFileFlagMap, flagMapFromDriver) (to be done with flag defaulting).
+
+	// TODO(FUECHR) SetupTokenAndStorageManager for bucket access check.
+	// TODO(FUECHR) Implement cloud profiler hook.
+	// TODO(FUECHR) Clean errors in preparation for mount.
+
+	if err := mc.prepareConfigFile(); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to prepare config file: %v", err)
+	}
+
+	klog.Infof("Start mounting bucket %q to %q for volume %q", mc.BucketName, mc.SharedMountPoint, mc.VolumeName)
+
+	// Use the mounter servers long running ctx to prevent the one from NodeStageVolume from killing the gcsfuse process.
+	if err := ms.mounter.MountToNode(ctx, ms.serverCtx, &mc); err != nil {
+		return nil, err
+	}
+	return &mounter.MountResponse{}, nil
+}

--- a/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/sidecar_mounter/sidecar_mounter.go
+++ b/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/sidecar_mounter/sidecar_mounter.go
@@ -131,66 +131,10 @@ func (m *Mounter) Mount(ctx context.Context, mc *MountConfig) error {
 	// the /dev/fuse is passed as ExtraFiles below, and will always be FD 3
 	args = append(args, "/dev/fd/3")
 
-	cmdName := m.mounterPath
-	if mc.GcsFuseNumaNode >= 0 && numactlAllowed(ctx, mc.GcsFuseNumaNode) {
-		// A nonnegative numa node has been calculated by the csi driver by looking at network
-		// interface numa information. So we are confident enough to pass it directly to numactl
-		// without further checking.
-		klog.Infof("binding gcsfuse to numa node %d", mc.GcsFuseNumaNode)
-		numactlArgs := []string{
-			fmt.Sprintf("--cpunodebind=%d", mc.GcsFuseNumaNode),
-			fmt.Sprintf("--membind=%d", mc.GcsFuseNumaNode),
-			m.mounterPath,
-		}
-		args = append(numactlArgs, args...)
-		cmdName = "numactl"
-	}
-
-	//nolint: gosec
-	klog.Infof("gcsfuse mounting with %s %v...", cmdName, args)
-	cmd := exec.CommandContext(ctx, cmdName, args...)
-
-	if mc.EnableAutoGoMemLimit {
-		//  Set for the sidecar mounter process
-		appliedLimit, err := memlimit.SetGoMemLimitWithOpts(
-			memlimit.WithRatio(mc.AutoGoMemLimitRatio),
-			memlimit.WithProvider(memlimit.FromCgroup),
-		)
-		if err != nil {
-			klog.V(4).Infof("GOMEMLIMIT not set (expected if gke-gcsfuse-sidecar memory limit is unset): %v", err)
-		} else if appliedLimit > 0 {
-			// Export GOMEMLIMIT for the gcsfuse child process.
-			// If appliedLimit is 0, it means GOMEMLIMIT was already set in
-			// the environment or there is no memory limit; in both cases we
-			// should not override.
-			cmd.Env = append(os.Environ(), fmt.Sprintf("GOMEMLIMIT=%d", appliedLimit))
-			klog.Infof("Successfully set GOMEMLIMIT=%d for gcsfuse and sidecar_mounter", appliedLimit)
-		}
-	}
-
+	cmd := m.prepareMountCommand(ctx, mc, args)
 	cmd.ExtraFiles = []*os.File{os.NewFile(uintptr(mc.FileDescriptor), "/dev/fuse")}
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = io.MultiWriter(os.Stderr, mc.ErrWriter)
-	cmd.Cancel = func() error {
-		klog.V(4).Infof("sending SIGTERM to gcsfuse process: %v", cmd)
 
-		return cmd.Process.Signal(syscall.SIGTERM)
-	}
-
-	// when the ctx.Done() is closed,
-	// the main workload containers have exited,
-	// so it is safe to force kill the gcsfuse process.
-	go func(cmd *exec.Cmd) {
-		<-ctx.Done()
-		klog.V(4).Infof("context marked as done, sleep for 5 seconds, to evaluate gcsfuse process %d exit state", cmd.Process.Pid)
-		time.Sleep(time.Second * 5)
-		if cmd.ProcessState == nil || !cmd.ProcessState.Exited() {
-			klog.Warningf("after 5 seconds, process with id %v has not exited, force kill the process", cmd.Process.Pid)
-			if err := cmd.Process.Kill(); err != nil {
-				klog.Warningf("failed to force kill process with id %v", cmd.Process.Pid)
-			}
-		}
-	}(cmd)
+	startCleanupMonitor(ctx, cmd)
 
 	m.WaitGroup.Add(1)
 	go func() {
@@ -233,6 +177,80 @@ func (m *Mounter) Mount(ctx context.Context, mc *MountConfig) error {
 	}()
 
 	return nil
+}
+
+// MountToNode uses the mount config to initialize the GCSFuse process for a share node mount architecture.
+// gcsfuseContext is the long running context from the sidecar, this prevents the gcsfuse process from being killed when the NodeStageVolume context (the ctx variable) is canceled.
+func (m *Mounter) MountToNode(ctx context.Context, gcsfuseContext context.Context, mc *MountConfig) error {
+	return status.Errorf(codes.Unimplemented, "method MountToNode not implemented")
+}
+
+func startCleanupMonitor(ctx context.Context, cmd *exec.Cmd) {
+	// when the ctx.Done() is closed,
+	// the main workload containers have exited,
+	// so it is safe to force kill the gcsfuse process.
+	go func(cmd *exec.Cmd) {
+		<-ctx.Done()
+
+		klog.V(4).Infof("context marked as done, sleep for 5 seconds, to evaluate gcsfuse process %d exit state", cmd.Process.Pid)
+		time.Sleep(time.Second * 5)
+
+		if cmd.ProcessState == nil || !cmd.ProcessState.Exited() {
+			klog.Warningf("after 5 seconds, process with id %v has not exited, force kill the process", cmd.Process.Pid)
+			if err := cmd.Process.Kill(); err != nil {
+				klog.Warningf("failed to force kill process with id %v", cmd.Process.Pid)
+			}
+		}
+	}(cmd)
+}
+
+// prepareMountCommand prepares the exec.Cmd with optional NUMA node binding using numactl.
+func (m *Mounter) prepareMountCommand(ctx context.Context, mc *MountConfig, args []string) *exec.Cmd {
+	cmdName := m.mounterPath
+	if mc.GcsFuseNumaNode >= 0 && numactlAllowed(ctx, mc.GcsFuseNumaNode) {
+		// A nonnegative numa node has been calculated by the csi driver by looking at network
+		// interface numa information. So we are confident enough to pass it directly to numactl
+		// without further checking.
+		klog.Infof("binding gcsfuse to numa node %d", mc.GcsFuseNumaNode)
+		numactlArgs := []string{
+			fmt.Sprintf("--cpunodebind=%d", mc.GcsFuseNumaNode),
+			fmt.Sprintf("--membind=%d", mc.GcsFuseNumaNode),
+			m.mounterPath,
+		}
+		args = append(numactlArgs, args...)
+		cmdName = "numactl"
+	}
+
+	//nolint: gosec
+	klog.Infof("gcsfuse mounting with %s %v...", cmdName, args)
+	cmd := exec.CommandContext(ctx, cmdName, args...)
+
+	if mc.EnableAutoGoMemLimit {
+		//  Set for the sidecar mounter process
+		appliedLimit, err := memlimit.SetGoMemLimitWithOpts(
+			memlimit.WithRatio(mc.AutoGoMemLimitRatio),
+			memlimit.WithProvider(memlimit.FromCgroup),
+		)
+		if err != nil {
+			klog.V(4).Infof("GOMEMLIMIT not set (expected if gke-gcsfuse-sidecar memory limit is unset): %v", err)
+		} else if appliedLimit > 0 {
+			// Export GOMEMLIMIT for the gcsfuse child process.
+			// If appliedLimit is 0, it means GOMEMLIMIT was already set in
+			// the environment or there is no memory limit; in both cases we
+			// should not override.
+			cmd.Env = append(os.Environ(), fmt.Sprintf("GOMEMLIMIT=%d", appliedLimit))
+			klog.Infof("Successfully set GOMEMLIMIT=%d for gcsfuse and sidecar_mounter", appliedLimit)
+		}
+	}
+
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = io.MultiWriter(os.Stderr, mc.ErrWriter)
+	cmd.Cancel = func() error {
+		klog.V(4).Infof("sending SIGTERM to gcsfuse process: %v", cmd)
+		return cmd.Process.Signal(syscall.SIGTERM)
+	}
+
+	return cmd
 }
 
 func (m *Mounter) fetchTokenSource(saNamespace, saName string, audience string) (oauth2.TokenSource, error) {

--- a/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/sidecar_mounter/sidecar_mounter_config.go
+++ b/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/sidecar_mounter/sidecar_mounter_config.go
@@ -73,6 +73,7 @@ type MountConfig struct {
 	EnableAutoGoMemLimit           bool                  `json:"-"`
 	AutoGoMemLimitRatio            float64               `json:"-"`
 	StorageEndpoint                string                `json:"-"`
+	SharedMountPoint               string                `json:"-"`
 }
 
 // EnsureErrWriter safely initializes ErrWriter to the correct writer if it is nil.

--- a/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util/util.go
+++ b/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util/util.go
@@ -60,7 +60,6 @@ const (
 	EnableCloudProfilerForSidecarConst  = "enable-cloud-profiler-for-sidecar"
 	EnableCloudProfilerConst            = "enable-cloud-profiler"
 	SidecarContainerTmpVolumeName       = "gke-gcsfuse-tmp"
-	SidecarContainerTmpVolumePath       = "/gke-gcsfuse-tmp"
 	SidecarBucketAccessCheckErrorPrefix = "sidecar bucket access check error"
 	StorageServiceErrorStr              = "failed to setup storage service"
 	GCSFuseCsiDriverName                = "gcsfuse.csi.storage.gke.io"
@@ -73,6 +72,7 @@ const (
 	GoMemLimitCgroupPercentage          = 0.95
 	StorageEndpointInternal             = "storage-endpoint-internal"
 	KubeletDir                          = "/var/lib/kubelet"
+	KubeletPluginsGCSFuseDir            = "/var/lib/kubelet/plugins/kubernetes.io/csi/gcsfuse.csi.storage.gke.io"
 	VolumeContextKeyPVName              = "csi.storage.k8s.io/pv/name"
 	MounterPodNamePrefix                = "gcsfusecsi-mount"
 )

--- a/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/webhook/sidecar_spec.go
+++ b/test/vendor/github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/webhook/sidecar_spec.go
@@ -103,7 +103,7 @@ var (
 		MountPath: SidecarContainerCacheVolumeMountPath,
 	}
 
-	saTokenVolumeMount = corev1.VolumeMount{
+	SATokenVolumeMount = corev1.VolumeMount{
 		Name:      SidecarContainerSATokenVolumeName,
 		MountPath: SidecarContainerSATokenVolumeMountPath,
 	}
@@ -154,7 +154,7 @@ func GetSidecarContainerSpec(c *Config, credentialConfig *SidecarContainerCreden
 	volumeMounts := []corev1.VolumeMount{TmpVolumeMount, buffVolumeMount, cacheVolumeMount}
 	// Inject SA token only for Host Network pods
 	if c.PodHostNetworkSetting && c.ShouldInjectSAVolume {
-		volumeMounts = append(volumeMounts, saTokenVolumeMount)
+		volumeMounts = append(volumeMounts, SATokenVolumeMount)
 	}
 
 	container := corev1.Container{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**: Refactor clientset.go so that it's shared by scanner.go and controller.go. 

Since we need to track two different pods with different labels, we must create two different informers, since tracking multiple labels with an OR statement is not supported by Kubernetes. This is the most memory efficient way to handle this. Otherwise, we'd need to track all of the pods, which would be much more inefficient.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```