### PR TITLE
Refactor so that controller.go and scanner.go share the same SC

### DIFF
--- a/pkg/cloud_provider/clientset/clientset.go
+++ b/pkg/cloud_provider/clientset/clientset.go
@@ -294,6 +294,9 @@ func (c *Clientset) ConfigurePVCLister(ctx context.Context) {
 }
 
 func (c *Clientset) ConfigureSCLister(ctx context.Context) {
+	labelsToKeep := map[string]bool{
+		profilesutil.LabelProfile: true,
+	}
 	trim := func(obj any) (any, error) {
 		scObj, ok := obj.(*storagev1.StorageClass)
 		if !ok || scObj == nil {
@@ -302,7 +305,7 @@ func (c *Clientset) ConfigureSCLister(ctx context.Context) {
 		return &storagev1.StorageClass{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:   scObj.ObjectMeta.Name,
-				Labels: scObj.ObjectMeta.Labels, // Required by the gcsfuse profiles feature to know if the StorageClass is a profile.
+				Labels: trimMap(scObj.ObjectMeta.Labels, labelsToKeep), // Required by the gcsfuse profiles feature to know if the StorageClass is a profile.
 			},
 			MountOptions: scObj.MountOptions, // Required by the gcsfuse profiles feature to apply pre-bundled mount options.
 			Parameters:   scObj.Parameters,   // Required by the gcsfuse profiles feature to get profile configs.
@@ -313,6 +316,9 @@ func (c *Clientset) ConfigureSCLister(ctx context.Context) {
 		c.k8sClients,
 		time.Duration(c.informerResyncDurationSec)*time.Second,
 		informers.WithTransform(trim),
+		informers.WithTweakListOptions(func(options *metav1.ListOptions) {
+			options.LabelSelector = fmt.Sprintf("%s=%s", profilesutil.LabelProfile, util.TrueStr)
+		}),
 	)
 	scLister := informerFactory.Storage().V1().StorageClasses().Lister()
 

--- a/pkg/profiles/scanner.go
+++ b/pkg/profiles/scanner.go
@@ -78,7 +78,6 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	typedv1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	v1listers "k8s.io/client-go/listers/core/v1"
-	storagelisters "k8s.io/client-go/listers/storage/v1"
 )
 
 const (
@@ -243,9 +242,7 @@ type EventInfo struct {
 type Scanner struct {
 	kubeClient           kubernetes.Interface
 	pvcLister            v1listers.PersistentVolumeClaimLister
-	scLister             storagelisters.StorageClassLister
 	pvcSynced            cache.InformerSynced
-	scSynced             cache.InformerSynced
 	factory              informers.SharedInformerFactory
 	queue                workqueue.TypedRateLimitingInterface[string]
 	eventRecorder        record.EventRecorder
@@ -387,7 +384,6 @@ func NewScanner(config *ScannerConfig) (*Scanner, error) {
 	}
 	factory := informers.NewSharedInformerFactory(kubeClient, config.ResyncPeriod)
 	pvcInformer := factory.Core().V1().PersistentVolumeClaims()
-	scInformer := factory.Storage().V1().StorageClasses()
 
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartStructuredLogging(0)
@@ -399,9 +395,7 @@ func NewScanner(config *ScannerConfig) (*Scanner, error) {
 		kubeClient:     kubeClient,
 		factory:        factory,
 		pvcLister:      pvcInformer.Lister(),
-		scLister:       scInformer.Lister(),
 		pvcSynced:      pvcInformer.Informer().HasSynced,
-		scSynced:       scInformer.Informer().HasSynced,
 		queue:          workqueue.NewTypedRateLimitingQueue(rateLimiter),
 		trackedPVs:     make(map[string]syncInfo),
 		eventRecorder:  eventRecorder,
@@ -484,7 +478,7 @@ func (s *Scanner) run(ctx context.Context) {
 	s.factory.Start(stopCh)
 
 	klog.Info("Waiting for informer caches to sync")
-	if !cache.WaitForCacheSync(stopCh, s.pvcSynced, s.scSynced) {
+	if !cache.WaitForCacheSync(stopCh, s.pvcSynced) {
 		klog.Error("Failed to wait for caches to sync")
 		return
 	}
@@ -1870,7 +1864,7 @@ func (s *Scanner) getStorageClass(pv *v1.PersistentVolume) (*storagev1.StorageCl
 	if scName == "" {
 		return nil, nil
 	}
-	sc, err := s.scLister.Get(scName)
+	sc, err := s.config.K8SClients.GetSC(scName)
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
 			return nil, fmt.Errorf("failed to get StorageClass %q: %w", scName, err)

--- a/pkg/profiles/scanner_test.go
+++ b/pkg/profiles/scanner_test.go
@@ -164,6 +164,7 @@ type fakeK8sClients struct {
 	clientset.Interface
 	pvLister  corelisters.PersistentVolumeLister
 	podLister corelisters.PodLister
+	scLister  storagelisters.StorageClassLister
 }
 
 func (f *fakeK8sClients) GetPV(name string) (*v1.PersistentVolume, error) {
@@ -172,6 +173,10 @@ func (f *fakeK8sClients) GetPV(name string) (*v1.PersistentVolume, error) {
 
 func (f *fakeK8sClients) GetPod(namespace, name string) (*v1.Pod, error) {
 	return f.podLister.Pods(namespace).Get(name)
+}
+
+func (f *fakeK8sClients) GetSC(name string) (*storagev1.StorageClass, error) {
+	return f.scLister.Get(name)
 }
 
 // testFixture holds the necessary components for testing the Scanner.
@@ -241,9 +246,7 @@ func newTestFixture(t *testing.T, initialObjects ...runtime.Object) *testFixture
 	s := &Scanner{
 		kubeClient:     kubeClient,
 		pvcLister:      pvcInformer.Lister(),
-		scLister:       scInformer.Lister(),
 		pvcSynced:      pvcInformer.Informer().HasSynced,
-		scSynced:       scInformer.Informer().HasSynced,
 		factory:        factory,
 		queue:          workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()),
 		eventRecorder:  recorder,
@@ -255,12 +258,13 @@ func newTestFixture(t *testing.T, initialObjects ...runtime.Object) *testFixture
 			K8SClients: &fakeK8sClients{
 				pvLister:  pvInformer.Lister(),
 				podLister: podInformer.Lister(),
+				scLister:  scInformer.Lister(),
 			},
 		},
 	}
 
 	factory.Start(stopCh)
-	if !cache.WaitForCacheSync(stopCh, pvInformer.Informer().HasSynced, s.pvcSynced, s.scSynced, podInformer.Informer().HasSynced) {
+	if !cache.WaitForCacheSync(stopCh, pvInformer.Informer().HasSynced, s.pvcSynced, scInformer.Informer().HasSynced, podInformer.Informer().HasSynced) {
 		t.Fatalf("Failed to sync caches")
 	}
 


### PR DESCRIPTION
informer.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**: Refactor controller.go and scanner.go so they share the same SC, which will reduce memory usage in half when shared mount is launched. Also, make SC informer only track storage classes with profiles label.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```