### PR TITLE
Refactor scanner.go so it shares pvc lister with controller.go

### DIFF
--- a/cmd/csi_driver/main.go
+++ b/cmd/csi_driver/main.go
@@ -222,12 +222,7 @@ func main() {
 		FeatureGCSFuseProfiles: &driver.FeatureGCSFuseProfiles{
 			Enabled: *enableGCSFuseProfiles,
 			ScannerConfig: &profiles.ScannerConfig{
-				K8SClients: clientset,
-				// TODO(urielguzman): Remove KupeAPI options from here once all informers have been migrated to the clientset.
-				KubeAPIQPS:                       *kubeAPIQPS,
-				KubeAPIBurst:                     *kubeAPIBurst,
-				ResyncPeriod:                     time.Duration(*informerResyncDurationSec) * time.Second,
-				KubeConfigPath:                   *kubeconfigPath,
+				K8SClients:                       clientset,
 				CloudConfigPath:                  *cloudConfigFilePath,
 				RateLimiter:                      workqueue.NewTypedItemExponentialFailureRateLimiter[string](*retryIntervalStart, *retryIntervalMax),
 				LeaderElection:                   *leaderElection,
@@ -311,9 +306,9 @@ func main() {
 		if *enableSharedMount || *enableGCSFuseProfiles {
 			clientset.ConfigurePVLister(ctx, pvEventHandlerFuncs)
 			clientset.ConfigurePodLister(ctx, "", podEventHandlerFuncs)
+			clientset.ConfigurePVCLister(ctx)
 		}
 		if *enableSharedMount {
-			clientset.ConfigurePVCLister(ctx)
 			clientset.ConfigurePodTemplateLister(ctx)
 		}
 	}

--- a/pkg/profiles/scanner.go
+++ b/pkg/profiles/scanner.go
@@ -45,8 +45,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/informers"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
@@ -77,7 +75,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	typedv1 "k8s.io/client-go/kubernetes/typed/core/v1"
-	v1listers "k8s.io/client-go/listers/core/v1"
 )
 
 const (
@@ -192,10 +189,6 @@ type DatafluxConfig struct {
 // ScannerConfig holds the configuration for the Scanner.
 type ScannerConfig struct {
 	K8SClients                       clientset.Interface // Kubernetes clientset.
-	KubeAPIQPS                       float64             // QPS limit for Kubernetes API client.
-	KubeAPIBurst                     int                 // Burst limit for Kubernetes API client.
-	ResyncPeriod                     time.Duration       // Resync period for informers.
-	KubeConfigPath                   string              // Optional: Path to kubeconfig file. If empty, InClusterConfig is used.
 	CloudConfigPath                  string
 	RateLimiter                      workqueue.TypedRateLimiter[string]
 	DatafluxConfig                   *DatafluxConfig
@@ -240,10 +233,6 @@ type EventInfo struct {
 
 // Scanner is the main controller structure.
 type Scanner struct {
-	kubeClient           kubernetes.Interface
-	pvcLister            v1listers.PersistentVolumeClaimLister
-	pvcSynced            cache.InformerSynced
-	factory              informers.SharedInformerFactory
 	queue                workqueue.TypedRateLimitingInterface[string]
 	eventRecorder        record.EventRecorder
 	datafluxConfig       *DatafluxConfig
@@ -352,9 +341,11 @@ func buildCloudConfig(configPath string) (*ConfigFile, error) {
 
 // NewScanner creates a new Scanner instance.
 func NewScanner(config *ScannerConfig) (*Scanner, error) {
-	kubeconfig, err := buildKubeConfig(config.KubeConfigPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to build kubeconfig: %w", err)
+	if config == nil {
+		return nil, errors.New("config must not be nil")
+	}
+	if config.K8SClients == nil {
+		return nil, errors.New("K8SClients must be provided in ScannerConfig")
 	}
 
 	// Add a uniquifier so that two processes on the same host don't accidentally both become active.
@@ -365,37 +356,18 @@ func NewScanner(config *ScannerConfig) (*Scanner, error) {
 	}
 	id := hostname + "_" + string(uuid.NewUUID())
 
-	kubeconfig.QPS = float32(config.KubeAPIQPS)
-	kubeconfig.Burst = config.KubeAPIBurst
-	klog.Infof("KubeClient QPS: %f, Burst: %d", kubeconfig.QPS, kubeconfig.Burst)
-	kubeClient, err := kubernetes.NewForConfig(kubeconfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create kubernetes client: %w", err)
-	}
-
 	rateLimiter := config.RateLimiter
 	if rateLimiter == nil {
 		rateLimiter = workqueue.DefaultTypedControllerRateLimiter[string]()
 	}
 
-	// Factory for PV, PVC and SC informers
-	if config.K8SClients == nil {
-		return nil, errors.New("K8SClients must be provided in ScannerConfig")
-	}
-	factory := informers.NewSharedInformerFactory(kubeClient, config.ResyncPeriod)
-	pvcInformer := factory.Core().V1().PersistentVolumeClaims()
-
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartStructuredLogging(0)
-	eventBroadcaster.StartRecordingToSink(&typedv1.EventSinkImpl{Interface: kubeClient.CoreV1().Events("")})
+	eventBroadcaster.StartRecordingToSink(&typedv1.EventSinkImpl{Interface: config.K8SClients.K8sClient().CoreV1().Events("")})
 	eventRecorder := eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: scannerComponentName})
 	mux := http.NewServeMux()
 
 	scanner := &Scanner{
-		kubeClient:     kubeClient,
-		factory:        factory,
-		pvcLister:      pvcInformer.Lister(),
-		pvcSynced:      pvcInformer.Informer().HasSynced,
 		queue:          workqueue.NewTypedRateLimitingQueue(rateLimiter),
 		trackedPVs:     make(map[string]syncInfo),
 		eventRecorder:  eventRecorder,
@@ -474,16 +446,6 @@ func (s *Scanner) run(ctx context.Context) {
 
 	stopCh := ctx.Done()
 
-	klog.Info("Starting informers")
-	s.factory.Start(stopCh)
-
-	klog.Info("Waiting for informer caches to sync")
-	if !cache.WaitForCacheSync(stopCh, s.pvcSynced) {
-		klog.Error("Failed to wait for caches to sync")
-		return
-	}
-	klog.Info("Informer caches synced successfully")
-
 	klog.Info("Starting worker")
 	go wait.Until(func() { s.runWorker(ctx) }, time.Second, ctx.Done())
 
@@ -523,7 +485,7 @@ func (s *Scanner) runWithLeaderElection(ctx context.Context, cancel context.Canc
 		s.config.LeaderElectionNamespace,
 		leaseName,
 		nil,
-		s.kubeClient.CoordinationV1(),
+		s.config.K8SClients.K8sClient().CoordinationV1(),
 		resourcelock.ResourceLockConfig{
 			Identity: s.id,
 		})
@@ -692,7 +654,7 @@ func (s *Scanner) syncPod(ctx context.Context, key string) error {
 		}
 
 		pvcName := vol.PersistentVolumeClaim.ClaimName
-		pvc, err := s.pvcLister.PersistentVolumeClaims(namespace).Get(pvcName)
+		pvc, err := s.config.K8SClients.GetPVC(namespace, pvcName)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				klog.Warningf("PVC %q/%q for Pod %q not found, will recheck Pod later", namespace, pvcName, key)
@@ -790,7 +752,7 @@ func (s *Scanner) removeSchedulingGate(ctx context.Context, pod *v1.Pod) error {
 		return fmt.Errorf("failed to marshal patch data for Pod %q/%q: %w", pod.Namespace, pod.Name, err)
 	}
 
-	_, err = s.kubeClient.CoreV1().Pods(pod.Namespace).Patch(ctx, pod.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+	_, err = s.config.K8SClients.K8sClient().CoreV1().Pods(pod.Namespace).Patch(ctx, pod.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			klog.Warningf("Failed to patch Pod %q/%q because it was not found", pod.Namespace, pod.Name)
@@ -1492,7 +1454,7 @@ func (s *Scanner) ensurePVTrackingLabel(ctx context.Context, pv *v1.PersistentVo
 		return status.Errorf(codes.Internal, "failed to marshal label patch data for PV %q: %v", pv.Name, marshalErr)
 	}
 	klog.V(6).Infof("PV %q is missing the tracking label. Patching it with: %q", pv.Name, string(patchBytes))
-	_, patchErr := s.kubeClient.CoreV1().PersistentVolumes().Patch(ctx, pv.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+	_, patchErr := s.config.K8SClients.K8sClient().CoreV1().PersistentVolumes().Patch(ctx, pv.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
 	if patchErr != nil {
 		if apierrors.IsNotFound(patchErr) {
 			klog.Warningf("Failed to patch PV %q because it was not found", pv.Name)
@@ -1519,7 +1481,7 @@ func (s *Scanner) patchPVAnnotations(ctx context.Context, pvName string, annotat
 		return status.Errorf(codes.Internal, "failed to marshal annotation patch data for PV %q: %v", pvName, err)
 	}
 	klog.V(6).Infof("Patching PV %q annotations with: %q", pvName, string(patchBytes))
-	_, err = s.kubeClient.CoreV1().PersistentVolumes().Patch(ctx, pvName, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+	_, err = s.config.K8SClients.K8sClient().CoreV1().PersistentVolumes().Patch(ctx, pvName, types.MergePatchType, patchBytes, metav1.PatchOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			klog.Warningf("Failed to patch PV %q because it was not found", pvName)

--- a/pkg/profiles/scanner_test.go
+++ b/pkg/profiles/scanner_test.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
@@ -161,10 +162,12 @@ func (f *fakeScanBucketImplFunc) Scan(scanner *Scanner, ctx context.Context, buc
 }
 
 type fakeK8sClients struct {
+	kubeClient kubernetes.Interface
 	clientset.Interface
 	pvLister  corelisters.PersistentVolumeLister
 	podLister corelisters.PodLister
 	scLister  storagelisters.StorageClassLister
+	pvcLister corelisters.PersistentVolumeClaimLister
 }
 
 func (f *fakeK8sClients) GetPV(name string) (*v1.PersistentVolume, error) {
@@ -177,6 +180,13 @@ func (f *fakeK8sClients) GetPod(namespace, name string) (*v1.Pod, error) {
 
 func (f *fakeK8sClients) GetSC(name string) (*storagev1.StorageClass, error) {
 	return f.scLister.Get(name)
+}
+
+func (f *fakeK8sClients) GetPVC(namespace, name string) (*v1.PersistentVolumeClaim, error) {
+	return f.pvcLister.PersistentVolumeClaims(namespace).Get(name)
+}
+func (f *fakeK8sClients) K8sClient() kubernetes.Interface {
+	return f.kubeClient
 }
 
 // testFixture holds the necessary components for testing the Scanner.
@@ -244,10 +254,6 @@ func newTestFixture(t *testing.T, initialObjects ...runtime.Object) *testFixture
 
 	// Create the Scanner instance with fake/mock components.
 	s := &Scanner{
-		kubeClient:     kubeClient,
-		pvcLister:      pvcInformer.Lister(),
-		pvcSynced:      pvcInformer.Informer().HasSynced,
-		factory:        factory,
 		queue:          workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()),
 		eventRecorder:  recorder,
 		trackedPVs:     make(map[string]syncInfo),
@@ -256,15 +262,17 @@ func newTestFixture(t *testing.T, initialObjects ...runtime.Object) *testFixture
 		metricManager:  metrics.NewFakePrometheusMetricsManager(),
 		config: &ScannerConfig{
 			K8SClients: &fakeK8sClients{
-				pvLister:  pvInformer.Lister(),
-				podLister: podInformer.Lister(),
-				scLister:  scInformer.Lister(),
+				kubeClient: kubeClient,
+				pvLister:   pvInformer.Lister(),
+				podLister:  podInformer.Lister(),
+				scLister:   scInformer.Lister(),
+				pvcLister:  pvcInformer.Lister(),
 			},
 		},
 	}
 
 	factory.Start(stopCh)
-	if !cache.WaitForCacheSync(stopCh, pvInformer.Informer().HasSynced, s.pvcSynced, scInformer.Informer().HasSynced, podInformer.Informer().HasSynced) {
+	if !cache.WaitForCacheSync(stopCh, pvInformer.Informer().HasSynced, pvcInformer.Informer().HasSynced, scInformer.Informer().HasSynced, podInformer.Informer().HasSynced) {
 		t.Fatalf("Failed to sync caches")
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?** This PR refactors scanner.go so it shared the same PVC lister with controller go, reducing memory usage and API server watches by half in preparation for the upcoming shared mount feature.

The PR also removes now-unused informer factory related fields and makes the kube clients the same in order to de-duplicate the clients.
/kind feature

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```