### PR TITLE
Make controller.go obtain mounter pod image from ConfigMap

### DIFF
--- a/cmd/csi_driver/main.go
+++ b/cmd/csi_driver/main.go
@@ -76,7 +76,6 @@ var (
 	enableAutoGoMemLimit           = flag.Bool("enable-auto-gomemlimit", false, "Automatically set GOMEMLIMIT to a percentage of the container's cgroup memory limit.")
 	autoGoMemLimitRatio            = flag.Float64("auto-gomemlimit-ratio", util.GoMemLimitCgroupPercentage, "The ratio of the container's cgroup memory limit to set as GOMEMLIMIT when enable-auto-gomemlimit is enabled.")
 	universeDomain                 = flag.String("universe-domain", "googleapis.com", "The universe domain. The default value is googleapis.com.")
-	mounterPodImage                = flag.String("mounter-pod-image", "", "The image for the mounter pod.")
 
 	// GCSFuse kernel params feature.
 	enableGCSFuseKernelParams = flag.Bool("enable-gcsfuse-kernel-params", false, "Enable gcsfuse kernel params feature.")
@@ -98,7 +97,7 @@ var (
 
 	// Leader election flags.
 	leaderElection                   = flag.Bool("leader-election", false, "Enables leader election for stateful driver.")
-	leaderElectionNamespace          = flag.String("leader-election-namespace", "", "The namespace where the leader election resource exists. Should be set in deployments to use the pod's namespace.")
+	driverNamespace                  = flag.String("driver-namespace", "gcs-fuse-csi-driver", "The namespace where the driver resources are deployed.")
 	leaderElectionLeaseDuration      = flag.Duration("leader-election-lease-duration", 15*time.Second, "Duration, in seconds, that non-leader candidates will wait to force acquire leadership. Defaults to 15 seconds.")
 	leaderElectionRenewDeadline      = flag.Duration("leader-election-renew-deadline", 10*time.Second, "Duration, in seconds, that the acting leader will retry refreshing leadership before giving up. Defaults to 10 seconds.")
 	leaderElectionRetryPeriod        = flag.Duration("leader-election-retry-period", 5*time.Second, "Duration, in seconds, the LeaderElector clients should wait between tries of actions. Defaults to 5 seconds.")
@@ -226,7 +225,7 @@ func main() {
 				CloudConfigPath:                  *cloudConfigFilePath,
 				RateLimiter:                      workqueue.NewTypedItemExponentialFailureRateLimiter[string](*retryIntervalStart, *retryIntervalMax),
 				LeaderElection:                   *leaderElection,
-				LeaderElectionNamespace:          *leaderElectionNamespace,
+				LeaderElectionNamespace:          *driverNamespace,
 				LeaderElectionLeaseDuration:      *leaderElectionLeaseDuration,
 				LeaderElectionRenewDeadline:      *leaderElectionRenewDeadline,
 				LeaderElectionRetryPeriod:        *leaderElectionRetryPeriod,
@@ -249,8 +248,8 @@ func main() {
 		},
 		SharedMountOptions: &driver.SharedMountOptions{
 			Enabled:         *enableSharedMount,
-			MounterPodImage: *mounterPodImage,
 			FuseSocketDir:   *fuseSocketDir,
+			DriverNamespace: *driverNamespace,
 			EmptyDirBasePath: func(podUID string) string {
 				return filepath.Join(util.KubeletDir, "pods", podUID, "volumes", "kubernetes.io~empty-dir", util.SidecarContainerTmpVolumeName)
 			},
@@ -310,6 +309,7 @@ func main() {
 		}
 		if *enableSharedMount {
 			clientset.ConfigurePodTemplateLister(ctx)
+			clientset.ConfigureConfigMapLister(ctx, *driverNamespace)
 		}
 	}
 

--- a/deploy/base/controller/controller.yaml
+++ b/deploy/base/controller/controller.yaml
@@ -41,7 +41,7 @@ spec:
             - "--controller=true"
             - "--enable-gcsfuse-profiles=true"
             - "--leader-election=true"
-            - "--leader-election-namespace=$(CLOUDSTORAGECSI_NAMESPACE)"
+            - "--driver-namespace=$(CLOUDSTORAGECSI_NAMESPACE)"
             - "--cluster-location=$(CLUSTER_LOCATION)"
             - "--project-number=$(PROJECT_NUMBER)"
             - "--http-endpoint=:29633"

--- a/deploy/base/controller/controller_setup.yaml
+++ b/deploy/base/controller/controller_setup.yaml
@@ -136,9 +136,9 @@ rules:
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get", "list", "watch"]
-# Required to get PodTemplates when using shared node mount feature.
+# Required to get PodTemplates and ConfigMaps when using shared node mount feature.
   - apiGroups: [""]
-    resources: ["podtemplates"]
+    resources: ["podtemplates", "configmaps"]
     verbs: ["get", "list", "watch"]
 ---
 kind: ClusterRoleBinding

--- a/deploy/overlays/shared-mount/enable_shared_mount_patch_controller.json
+++ b/deploy/overlays/shared-mount/enable_shared_mount_patch_controller.json
@@ -3,23 +3,5 @@
     "op": "add",
     "path": "/spec/template/spec/containers/1/args/-",
     "value": "--enable-shared-mount=true"
-  },
-  {
-    "op": "add",
-    "path": "/spec/template/spec/containers/1/args/-",
-    "value": "--mounter-pod-image=$(MOUNTER_POD_IMAGE)"
-  },
-  {
-    "op": "add",
-    "path": "/spec/template/spec/containers/1/env/-",
-    "value": {
-      "name": "MOUNTER_POD_IMAGE",
-      "valueFrom": {
-        "configMapKeyRef": {
-          "name": "gcsfusecsi-image-config",
-          "key": "sidecar-image"
-        }
-      }
-    }
   }
 ]

--- a/pkg/cloud_provider/clientset/clientset.go
+++ b/pkg/cloud_provider/clientset/clientset.go
@@ -55,6 +55,7 @@ type Interface interface {
 	ConfigurePVCLister(ctx context.Context)
 	ConfigureSCLister(ctx context.Context)
 	ConfigurePodTemplateLister(ctx context.Context)
+	ConfigureConfigMapLister(ctx context.Context, namespace string)
 	GetPod(namespace, name string) (*corev1.Pod, error)
 	GetMounterPod(namespace, name string) (*corev1.Pod, error)
 	GetMounterPodsByName(name string) ([]*corev1.Pod, error)
@@ -63,6 +64,7 @@ type Interface interface {
 	GetPVC(namespace string, name string) (*corev1.PersistentVolumeClaim, error)
 	GetSC(name string) (*storagev1.StorageClass, error)
 	GetPodTemplate(namespace, name string) (*corev1.PodTemplate, error)
+	GetConfigMap(namespace, name string) (*corev1.ConfigMap, error)
 	CreateServiceAccountToken(ctx context.Context, namespace, name string, tokenRequest *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error)
 	GetGCPServiceAccountName(ctx context.Context, namespace, name string) (string, error)
 }
@@ -82,6 +84,7 @@ type Clientset struct {
 	pvcLister                 listersv1.PersistentVolumeClaimLister
 	scLister                  storagelisters.StorageClassLister
 	podTemplateLister         listersv1.PodTemplateLister
+	configMapLister           listersv1.ConfigMapLister
 	informerResyncDurationSec int
 	runController             bool
 	enableGCSFuseProfiles     bool
@@ -356,6 +359,38 @@ func (c *Clientset) ConfigurePodTemplateLister(ctx context.Context) {
 	informerFactory.WaitForCacheSync(ctx.Done())
 
 	c.podTemplateLister = podTemplateLister
+}
+
+func (c *Clientset) ConfigureConfigMapLister(ctx context.Context, namespace string) {
+	trim := func(obj any) (any, error) {
+		cmObj, ok := obj.(*corev1.ConfigMap)
+		if !ok || cmObj == nil {
+			return obj, nil
+		}
+		return &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      cmObj.ObjectMeta.Name,
+				Namespace: cmObj.ObjectMeta.Namespace,
+			},
+			Data: cmObj.Data,
+		}, nil
+	}
+
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(
+		c.k8sClients,
+		time.Duration(c.informerResyncDurationSec)*time.Second,
+		informers.WithNamespace(namespace),
+		informers.WithTweakListOptions(func(options *metav1.ListOptions) {
+			options.FieldSelector = fmt.Sprintf("metadata.name=%s", util.SidecarImageConfigMapName)
+		}),
+		informers.WithTransform(trim),
+	)
+	configMapLister := informerFactory.Core().V1().ConfigMaps().Lister()
+
+	informerFactory.Start(ctx.Done())
+	informerFactory.WaitForCacheSync(ctx.Done())
+
+	c.configMapLister = configMapLister
 }
 
 func New(kubeconfigPath string, informerResyncDurationSec int, runController bool, kubeAPIBurst int, kubeAPIQPS float64, enableGCSFuseProfiles, enableSharedMount bool) (Interface, error) {
@@ -652,6 +687,14 @@ func (c *Clientset) GetPodTemplate(namespace, name string) (*corev1.PodTemplate,
 	}
 
 	return c.podTemplateLister.PodTemplates(namespace).Get(name)
+}
+
+func (c *Clientset) GetConfigMap(namespace, name string) (*corev1.ConfigMap, error) {
+	if c.configMapLister == nil {
+		return nil, errors.New("configmap informer is not ready")
+	}
+
+	return c.configMapLister.ConfigMaps(namespace).Get(name)
 }
 
 func (c *Clientset) CreateServiceAccountToken(ctx context.Context, namespace, name string, tokenRequest *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error) {

--- a/pkg/cloud_provider/clientset/fake.go
+++ b/pkg/cloud_provider/clientset/fake.go
@@ -80,6 +80,12 @@ type FakePodTemplateConfig struct {
 	Template  corev1.PodTemplateSpec
 }
 
+type FakeConfigMapConfig struct {
+	Name      string
+	Namespace string
+	Data      map[string]string
+}
+
 type FakeClientset struct {
 	Client            kubernetes.Interface
 	fakePod           *corev1.Pod
@@ -87,8 +93,9 @@ type FakeClientset struct {
 	fakePVs           map[string]*corev1.PersistentVolume
 	fakePVCs          map[string]*corev1.PersistentVolumeClaim
 	fakeSCs           map[string]*storagev1.StorageClass
-	fakePods          []*corev1.Pod
 	fakePodTemplates  map[string]*corev1.PodTemplate
+	fakeConfigMaps    map[string]*corev1.ConfigMap
+	fakePods          []*corev1.Pod
 	ListPodErr        error
 	GetPodErr         error
 	GetPodTemplateErr error
@@ -102,6 +109,7 @@ func NewFakeClientset() *FakeClientset {
 		fakePVCs:         make(map[string]*corev1.PersistentVolumeClaim),
 		fakeSCs:          make(map[string]*storagev1.StorageClass),
 		fakePodTemplates: make(map[string]*corev1.PodTemplate),
+		fakeConfigMaps:   make(map[string]*corev1.ConfigMap),
 		fakePods:         []*corev1.Pod{},
 	}
 	// Default setting for most unit tests is pod doesn't use host network & workload identity is enabled on the node
@@ -111,6 +119,7 @@ func NewFakeClientset() *FakeClientset {
 	fakeClientSet.CreatePVC(FakePVCConfig{})
 	fakeClientSet.CreateSC(FakeSCConfig{})
 	fakeClientSet.CreatePodTemplate(FakePodTemplateConfig{})
+	fakeClientSet.CreateConfigMap(FakeConfigMapConfig{})
 
 	return fakeClientSet
 }
@@ -347,6 +356,27 @@ func (c *FakeClientset) GetPodTemplate(namespace, name string) (*corev1.PodTempl
 	}
 
 	return c.fakePodTemplates[""], nil
+}
+
+func (c *FakeClientset) ConfigureConfigMapLister(_ context.Context, _ string) {}
+
+func (c *FakeClientset) GetConfigMap(namespace, name string) (*corev1.ConfigMap, error) {
+	if cm, ok := c.fakeConfigMaps[name]; ok {
+		return cm, nil
+	}
+	return c.fakeConfigMaps[""], nil
+}
+
+func (c *FakeClientset) CreateConfigMap(cmConfig FakeConfigMapConfig) {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cmConfig.Name,
+			Namespace: cmConfig.Namespace,
+		},
+		Data: cmConfig.Data,
+	}
+
+	c.fakeConfigMaps[cmConfig.Name] = cm
 }
 
 func (c *FakeClientset) CreateServiceAccountToken(_ context.Context, _, _ string, _ *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error) {

--- a/pkg/csi_driver/controller.go
+++ b/pkg/csi_driver/controller.go
@@ -150,7 +150,6 @@ func (s *controllerServer) ControllerPublishVolume(ctx context.Context, req *csi
 	if !s.driver.sharedMount(vc) {
 		return &csi.ControllerPublishVolumeResponse{}, nil
 	}
-
 	// Find the workload namespace where the mounter pod should be created by identifying the PVC
 	// bound to this volume's PV.
 	clientset := s.driver.config.K8sClients
@@ -196,9 +195,28 @@ func (s *controllerServer) ControllerPublishVolume(ctx context.Context, req *csi
 	// Extract overrides specifically from the container named "gcsfusecsi-mount".
 	var containerResources *corev1.ResourceRequirements
 	var containerImage string
-	if s.features != nil && s.features.SharedMountOptions != nil {
-		containerImage = s.features.SharedMountOptions.MounterPodImage
+
+	// Retrieve the mounter pod image from the ConfigMap.
+	if s.features == nil || s.features.SharedMountOptions == nil {
+		return nil, status.Error(codes.Internal, "shared mount options can't be nil")
 	}
+	driverNamespace := s.features.SharedMountOptions.DriverNamespace
+	if driverNamespace == "" {
+		return nil, status.Error(codes.Internal, "driver namespace can't be empty")
+	}
+	configMap, err := clientset.GetConfigMap(driverNamespace, util.SidecarImageConfigMapName)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to get image configmap %s/%s: %v", driverNamespace, util.SidecarImageConfigMapName, err)
+	}
+	if configMap == nil || configMap.Data == nil {
+		return nil, status.Errorf(codes.Internal, "%s/%s ConfigMap data can't be empty", driverNamespace, util.SidecarImageConfigMapName)
+	}
+	var ok bool
+	containerImage, ok = configMap.Data[util.SidecarImageConfigMapKey]
+	if !ok || containerImage == "" {
+		return nil, status.Errorf(codes.Internal, "%s/%s ConfigMap is missing key %q or it is empty", driverNamespace, util.SidecarImageConfigMapName, util.SidecarImageConfigMapKey)
+	}
+
 	for i := range podTemplate.Template.Spec.Containers {
 		container := &podTemplate.Template.Spec.Containers[i]
 		if container.Name != util.MounterPodNamePrefix {

--- a/pkg/csi_driver/controller_test.go
+++ b/pkg/csi_driver/controller_test.go
@@ -68,6 +68,7 @@ type fakeClientsetConfig struct {
 	ptConfig  *clientset.FakePodTemplateConfig
 	podConfig *clientset.FakePodConfig
 	scConfig  *clientset.FakeSCConfig
+	cmConfig  *clientset.FakeConfigMapConfig
 }
 
 func setupFakeBase(cfg fakeClientsetConfig) *clientset.FakeClientset {
@@ -86,6 +87,9 @@ func setupFakeBase(cfg fakeClientsetConfig) *clientset.FakeClientset {
 	}
 	if cfg.scConfig != nil {
 		fc.CreateSC(*cfg.scConfig)
+	}
+	if cfg.cmConfig != nil {
+		fc.CreateConfigMap(*cfg.cmConfig)
 	}
 	return fc
 }
@@ -110,6 +114,13 @@ func getDefaultFakeClientsetConfig() fakeClientsetConfig {
 		ptConfig: &clientset.FakePodTemplateConfig{
 			Name:      testMounterPodTemplate,
 			Namespace: testNamespace,
+		},
+		cmConfig: &clientset.FakeConfigMapConfig{
+			Name:      util.SidecarImageConfigMapName,
+			Namespace: "gcs-fuse-csi-driver",
+			Data: map[string]string{
+				util.SidecarImageConfigMapKey: testImage,
+			},
 		},
 	}
 }
@@ -487,6 +498,46 @@ func TestControllerPublishVolume(t *testing.T) {
 
 				if !reflect.DeepEqual(container.Image, expectedImage) {
 					t.Errorf("Mounter pod image does not match expected overrides.\nGot: %+v\nWant: %+v", container.Image, expectedImage)
+				}
+			},
+		},
+		{
+			name: "sharedMount true - sidecar image from ConfigMap - should create pod with image from ConfigMap",
+			req: &csi.ControllerPublishVolumeRequest{
+				VolumeId:         testVolumeID,
+				NodeId:           testNodeID,
+				VolumeCapability: testVolumeCapability,
+				VolumeContext: map[string]string{
+					"sharedMount":               "true",
+					util.VolumeContextKeyPVName: testPV,
+				},
+			},
+			setupFake: func() *clientset.FakeClientset {
+				cfg := getDefaultFakeClientsetConfig()
+				fakeClient := setupFakeBase(cfg)
+				fakeClient.CreateConfigMap(clientset.FakeConfigMapConfig{
+					Name:      util.SidecarImageConfigMapName,
+					Namespace: "gcs-fuse-csi-driver",
+					Data: map[string]string{
+						util.SidecarImageConfigMapKey: "gcr.io/gke-release/gcs-fuse-csi-driver-sidecar-mounter:v1.0.0-from-configmap",
+					},
+				})
+				return fakeClient
+			},
+			wantPublishContext: map[string]string{
+				PublishContextKeyMounterPodNamespace: testNamespace,
+				PublishContextKeyMounterPodName:      createMounterPodName(testNodeID, testVolumeID),
+			},
+			podGetErr: apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "pods"}, ""),
+			expectErr: false,
+			verifyCreatedPod: func(t *testing.T, pod *corev1.Pod) {
+				if len(pod.Spec.Containers) != 1 {
+					t.Fatalf("Expected 1 container in created pod, got %d", len(pod.Spec.Containers))
+				}
+				container := pod.Spec.Containers[0]
+				expectedImage := "gcr.io/gke-release/gcs-fuse-csi-driver-sidecar-mounter:v1.0.0-from-configmap"
+				if container.Image != expectedImage {
+					t.Errorf("Expected image %q, got %q", expectedImage, container.Image)
 				}
 			},
 		},

--- a/pkg/csi_driver/gcs_fuse_driver.go
+++ b/pkg/csi_driver/gcs_fuse_driver.go
@@ -53,8 +53,8 @@ type GoMemLimitOptions struct {
 
 type SharedMountOptions struct {
 	Enabled         bool
-	MounterPodImage string
 	FuseSocketDir   string
+	DriverNamespace string
 	// Needed to override the mounter pods emptydir base path, otherwise tests will try to write to var/lib/kubelet which it won't have access to.
 	EmptyDirBasePath func(podUID string) string
 }

--- a/pkg/csi_driver/gcs_fuse_driver_test.go
+++ b/pkg/csi_driver/gcs_fuse_driver_test.go
@@ -47,8 +47,8 @@ func initTestDriver(t *testing.T, fm *mount.FakeMounter, clientset clientset.Int
 			FeatureGCSFuseProfiles: &FeatureGCSFuseProfiles{},
 			SharedMountOptions: &SharedMountOptions{
 				Enabled:         true,
-				MounterPodImage: testImage,
 				FuseSocketDir:   "/tmp/fuse-sockets",
+				DriverNamespace: "gcs-fuse-csi-driver",
 			},
 		},
 	}
@@ -83,8 +83,8 @@ func initTestDriverWithCustomNodeServer(t *testing.T, fm *mount.FakeMounter, cli
 			FeatureGCSFuseProfiles: &FeatureGCSFuseProfiles{},
 			SharedMountOptions: &SharedMountOptions{
 				Enabled:         true,
-				MounterPodImage: testImage,
 				FuseSocketDir:   "/tmp/fuse-sockets",
+				DriverNamespace: "gcs-fuse-csi-driver",
 			},
 		},
 		AssumeGoodSidecarVersion: true,

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -75,6 +75,8 @@ const (
 	KubeletPluginsGCSFuseDir            = "/var/lib/kubelet/plugins/kubernetes.io/csi/gcsfuse.csi.storage.gke.io"
 	VolumeContextKeyPVName              = "csi.storage.k8s.io/pv/name"
 	MounterPodNamePrefix                = "gcsfusecsi-mount"
+	SidecarImageConfigMapName           = "gcsfusecsi-image-config"
+	SidecarImageConfigMapKey            = "sidecar-image"
 )
 
 var (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
This PR modifies controller.go so that it retreives the mounter pod image from the existing ConfigMap which is used by the webhook to obtain the sidecar mounter image. The PR introduces a new ConfigMap informer that only tracks for ConfigMaps in the driver's namespace and trims irrelevant data, making it resource efficient. The code also renames `leader-election-namespace` to a more generic `driver-namespace`. The rename is safe, since the controller.yaml downstream will be modified to `driver-namespace` at the same time the shared mount feature is released.

/kind feature

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```