### PR TITLE
Update Go builder images to 1.24.4 (release-1.5)

### DIFF
--- a/cmd/csi_driver/Dockerfile
+++ b/cmd/csi_driver/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Build driver go binary
-FROM --platform=$BUILDPLATFORM golang:1.23.3 AS driver-builder
+FROM --platform=$BUILDPLATFORM golang:1.24.4 AS driver-builder
 
 ARG STAGINGVERSION
 ARG TARGETPLATFORM

--- a/cmd/sidecar_mounter/Dockerfile
+++ b/cmd/sidecar_mounter/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Build sidecar-mounter go binary
-FROM --platform=$BUILDPLATFORM golang:1.23.3 AS sidecar-mounter-builder
+FROM --platform=$BUILDPLATFORM golang:1.24.4 AS sidecar-mounter-builder
 
 ARG STAGINGVERSION
 ARG TARGETPLATFORM

--- a/cmd/webhook/Dockerfile
+++ b/cmd/webhook/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Build webhook go binary
-FROM --platform=$BUILDPLATFORM golang:1.23.3 AS webhook-builder
+FROM --platform=$BUILDPLATFORM golang:1.24.4 AS webhook-builder
 
 ARG STAGINGVERSION
 ARG TARGETPLATFORM

--- a/test/e2e/testsuites/gcsfuse_integration.go
+++ b/test/e2e/testsuites/gcsfuse_integration.go
@@ -206,7 +206,7 @@ func (t *gcsFuseCSIGCSFuseIntegrationTestSuite) DefineTests(driver storageframew
 		tPod.VerifyExecInPodSucceedWithFullOutput(f, specs.TesterContainerName, "apt-get update && apt-get install -y google-cloud-cli")
 
 		ginkgo.By("Checking that the gcsfuse integration tests exits with no error")
-		baseTestCommand := fmt.Sprintf("export GOTOOLCHAIN=go1.22.4 && export PATH=$PATH:/usr/local/go/bin && cd %v/%v && GODEBUG=asyncpreemptoff=1 go test . -p 1 --integrationTest -v --mountedDirectory=%v", gcsfuseIntegrationTestsBasePath, testName, mountPath)
+		baseTestCommand := fmt.Sprintf("export GOTOOLCHAIN=go1.24.4 && export PATH=$PATH:/usr/local/go/bin && cd %v/%v && GODEBUG=asyncpreemptoff=1 go test . -p 1 --integrationTest -v --mountedDirectory=%v", gcsfuseIntegrationTestsBasePath, testName, mountPath)
 		baseTestCommandWithTestBucket := baseTestCommand + fmt.Sprintf(" --testbucket=%v", bucketName)
 		switch testName {
 		case testNameReadonly:

--- a/test/e2e/testsuites/gcsfuse_integration_file_cache.go
+++ b/test/e2e/testsuites/gcsfuse_integration_file_cache.go
@@ -155,7 +155,7 @@ func (t *gcsFuseCSIGCSFuseIntegrationFileCacheTestSuite) DefineTests(driver stor
 		ginkgo.By("Checking that the gcsfuse integration tests exits with no error")
 		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("git clone --branch %v https://github.com/GoogleCloudPlatform/gcsfuse.git", gcsfuseTestBranch))
 
-		baseTestCommand := fmt.Sprintf("export GOTOOLCHAIN=go1.22.4 && export PATH=$PATH:/usr/local/go/bin && cd %v/read_cache && GODEBUG=asyncpreemptoff=1 go test . -p 1 --integrationTest -v --mountedDirectory=%v --testbucket=%v -run %v", gcsfuseIntegrationTestsBasePath, mountPath, bucketName, testName)
+		baseTestCommand := fmt.Sprintf("export GOTOOLCHAIN=go1.24.4 && export PATH=$PATH:/usr/local/go/bin && cd %v/read_cache && GODEBUG=asyncpreemptoff=1 go test . -p 1 --integrationTest -v --mountedDirectory=%v --testbucket=%v -run %v", gcsfuseIntegrationTestsBasePath, mountPath, bucketName, testName)
 		tPod.VerifyExecInPodSucceedWithFullOutput(f, specs.TesterContainerName, baseTestCommand)
 	}
 


### PR DESCRIPTION
### Previous Behavior / Problem
Louhi release pipeline build is expected to fail during the `Build driver` stage on branch `release-1.5.7-gke` (or similar release branches based on `release-1.5`).
This is because `go.mod` was updated to require `go >= 1.24.0` (to support runc vulnerability fixes), but the Dockerfile builders were still using `golang:1.23.3`.

### Fix Implementation
- Updated the base builder image from `golang:1.23.3` to `golang:1.24.4` in the following Dockerfiles:
  - `cmd/csi_driver/Dockerfile`
  - `cmd/sidecar_mounter/Dockerfile`
  - `cmd/webhook/Dockerfile`
- Updated the `GOTOOLCHAIN` environment variable to `go1.24.4` in the integration test suites (previously `go1.22.4`):
  - `test/e2e/testsuites/gcsfuse_integration.go`
  - `test/e2e/testsuites/gcsfuse_integration_file_cache.go`