### PR TITLE
Unset GOROOT during unit-test to fix covdata issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -339,7 +339,7 @@ verify:
 	hack/verify-all.sh
 
 unit-test:
-	GOTOOLCHAIN=go1.25.1+auto go test -v -mod=vendor -timeout 30s "./pkg/..." -cover
+	env -u GOROOT GOTOOLCHAIN=go1.25.1+auto go test -v -mod=vendor -timeout 30s "./pkg/..." -cover
 
 sanity-test:
 	cd test && go mod tidy && GOTOOLCHAIN=go1.25.1+auto go test -mod=readonly -v -timeout 30s "./sanity/" -run TestSanity

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+unexport GOROOT
+
 BINDIR ?= $(shell pwd)/bin
 
 ifeq ($(ENABLE_ZB), true)
@@ -339,7 +341,7 @@ verify:
 	hack/verify-all.sh
 
 unit-test:
-	env -u GOROOT GOTOOLCHAIN=go1.25.1+auto go test -v -mod=vendor -timeout 30s "./pkg/..." -cover
+	GOTOOLCHAIN=go1.25.1+auto go test -v -mod=vendor -timeout 30s "./pkg/..." -cover
 
 sanity-test:
 	cd test && go mod tidy && GOTOOLCHAIN=go1.25.1+auto go test -mod=readonly -v -timeout 30s "./sanity/" -run TestSanity


### PR DESCRIPTION
Unsets GOROOT during unit-test to prevent toolchain resolution issues in Prow when host GOROOT is set to an older version.