### PR TITLE
Implement Auto Go Mem Limit for shared node mount

### DIFF
--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -325,41 +325,7 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 		})
 	}
 
-	// Check if the user explicitly provided GOMEMLIMIT flags in their
-	// volume's mountOptions.
-	userProvidedAutoMemLimit := false
-	userProvidedRatio := false
-	for _, opt := range args.fuseMountOptions {
-		if opt == util.EnableAutoGoMemLimitConst || strings.HasPrefix(opt, util.EnableAutoGoMemLimitConst+"=") {
-			userProvidedAutoMemLimit = true
-		}
-		if strings.HasPrefix(opt, util.AutoGoMemLimitRatioConst+"=") {
-			userProvidedRatio = true
-		}
-	}
-
-	// Inject driver defaults if the sidecar supports the GOMEMLIMIT feature.
-	// We evaluate the ratio independently so users who manually opt-in via
-	// mountOptions without specifying a ratio still receive the driver's
-	// default.
-	if s.driver.isSidecarVersionSupportedForGivenFeature(gcsFuseSidecarImage, SidecarAutoGoMemLimitMinVersion) {
-		var extraOpts []string
-		enableAutoGoMemLimit := s.driver.config.FeatureOptions.GoMemLimitOptions != nil && s.driver.config.FeatureOptions.GoMemLimitOptions.EnableAutoGoMemLimit
-		if enableAutoGoMemLimit && !userProvidedAutoMemLimit {
-			extraOpts = append(extraOpts, util.EnableAutoGoMemLimitConst+"=true")
-		}
-		//  We check this to prevent injecting the ratio and adding unnecessary
-		// noise to the mount options when the feature is completely disabled.
-		sidecarFeatureWillBeEnabled := enableAutoGoMemLimit || userProvidedAutoMemLimit
-		if !userProvidedRatio && sidecarFeatureWillBeEnabled && s.driver.config.FeatureOptions.GoMemLimitOptions != nil {
-			autoGoMemLimitRatio := s.driver.config.FeatureOptions.GoMemLimitOptions.AutoGoMemLimitRatio
-			extraOpts = append(extraOpts, util.AutoGoMemLimitRatioConst+"="+strconv.FormatFloat(autoGoMemLimitRatio, 'f', -1, 64))
-		}
-
-		if len(extraOpts) > 0 {
-			args.fuseMountOptions = joinMountOptions(args.fuseMountOptions, extraOpts)
-		}
-	}
+	args.fuseMountOptions = s.appendAutoGoMemLimitOptions(gcsFuseSidecarImage, args.fuseMountOptions)
 
 	node, err := s.k8sClients.GetNode(s.driver.config.NodeID)
 	if err != nil {
@@ -789,6 +755,47 @@ func (s *nodeServer) populateTokenAndBucketAccessCheckOptions(pod *corev1.Pod, i
 	}
 }
 
+// appendAutoGoMemLimitOptions evaluates and appends enable-auto-gomemlimit and auto-gomemlimit-ratio
+// mount options if supported by the container image and enabled in driver options, unless explicitly overridden.
+func (s *nodeServer) appendAutoGoMemLimitOptions(mounterImage string, mountOptions []string) []string {
+	// Check if the user explicitly provided GOMEMLIMIT flags in their
+	// volume's mountOptions.
+	userProvidedAutoMemLimit := false
+	userProvidedRatio := false
+	for _, opt := range mountOptions {
+		if opt == util.EnableAutoGoMemLimitConst || strings.HasPrefix(opt, util.EnableAutoGoMemLimitConst+"=") {
+			userProvidedAutoMemLimit = true
+		}
+		if strings.HasPrefix(opt, util.AutoGoMemLimitRatioConst+"=") {
+			userProvidedRatio = true
+		}
+	}
+
+	// Inject driver defaults if the sidecar supports the GOMEMLIMIT feature.
+	// We evaluate the ratio independently so users who manually opt-in via
+	// mountOptions without specifying a ratio still receive the driver's
+	// default.
+	if s.driver.isSidecarVersionSupportedForGivenFeature(mounterImage, SidecarAutoGoMemLimitMinVersion) {
+		var extraOpts []string
+		enableAutoGoMemLimit := s.driver.config.FeatureOptions != nil && s.driver.config.FeatureOptions.GoMemLimitOptions != nil && s.driver.config.FeatureOptions.GoMemLimitOptions.EnableAutoGoMemLimit
+		if enableAutoGoMemLimit && !userProvidedAutoMemLimit {
+			extraOpts = append(extraOpts, util.EnableAutoGoMemLimitConst+"=true")
+		}
+		// We check this to prevent injecting the ratio and adding unnecessary
+		// noise to the mount options when the feature is completely disabled.
+		sidecarFeatureWillBeEnabled := enableAutoGoMemLimit || userProvidedAutoMemLimit
+		if !userProvidedRatio && sidecarFeatureWillBeEnabled && s.driver.config.FeatureOptions != nil && s.driver.config.FeatureOptions.GoMemLimitOptions != nil {
+			autoGoMemLimitRatio := s.driver.config.FeatureOptions.GoMemLimitOptions.AutoGoMemLimitRatio
+			extraOpts = append(extraOpts, util.AutoGoMemLimitRatioConst+"="+strconv.FormatFloat(autoGoMemLimitRatio, 'f', -1, 64))
+		}
+
+		if len(extraOpts) > 0 {
+			return joinMountOptions(mountOptions, extraOpts)
+		}
+	}
+	return mountOptions
+}
+
 func gcsFuseSidecarContainerImage(pod *corev1.Pod) string {
 	for _, container := range pod.Spec.InitContainers {
 		if container.Name == webhook.GcsFuseSidecarName {
@@ -972,6 +979,7 @@ func (s *nodeServer) executeNodeStageVolume(ctx context.Context, req *csi.NodeSt
 	}
 
 	s.populateTokenAndBucketAccessCheckOptions(pod, podImage, vc, &args, podNamespace, pod.Spec.ServiceAccountName)
+	args.fuseMountOptions = s.appendAutoGoMemLimitOptions(podImage, args.fuseMountOptions)
 
 	// We initialize volumeState if bucket name is NOT "_", I.e. It's not a dynamic mount.
 	var vs *util.VolumeState

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -2658,6 +2658,147 @@ func TestNodePublishVolumeForSharedMount(t *testing.T) {
 	}
 }
 
+func TestNodeStageVolumeEnableAutoGoMemLimit(t *testing.T) {
+	nodeID := "test-node"
+	volID := testVolumeID
+	podNamespace := "test-ns"
+	podName := createMounterPodName(nodeID, volID)
+	podUID := types.UID(podName)
+
+	cases := []struct {
+		name                     string
+		enableAutoGoMemLimit     bool
+		autoGoMemLimitRatio      float64
+		assumeGoodSidecarVersion bool
+		userMountOptions         string
+		expectedOptions          []string
+		unexpectedOptions        []string
+	}{
+		{
+			name:                     "feature flag enabled, mounter pod image supported, no user overrides, expect all driver defaults",
+			enableAutoGoMemLimit:     true,
+			autoGoMemLimitRatio:      0.95,
+			assumeGoodSidecarVersion: true,
+			expectedOptions:          []string{"enable-auto-gomemlimit=true", "auto-gomemlimit-ratio=0.95"},
+		},
+		{
+			name:                     "feature flag disabled, mounter pod image supported, no user overrides, expect no driver defaults",
+			enableAutoGoMemLimit:     false,
+			autoGoMemLimitRatio:      0.95,
+			assumeGoodSidecarVersion: true,
+			unexpectedOptions:        []string{"enable-auto-gomemlimit=true", "auto-gomemlimit-ratio=0.95"},
+		},
+		{
+			name:                     "feature flag enabled, mounter pod image not supported, no user overrides, expect no driver defaults",
+			enableAutoGoMemLimit:     true,
+			autoGoMemLimitRatio:      0.95,
+			assumeGoodSidecarVersion: false,
+			unexpectedOptions:        []string{"enable-auto-gomemlimit=true", "auto-gomemlimit-ratio=0.95"},
+		},
+		{
+			name:                     "feature flag enabled, mounter pod image supported, user overrides ratio, expect driver default enable flag and user ratio",
+			enableAutoGoMemLimit:     true,
+			autoGoMemLimitRatio:      0.95,
+			assumeGoodSidecarVersion: true,
+			userMountOptions:         "auto-gomemlimit-ratio=0.8",
+			expectedOptions:          []string{"auto-gomemlimit-ratio=0.8", "enable-auto-gomemlimit=true"},
+		},
+		{
+			name:                     "feature flag enabled, mounter pod image supported, user overrides enable flag to false, expect user enable flag and driver default ratio",
+			enableAutoGoMemLimit:     true,
+			autoGoMemLimitRatio:      0.95,
+			assumeGoodSidecarVersion: true,
+			userMountOptions:         "enable-auto-gomemlimit=false",
+			expectedOptions:          []string{"enable-auto-gomemlimit=false", "auto-gomemlimit-ratio=0.95"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			testStagingPath, cleanupStaging := setupTestStagingPath(t)
+			defer cleanupStaging()
+
+			tmpDir, err := os.MkdirTemp("/tmp", "s")
+			if err != nil {
+				t.Fatalf("failed to create temp dir: %v", err)
+			}
+			t.Cleanup(func() { os.RemoveAll(tmpDir) })
+			socketDir := filepath.Join(tmpDir, "s")
+			emptyDirBasePath := filepath.Join(tmpDir, "e")
+
+			sockFile := filepath.Join(emptyDirBasePath, string(podUID), MounterPodSocketFile)
+			mounterServer := startFakeMounterServer(t, sockFile)
+
+			fc := clientset.NewFakeClientset()
+			fc.CreatePod(clientset.FakePodConfig{
+				Name:         podName,
+				Namespace:    podNamespace,
+				UID:          podUID,
+				PodStatus:    &corev1.PodStatus{Phase: corev1.PodRunning},
+				IsMounterPod: true,
+			})
+
+			fakeMounter := mount.NewFakeMounter([]mount.MountPoint{})
+
+			testEnv := initTestNodeServerWithCustomClientset(t, fc, false)
+			ns, ok := testEnv.ns.(*nodeServer)
+			if !ok {
+				t.Fatalf("Failed to cast NodeServer to *nodeServer")
+			}
+			ns.mounter = fakeMounter
+
+			ns.driver.config.FeatureOptions.GoMemLimitOptions = &GoMemLimitOptions{
+				EnableAutoGoMemLimit: tc.enableAutoGoMemLimit,
+				AutoGoMemLimitRatio:  tc.autoGoMemLimitRatio,
+			}
+			ns.driver.config.AssumeGoodSidecarVersion = tc.assumeGoodSidecarVersion
+			ns.driver.config.FeatureOptions.SharedMountOptions = &SharedMountOptions{
+				Enabled:       true,
+				FuseSocketDir: socketDir,
+				EmptyDirBasePath: func(podUID string) string {
+					return filepath.Join(emptyDirBasePath, podUID)
+				},
+			}
+
+			vc := map[string]string{
+				VolumeContextSharedNodeMount: "true",
+				util.VolumeContextKeyPVName:  volID,
+			}
+			if tc.userMountOptions != "" {
+				vc[VolumeContextKeyMountOptions] = tc.userMountOptions
+			}
+
+			stageReq := &csi.NodeStageVolumeRequest{
+				VolumeId:          volID,
+				StagingTargetPath: testStagingPath,
+				VolumeCapability:  testVolumeCapability,
+				VolumeContext:     vc,
+				PublishContext: map[string]string{
+					PublishContextKeyMounterPodName:      podName,
+					PublishContextKeyMounterPodNamespace: podNamespace,
+				},
+			}
+
+			_, err = ns.NodeStageVolume(context.Background(), stageReq)
+			if err != nil {
+				t.Fatalf("NodeStageVolume failed: %v", err)
+			}
+			defer func() {
+				if vs, ok := ns.volumeStateStore.Load(testStagingPath); ok && vs != nil {
+					if vs.GCSFuseKernelMonitorState.CancelFunc != nil {
+						vs.GCSFuseKernelMonitorState.CancelFunc()
+					}
+				}
+			}()
+
+			if mounterServer.req == nil {
+				t.Fatalf("expected mounterServer.req to be non-nil, but got nil")
+			}
+			validateMountOptions(t, mounterServer.req.MountOptions, tc.expectedOptions, tc.unexpectedOptions)
+		})
+	}
+}
+
 func TestNodeStageVolumeEnableGCSFuseKernelParams(t *testing.T) {
 	nodeID := "test-node"
 	volID := testVolumeID

--- a/pkg/sidecar_mounter/mounter_server.go
+++ b/pkg/sidecar_mounter/mounter_server.go
@@ -53,16 +53,16 @@ func (ms *MounterServer) Mount(ctx context.Context, req *mounter.MountRequest) (
 	}
 
 	mc := MountConfig{
-		VolumeName:       req.GetVolumeId(), // Set VolumeName to VolumeId for logging purposes.
-		BucketName:       util.ParseVolumeID(req.GetVolumeId()),
-		Options:          req.GetMountOptions(),
-		SharedMountPoint: req.GetMountPoint(),
-		TempDir:          webhook.SidecarContainerTmpVolumeMountPath,
-		ErrWriter:        NewErrorWriter(filepath.Join(webhook.SidecarContainerTmpVolumeMountPath, util.ErrorFileName)),
-		BufferDir:        webhook.SidecarContainerBufferVolumeMountPath,
-		CacheDir:         webhook.SidecarContainerCacheVolumeMountPath,
-		ConfigFile:       filepath.Join(webhook.SidecarContainerTmpVolumeMountPath, "config.yaml"),
-		// TODO(FUECHR): Implement Auto Go Mem Limit.
+		VolumeName:          req.GetVolumeId(), // Set VolumeName to VolumeId for logging purposes.
+		BucketName:          util.ParseVolumeID(req.GetVolumeId()),
+		Options:             req.GetMountOptions(),
+		SharedMountPoint:    req.GetMountPoint(),
+		TempDir:             webhook.SidecarContainerTmpVolumeMountPath,
+		ErrWriter:           NewErrorWriter(filepath.Join(webhook.SidecarContainerTmpVolumeMountPath, util.ErrorFileName)),
+		BufferDir:           webhook.SidecarContainerBufferVolumeMountPath,
+		CacheDir:            webhook.SidecarContainerCacheVolumeMountPath,
+		ConfigFile:          filepath.Join(webhook.SidecarContainerTmpVolumeMountPath, "config.yaml"),
+		AutoGoMemLimitRatio: util.GoMemLimitCgroupPercentage,
 	}
 
 	// TODO(FUECHR): Implement defaultingFlagFileParsing.


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:
This PR enables and integrates the Auto Go Mem Limit feature for the new Shared Node Mount architecture. 

Specifically, it:
1. **Node Driver**: Adds a new helper function `appendAutoGoMemLimitOptions` to append `enable-auto-gomemlimit` and `auto-gomemlimit-ratio` to the `fuseMountOptions` array passed to the Mounter Pod and Sidecar.
2. **Mounter Config**: Updates `mounter_server.go` to properly initialize `AutoGoMemLimitRatio`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Tested manually on a live GKE cluster. Verified the mount options are correctly parsed and passed to the Mounter Pod across 3 scenarios:
1. Default
2. User ratio override
3. Explicitly disabled via PV mountOptions

**Does this PR introduce a user-facing change?**:
```release-note