### PR TITLE
Fix Go 1.25 covdata bug on empty test dirs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-unexport GOROOT
-
 BINDIR ?= $(shell pwd)/bin
 
 ifeq ($(ENABLE_ZB), true)
@@ -341,10 +339,10 @@ verify:
 	hack/verify-all.sh
 
 unit-test:
-	GOTOOLCHAIN=go1.25.1+auto go test -v -mod=vendor -timeout 30s "./pkg/..." -cover
+	go test -v -mod=vendor -timeout 30s "./pkg/..." -cover
 
 sanity-test:
-	cd test && go mod tidy && GOTOOLCHAIN=go1.25.1+auto go test -mod=readonly -v -timeout 30s "./sanity/" -run TestSanity
+	cd test && go mod tidy && go test -mod=readonly -v -timeout 30s "./sanity/" -run TestSanity
 
 build-e2e-test:
 	cd test && go build -o ../bin/e2e-test-ci ./e2e

--- a/pkg/cloud_provider/auth/dummy_test.go
+++ b/pkg/cloud_provider/auth/dummy_test.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import "testing"
+
+func TestDummy(t *testing.T) {
+	// Dummy test to work around Go 1.25 covdata bug on empty test dirs (https://github.com/golang/go/issues/75031)
+}

--- a/pkg/cloud_provider/metadata/dummy_test.go
+++ b/pkg/cloud_provider/metadata/dummy_test.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metadata
+
+import "testing"
+
+func TestDummy(t *testing.T) {
+	// Dummy test to work around Go 1.25 covdata bug on empty test dirs (https://github.com/golang/go/issues/75031)
+}

--- a/pkg/util/goclientobjectcommands/dummy_test.go
+++ b/pkg/util/goclientobjectcommands/dummy_test.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package goclientobjectcommands
+
+import "testing"
+
+func TestDummy(t *testing.T) {
+	// Dummy test to work around Go 1.25 covdata bug on empty test dirs (https://github.com/golang/go/issues/75031)
+}


### PR DESCRIPTION
Fix Go 1.25 covdata bug on empty test dirs

Add dummy tests to packages lacking them to bypass Go Issue #75031
where go test -cover fails when encountering empty test directories.
Also revert GOTOOLCHAIN and GOROOT workarounds from Makefile to avoid
hardcoding Go versions.

References: https://github.com/golang/go/issues/75031
