### PR TITLE
Implement Machine Type Defaulting for Shared Node Mount

### DIFF
--- a/cmd/sidecar_mounter/main.go
+++ b/cmd/sidecar_mounter/main.go
@@ -110,16 +110,11 @@ func main() {
 	if err != nil {
 		klog.Fatalf("failed to look up socket paths: %v", err)
 	}
-	flagsFromDriver := map[string]string{}
-	defaultingFlagFilePath := *volumeBasePath + "/" + driver.FlagFileForDefaultingPath
+	defaultingFlagFilePath := filepath.Join(*volumeBasePath, driver.FlagFileForDefaultingPath)
 	klog.Infof("Checking if defaulting-flag file %q exists", defaultingFlagFilePath)
-	if _, err := os.Stat(defaultingFlagFilePath); err == nil {
-		machineTypeBytes, err := os.ReadFile(defaultingFlagFilePath)
-		if err != nil {
-			klog.Fatalf("failed to read defaulting-flag file: %v", err)
-		}
-		fileContent := string(machineTypeBytes)
-		flagsFromDriver = driver.ParseFlagMapFromFlagFile(fileContent)
+	flagsFromDriver, err := sidecarmounter.ReadDriverFlagsForDefaulting(defaultingFlagFilePath)
+	if err != nil {
+		klog.Fatalf("failed to read defaulting-flag file: %v", err)
 	}
 	var startProfilerOnce sync.Once
 	for _, sp := range socketPaths {

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -215,6 +215,28 @@ func (s *nodeServer) NodePublishVolumeForSharedMount(_ context.Context, req *csi
 
 	return &csi.NodePublishVolumeResponse{}, nil
 }
+func (s *nodeServer) populateDriverFlagsForDefaulting(node *corev1.Node, mounterImage string, emptyDirBasePath string) error {
+	if node == nil {
+		return fmt.Errorf("node cannot be nil")
+	}
+	if !s.driver.isSidecarVersionSupportedForGivenFeature(mounterImage, MachineTypeAutoConfigSidecarMinVersion) {
+		return nil
+	}
+
+	shouldDisableAutoConfig := s.driver.config.DisableAutoconfig
+	machineType, ok := node.Labels[clientset.MachineTypeKey]
+	if !ok {
+		klog.Warningf("Unable to fetch target node %v's machine type", node.Name)
+		return nil
+	}
+
+	flagMap := map[string]string{
+		"machine-type":       machineType,
+		"disable-autoconfig": strconv.FormatBool(shouldDisableAutoConfig),
+	}
+
+	return writeDriverFlagsFile(flagMap, emptyDirBasePath)
+}
 
 func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
 	// Rate limit NodePublishVolume calls to avoid kube API throttling.
@@ -376,27 +398,16 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 		}
 	}
 
-	// Only pass mountOptions flags for defaulting if sidecar container is managed and satisifies min version requirement
-	if s.driver.isSidecarVersionSupportedForGivenFeature(gcsFuseSidecarImage, MachineTypeAutoConfigSidecarMinVersion) {
-		shouldDisableAutoConfig := s.driver.config.DisableAutoconfig
-		machineType, ok := node.Labels[clientset.MachineTypeKey]
-		if ok {
-			flagMap := map[string]string{"machine-type": machineType, "disable-autoconfig": strconv.FormatBool(shouldDisableAutoConfig)}
-			if err := PutFlagsFromDriverToTargetPath(flagMap, targetPath, FlagFileForDefaultingPath); err != nil {
-				return nil, status.Error(codes.Internal, err.Error())
-			}
-		} else {
-			klog.Warningf("Unable to fetch target node %v's machine type", node.Name)
-		}
+	emptyDirBasePath, err := util.PrepareEmptyDir(targetPath, true)
+	if err != nil {
+		klog.Warningf("Failed to prepare empty dir from target path %q: %v", targetPath, err)
 	}
 
-	var podUID, volumeName, emptyDirBasePath string
+	var podUID, volumeName string
 	if s.isGcsFuseKernelParamsFeatureSupported(gcsFuseSidecarImage, vs) {
 		var err error
 		if podUID, volumeName, err = util.ParsePodIDVolumeFromTargetpath(targetPath); err != nil {
 			klog.Warningf("Failed to parse pod ID and volume name from target path %q for kernel params monitor: %v. Monitor will not be started.", targetPath, err)
-		} else if emptyDirBasePath, err = util.PrepareEmptyDir(targetPath, false); err != nil {
-			klog.Warningf("Failed to prepare empty dir from target path %q for kernel params monitor: %v. Monitor will not be started.", targetPath, err)
 		}
 	}
 
@@ -439,6 +450,13 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 		klog.V(4).Infof("NodePublishVolume succeeded on volume %q to target path %q, mount already exists.", args.bucketName, targetPath)
 
 		return &csi.NodePublishVolumeResponse{}, nil
+	}
+
+	// Only pass mountOptions flags for defaulting if sidecar container is managed and satisfies min version requirement
+	if emptyDirBasePath != "" {
+		if err := s.populateDriverFlagsForDefaulting(node, gcsFuseSidecarImage, filepath.Dir(emptyDirBasePath)); err != nil {
+			return nil, status.Error(codes.Internal, err.Error())
+		}
 	}
 
 	// Unlike other features, we'll assume multi NIC can be used unless we know for certain we have a version mismatch.
@@ -1016,6 +1034,20 @@ func (s *nodeServer) executeNodeStageVolume(ctx context.Context, req *csi.NodeSt
 	klog.Infof("NodeStageVolume attempting mkdir for staging path %q", stagingPath)
 	if err := os.MkdirAll(stagingPath, 0750); err != nil {
 		return nil, status.Errorf(codes.Internal, "mkdir failed for path %q: %v", stagingPath, err)
+	}
+
+	// Fetch the node to pass its labels for auto-config
+	node, err := s.k8sClients.GetNode(s.driver.config.NodeID)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	if node == nil {
+		return nil, status.Errorf(codes.Internal, "Node %q not found", s.driver.config.NodeID)
+	}
+
+	// Only pass mountOptions flags for defaulting if sidecar container is managed and satisfies min version requirement
+	if err := s.populateDriverFlagsForDefaulting(node, podImage, emptyDirBasePath); err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
 	}
 
 	// Wait for the mounter pod grpc server to be ready.

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -3034,3 +3034,132 @@ func TestNodeStageVolumeHostNetwork(t *testing.T) {
 		})
 	}
 }
+
+func TestNodeStageVolumeMachineTypeDefaulting(t *testing.T) {
+	t.Parallel()
+
+	nodeID := "test-node"
+	volID := testVolumeID
+	podNamespace := "test-ns"
+	podName := createMounterPodName(nodeID, volID)
+	podUID := types.UID(podName)
+	expectedMachineType := "e2-medium" // default set by FakeClientset.CreateNode
+
+	cases := []struct {
+		name                     string
+		assumeGoodSidecarVersion bool
+		disableAutoconfig        bool
+		expectFlagFileWritten    bool
+	}{
+		{
+			name:                     "version check passes - flag file should be written with machine-type and disable-autoconfig",
+			assumeGoodSidecarVersion: true,
+			disableAutoconfig:        false,
+			expectFlagFileWritten:    true,
+		},
+		{
+			name:                     "version check passes, autoconfig disabled - flag file written with disable-autoconfig=true",
+			assumeGoodSidecarVersion: true,
+			disableAutoconfig:        true,
+			expectFlagFileWritten:    true,
+		},
+		{
+			name:                     "version check fails - flag file should not be written",
+			assumeGoodSidecarVersion: false,
+			disableAutoconfig:        false,
+			expectFlagFileWritten:    false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			testStagingPath, cleanupStaging := setupTestStagingPath(t)
+			defer cleanupStaging()
+
+			tmpDir, err := os.MkdirTemp("/tmp", "s")
+			if err != nil {
+				t.Fatalf("failed to create temp dir: %v", err)
+			}
+			t.Cleanup(func() { os.RemoveAll(tmpDir) })
+			socketDir := filepath.Join(tmpDir, "s")
+			emptyDirBaseRoot := filepath.Join(tmpDir, "e")
+
+			sockFile := filepath.Join(emptyDirBaseRoot, string(podUID), MounterPodSocketFile)
+			_ = startFakeMounterServer(t, sockFile)
+
+			fc := clientset.NewFakeClientset()
+			fc.CreatePod(clientset.FakePodConfig{
+				Name:         podName,
+				Namespace:    podNamespace,
+				UID:          podUID,
+				PodStatus:    &corev1.PodStatus{Phase: corev1.PodRunning},
+				IsMounterPod: true,
+			})
+
+			testEnv := initTestNodeServerWithCustomClientset(t, fc, false)
+			ns, ok := testEnv.ns.(*nodeServer)
+			if !ok {
+				t.Fatalf("Failed to cast NodeServer to *nodeServer")
+			}
+			ns.mounter = mount.NewFakeMounter([]mount.MountPoint{})
+			ns.driver.config.AssumeGoodSidecarVersion = tc.assumeGoodSidecarVersion
+			ns.driver.config.DisableAutoconfig = tc.disableAutoconfig
+			ns.driver.config.FeatureOptions.SharedMountOptions = &SharedMountOptions{
+				Enabled:       true,
+				FuseSocketDir: socketDir,
+				EmptyDirBasePath: func(uid string) string {
+					return filepath.Join(emptyDirBaseRoot, uid)
+				},
+			}
+
+			stageReq := &csi.NodeStageVolumeRequest{
+				VolumeId:          volID,
+				StagingTargetPath: testStagingPath,
+				VolumeCapability:  testVolumeCapability,
+				VolumeContext: map[string]string{
+					VolumeContextSharedNodeMount: "true",
+					util.VolumeContextKeyPVName:  volID,
+				},
+				PublishContext: map[string]string{
+					PublishContextKeyMounterPodName:      podName,
+					PublishContextKeyMounterPodNamespace: podNamespace,
+				},
+			}
+
+			_, err = ns.NodeStageVolume(context.Background(), stageReq)
+			if err != nil {
+				t.Fatalf("NodeStageVolume failed: %v", err)
+			}
+			defer func() {
+				if vs, ok := ns.volumeStateStore.Load(testStagingPath); ok && vs != nil {
+					if vs.GCSFuseKernelMonitorState.CancelFunc != nil {
+						vs.GCSFuseKernelMonitorState.CancelFunc()
+					}
+				}
+			}()
+
+			emptyDirPath := ns.driver.config.FeatureOptions.SharedMountOptions.EmptyDirBasePath(string(podUID))
+			flagFilePath := filepath.Join(emptyDirPath, FlagFileForDefaultingPath)
+			content, readErr := os.ReadFile(flagFilePath)
+
+			if tc.expectFlagFileWritten {
+				if readErr != nil {
+					t.Fatalf("expected flags-for-defaulting file at %q, got error: %v", flagFilePath, readErr)
+				}
+				flags := ParseFlagMapFromFlagFile(string(content))
+				if got := flags["machine-type"]; got != expectedMachineType {
+					t.Errorf("flags[%q] = %q, want %q", "machine-type", got, expectedMachineType)
+				}
+				if got := flags["disable-autoconfig"]; got != strconv.FormatBool(tc.disableAutoconfig) {
+					t.Errorf("flags[%q] = %q, want %q", "disable-autoconfig", got, strconv.FormatBool(tc.disableAutoconfig))
+				}
+			} else {
+				if readErr == nil {
+					t.Errorf("expected no flags-for-defaulting file to be written, but found one with content: %q", string(content))
+				}
+			}
+		})
+	}
+}

--- a/pkg/csi_driver/utils.go
+++ b/pkg/csi_driver/utils.go
@@ -680,27 +680,24 @@ func (d *GCSDriver) isSidecarVersionSupportedForGivenFeature(imageName string, s
 	return false
 }
 
-func PutFlagsFromDriverToTargetPath(flagMap map[string]string, targetPath string, fileName string) error {
-	emptyDirBasePath, err := util.PrepareEmptyDir(targetPath, true)
-	if err != nil {
-		return fmt.Errorf("failed to get emptyDir path: %w", err)
+func writeDriverFlagsFile(flagMap map[string]string, emptyDirBasePath string) error {
+	if err := os.MkdirAll(emptyDirBasePath, 0750); err != nil {
+		return fmt.Errorf("failed to create directory %q: %w", emptyDirBasePath, err)
 	}
 
-	absolutePath := filepath.Dir(emptyDirBasePath) + "/" + fileName
+	absolutePath := filepath.Join(emptyDirBasePath, FlagFileForDefaultingPath)
 	klog.V(4).Infof("Writing flags needed for gcsfuse defaulting logic to file %q: %v", absolutePath, flagMap)
-
-	parentDir := filepath.Dir(emptyDirBasePath)
 
 	// Pin the parent directory by opening its file descriptor with O_DIRECTORY and O_NOFOLLOW.
 	// This locks the parent directory inode in memory, preventing concurrent TOCTOU symlink-swapping
 	// attacks during subsequent relative operations (using unix.Openat).
-	parentFd, err := unix.Open(parentDir, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW, 0)
+	parentFd, err := unix.Open(emptyDirBasePath, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW, 0)
 	if err != nil {
-		return fmt.Errorf("failed to open parent directory %q: %w", parentDir, err)
+		return fmt.Errorf("failed to open parent directory %q: %w", emptyDirBasePath, err)
 	}
 	defer unix.Close(parentFd)
 
-	fd, err := unix.Openat(parentFd, filepath.Base(fileName), unix.O_RDWR|unix.O_CREAT|unix.O_TRUNC|unix.O_NOFOLLOW, 0644)
+	fd, err := unix.Openat(parentFd, FlagFileForDefaultingPath, unix.O_RDWR|unix.O_CREAT|unix.O_TRUNC|unix.O_NOFOLLOW, 0644)
 	if err != nil {
 		return fmt.Errorf("failed to securely open defaulting-flag file: %w", err)
 	}
@@ -730,12 +727,10 @@ func ParseFlagMapFromFlagFile(flagFileContent string) map[string]string {
 	configFlags := make(map[string]string)
 	lines := strings.Split(flagFileContent, "\n")
 	for _, line := range lines {
-		if line == "" { // Skip empty lines
+		key, value, found := strings.Cut(line, ":")
+		if !found || key == "" {
 			continue
 		}
-		parts := strings.Split(line, ":")
-		key := parts[0]
-		value := parts[1]
 		configFlags[key] = value
 	}
 	return configFlags

--- a/pkg/csi_driver/utils_test.go
+++ b/pkg/csi_driver/utils_test.go
@@ -19,6 +19,8 @@ package driver
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -1190,6 +1192,108 @@ func TestGetInternalMountOptionValue(t *testing.T) {
 			got := getInternalMountOptionValue(tc.options, tc.key)
 			if got != tc.expected {
 				t.Errorf("getInternalMountOptionValue(%v, %q) = %q; want %q", tc.options, tc.key, got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestWriteDriverFlagsFile(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		flagMap map[string]string
+	}{
+		{
+			name: "valid flags",
+			flagMap: map[string]string{
+				"machine-type":       "n1-standard-1",
+				"disable-autoconfig": "false",
+			},
+		},
+		{
+			name:    "empty flag map",
+			flagMap: map[string]string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tmpDir := t.TempDir()
+
+			err := writeDriverFlagsFile(tc.flagMap, tmpDir)
+			if err != nil {
+				t.Fatalf("writeDriverFlagsFile failed: %v", err)
+			}
+
+			filePath := filepath.Join(tmpDir, FlagFileForDefaultingPath)
+			content, err := os.ReadFile(filePath)
+			if err != nil {
+				t.Fatalf("failed to read flag file: %v", err)
+			}
+
+			parsed := ParseFlagMapFromFlagFile(string(content))
+			if len(tc.flagMap) == 0 {
+				if len(parsed) != 0 {
+					t.Errorf("parsed flags %v, want empty map", parsed)
+				}
+			} else if !reflect.DeepEqual(parsed, tc.flagMap) {
+				t.Errorf("parsed flags %v, want %v", parsed, tc.flagMap)
+			}
+		})
+	}
+}
+
+func TestParseFlagMapFromFlagFile(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		content  string
+		expected map[string]string
+	}{
+		{
+			name:     "empty content",
+			content:  "",
+			expected: map[string]string{},
+		},
+		{
+			name:    "valid key value pairs",
+			content: "machine-type:n1-standard-1\ndisable-autoconfig:false\n",
+			expected: map[string]string{
+				"machine-type":       "n1-standard-1",
+				"disable-autoconfig": "false",
+			},
+		},
+		{
+			name:    "malformed lines without colon",
+			content: "machine-type:n1-standard-1\nmalformed_line_no_colon\ndisable-autoconfig:false\n",
+			expected: map[string]string{
+				"machine-type":       "n1-standard-1",
+				"disable-autoconfig": "false",
+			},
+		},
+		{
+			name:    "value contains colon",
+			content: "custom-flag:value:with:colons\n",
+			expected: map[string]string{
+				"custom-flag": "value:with:colons",
+			},
+		},
+		{
+			name:     "empty key skipped",
+			content:  ":value_without_key\n",
+			expected: map[string]string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := ParseFlagMapFromFlagFile(tc.content)
+			if !reflect.DeepEqual(got, tc.expected) {
+				t.Errorf("ParseFlagMapFromFlagFile(%q) = %v, want %v", tc.content, got, tc.expected)
 			}
 		})
 	}

--- a/pkg/sidecar_mounter/mounter_server.go
+++ b/pkg/sidecar_mounter/mounter_server.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"path/filepath"
 
+	driver "github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/csi_driver"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/webhook"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/proto/mounter"
@@ -71,11 +72,15 @@ func (ms *MounterServer) Mount(ctx context.Context, req *mounter.MountRequest) (
 		AutoGoMemLimitRatio: util.GoMemLimitCgroupPercentage,
 	}
 
-	// TODO(FUECHR): Implement defaultingFlagFileParsing.
+	defaultingFlagFilePath := filepath.Join(webhook.SidecarContainerTmpVolumeMountPath, driver.FlagFileForDefaultingPath)
+	flagsFromDriver, err := ReadDriverFlagsForDefaulting(defaultingFlagFilePath)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to read defaulting-flag file: %v", err)
+	}
 
 	mc.prepareMountArgs()
 
-	// TODO(FUECHR): Call mergeFlags(mc.ConfigFileFlagMap, flagMapFromDriver) (to be done with flag defaulting).
+	mergeFlags(mc.ConfigFileFlagMap, flagsFromDriver)
 
 	// TODO(FUECHR) SetupTokenAndStorageManager for bucket access check.
 	// TODO(FUECHR) Implement cloud profiler hook.

--- a/pkg/sidecar_mounter/sidecar_mounter_config.go
+++ b/pkg/sidecar_mounter/sidecar_mounter_config.go
@@ -29,6 +29,7 @@ import (
 	"syscall"
 	"time"
 
+	driver "github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/csi_driver"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/webhook"
 	"gopkg.in/yaml.v3"
@@ -201,6 +202,20 @@ func mergeFlags(mountConfigFlagMap map[string]string, driverFlagMap map[string]s
 			mountConfigFlagMap[key] = value
 		}
 	}
+}
+
+// ReadDriverFlagsForDefaulting reads the defaulting flags file written by the CSI driver
+// into the emptyDir volume and parses its content into a map of flag key-value pairs.
+// If the file does not exist, it returns an empty map and nil error.
+func ReadDriverFlagsForDefaulting(defaultFilePath string) (map[string]string, error) {
+	machineTypeBytes, err := os.ReadFile(defaultFilePath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return map[string]string{}, nil
+		}
+		return nil, fmt.Errorf("failed to read defaulting-flag file %q: %w", defaultFilePath, err)
+	}
+	return driver.ParseFlagMapFromFlagFile(string(machineTypeBytes)), nil
 }
 
 func (mc *MountConfig) prepareMountArgs() {

--- a/pkg/sidecar_mounter/sidecar_mounter_config_test.go
+++ b/pkg/sidecar_mounter/sidecar_mounter_config_test.go
@@ -884,7 +884,7 @@ func TestPrepareConfigFile(t *testing.T) {
 }
 
 func TestPrepareMountArgs_AutoGoMemLimit(t *testing.T) {
-	t.Parallel()
+	// Do not parallelize because prepareMountArgs modifies shared prometheusPort.
 
 	testCases := []struct {
 		name           string
@@ -935,6 +935,74 @@ func TestPrepareMountArgs_AutoGoMemLimit(t *testing.T) {
 
 			if mc.AutoGoMemLimitRatio != tc.expectedRatio {
 				t.Errorf("Got AutoGoMemLimitRatio %v, expected %v", mc.AutoGoMemLimitRatio, tc.expectedRatio)
+			}
+		})
+	}
+}
+
+func TestReadDriverFlagsForDefaulting(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		name          string
+		fileExists    bool
+		unreadable    bool
+		fileContent   string
+		expectedFlags map[string]string
+		expectErr     bool
+	}{
+		{
+			name:          "File does not exist",
+			fileExists:    false,
+			expectedFlags: map[string]string{},
+			expectErr:     false,
+		},
+		{
+			name:        "File exists and contains flags",
+			fileExists:  true,
+			fileContent: "machine-type:e2-standard-4\ndisable-autoconfig:false\n",
+			expectedFlags: map[string]string{
+				"machine-type":       "e2-standard-4",
+				"disable-autoconfig": "false",
+			},
+			expectErr: false,
+		},
+		{
+			name:        "File exists but is unreadable",
+			fileExists:  true,
+			unreadable:  true,
+			fileContent: "machine-type:e2-standard-4\n",
+			expectErr:   true,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			flagFilePath := filepath.Join(t.TempDir(), "flags-for-defaulting")
+
+			if tc.fileExists {
+				if err := os.WriteFile(flagFilePath, []byte(tc.fileContent), 0644); err != nil {
+					t.Fatalf("Failed to write mock flag file: %v", err)
+				}
+				if tc.unreadable {
+					_ = os.Chmod(flagFilePath, 0000)
+				}
+			}
+
+			flagMap, err := ReadDriverFlagsForDefaulting(flagFilePath)
+
+			if tc.expectErr {
+				if err == nil {
+					t.Errorf("Expected error reading %s, got nil", flagFilePath)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error reading %s: %v", flagFilePath, err)
+				}
+				if !reflect.DeepEqual(flagMap, tc.expectedFlags) {
+					t.Errorf("Expected flags %v, got: %v", tc.expectedFlags, flagMap)
+				}
 			}
 		})
 	}

--- a/test/e2e/testsuites/mount.go
+++ b/test/e2e/testsuites/mount.go
@@ -282,7 +282,7 @@ func (t *gcsFuseCSIMountTestSuite) DefineTests(driver storageframework.TestDrive
 	}
 
 	ginkgo.It("should pass --machine-type and --disable-autoconfig=false from driver to gcsfuse", func() {
-		testDefaultingFlags(specs.DisableAutoconfig)
+		testDefaultingFlags()
 	})
 
 	ginkgo.It("should pass --disable-autoconfig=true as a user-specified mountOption to gcsfuse", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:
This PR extends machine type defaulting to the shared node mount mode.

- `PutFlagsFromDriverToTargetPath` is renamed to `writeDriverFlagsFile` and made unexported. The old name was misleading (it operates on an emptyDir base path, not a target path), and the function is only ever called from the `populateDriverFlagsForDefaulting` helper, so making it unexported is safe. The `fileName` parameter is also removed from the method since the file name is always `FlagFileForDefaultingPath`.
- Add new method`ReadDriverFlagsForDefaulting` in `pkg/sidecar_mounter` so the same logic is shared between the sidecar main loop and the mounter server's `Mount` handler.
- Fix a bug in the defaulting flags E2E test suite (`test/e2e/testsuites/mount.go`) where the test case intended for `--disable-autoconfig=false` mistakenly passed `specs.DisableAutoconfig`, causing both E2E test cases to test `--disable-autoconfig=true`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
I have tested manually and verified the machine type defaulting works on shared mount and sidecar. I also verified the e2e tests passed after the change:
```
E2E_TEST_USE_GKE_MANAGED_DRIVER=false \
E2E_TEST_BUILD_DRIVER=true \
REGISTRY=${REGISTRY} \
STAGINGVERSION=${STAGINGVERSION} \
E2E_TEST_FOCUS="disable-autoconfig" \
make e2e-test

Ran 4 of 671 Specs in 13.539 seconds
SUCCESS! -- 4 Passed | 0 Failed | 0 Pending | 667 Skipped


Ginkgo ran 1 suite in 29.087633152s
Test Suite Passed
```
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```