### PR TITLE
Automated cherry pick of #1371: cleanup gcsfuse errofile before next NPV attempt
#1443: address stderrWrirter nil poinetr failure case

### DIFF
--- a/cmd/sidecar_mounter/main.go
+++ b/cmd/sidecar_mounter/main.go
@@ -105,6 +105,11 @@ func main() {
 					klog.Fatalf("Failed to fetch identity pool and identity provider details required for bucket access check, got error %v", err)
 				}
 			}
+			// Clean up any errors raised until this point due to transient metadata and storage service creation issues.
+			if err := mc.ErrWriter.Clean(); err != nil {
+				klog.Warningf("failed to cleanup error file: %v", err)
+			}
+
 			if err := mounter.Mount(ctx, mc); err != nil {
 				mc.ErrWriter.WriteMsg(fmt.Sprintf("failed to mount bucket %q for volume %q: %v\n", mc.BucketName, mc.VolumeName, err))
 			}

--- a/cmd/sidecar_mounter/main.go
+++ b/cmd/sidecar_mounter/main.go
@@ -83,17 +83,19 @@ func main() {
 		// 2. memory usage peak.
 		time.Sleep(1500 * time.Millisecond)
 		mc := sidecarmounter.NewMountConfig(sp, flagsFromDriver)
-		if mc.EnableCloudProfilerForSidecar {
-			cfg := profiler.Config{
-				Service: "gke-gcsfuse-sidecar",
-			}
-			if err := profiler.Start(cfg); err != nil {
-				klog.Errorf("Errored while starting cloud profiler, got %v", err)
-			} else {
-				klog.Infof("Running cloud profiler on %s", cfg.Service)
-			}
-		}
 		if mc != nil {
+			mc.EnsureErrWriter()
+			if mc.EnableCloudProfilerForSidecar {
+				cfg := profiler.Config{
+					Service: "gke-gcsfuse-sidecar",
+				}
+				if err := profiler.Start(cfg); err != nil {
+					klog.Errorf("Errored while starting cloud profiler, got %v", err)
+				} else {
+					klog.Infof("Running cloud profiler on %s", cfg.Service)
+				}
+			}
+
 			if mc.EnableSidecarBucketAccessCheck {
 				mc.SidecarRetryConfig.Cap = *storageServiceAndBucketAccessCap
 				mc.SidecarRetryConfig.Steps = *storageServiceAndBucketAccessSteps

--- a/pkg/csi_mounter/csi_mounter.go
+++ b/pkg/csi_mounter/csi_mounter.go
@@ -153,9 +153,9 @@ func (m *Mounter) Mount(source string, target string, fstype string, options []s
 		klog.Errorf("failed to get emptyDir path: %v", err)
 	}
 
-	err = util.CheckAndDeleteStaleFile(emptyDirBasePath, "/error")
+	err = util.CheckAndDeleteStaleFile(emptyDirBasePath, util.ErrorFileName)
 	if err != nil {
-		klog.Errorf("failed to check and delete stale /error file: %v", err)
+		klog.Errorf("failed to check and delete stale %s file: %v", util.ErrorFileName, err)
 	}
 
 	err = util.CheckAndDeleteStaleFile(emptyDirBasePath, util.GCSFuseKernelParamsFileName)

--- a/pkg/sidecar_mounter/logger.go
+++ b/pkg/sidecar_mounter/logger.go
@@ -28,6 +28,7 @@ import (
 type stderrWriterInterface interface {
 	io.Writer
 	WriteMsg(errMsg string)
+	Clean() error
 }
 
 type stderrWriter struct {
@@ -36,6 +37,22 @@ type stderrWriter struct {
 
 func NewErrorWriter(errorFile string) stderrWriterInterface {
 	return &stderrWriter{errorFile: errorFile}
+}
+
+func (w *stderrWriter) Clean() error {
+	if w.errorFile != "" {
+		err := os.Remove(w.errorFile)
+		if os.IsNotExist(err) {
+			// File does not exist.
+			klog.V(4).Infof("File '%s' not found. No action needed.", w.errorFile)
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("failed to clean up error file %q: %w", w.errorFile, err)
+		}
+		klog.V(4).Infof("Cleaned up error file %q", w.errorFile)
+	}
+	return nil
 }
 
 // Write writes the error message to a given local file.

--- a/pkg/sidecar_mounter/logger_test.go
+++ b/pkg/sidecar_mounter/logger_test.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+Copyright 2024 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sidecarmounter
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestClean(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	// Setup for existing file
+	existingFile := filepath.Join(tmpDir, "existing.log")
+	if err := os.WriteFile(existingFile, []byte("test"), 0o644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	testCases := []struct {
+		name        string
+		w           *stderrWriter
+		expectError bool
+		verifyFunc  func(t *testing.T)
+	}{
+		{
+			name: "empty error file",
+			w:    &stderrWriter{errorFile: ""},
+		},
+		{
+			name: "existing file",
+			w:    &stderrWriter{errorFile: existingFile},
+			verifyFunc: func(t *testing.T) {
+				if _, err := os.Stat(existingFile); !os.IsNotExist(err) {
+					t.Errorf("expected file to be deleted")
+				}
+			},
+		},
+		{
+			name: "non-existing file",
+			w:    &stderrWriter{errorFile: filepath.Join(tmpDir, "nonexistent.log")},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.w.Clean()
+			if (err != nil) != tc.expectError {
+				t.Errorf("expected error: %v, got: %v", tc.expectError, err)
+			}
+			if tc.verifyFunc != nil {
+				tc.verifyFunc(t)
+			}
+		})
+	}
+}
+
+func TestWrite(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	msg := []byte("hello world")
+	validFile := filepath.Join(tmpDir, "error.log")
+
+	testCases := []struct {
+		name         string
+		w            *stderrWriter
+		msg          []byte
+		expectedN    int
+		expectError  bool
+		expectedFile string
+	}{
+		{
+			name:      "empty error file",
+			w:         &stderrWriter{errorFile: ""},
+			msg:       msg,
+			expectedN: len(msg),
+		},
+		{
+			name:         "valid file",
+			w:            &stderrWriter{errorFile: validFile},
+			msg:          msg,
+			expectedN:    len(msg),
+			expectedFile: validFile,
+		},
+		{
+			name:        "invalid file path",
+			w:           &stderrWriter{errorFile: filepath.Join(tmpDir, "nonexistent_dir", "error.log")},
+			msg:         msg,
+			expectedN:   0,
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			n, err := tc.w.Write(tc.msg)
+			if (err != nil) != tc.expectError {
+				t.Errorf("expected error: %v, got: %v", tc.expectError, err)
+			}
+			if n != tc.expectedN {
+				t.Errorf("expected n=%d, got %d", tc.expectedN, n)
+			}
+			if tc.expectedFile != "" {
+				b, err := os.ReadFile(tc.expectedFile)
+				if err != nil {
+					t.Fatalf("failed to read file: %v", err)
+				}
+				if string(b) != string(tc.msg) {
+					t.Errorf("expected file content %q, got %q", string(tc.msg), string(b))
+				}
+			}
+		})
+	}
+}
+
+func TestWriteMsg(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	errMsg := "test error message"
+	validFile := filepath.Join(tmpDir, "error.log")
+
+	testCases := []struct {
+		name         string
+		w            *stderrWriter
+		msg          string
+		expectedFile string
+	}{
+		{
+			name:         "valid file",
+			w:            &stderrWriter{errorFile: validFile},
+			msg:          errMsg,
+			expectedFile: validFile,
+		},
+		{
+			name: "invalid file path",
+			w:    &stderrWriter{errorFile: filepath.Join(tmpDir, "nonexistent_dir", "error.log")},
+			msg:  errMsg,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.w.WriteMsg(tc.msg)
+
+			if tc.expectedFile != "" {
+				b, err := os.ReadFile(tc.expectedFile)
+				if err != nil {
+					t.Fatalf("failed to read file: %v", err)
+				}
+				if string(b) != tc.msg {
+					t.Errorf("expected file content %q, got %q", tc.msg, string(b))
+				}
+			}
+		})
+	}
+}

--- a/pkg/sidecar_mounter/sidecar_mounter.go
+++ b/pkg/sidecar_mounter/sidecar_mounter.go
@@ -103,6 +103,12 @@ func (m *Mounter) Mount(ctx context.Context, mc *MountConfig) error {
 		}
 	}
 
+	// Clear the GCS Fuse error file after the sidecar bucket access check completes and just before the GCS Fuse mount starts.
+	// This ensures the NodePublish volume will always fail if the error persists until the GCS Fuse mount actually starts.
+	if err := mc.ErrWriter.Clean(); err != nil {
+		klog.Warningf("failed to cleanup error file: %v", err)
+	}
+
 	klog.Infof("start to mount bucket %q for volume %q", mc.BucketName, mc.VolumeName)
 
 	if err := os.MkdirAll(mc.BufferDir+TempDir, os.ModePerm); err != nil {

--- a/pkg/sidecar_mounter/sidecar_mounter.go
+++ b/pkg/sidecar_mounter/sidecar_mounter.go
@@ -72,6 +72,7 @@ func New(mounterPath string) *Mounter {
 }
 
 func (m *Mounter) Mount(ctx context.Context, mc *MountConfig) error {
+	mc.EnsureErrWriter()
 	// Start the token server for HostNetwork enabled pods.
 	// For managed sidecar, the token server identity provider is only populated when host network pod ksa feature is opted in.
 	var tokenSource oauth2.TokenSource
@@ -516,6 +517,8 @@ func getAudienceFromContextAndIdentityProvider(ctx context.Context, identityProv
 }
 
 func (m *Mounter) SetupTokenAndStorageManager(ctx context.Context, clientset clientset.Interface, mc *MountConfig) error {
+	mc.EnsureErrWriter()
+
 	if mc.TokenServerIdentityPool != "" && mc.TokenServerIdentityProvider != "" {
 		var tm auth.TokenManager
 		var ssm storage.ServiceManager

--- a/pkg/sidecar_mounter/sidecar_mounter_config.go
+++ b/pkg/sidecar_mounter/sidecar_mounter_config.go
@@ -111,7 +111,11 @@ func NewMountConfig(sp string, flagMapFromDriver map[string]string) *MountConfig
 		CacheDir:   filepath.Join(webhook.SidecarContainerCacheVolumeMountPath, ".volumes", volumeName),
 		TempDir:    tempDir,
 		ConfigFile: filepath.Join(webhook.SidecarContainerTmpVolumeMountPath, ".volumes", volumeName, "config.yaml"),
-		ErrWriter:  NewErrorWriter(filepath.Join(tempDir, "error")),
+		ErrWriter:  NewErrorWriter(filepath.Join(tempDir, util.ErrorFileName)),
+	}
+
+	if err := mc.ErrWriter.Clean(); err != nil {
+		klog.Warningf("failed to cleanup stale error file: %v", err)
 	}
 
 	klog.Infof("connecting to socket %q", sp)

--- a/pkg/sidecar_mounter/sidecar_mounter_config.go
+++ b/pkg/sidecar_mounter/sidecar_mounter_config.go
@@ -69,7 +69,24 @@ type MountConfig struct {
 	GcsFuseNumaNode                int                   `json:"-"`
 }
 
-// sidecarRetryConfig controls the retry configurations for sidecarRetry behivior for storage service creation and bucket access check.
+// EnsureErrWriter safely initializes ErrWriter to the correct writer if it is nil.
+func (mc *MountConfig) EnsureErrWriter() {
+	if mc == nil {
+		return
+	}
+	if mc.ErrWriter != nil {
+		return
+	}
+	if mc.TempDir != "" {
+		mc.ErrWriter = NewErrorWriter(filepath.Join(mc.TempDir, util.ErrorFileName))
+		klog.V(4).Infof("Initialized ErrWriter for volume %q", mc.VolumeName)
+		return
+	}
+	klog.Warningf("ErrWriter initialization failed for volume %q, creating a no-op error writer", mc.VolumeName)
+	mc.ErrWriter = NewErrorWriter("")
+}
+
+// sidecarRetryConfig controls the retry configurations for sidecarRetry behavior for storage service creation and bucket access check.
 type sidecarRetryConfig struct {
 	Duration time.Duration
 	Factor   float64

--- a/pkg/sidecar_mounter/sidecar_mounter_config.go
+++ b/pkg/sidecar_mounter/sidecar_mounter_config.go
@@ -114,10 +114,6 @@ func NewMountConfig(sp string, flagMapFromDriver map[string]string) *MountConfig
 		ErrWriter:  NewErrorWriter(filepath.Join(tempDir, util.ErrorFileName)),
 	}
 
-	if err := mc.ErrWriter.Clean(); err != nil {
-		klog.Warningf("failed to cleanup stale error file: %v", err)
-	}
-
 	klog.Infof("connecting to socket %q", sp)
 	c, err := net.Dial("unix", sp)
 	if err != nil {

--- a/pkg/sidecar_mounter/sidecar_mounter_config_test.go
+++ b/pkg/sidecar_mounter/sidecar_mounter_config_test.go
@@ -18,6 +18,7 @@ limitations under the License.
 package sidecarmounter
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -496,6 +497,37 @@ func TestPrepareMountArgs(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestMountErrorFileCleanup(t *testing.T) {
+	t.Parallel()
+
+	tempDir, err := os.MkdirTemp("", "sidecar-mounter-test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	errFilePath := filepath.Join(tempDir, util.ErrorFileName)
+	if err := os.WriteFile(errFilePath, []byte("fake error"), 0644); err != nil {
+		t.Fatalf("failed to write error file: %v", err)
+	}
+
+	mc := &MountConfig{
+		BucketName: "test-bucket",
+		VolumeName: "test-volume",
+		TempDir:    tempDir,
+		BufferDir:  filepath.Join(tempDir, "buffer"),
+		CacheDir:   filepath.Join(tempDir, "cache"),
+		ErrWriter:  NewErrorWriter(filepath.Join(tempDir, util.ErrorFileName)),
+	}
+
+	mounter := New("invalid-gcsfuse-path")
+	_ = mounter.Mount(context.Background(), mc)
+
+	if _, err := os.Stat(errFilePath); !os.IsNotExist(err) {
+		t.Fatalf("expected error file to be deleted, but it still exists (or another error occurred: %v)", err)
 	}
 }
 

--- a/pkg/sidecar_mounter/sidecar_mounter_config_test.go
+++ b/pkg/sidecar_mounter/sidecar_mounter_config_test.go
@@ -514,17 +514,25 @@ func TestMountErrorFileCleanup(t *testing.T) {
 		t.Fatalf("failed to write error file: %v", err)
 	}
 
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	defer w.Close()
+
 	mc := &MountConfig{
-		BucketName: "test-bucket",
-		VolumeName: "test-volume",
-		TempDir:    tempDir,
-		BufferDir:  filepath.Join(tempDir, "buffer"),
-		CacheDir:   filepath.Join(tempDir, "cache"),
-		ErrWriter:  NewErrorWriter(filepath.Join(tempDir, util.ErrorFileName)),
+		BucketName:     "test-bucket",
+		VolumeName:     "test-volume",
+		TempDir:        tempDir,
+		BufferDir:      filepath.Join(tempDir, "buffer"),
+		CacheDir:       filepath.Join(tempDir, "cache"),
+		ErrWriter:      NewErrorWriter(errFilePath),
+		FileDescriptor: int(r.Fd()),
 	}
 
-	mounter := New("invalid-gcsfuse-path")
+	mounter := New("true")
 	_ = mounter.Mount(context.Background(), mc)
+	mounter.WaitGroup.Wait()
 
 	if _, err := os.Stat(errFilePath); !os.IsNotExist(err) {
 		t.Fatalf("expected error file to be deleted, but it still exists (or another error occurred: %v)", err)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -51,6 +51,7 @@ const (
 	FileCacheMediumConst                = "file-cache-medium"
 	EnableGCSFuseKernelParams           = "enable-gcsfuse-kernel-params"
 	GCSFuseKernelParamsFileName         = "kernel-params.json"
+	ErrorFileName                       = "error"
 	MediumRAM                           = "ram"
 	MediumLSSD                          = "lssd"
 	OptInHnw                            = "hnw-ksa"

--- a/test/e2e/testsuites/failed_mount.go
+++ b/test/e2e/testsuites/failed_mount.go
@@ -319,12 +319,22 @@ func (t *gcsFuseCSIFailedMountTestSuite) DefineTests(driver storageframework.Tes
 		init(configPrefix...)
 		defer cleanup()
 
-		// The test driver uses config.Prefix to pass the bucket names back to the test suite.
-		bucketName := l.config.Prefix
+		var bucketName string
+		if l.volumeResource.Pv != nil {
+			bucketName = l.volumeResource.Pv.Spec.CSI.VolumeHandle
+		} else {
+			bucketName = l.volumeResource.VolSource.CSI.VolumeAttributes["bucketName"]
+		}
+
+		volumeFolder := volumeName
+		if l.volumeResource.Pv != nil {
+			volumeFolder = l.volumeResource.Pv.Name
+		}
 
 		ginkgo.By("Configuring the pod")
 		tPod := specs.NewTestPod(f.ClientSet, f.Namespace)
 		tPod.SetupVolume(l.volumeResource, volumeName, mountPath, false)
+		tPod.SetupTmpVolumeMount("/gcsfuse-tmp")
 
 		ginkgo.By("Deploying a Kubernetes service account without access to the GCS bucket")
 		saName := "sa-without-access"
@@ -337,15 +347,13 @@ func (t *gcsFuseCSIFailedMountTestSuite) DefineTests(driver storageframework.Tes
 		defer tPod.Cleanup(ctx)
 
 		ginkgo.By("Checking that the pod has failed mount error PermissionDenied")
-		if enableSidecarBucketAccessCheck {
-			if slices.Contains(configPrefix, specs.SkipCSIBucketAccessCheckPrefix) {
-				tPod.WaitForFailedContainerError(ctx, "Error: failed to reserve container name")
-				tPod.WaitForLog(ctx, webhook.GcsFuseSidecarName, "does not have storage.objects.list access to the Google Cloud Storage bucket")
-				return
-			}
+		if enableSidecarBucketAccessCheck && slices.Contains(configPrefix, specs.SkipCSIBucketAccessCheckPrefix) {
+			tPod.WaitForFailedContainerError(ctx, "Error: failed to reserve container name")
+			tPod.WaitForLog(ctx, webhook.GcsFuseSidecarName, "does not have storage.objects.list access to the Google Cloud Storage bucket")
+		} else {
+			tPod.WaitForFailedMountError(ctx, codes.PermissionDenied.String())
+			tPod.WaitForFailedMountError(ctx, "does not have storage.objects.list access to the Google Cloud Storage bucket.")
 		}
-		tPod.WaitForFailedMountError(ctx, codes.PermissionDenied.String())
-		tPod.WaitForFailedMountError(ctx, "does not have storage.objects.list access to the Google Cloud Storage bucket.")
 
 		ginkgo.By("Setting up SA IAM policy")
 		setupIAMPolicy(bucketName, f.Namespace.Name, saName)
@@ -356,6 +364,9 @@ func (t *gcsFuseCSIFailedMountTestSuite) DefineTests(driver storageframework.Tes
 		ginkgo.By("Checking that the pod command exits with no error")
 		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("mount | grep %v | grep rw,", mountPath))
 		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("echo 'hello world' > %v/data && grep 'hello world' %v/data", mountPath, mountPath))
+
+		ginkgo.By("Checking that the error file is deleted")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("test ! -f /gcsfuse-tmp/.volumes/%v/error", volumeFolder))
 
 		ginkgo.By("Removing SA IAM policy")
 		removeIAMPolicy(bucketName, f.Namespace.Name, saName)
@@ -373,7 +384,7 @@ func (t *gcsFuseCSIFailedMountTestSuite) DefineTests(driver storageframework.Tes
 		if !enableSidecarBucketAccessCheck {
 			// We are skipping this test combination because this configuration disables bucket access checks in both the node driver and the sidecar.
 			// This prevents the system from recovering from any permission issues
-			e2eskipper.Skipf("skip permission change test for sidecar bcuekt access check not enabled and skip-csi-bucket-access-check set")
+			e2eskipper.Skipf("skip permission change test for sidecar bucket access check not enabled and skip-csi-bucket-access-check set")
 		}
 		testCasePermissionChanges(specs.SkipCSIBucketAccessCheckPrefix)
 	})


### PR DESCRIPTION
Cherry pick of #1371 #1443 on release-1.22.

#1371: cleanup gcsfuse errofile before next NPV attempt
#1443: address stderrWrirter nil poinetr failure case

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

Backport approval for 1.35 : b/529494837#comment8
**Tested**
```
export REGISTRY=us-central1-docker.pkg.dev/snehaaradhey-gke-dev/csi-dev
export STAGINGVERSION=test-sidecar-cherrypick-errorfile-prow-gob-internal-boskos-1
make e2e-test E2E_TEST_USE_GKE_MANAGED_DRIVER=false    STAGINGVERSION=$STAGINGVERSION  REGISTRY=$REGISTRY

...

------------------------------
[ReportAfterSuite] PASSED [301.337 seconds]
[ReportAfterSuite] Autogenerated ReportAfterSuite for --junit-report
autogenerated by Ginkgo
------------------------------

Ran 347 of 481 Specs in 5593.070 seconds
SUCCESS! -- 347 Passed | 0 Failed | 0 Pending | 134 Skipped


Ginkgo ran 1 suite in 1h33m14.434984195s
Test Suite Passed


```

```release-note
Removes excessive logging caused by transient Node Publish Volume failures.
NONE
```