### PR TITLE
metrics: Extract jobset_name and remove pod_uid from metric labels

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -125,7 +125,10 @@ func (mm *manager) RegisterMetricsCollector(targetPath, podNamespace, podName, b
 
 	jobsetName := ""
 	if mm.clientset != nil {
-		if pod, err := mm.clientset.GetPod(podNamespace, podName); err == nil && pod != nil {
+		pod, err := mm.clientset.GetPod(podNamespace, podName)
+		if err != nil {
+			klog.V(4).Infof("Failed to get pod %s/%s for jobset_name label: %v", podNamespace, podName, err)
+		} else if pod != nil {
 			if val, ok := pod.Labels[JobSetNameLabel]; ok {
 				jobsetName = val
 			} else if val, ok := pod.Annotations[JobSetNameAnnotation]; ok {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -49,6 +49,9 @@ const (
 
 	metricsPath = "/metrics"
 	unixURL     = "http://unix/"
+
+	JobSetNameLabel      = "jobset.sigs.k8s.io/jobset-name"
+	JobSetNameAnnotation = "jobset.sigs.k8s.io/jobset-name"
 )
 
 type Manager interface {
@@ -120,13 +123,24 @@ func (mm *manager) RegisterMetricsCollector(targetPath, podNamespace, podName, b
 		return
 	}
 
+	jobsetName := ""
+	if mm.clientset != nil {
+		if pod, err := mm.clientset.GetPod(podNamespace, podName); err == nil && pod != nil {
+			if val, ok := pod.Labels[JobSetNameLabel]; ok {
+				jobsetName = val
+			} else if val, ok := pod.Annotations[JobSetNameAnnotation]; ok {
+				jobsetName = val
+			}
+		}
+	}
+
 	podUID, volumeName, _ := util.ParsePodIDVolumeFromTargetpath(targetPath)
 	c := NewMetricsCollector(socketBasePath, emptyDirBasePath, podNamespace, podName, podUID, volumeName, map[string]string{
 		"pod_name":       podName,
 		"namespace_name": podNamespace,
 		"volume_name":    volumeName,
 		"bucket_name":    bucketName,
-		"pod_uid":        "", // podUID is emptied to avoid infinite cardinality in the metric labels
+		"jobset_name":    jobsetName,
 	}, mm.clientset, mm.streamMetrics)
 
 	// Lock the number of registered collectors while we attempt to register a new collector.

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -27,6 +27,7 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func TestNewMetricsManager(t *testing.T) {
@@ -244,4 +245,27 @@ func BenchmarkEmitMetricFamily(b *testing.B) {
 	b.StopTimer()
 	close(ch)
 	<-done
+}
+
+func TestJobSetNameExtraction(t *testing.T) {
+	fakeClient := clientset.NewFakeClientset()
+	fakeClient.CreatePod(clientset.FakePodConfig{
+		Name:      "test-pod",
+		Namespace: "default",
+		PodStatus: &corev1.PodStatus{Phase: corev1.PodRunning},
+	})
+	if pod, err := fakeClient.GetPod("default", "test-pod"); err == nil && pod != nil {
+		pod.Labels = map[string]string{
+			JobSetNameLabel: "my-jobset",
+		}
+	}
+
+	targetPath := "/var/lib/kubelet/pods/d2013878-3d56-45f9-89ec-0826612c89b6/volumes/kubernetes.io~csi/test-volume/mount"
+	socketDir := t.TempDir()
+	m := NewMetricsManager(":9920", socketDir, 5, fakeClient, false).(*manager)
+	m.RegisterMetricsCollector(targetPath, "default", "test-pod", "test-bucket", "test-node")
+
+	if !m.volumePublishPathRegistered.Has(targetPath) {
+		t.Errorf("expected collector to be registered for targetPath")
+	}
 }

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -269,3 +269,53 @@ func TestJobSetNameExtraction(t *testing.T) {
 		t.Errorf("expected collector to be registered for targetPath")
 	}
 }
+
+func TestEmitMetricFamily_JobSetName(t *testing.T) {
+	name := "fs_ops_count"
+	help := "number of fs ops"
+	metricType := dto.MetricType_COUNTER
+	val := float64(10.0)
+
+	mf := &dto.MetricFamily{
+		Name: &name,
+		Help: &help,
+		Type: &metricType,
+		Metric: []*dto.Metric{
+			{
+				Counter: &dto.Counter{Value: &val},
+			},
+		},
+	}
+
+	c := &metricsCollector{
+		constLabels: map[string]string{
+			"jobset_name": "my-jobset-123",
+			"volume_name": "test-vol",
+			"bucket_name": "test-bucket",
+		},
+	}
+
+	ch := make(chan prometheus.Metric, 10)
+	c.emitMetricFamily(mf, ch)
+	close(ch)
+
+	metric := <-ch
+	var m dto.Metric
+	if err := metric.Write(&m); err != nil {
+		t.Fatalf("failed to write metric: %v", err)
+	}
+
+	foundJobSet := false
+	for _, l := range m.Label {
+		if l.GetName() == "jobset_name" {
+			foundJobSet = true
+			if l.GetValue() != "my-jobset-123" {
+				t.Errorf("expected jobset_name to be 'my-jobset-123', got %q", l.GetValue())
+			}
+		}
+	}
+
+	if !foundJobSet {
+		t.Errorf("expected jobset_name label in emitted metric, but none found")
+	}
+}


### PR DESCRIPTION
## Description
- Extract `jobset_name` from `pod.Labels` and `pod.Annotations` using key `jobset.sigs.k8s.io/jobset-name` and populate it in `constLabels` for scraped GCSFuse metrics.
- Remove `pod_uid` completely from `constLabels` to avoid infinite cardinality in metric labels for the new `gke.googleapis.com/GcsFuse` monitored resource.

## Link to Design Doc
https://docs.google.com/document/d/1Mtyg1NdjLkyhv3Je7sferZcCLExlUf3YA7xRzM1yDto/edit

## Testing
- Added `TestJobSetNameExtraction` in `pkg/metrics/metrics_test.go`.
- Ran unit tests: `go test -v -mod=readonly github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/metrics` (**PASS**).