### PR TITLE
Implement metrics collector register for shared mount.

### DIFF
--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -136,6 +136,10 @@ func (s *nodeServer) NodePublishVolumeForSharedMount(_ context.Context, req *csi
 	if len(mounterPodName) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "NodePublishVolume Mounter Pod Name must be provided")
 	}
+	args, err := parseRequestArguments(req.GetVolumeId(), req.GetReadonly(), req.GetVolumeCapability(), req.GetVolumeContext())
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
 
 	// Acquire a lock on the target path instead of volumeID, since we do not want to serialize multiple node publish calls on the same volume.
 	if acquired := s.volumeLocks.TryAcquire(targetPath); !acquired {
@@ -169,6 +173,19 @@ func (s *nodeServer) NodePublishVolumeForSharedMount(_ context.Context, req *csi
 		return nil, status.Error(code, err.Error())
 	}
 
+	// We ignore the pod UID parsed from the target path, since we register the mounter pod's UID instead.
+	_, volumeName, err := util.ParsePodIDVolumeFromTargetpath(targetPath)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to parse volume name from target path %q: %v", targetPath, err)
+	}
+	mounterPodUID := string(mounterPod.UID)
+
+	// Start monitoring goroutine for new mounts.
+	mounterPodImage, err := mounterPodImage(mounterPod)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to get image of mounter pod %s/%s: %v", mounterPodNamespace, mounterPodName, err)
+	}
+
 	// NodePublish is guaranteed to be called after NodeStage has waited for mounter pod to become running.
 	// Mounter pod not running at this stage means that the pod started and failed (e.g. killed by Kubelet
 	// during OOMKILL).
@@ -185,6 +202,30 @@ func (s *nodeServer) NodePublishVolumeForSharedMount(_ context.Context, req *csi
 		return nil, status.Errorf(codes.Internal, "staging path %s was not found mounted", stagingPath)
 	}
 
+	// Use staging path as the volume identifier because NodePublishVolumeForSharedMount is only
+	// called when the shared mount feature is being used. VolumeState stores the shared state of
+	// all bind-mounted target paths from the same staging path, and is used to idempotently start
+	// and re-start processes such as GCSFuse Kernel Params monitoring and metrics registration, which need to
+	// be re-invoked when the driver restarts, by leveraging the node re-publish capability.
+	startSharedMountProcesses := func() {
+		vs, _ := s.volumeStateStore.LoadOrStore(stagingPath, &util.VolumeState{
+			// Store the mounterPodUID and the volumeName, so that NodeUnstageVolume can call UnregisterMetricsCollector, since
+			// these fields aren't available during node unstaging. If the driver restarts, the VolumeState will no longer
+			// be in memory, so these fields will be lost, but the metrics collector will also not be running anymore, so we don't
+			// need to unregister it.
+			MounterPodUID: mounterPodUID,
+			VolumeName:    volumeName,
+		})
+
+		s.startGcsFuseKernelParamsMonitoring(stagingPath, emptyDirPath, mounterPodUID, volumeName, mounterPodImage, args.bucketName, vs)
+
+		if s.driver.config.MetricsManager != nil && !args.disableMetricsCollection {
+			klog.V(4).Infof("NodePublishVolume enabling metrics collector for staging path %q", stagingPath)
+			s.driver.config.MetricsManager.RegisterMetricsCollector(stagingPath, mounterPodNamespace, mounterPodName, args.bucketName, s.driver.config.NodeID, emptyDirPath, mounterPodUID, volumeName)
+		}
+		return
+	}
+
 	// Succeed if the target path was already mounted.
 	targetPathMounted, err := s.isDirMounted(targetPath)
 	if err != nil {
@@ -192,6 +233,7 @@ func (s *nodeServer) NodePublishVolumeForSharedMount(_ context.Context, req *csi
 	}
 	if targetPathMounted {
 		klog.Infof("NodePublishVolume succeeded on staging path %q to target path %q, mount already exists.", stagingPath, targetPath)
+		startSharedMountProcesses()
 		return &csi.NodePublishVolumeResponse{}, nil
 	}
 
@@ -213,8 +255,10 @@ func (s *nodeServer) NodePublishVolumeForSharedMount(_ context.Context, req *csi
 		return nil, status.Errorf(codes.Internal, "failed to bind mount staging path %q to target path %q: %v", stagingPath, targetPath, err)
 	}
 
+	startSharedMountProcesses()
 	return &csi.NodePublishVolumeResponse{}, nil
 }
+
 func (s *nodeServer) populateDriverFlagsForDefaulting(node *corev1.Node, mounterImage string, emptyDirBasePath string) error {
 	if node == nil {
 		return fmt.Errorf("node cannot be nil")
@@ -376,6 +420,14 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 
 	// Register metrics collector.
 	// It is idempotent to register the same collector in node republish calls.
+	podUID, volumeName, err := util.ParsePodIDVolumeFromTargetpath(targetPath)
+	if err != nil {
+		klog.Warningf("Failed to parse pod ID and volume name from target path %q: %v.", targetPath, err)
+	}
+	emptyDirBasePath, err := util.PrepareEmptyDir(targetPath, true)
+	if err != nil {
+		klog.Warningf("Failed to prepare empty dir from target path %q: %v.", targetPath, err)
+	}
 	if s.driver.config.MetricsManager != nil && !args.disableMetricsCollection {
 		gcsFuseVolumeCount, err := s.countGcsFuseVolumes(pod)
 
@@ -383,9 +435,9 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 			klog.Errorf("Metrics collection is disabled for Pod %s/%s as counting the number of GCS FUSE volumes failed with error: %v", pod.Namespace, pod.Name, err)
 		} else if gcsFuseVolumeCount > maxGCSFuseVolumesForMetrics {
 			klog.Warningf("Metrics collection is disabled for Pod %s/%s as the number of GCS FUSE volumes is %d, which is greater than the limit of %d.", pod.Namespace, pod.Name, gcsFuseVolumeCount, maxGCSFuseVolumesForMetrics)
-		} else {
+		} else if podUID != "" && volumeName != "" && emptyDirBasePath != "" {
 			klog.V(4).Infof("NodePublishVolume enabling metrics collector for target path %q", targetPath)
-			s.driver.config.MetricsManager.RegisterMetricsCollector(targetPath, pod.Namespace, pod.Name, args.bucketName, s.driver.config.NodeID)
+			s.driver.config.MetricsManager.RegisterMetricsCollector(targetPath, pod.Namespace, pod.Name, args.bucketName, s.driver.config.NodeID, emptyDirBasePath, podUID, volumeName)
 		}
 	}
 
@@ -395,19 +447,6 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 	if !isInitContainer {
 		if err := putExitFile(pod, targetPath); err != nil {
 			return nil, status.Error(codes.Internal, err.Error())
-		}
-	}
-
-	emptyDirBasePath, err := util.PrepareEmptyDir(targetPath, true)
-	if err != nil {
-		klog.Warningf("Failed to prepare empty dir from target path %q: %v", targetPath, err)
-	}
-
-	var podUID, volumeName string
-	if s.isGcsFuseKernelParamsFeatureSupported(gcsFuseSidecarImage, vs) {
-		var err error
-		if podUID, volumeName, err = util.ParsePodIDVolumeFromTargetpath(targetPath); err != nil {
-			klog.Warningf("Failed to parse pod ID and volume name from target path %q for kernel params monitor: %v. Monitor will not be started.", targetPath, err)
 		}
 	}
 
@@ -443,8 +482,8 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 		// TODO: Check if the socket listener timed out
 
 		// Restart monitoring goroutine if the driver restarts for existing mounts.
-		if emptyDirBasePath != "" {
-			s.startGcsFuseKernelParamsMonitoring(targetPath, emptyDirBasePath, podUID, volumeName, gcsFuseSidecarImage, vs)
+		if podUID != "" && volumeName != "" && emptyDirBasePath != "" {
+			s.startGcsFuseKernelParamsMonitoring(targetPath, emptyDirBasePath, podUID, volumeName, gcsFuseSidecarImage, args.bucketName, vs)
 		}
 
 		klog.V(4).Infof("NodePublishVolume succeeded on volume %q to target path %q, mount already exists.", args.bucketName, targetPath)
@@ -480,7 +519,7 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 	}
 
 	// Pass kernel params file flag to GCSFuse iff GCSFuse Kernel Params feature is supported.
-	if s.isGcsFuseKernelParamsFeatureSupported(gcsFuseSidecarImage, vs) {
+	if s.isGcsFuseKernelParamsFeatureSupported(gcsFuseSidecarImage, args.bucketName) {
 		// Note: enable-gcsfuse-kernel-params *must* be delimeted with an "=" sign, since it's an internal CSI flag.
 		args.fuseMountOptions = joinMountOptions(args.fuseMountOptions, []string{util.EnableGCSFuseKernelParams + "=true"})
 	}
@@ -499,8 +538,8 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 	}
 
 	// Start monitoring goroutine for new mounts.
-	if emptyDirBasePath != "" {
-		s.startGcsFuseKernelParamsMonitoring(targetPath, emptyDirBasePath, podUID, volumeName, gcsFuseSidecarImage, vs)
+	if podUID != "" && volumeName != "" && emptyDirBasePath != "" {
+		s.startGcsFuseKernelParamsMonitoring(targetPath, emptyDirBasePath, podUID, volumeName, gcsFuseSidecarImage, args.bucketName, vs)
 	}
 	klog.V(4).Infof("NodePublishVolume succeeded on volume %q to target path %q", args.bucketName, targetPath)
 
@@ -510,8 +549,8 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 // startGcsFuseKernelParamsMonitoring starts a single long lived goroutine to monitor the
 // GCSFuse kernel parameters file per mount point if the feature is enabled and supported.
 // It uses sync.Once to ensure the monitor is started only once.
-func (s *nodeServer) startGcsFuseKernelParamsMonitoring(mountPoint, emptyDirBasePath, podUID, volumeName, gcsFuseContainerImage string, vs *util.VolumeState) {
-	if s.isGcsFuseKernelParamsFeatureSupported(gcsFuseContainerImage, vs) {
+func (s *nodeServer) startGcsFuseKernelParamsMonitoring(mountPoint, emptyDirBasePath, podUID, volumeName, gcsFuseContainerImage, bucketName string, vs *util.VolumeState) {
+	if vs != nil && s.isGcsFuseKernelParamsFeatureSupported(gcsFuseContainerImage, bucketName) {
 		vs.GCSFuseKernelMonitorState.StartKernelParamsFileMonitorOnce.Do(func() {
 			ctx, cancel := context.WithCancel(context.Background())
 			vs.GCSFuseKernelMonitorState.CancelFunc = cancel
@@ -525,9 +564,9 @@ func (s *nodeServer) startGcsFuseKernelParamsMonitoring(mountPoint, emptyDirBase
 
 // isGcsFuseKernelParamsFeatureSupported returns true if the GCSFuse kernel parameters feature is enabled and supported by sidecar/mounter version.
 // GCSFuse Kernel Params feature is not applicable for dynamic mounts as a single kernel parameter setting doesn’t apply for different type
-// of buckets that a dynamic mount serves. This feature is only applicable for non-dynamic mounts i.e when volumeState(vs) is not nil.
-func (s *nodeServer) isGcsFuseKernelParamsFeatureSupported(gcsFuseContainerImage string, vs *util.VolumeState) bool {
-	return vs != nil &&
+// of buckets that a dynamic mount serves. This feature is only applicable for non-dynamic mounts.
+func (s *nodeServer) isGcsFuseKernelParamsFeatureSupported(gcsFuseContainerImage, bucketName string) bool {
+	return bucketName != "_" &&
 		s.driver.config.FeatureOptions != nil &&
 		s.driver.config.FeatureOptions.EnableGCSFuseKernelParams &&
 		s.driver.isSidecarVersionSupportedForGivenFeature(gcsFuseContainerImage, GCSFuseKernelParamsMinVersion)
@@ -546,10 +585,15 @@ func (s *nodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpub
 	}
 	defer s.volumeLocks.Release(targetPath)
 
-	// Unregister metrics collecter.
+	// Unregister metrics collector.
 	// It is idempotent to unregister the same collector.
 	if s.driver.config.MetricsManager != nil {
-		s.driver.config.MetricsManager.UnregisterMetricsCollector(targetPath, s.driver.config.NodeID)
+		podUID, volumeName, err := util.ParsePodIDVolumeFromTargetpath(targetPath)
+		if err != nil {
+			klog.Warningf("Failed to parse pod ID and volume name from target path %q: %v.", targetPath, err)
+		} else {
+			s.driver.config.MetricsManager.UnregisterMetricsCollector(targetPath, s.driver.config.NodeID, podUID, volumeName)
+		}
 	}
 
 	// Stop GCSFuse Kernel Params monitoring.
@@ -883,7 +927,6 @@ func (s *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolu
 	if !s.driver.sharedMount(req.GetVolumeContext()) {
 		return &csi.NodeStageVolumeResponse{}, nil
 	}
-
 	publishContext := req.GetPublishContext()
 	if publishContext == nil {
 		return nil, status.Error(codes.InvalidArgument, "publishContext must be provided")
@@ -999,16 +1042,6 @@ func (s *nodeServer) executeNodeStageVolume(ctx context.Context, req *csi.NodeSt
 	s.populateTokenAndBucketAccessCheckOptions(pod, podImage, vc, &args, podNamespace, pod.Spec.ServiceAccountName)
 	args.fuseMountOptions = s.appendAutoGoMemLimitOptions(podImage, args.fuseMountOptions)
 
-	// We initialize volumeState if bucket name is NOT "_", I.e. It's not a dynamic mount.
-	var vs *util.VolumeState
-	if args.bucketName != "_" {
-		var ok bool
-		if vs, ok = s.volumeStateStore.Load(stagingPath); !ok {
-			vs = &util.VolumeState{}
-			s.volumeStateStore.Store(stagingPath, vs)
-		}
-	}
-
 	podUID := string(pod.UID)
 	emptyDirBasePath := s.driver.config.FeatureOptions.SharedMountOptions.EmptyDirBasePath(podUID)
 
@@ -1017,16 +1050,14 @@ func (s *nodeServer) executeNodeStageVolume(ctx context.Context, req *csi.NodeSt
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to check if path %q is already mounted: %v", stagingPath, err)
 	}
-	if mounted {
-		// Restart monitoring goroutine if the driver restarts for existing mounts.
-		s.startGcsFuseKernelParamsMonitoring(stagingPath, emptyDirBasePath, podUID, pvName, podImage, vs)
 
+	if mounted {
 		klog.Infof("NodeStageVolume succeeded on staging path %q for volume %q, mount already exists.", stagingPath, req.GetVolumeId())
 		return &csi.NodeStageVolumeResponse{}, nil
 	}
 
 	// Pass kernel params file flag to GCSFuse iff GCSFuse Kernel Params feature is supported.
-	if s.isGcsFuseKernelParamsFeatureSupported(podImage, vs) {
+	if s.isGcsFuseKernelParamsFeatureSupported(podImage, args.bucketName) {
 		args.fuseMountOptions = joinMountOptions(args.fuseMountOptions, []string{util.EnableGCSFuseKernelParams + "=true"})
 	}
 
@@ -1063,9 +1094,6 @@ func (s *nodeServer) executeNodeStageVolume(ctx context.Context, req *csi.NodeSt
 		}
 		return nil, err
 	}
-
-	// Start monitoring goroutine for new shared mounts.
-	s.startGcsFuseKernelParamsMonitoring(stagingPath, emptyDirBasePath, podUID, pvName, podImage, vs)
 
 	klog.Infof("Mounter pod %s/%s is running and staging path %s is mounted", podNamespace, podName, stagingPath)
 
@@ -1152,6 +1180,25 @@ func (s *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstage
 	}
 	defer s.volumeLocks.Release(stagingPath)
 
+	// If the driver restarted after NodeStageVolume and before NodeUnstageVolume, and before the next node re-publish,
+	// VolumeStateStore will be nil, and UnregisterMetricsCollector and vs.GCSFuseKernelMonitorState.CancelFunc
+	// will not be invoked. This is acceptable, since this implies that the metrics collector process and the
+	// GCSFuse Kernel Params monitoring go routine are no longer running anymore, meaning they don't need to be stopped.
+	if vs, ok := s.volumeStateStore.Load(stagingPath); ok {
+		// Unregister metrics collector.
+		// It is idempotent to unregister the same collector.
+		if s.driver.config.MetricsManager != nil {
+			s.driver.config.MetricsManager.UnregisterMetricsCollector(stagingPath, s.driver.config.NodeID, vs.MounterPodUID, vs.VolumeName)
+		}
+
+		// Stop GCSFuse Kernel Params monitoring.
+		if vs.GCSFuseKernelMonitorState.CancelFunc != nil {
+			vs.GCSFuseKernelMonitorState.CancelFunc()
+		}
+
+		s.volumeStateStore.Delete(stagingPath)
+	}
+
 	if err := s.cleanupStagingPath(stagingPath); err != nil {
 		return nil, err
 	}
@@ -1161,14 +1208,6 @@ func (s *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstage
 }
 
 func (s *nodeServer) cleanupStagingPath(stagingPath string) error {
-	// Stop GCSFuse Kernel Params monitoring.
-	if vs, ok := s.volumeStateStore.Load(stagingPath); ok && vs != nil {
-		if vs.GCSFuseKernelMonitorState.CancelFunc != nil {
-			vs.GCSFuseKernelMonitorState.CancelFunc()
-		}
-		s.volumeStateStore.Delete(stagingPath)
-	}
-
 	// Unmount staging path.
 	mounted, err := s.isDirMounted(stagingPath)
 	if err != nil {

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -2266,10 +2266,11 @@ func TestNodePublishVolumeForSharedMount(t *testing.T) {
 			setupClient: func() *clientset.FakeClientset {
 				fc := clientset.NewFakeClientset()
 				fc.CreatePod(clientset.FakePodConfig{
-					Name:      podName,
-					Namespace: podNamespace,
-					UID:       podUID,
-					PodStatus: &corev1.PodStatus{Phase: corev1.PodRunning},
+					Name:         podName,
+					Namespace:    podNamespace,
+					UID:          podUID,
+					PodStatus:    &corev1.PodStatus{Phase: corev1.PodRunning},
+					IsMounterPod: true,
 				})
 				return fc
 			},
@@ -2497,10 +2498,11 @@ func TestNodePublishVolumeForSharedMount(t *testing.T) {
 			setupClient: func() *clientset.FakeClientset {
 				fc := clientset.NewFakeClientset()
 				fc.CreatePod(clientset.FakePodConfig{
-					Name:      podName,
-					Namespace: podNamespace,
-					UID:       podUID,
-					PodStatus: &corev1.PodStatus{Phase: corev1.PodRunning},
+					Name:         podName,
+					Namespace:    podNamespace,
+					UID:          podUID,
+					PodStatus:    &corev1.PodStatus{Phase: corev1.PodRunning},
+					IsMounterPod: true,
 				})
 				return fc
 			},
@@ -2528,10 +2530,11 @@ func TestNodePublishVolumeForSharedMount(t *testing.T) {
 			setupClient: func() *clientset.FakeClientset {
 				fc := clientset.NewFakeClientset()
 				fc.CreatePod(clientset.FakePodConfig{
-					Name:      podName,
-					Namespace: podNamespace,
-					UID:       podUID,
-					PodStatus: &corev1.PodStatus{Phase: corev1.PodRunning},
+					Name:         podName,
+					Namespace:    podNamespace,
+					UID:          podUID,
+					PodStatus:    &corev1.PodStatus{Phase: corev1.PodRunning},
+					IsMounterPod: true,
 				})
 				return fc
 			},
@@ -2560,10 +2563,11 @@ func TestNodePublishVolumeForSharedMount(t *testing.T) {
 			setupClient: func() *clientset.FakeClientset {
 				fc := clientset.NewFakeClientset()
 				fc.CreatePod(clientset.FakePodConfig{
-					Name:      podName,
-					Namespace: podNamespace,
-					UID:       podUID,
-					PodStatus: &corev1.PodStatus{Phase: corev1.PodRunning},
+					Name:         podName,
+					Namespace:    podNamespace,
+					UID:          podUID,
+					PodStatus:    &corev1.PodStatus{Phase: corev1.PodRunning},
+					IsMounterPod: true,
 				})
 				return fc
 			},

--- a/pkg/csi_mounter/csi_mounter.go
+++ b/pkg/csi_mounter/csi_mounter.go
@@ -256,7 +256,11 @@ func (m *Mounter) createSocket(target string, logPrefix string) (net.Listener, e
 	// Need to create symbolic link of emptyDirBasePath to socketBasePath,
 	// because the socket absolute path is longer than 104 characters,
 	// which will cause "bind: invalid argument" errors.
-	socketBasePath := util.GetSocketBasePath(target, m.fuseSocketDir)
+	podUID, volumeName, err := util.ParsePodIDVolumeFromTargetpath(target)
+	if err != nil {
+		klog.Warningf("Failed to parse pod ID and volume name from target path %q: %v.", target, err)
+	}
+	socketBasePath := util.GetSocketBasePath(podUID, volumeName, m.fuseSocketDir)
 	if err := os.Symlink(emptyDirBasePath, socketBasePath); err != nil && !os.IsExist(err) {
 		return nil, fmt.Errorf("failed to create symbolic link to path %q: %w", socketBasePath, err)
 	}
@@ -322,7 +326,11 @@ func (m *Mounter) createSocket(target string, logPrefix string) (net.Listener, e
 }
 
 func (m *Mounter) cleanupSocket(target string) {
-	socketBasePath := util.GetSocketBasePath(target, m.fuseSocketDir)
+	podUID, volumeName, err := util.ParsePodIDVolumeFromTargetpath(target)
+	if err != nil {
+		klog.Warningf("Failed to parse pod ID and volume name from target path %q: %v.", target, err)
+	}
+	socketBasePath := util.GetSocketBasePath(podUID, volumeName, m.fuseSocketDir)
 	socketPath := filepath.Join(socketBasePath, socketName)
 	if err := syscall.Unlink(socketPath); err != nil {
 		if !os.IsNotExist(err) {

--- a/pkg/metrics/fake.go
+++ b/pkg/metrics/fake.go
@@ -36,17 +36,17 @@ func NewFakeMetricsManager() *FakeMetricsManager {
 func (*FakeMetricsManager) InitializeHTTPHandler() {}
 
 // RegisterMetricsCollector records the registration of a metrics collector.
-func (f *FakeMetricsManager) RegisterMetricsCollector(targetPath, _, _, bucketName, nodeName string) {
+func (f *FakeMetricsManager) RegisterMetricsCollector(mountPath, _, _, bucketName, nodeName, _, _, _ string) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.collectors[targetPath] = bucketName
+	f.collectors[mountPath] = bucketName
 }
 
 // UnregisterMetricsCollector records the unregistration of a metrics collector.
-func (f *FakeMetricsManager) UnregisterMetricsCollector(targetPath, nodeName string) {
+func (f *FakeMetricsManager) UnregisterMetricsCollector(mountPath, nodeName, _, _ string) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	delete(f.collectors, targetPath)
+	delete(f.collectors, mountPath)
 }
 
 // GetCollectors returns the map of registered collectors.

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -53,8 +53,8 @@ const (
 
 type Manager interface {
 	InitializeHTTPHandler()
-	RegisterMetricsCollector(targetPath, podNamespace, podName, bucketName, nodeName string)
-	UnregisterMetricsCollector(targetPath, nodeName string)
+	RegisterMetricsCollector(mountPath, podNamespace, podName, bucketName, nodeName, emptyDirBasePath, podUID, volumeName string)
+	UnregisterMetricsCollector(mountPath, nodeName, podUID, volumeName string)
 }
 
 type manager struct {
@@ -64,21 +64,21 @@ type manager struct {
 	clientset       clientset.Interface
 	streamMetrics   bool
 
-	maximumNumberOfCollectors   int
-	volumePublishPathRegistered sets.Set[string]
-	mutex                       sync.Mutex
+	maximumNumberOfCollectors int
+	volumeMountPathRegistered sets.Set[string]
+	mutex                     sync.Mutex
 }
 
 func NewMetricsManager(metricsEndpoint, fuseSocketDir string, maximumNumberOfCollectors int, clientset clientset.Interface, streamMetrics bool) Manager {
 	mm := &manager{
-		registry:                    prometheus.NewRegistry(),
-		metricsEndpoint:             metricsEndpoint,
-		fuseSocketDir:               fuseSocketDir,
-		clientset:                   clientset,
-		streamMetrics:               streamMetrics,
-		volumePublishPathRegistered: sets.Set[string]{},
-		maximumNumberOfCollectors:   maximumNumberOfCollectors,
-		mutex:                       sync.Mutex{},
+		registry:                  prometheus.NewRegistry(),
+		metricsEndpoint:           metricsEndpoint,
+		fuseSocketDir:             fuseSocketDir,
+		clientset:                 clientset,
+		streamMetrics:             streamMetrics,
+		volumeMountPathRegistered: sets.Set[string]{},
+		maximumNumberOfCollectors: maximumNumberOfCollectors,
+		mutex:                     sync.Mutex{},
 	}
 
 	return mm
@@ -107,20 +107,13 @@ func (mm *manager) InitializeHTTPHandler() {
 }
 
 // RegisterMetricsCollector registers the metrics collector. It is idempotent to register the same collector.
-func (mm *manager) RegisterMetricsCollector(targetPath, podNamespace, podName, bucketName, nodeName string) {
-	emptyDirBasePath, err := util.PrepareEmptyDir(targetPath, false)
-	if err != nil {
-		klog.Errorf("failed to register metrics collector for target path %q, bucket %q: %v", targetPath, bucketName, err)
-		return
-	}
-
-	socketBasePath := util.GetSocketBasePath(targetPath, mm.fuseSocketDir)
+func (mm *manager) RegisterMetricsCollector(mountPath, podNamespace, podName, bucketName, nodeName, emptyDirBasePath, podUID, volumeName string) {
+	socketBasePath := util.GetSocketBasePath(podUID, volumeName, mm.fuseSocketDir)
 	if err := os.Symlink(emptyDirBasePath, socketBasePath); err != nil && !os.IsExist(err) {
 		klog.Errorf("failed to create symbolic link to path %q: %v", socketBasePath, err)
 		return
 	}
 
-	podUID, volumeName, _ := util.ParsePodIDVolumeFromTargetpath(targetPath)
 	c := NewMetricsCollector(socketBasePath, emptyDirBasePath, podNamespace, podName, podUID, volumeName, map[string]string{
 		"pod_name":       podName,
 		"namespace_name": podNamespace,
@@ -134,7 +127,7 @@ func (mm *manager) RegisterMetricsCollector(targetPath, podNamespace, podName, b
 	defer mm.mutex.Unlock()
 
 	if mm.maximumNumberOfCollectors == 0 {
-		klog.Infof("could not register metrics collector for target path %q. The metrics collector limit for node %q is set to zero.", targetPath, nodeName)
+		klog.Infof("could not register metrics collector for mount path %q. The metrics collector limit for node %q is set to zero.", mountPath, nodeName)
 		return
 	}
 
@@ -144,32 +137,30 @@ func (mm *manager) RegisterMetricsCollector(targetPath, podNamespace, podName, b
 	if mm.maximumNumberOfCollectors > 0 {
 		// If volume is already registered, do not register again. This flow can get triggered
 		//  since CSI driver has republishVolume capability.
-		if mm.volumePublishPathRegistered.Has(targetPath) {
+		if mm.volumeMountPathRegistered.Has(mountPath) {
 			return
 		}
 		// If collector hasn't been registered and there's no space left, log a warning.
-		if mm.volumePublishPathRegistered.Len() >= mm.maximumNumberOfCollectors {
-			klog.V(4).Infof("could not register a metrics collector for target path %q. There's already %d collectors registered on node %q.", targetPath, mm.volumePublishPathRegistered.Len(), nodeName)
+		if mm.volumeMountPathRegistered.Len() >= mm.maximumNumberOfCollectors {
+			klog.V(4).Infof("could not register a metrics collector for mount path %q. There's already %d collectors registered on node %q.", mountPath, mm.volumeMountPathRegistered.Len(), nodeName)
 			return
 		}
 	}
 
 	// Attempt to register new metrics collector and record success.
-	err = mm.registry.Register(c)
+	err := mm.registry.Register(c)
 	if err != nil {
 		if !strings.Contains(err.Error(), prometheus.AlreadyRegisteredError{}.Error()) {
-			klog.Errorf("failed to register metrics collector for target path %q, bucket %q: %v", targetPath, bucketName, err)
+			klog.Errorf("failed to register metrics collector for mount path %q, bucket %q: %v", mountPath, bucketName, err)
 		}
 	} else {
-		mm.volumePublishPathRegistered.Insert(targetPath)
-		klog.Infof("successfully registered a new metrics collector for target path %q. There's %d collectors registered on node %q.", targetPath, mm.volumePublishPathRegistered.Len(), nodeName)
+		mm.volumeMountPathRegistered.Insert(mountPath)
+		klog.Infof("successfully registered a new metrics collector for mount path %q. There's %d collectors registered on node %q.", mountPath, mm.volumeMountPathRegistered.Len(), nodeName)
 	}
 }
 
 // UnregisterMetricsCollector unregisters the metrics collector. It is idempotent to unregister the same collector.
-func (mm *manager) UnregisterMetricsCollector(targetPath, nodeName string) {
-	podUID, volumeName, _ := util.ParsePodIDVolumeFromTargetpath(targetPath)
-
+func (mm *manager) UnregisterMetricsCollector(mountPath, nodeName, podUID, volumeName string) {
 	// metricsCollector uses a hash of pod UID and volume name as an identifier.
 	c := NewMetricsCollector("", "", "", "", podUID, volumeName, nil, nil, mm.streamMetrics)
 
@@ -178,10 +169,10 @@ func (mm *manager) UnregisterMetricsCollector(targetPath, nodeName string) {
 	defer mm.mutex.Unlock()
 
 	if ok := mm.registry.Unregister(c); !ok {
-		klog.Infof("Unregister metrics collector for target path %q is not needed since the collector is not registered.", targetPath)
+		klog.Infof("Unregister metrics collector for mount path %q is not needed since the collector is not registered.", mountPath)
 	} else {
-		mm.volumePublishPathRegistered.Delete(targetPath)
-		klog.Infof("successfully unregistered a metrics collector for target path %q. There's %d collectors registered on node %q.", targetPath, mm.volumePublishPathRegistered.Len(), nodeName)
+		mm.volumeMountPathRegistered.Delete(mountPath)
+		klog.Infof("successfully unregistered a metrics collector for mount path %q. There's %d collectors registered on node %q.", mountPath, mm.volumeMountPathRegistered.Len(), nodeName)
 	}
 }
 

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -19,6 +19,8 @@ package metrics
 import (
 	"fmt"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -70,11 +72,79 @@ func TestNewMetricsManager(t *testing.T) {
 			if manager.registry == nil {
 				t.Errorf("NewMetricsManager did not initialize registry")
 			}
-			if manager.volumePublishPathRegistered == nil {
-				t.Errorf("NewMetricsManager did not initialize volumePublishPathRegistered")
+			if manager.volumeMountPathRegistered == nil {
+				t.Errorf("NewMetricsManager did not initialize volumeMountPathRegistered")
 			}
 		}
 	})
+}
+
+func TestRegisterUnregisterMetricsCollector(t *testing.T) {
+	tempDir := t.TempDir()
+	fuseSocketDir := filepath.Join(tempDir, "sockets")
+	emptyDirBasePath := filepath.Join(tempDir, "emptyDir")
+
+	// Pre-create sockets directory as the symlink is created inside it.
+	if err := os.MkdirAll(fuseSocketDir, 0755); err != nil {
+		t.Fatalf("failed to create fuseSocketDir: %v", err)
+	}
+	if err := os.MkdirAll(emptyDirBasePath, 0755); err != nil {
+		t.Fatalf("failed to create emptyDirBasePath: %v", err)
+	}
+
+	clientset := clientset.NewFakeClientset()
+	mm := NewMetricsManager(":9920", fuseSocketDir, 5, clientset, false).(*manager)
+
+	mountPath := "/mnt/test-volume"
+	podNamespace := "default"
+	podName := "test-pod"
+	bucketName := "test-bucket"
+	nodeName := "test-node"
+	podUID := "test-pod-uid-123"
+	volumeName := "test-volume-abc"
+
+	// 1. Test Registration
+	mm.RegisterMetricsCollector(mountPath, podNamespace, podName, bucketName, nodeName, emptyDirBasePath, podUID, volumeName)
+
+	if !mm.volumeMountPathRegistered.Has(mountPath) {
+		t.Errorf("expected mountPath %q to be registered in volumeMountPathRegistered", mountPath)
+	}
+
+	// Verify collector is actually in the Prometheus registry by trying to register a dummy with same descriptors
+	cDummy := NewMetricsCollector("", "", "", "", podUID, volumeName, nil, nil, false)
+	err := mm.registry.Register(cDummy)
+	if err == nil {
+		t.Errorf("expected duplicate registration to fail, but it succeeded")
+		mm.registry.Unregister(cDummy) // Clean up
+	} else if !strings.Contains(err.Error(), prometheus.AlreadyRegisteredError{}.Error()) {
+		t.Errorf("expected AlreadyRegisteredError, but got: %v", err)
+	}
+
+	// 2. Test Unregistration with incorrect identifiers
+	mm.UnregisterMetricsCollector(mountPath, nodeName, "wrong-uid", "wrong-volume")
+	if !mm.volumeMountPathRegistered.Has(mountPath) {
+		t.Errorf("expected mountPath %q to still be registered after incorrect unregistration identifiers", mountPath)
+	}
+
+	// 3. Test Unregistration with empty identifiers
+	mm.UnregisterMetricsCollector(mountPath, nodeName, "", "")
+	if !mm.volumeMountPathRegistered.Has(mountPath) {
+		t.Errorf("expected mountPath %q to still be registered after empty unregistration identifiers", mountPath)
+	}
+
+	// 4. Test Unregistration with correct identifiers
+	mm.UnregisterMetricsCollector(mountPath, nodeName, podUID, volumeName)
+	if mm.volumeMountPathRegistered.Has(mountPath) {
+		t.Errorf("expected mountPath %q to be unregistered from volumeMountPathRegistered", mountPath)
+	}
+
+	// Verify that the collector is no longer in the registry by attempting to register again
+	err = mm.registry.Register(cDummy)
+	if err != nil {
+		t.Errorf("expected registration of collector to succeed after unregistration, but failed: %v", err)
+	} else {
+		mm.registry.Unregister(cDummy) // Clean up
+	}
 }
 
 func TestPrometheusCounters(t *testing.T) {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -213,17 +213,15 @@ func sha1Hash(str string) string {
 }
 
 // GetSocketBasePath constructs the base path for a Unix domain socket.
-// It takes the target path and the directory where Fuse sockets are stored as input.
-func GetSocketBasePath(targetPath, fuseSocketDir string) string {
-	podID, volumeName, _ := ParsePodIDVolumeFromTargetpath(targetPath)
-
+// It takes the podUID, volumeName, and the directory where Fuse sockets are stored as input.
+func GetSocketBasePath(podUID, volumeName, fuseSocketDir string) string {
 	// We hash the combined pod ID and volume name because Unix domain socket paths
 	// have a length limitation (often around 104 characters). Directly using potentially
 	// long pod IDs and volume names could easily violate this limit. SHA1 provides a
 	// fixed-length, short representation (40 hexadecimal characters) that ensures
 	// we stay within these constraints while still providing a unique identifier
 	// based on the pod and volume.
-	return filepath.Join(fuseSocketDir, sha1Hash(podID+"_"+volumeName))
+	return filepath.Join(fuseSocketDir, sha1Hash(podUID+"_"+volumeName))
 }
 
 func CheckAndDeleteStaleFile(dirPath, fileName string) error {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -359,24 +359,19 @@ func TestGetSocketBasePath(t *testing.T) {
 	fuseSocketDir := "/tmp/fuse-sockets"
 
 	testCases := []struct {
-		targetPath   string
 		expectedBase string
-		parseError   bool
+		podUID       string
+		volumeName   string
 	}{
 		{
-			targetPath:   "/var/lib/kubelet/pods/pod-xyz123/volumes/kubernetes.io~csi/pvc-abc456/mount",
+			podUID:       "pod-xyz123",
+			volumeName:   "pvc-abc456",
 			expectedBase: filepath.Join(fuseSocketDir, fmt.Sprintf("%x", sha1.Sum([]byte("pod-xyz123_pvc-abc456")))),
-			parseError:   false,
 		},
 		{
-			targetPath:   "/var/lib/kubelet/pods/pod-def789/volumes/kubernetes.io~csi/data-uvw012/mount",
+			podUID:       "pod-def789",
+			volumeName:   "data-uvw012",
 			expectedBase: filepath.Join(fuseSocketDir, fmt.Sprintf("%x", sha1.Sum([]byte("pod-def789_data-uvw012")))),
-			parseError:   false,
-		},
-		{
-			targetPath:   "/invalid/path",
-			expectedBase: "",
-			parseError:   true,
 		},
 	}
 
@@ -388,17 +383,9 @@ func TestGetSocketBasePath(t *testing.T) {
 	defer os.RemoveAll(fuseSocketDir) // Clean up after the test
 
 	for _, tc := range testCases {
-		actualBase := GetSocketBasePath(tc.targetPath, fuseSocketDir)
-
-		if tc.parseError {
-			podID, volumeName, err := ParsePodIDVolumeFromTargetpath(tc.targetPath)
-			if err == nil {
-				t.Errorf("GetSocketBasePath(%q, %q) expected ParsePodIDVolumeFromTargetpath to return an error, but got podID: %q, volumeName: %q", tc.targetPath, fuseSocketDir, podID, volumeName)
-			}
-		} else {
-			if actualBase != tc.expectedBase {
-				t.Errorf("GetSocketBasePath(%q, %q) = %q, expected %q", tc.targetPath, fuseSocketDir, actualBase, tc.expectedBase)
-			}
+		actualBase := GetSocketBasePath(tc.podUID, tc.volumeName, fuseSocketDir)
+		if actualBase != tc.expectedBase {
+			t.Errorf("GetSocketBasePath(%q, %q, %q) = %q, expected %q", tc.podUID, tc.volumeName, fuseSocketDir, actualBase, tc.expectedBase)
 		}
 	}
 }

--- a/pkg/util/volume_state_store_lock.go
+++ b/pkg/util/volume_state_store_lock.go
@@ -32,6 +32,8 @@ type VolumeStateStore struct {
 type VolumeState struct {
 	BucketAccessCheckPassed   bool
 	GCSFuseKernelMonitorState GCSFuseKernelParamsMonitor
+	VolumeName                string
+	MounterPodUID             string
 }
 
 // GCSFuseKernelParamsMonitor holds the state for a goroutine that monitors the GCSFuse kernel parameters file.
@@ -68,6 +70,17 @@ func (vss *VolumeStateStore) Load(volumeID string) (*VolumeState, bool) {
 	}
 
 	return nil, false
+}
+
+// LoadOrStore returns the existing value for the key if present.
+// Otherwise, it stores and returns the given value.
+// The loaded result is true if the value was loaded, false if stored.
+func (vss *VolumeStateStore) LoadOrStore(volumeID string, state *VolumeState) (*VolumeState, bool) {
+	actual, loaded := vss.store.LoadOrStore(volumeID, state)
+	if !loaded {
+		atomic.AddInt32(&vss.size, 1)
+	}
+	return actual.(*VolumeState), loaded
 }
 
 // Delete removes a volume from the store.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**: This PR handles registration of metrics collector during NodePublishVolumeWithSharedMount, and deregistration during NodeUnstageVolume. The PR also refactors `RegisterMetricsCollector` so it accepts a generic mount path, and allows passing `podUID`, `emptyDirBasePath`, and `volumeName` as parameters, breaking the dependency on the targetPath.

The registration is added during NodePublishVolume to ensure that if the driver restarts while the volume is already mounted, the next time that node re-publish is called, it gets registered again. 

The unregistration is performed during NodeStageVolume to ensure that all of the dependent workloads have already been unmounted and no longer require the metrics collector.

The same rationale is applicable to the GCSFuse Kernel Params Monitoring feature, so it is also moved with the same pattern.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```