### PR TITLE
[Shared Mount] Implement Cloud Profiler

### DIFF
--- a/cmd/sidecar_mounter/main.go
+++ b/cmd/sidecar_mounter/main.go
@@ -26,14 +26,11 @@ import (
 	"os/signal"
 	"path/filepath"
 	"strconv"
-	"sync"
 	"syscall"
 	"time"
 
-	"cloud.google.com/go/profiler"
 	driver "github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/csi_driver"
 	sidecarmounter "github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/sidecar_mounter"
-	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/webhook"
 	"k8s.io/klog/v2"
 )
@@ -116,7 +113,6 @@ func main() {
 	if err != nil {
 		klog.Fatalf("failed to read defaulting-flag file: %v", err)
 	}
-	var startProfilerOnce sync.Once
 	for _, sp := range socketPaths {
 		klog.V(4).Infof("in sidecar mounter, found socket path %s", sp)
 		// sleep 1.5 seconds before launch the next gcsfuse to avoid
@@ -127,23 +123,7 @@ func main() {
 		if mc != nil {
 			mc.EnsureErrWriter()
 			if mc.EnableCloudProfilerForSidecar {
-				serviceVersion := util.GetCloudProfilerServiceVersion(mc.PodName, mc.PodUID)
-				if serviceVersion == "" {
-					klog.Warning("Cloud Profiler is disabled because both PodName and PodUID are empty.")
-				} else {
-					// Use sync.Once to ensure Cloud Profiler only start once per process.
-					startProfilerOnce.Do(func() {
-						cfg := profiler.Config{
-							Service:        "gke-gcsfuse-sidecar",
-							ServiceVersion: serviceVersion,
-						}
-						if err := profiler.Start(cfg); err != nil {
-							klog.Errorf("Errored while starting cloud profiler, got %v", err)
-						} else {
-							klog.Infof("Running cloud profiler on %s with version %s", cfg.Service, cfg.ServiceVersion)
-						}
-					})
-				}
+				sidecarmounter.StartCloudProfiler(webhook.GcsFuseSidecarName, mc.PodName, mc.PodUID)
 			}
 			if mc.EnableSidecarBucketAccessCheck {
 				mc.SidecarRetryConfig.Cap = *storageServiceAndBucketAccessCap

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -338,15 +338,7 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 	}
 
 	s.populateTokenAndBucketAccessCheckOptions(pod, gcsFuseSidecarImage, vc, &args, vc[VolumeContextKeyPodNamespace], vc[VolumeContextKeyServiceAccountName])
-
-	if args.enableCloudProfilerForSidecar && s.driver.isSidecarVersionSupportedForGivenFeature(gcsFuseSidecarImage, SidecarCloudProfilerMinVersion) {
-		args.fuseMountOptions = joinMountOptions(args.fuseMountOptions, []string{
-			util.EnableCloudProfilerForSidecarConst + "=" + strconv.FormatBool(args.enableCloudProfilerForSidecar),
-			util.PodNameConst + "=" + vc[VolumeContextKeyPodName],
-			util.PodUIDConst + "=" + string(pod.UID),
-		})
-	}
-
+	args.fuseMountOptions = s.appendCloudProfilerOptions(gcsFuseSidecarImage, args.enableCloudProfilerForSidecar, vc[VolumeContextKeyPodName], string(pod.UID), args.fuseMountOptions)
 	args.fuseMountOptions = s.appendAutoGoMemLimitOptions(gcsFuseSidecarImage, args.fuseMountOptions)
 
 	node, err := s.k8sClients.GetNode(s.driver.config.NodeID)
@@ -768,6 +760,27 @@ func (s *nodeServer) populateTokenAndBucketAccessCheckOptions(pod *corev1.Pod, i
 	}
 }
 
+// appendCloudProfilerOptions evaluates and appends enable-cloud-profiler-for-sidecar, pod-name, and pod-uid
+// mount options if enabled in driver options and supported by the container image.
+func (s *nodeServer) appendCloudProfilerOptions(mounterImage string, enableCloudProfiler bool, podName string, podUID string, mountOptions []string) []string {
+	if !enableCloudProfiler || !s.driver.isSidecarVersionSupportedForGivenFeature(mounterImage, SidecarCloudProfilerMinVersion) {
+		return mountOptions
+	}
+	if podName == "" {
+		klog.Warning("Pod name is empty, skipping cloud profiler mount options")
+		return mountOptions
+	}
+	if podUID == "" {
+		klog.Warning("Pod UID is empty, skipping cloud profiler mount options")
+		return mountOptions
+	}
+	return joinMountOptions(mountOptions, []string{
+		util.EnableCloudProfilerForSidecarConst + "=true",
+		util.PodNameConst + "=" + podName,
+		util.PodUIDConst + "=" + podUID,
+	})
+}
+
 // appendAutoGoMemLimitOptions evaluates and appends enable-auto-gomemlimit and auto-gomemlimit-ratio
 // mount options if supported by the container image and enabled in driver options, unless explicitly overridden.
 func (s *nodeServer) appendAutoGoMemLimitOptions(mounterImage string, mountOptions []string) []string {
@@ -1002,6 +1015,7 @@ func (s *nodeServer) executeNodeStageVolume(ctx context.Context, req *csi.NodeSt
 	}
 
 	s.populateTokenAndBucketAccessCheckOptions(pod, podImage, vc, &args, podNamespace, pod.Spec.ServiceAccountName)
+	args.fuseMountOptions = s.appendCloudProfilerOptions(podImage, args.enableCloudProfilerForSidecar, podName, string(pod.UID), args.fuseMountOptions)
 	args.fuseMountOptions = s.appendAutoGoMemLimitOptions(podImage, args.fuseMountOptions)
 
 	// We initialize volumeState if bucket name is NOT "_", I.e. It's not a dynamic mount.

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -1273,6 +1273,28 @@ func TestNodeStageVolume(t *testing.T) {
 				MountOptions: []string{"log-severity=trace"},
 			},
 		},
+		{
+			name: "valid request with sharedMount true and cloud profiler enabled",
+			req: &csi.NodeStageVolumeRequest{
+				VolumeId:          testVolumeID,
+				StagingTargetPath: stagingPath,
+				VolumeCapability:  testVolumeCapability,
+				VolumeContext: map[string]string{
+					VolumeContextSharedNodeMount:               "true",
+					util.VolumeContextKeyPVName:                testVolumeID,
+					VolumeContextEnableCloudProfilerForSidecar: "true",
+				},
+				PublishContext: map[string]string{
+					PublishContextKeyMounterPodName:      createMounterPodName("test-node", testVolumeID),
+					PublishContextKeyMounterPodNamespace: "test-ns",
+				},
+			},
+			expectedMountOptions: []string{
+				util.EnableCloudProfilerForSidecarConst + "=true",
+				util.PodNameConst + "=" + createMounterPodName("test-node", testVolumeID),
+				util.PodUIDConst + "=" + createMounterPodName("test-node", testVolumeID),
+			},
+		},
 	}
 
 	for _, test := range cases {
@@ -3163,6 +3185,84 @@ func TestNodeStageVolumeWILabelCheck(t *testing.T) {
 				if vs.GCSFuseKernelMonitorState.CancelFunc != nil {
 					vs.GCSFuseKernelMonitorState.CancelFunc()
 				}
+			}
+		})
+	}
+}
+
+func TestAppendCloudProfilerOptions(t *testing.T) {
+	t.Parallel()
+	fakeMounter := mount.NewFakeMounter([]mount.MountPoint{})
+	driver := initTestDriver(t, fakeMounter, clientset.NewFakeClientset())
+	ns := newNodeServer(driver, fakeMounter).(*nodeServer)
+
+	testCases := []struct {
+		name                string
+		mounterImage        string
+		enableCloudProfiler bool
+		podName             string
+		podUID              string
+		mountOptions        []string
+		expectedOptions     []string
+	}{
+		{
+			name:                "podName is empty - should return options unchanged",
+			mounterImage:        "gke.gcr.io/gcs-fuse-csi-driver-sidecar-mounter:v1.23.7-gke.0",
+			enableCloudProfiler: true,
+			podName:             "",
+			podUID:              "test-uid",
+			mountOptions:        []string{"debug_gcs", "ro"},
+			expectedOptions:     []string{"debug_gcs", "ro"},
+		},
+		{
+			name:                "podUID is empty - should return options unchanged",
+			mounterImage:        "gke.gcr.io/gcs-fuse-csi-driver-sidecar-mounter:v1.23.7-gke.0",
+			enableCloudProfiler: true,
+			podName:             "test-pod",
+			podUID:              "",
+			mountOptions:        []string{"debug_gcs", "ro"},
+			expectedOptions:     []string{"debug_gcs", "ro"},
+		},
+		{
+			name:                "enableCloudProfiler is false - should return options unchanged",
+			mounterImage:        "gke.gcr.io/gcs-fuse-csi-driver-sidecar-mounter:v1.23.7-gke.0",
+			enableCloudProfiler: false,
+			podName:             "test-pod",
+			podUID:              "test-uid",
+			mountOptions:        []string{"debug_gcs", "ro"},
+			expectedOptions:     []string{"debug_gcs", "ro"},
+		},
+		{
+			name:                "unsupported sidecar version - should return options unchanged",
+			mounterImage:        "gke.gcr.io/gcs-fuse-csi-driver-sidecar-mounter:v1.23.6-gke.0",
+			enableCloudProfiler: true,
+			podName:             "test-pod",
+			podUID:              "test-uid",
+			mountOptions:        []string{"debug_gcs", "ro"},
+			expectedOptions:     []string{"debug_gcs", "ro"},
+		},
+		{
+			name:                "valid inputs and supported sidecar - should append cloud profiler options",
+			mounterImage:        "gke.gcr.io/gcs-fuse-csi-driver-sidecar-mounter:v1.23.7-gke.0",
+			enableCloudProfiler: true,
+			podName:             "test-pod",
+			podUID:              "test-uid",
+			mountOptions:        []string{"debug_gcs", "ro"},
+			expectedOptions: []string{
+				"debug_gcs",
+				util.EnableCloudProfilerForSidecarConst + "=true",
+				util.PodNameConst + "=test-pod",
+				util.PodUIDConst + "=test-uid",
+				"ro",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ns.appendCloudProfilerOptions(tc.mounterImage, tc.enableCloudProfiler, tc.podName, tc.podUID, tc.mountOptions)
+			if !reflect.DeepEqual(got, tc.expectedOptions) {
+				t.Errorf("appendCloudProfilerOptions() = %v, want %v", got, tc.expectedOptions)
 			}
 		})
 	}

--- a/pkg/sidecar_mounter/mounter_server.go
+++ b/pkg/sidecar_mounter/mounter_server.go
@@ -83,7 +83,6 @@ func (ms *MounterServer) Mount(ctx context.Context, req *mounter.MountRequest) (
 	mergeFlags(mc.ConfigFileFlagMap, flagsFromDriver)
 
 	// TODO(FUECHR) SetupTokenAndStorageManager for bucket access check.
-	// TODO(FUECHR) Implement cloud profiler hook.
 	// TODO(FUECHR) Clean errors in preparation for mount.
 
 	if err := mc.prepareConfigFile(); err != nil {
@@ -91,6 +90,10 @@ func (ms *MounterServer) Mount(ctx context.Context, req *mounter.MountRequest) (
 	}
 
 	klog.Infof("Start mounting bucket %q to %q for volume %q", mc.BucketName, mc.SharedMountPoint, mc.VolumeName)
+
+	if mc.EnableCloudProfilerForSidecar {
+		StartCloudProfiler(util.MounterPodNamePrefix, mc.PodName, mc.PodUID)
+	}
 
 	// Use the mounter servers long running ctx to prevent the one from NodeStageVolume from killing the gcsfuse process.
 	if err := ms.mounter.MountToNode(ctx, ms.serverCtx, &mc); err != nil {

--- a/pkg/sidecar_mounter/sidecar_mounter_config.go
+++ b/pkg/sidecar_mounter/sidecar_mounter_config.go
@@ -26,9 +26,11 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
+	"cloud.google.com/go/profiler"
 	driver "github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/csi_driver"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/webhook"
@@ -103,7 +105,10 @@ type sidecarRetryConfig struct {
 	Jitter   float64
 }
 
-var prometheusPort = 62990
+var (
+	prometheusPort    = 62990
+	startProfilerOnce sync.Once
+)
 
 // DisallowedFlags is a map of flags that are disallowed to be passed to sidecar mounter directly.
 // They are mapped to their config file style representation so that they can be passed in config file format
@@ -486,4 +491,25 @@ func (mc *MountConfig) prepareConfigFile() error {
 	klog.Infof("gcsfuse config file content: %v", configMap)
 
 	return os.WriteFile(mc.ConfigFile, yamlData, 0o400)
+}
+
+// StartCloudProfiler starts the Google Cloud Profiler.
+// It uses sync.Once to ensure the profiler is started at most once per process.
+func StartCloudProfiler(serviceName string, podName string, podUID string) {
+	if podName == "" || podUID == "" {
+		klog.Warningf("Cloud Profiler is disabled because PodName (%q) or PodUID (%q) is empty.", podName, podUID)
+		return
+	}
+	serviceVersion := util.GetCloudProfilerServiceVersion(podName, podUID)
+	startProfilerOnce.Do(func() {
+		cfg := profiler.Config{
+			Service:        serviceName,
+			ServiceVersion: serviceVersion,
+		}
+		if err := profiler.Start(cfg); err != nil {
+			klog.Errorf("Errored while starting cloud profiler, got %v", err)
+		} else {
+			klog.Infof("Running cloud profiler on %s with version %s", cfg.Service, cfg.ServiceVersion)
+		}
+	})
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -555,6 +555,39 @@ func TestIsGKEIdentityProvider(t *testing.T) {
 	}
 }
 
+func TestGetCloudProfilerServiceVersion(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name                   string
+		podName                string
+		podUID                 string
+		expectedServiceVersion string
+	}{
+		{
+			name:                   "both empty",
+			podName:                "",
+			podUID:                 "",
+			expectedServiceVersion: "",
+		},
+		{
+			name:                   "short pod name and standard uid",
+			podName:                "test-pod",
+			podUID:                 "12345678-1234-1234-1234-123456789012",
+			expectedServiceVersion: "test-pod_12345678-1234-1234-1234-123456789012",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := GetCloudProfilerServiceVersion(tc.podName, tc.podUID)
+			if got != tc.expectedServiceVersion {
+				t.Errorf("GetCloudProfilerServiceVersion(%q, %q) = %q (len %d), want %q (len %d)", tc.podName, tc.podUID, got, len(got), tc.expectedServiceVersion, len(tc.expectedServiceVersion))
+			}
+		})
+	}
+}
+
 func TestCheckNotSymlink(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:
This pr enabled cloud profiler for mounter pod by adding the following
    - Passes pod uid and pod name to the gcsfuse mount args to allow gcsfuse to use cloud profiler.
    - Enabled cloud profiler on the sidecar during mount operation (part of NSV)
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```