### PR TITLE
Validate Workload Identity node label in NodeStageVolume for shared m…

### DIFF
--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -354,13 +354,8 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 		return nil, status.Errorf(codes.NotFound, "failed to get node: %v", err)
 	}
 
-	if s.driver.config.WINodeLabelCheck {
-		val, ok := node.Labels[clientset.GkeMetaDataServerKey]
-		// If Workload Identity is not enabled, the key should be missing; the check for "val == false" is just for extra caution
-		isWorkloadIdentityDisabled := val != "true" || !ok
-		if isWorkloadIdentityDisabled && !pod.Spec.HostNetwork {
-			return nil, status.Errorf(codes.FailedPrecondition, "Workload Identity Federation is not enabled on node. Please make sure this is enabled on both cluster and node pool level (https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity)")
-		}
+	if err := s.checkWINodeLabel(node, pod.Spec.HostNetwork); err != nil {
+		return nil, err
 	}
 
 	// Since the webhook mutating ordering is not definitive,
@@ -452,7 +447,7 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 		return &csi.NodePublishVolumeResponse{}, nil
 	}
 
-	// Only pass mountOptions flags for defaulting if sidecar container is managed and satisfies min version requirement
+	// Only pass mountOptions flags for defaulting if mounter pod container is managed and satisfies min version requirement
 	if emptyDirBasePath != "" {
 		if err := s.populateDriverFlagsForDefaulting(node, gcsFuseSidecarImage, filepath.Dir(emptyDirBasePath)); err != nil {
 			return nil, status.Error(codes.Internal, err.Error())
@@ -927,7 +922,6 @@ func (s *nodeServer) executeNodeStageVolume(ctx context.Context, req *csi.NodeSt
 		return nil, status.Errorf(codes.Internal, "shared mount options are not fully configured")
 	}
 
-	clientset := s.driver.config.K8sClients
 	stagingPath := req.GetStagingTargetPath()
 
 	// Validate staging path and mounter pod information from the request.
@@ -938,7 +932,7 @@ func (s *nodeServer) executeNodeStageVolume(ctx context.Context, req *csi.NodeSt
 	klog.Infof("Executing NodeStageVolume. Mounter pod: %s/%s, node: %q, volume: %q, staging path: %q", podNamespace, podName, s.driver.config.NodeID, req.GetVolumeId(), stagingPath)
 
 	// Verify mounter pod exists.
-	pod, err := clientset.GetPod(podNamespace, podName)
+	pod, err := s.k8sClients.GetPod(podNamespace, podName)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, status.Errorf(codes.FailedPrecondition, "mounter pod %s/%s expected to exist but was not found", podNamespace, podName)
@@ -947,6 +941,17 @@ func (s *nodeServer) executeNodeStageVolume(ctx context.Context, req *csi.NodeSt
 	}
 	if pod == nil {
 		return nil, status.Errorf(codes.Internal, "mounter pod %s/%s can't be nil", podNamespace, podName)
+	}
+
+	node, err := s.k8sClients.GetNode(s.driver.config.NodeID)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, status.Errorf(codes.NotFound, "failed to get node: %v", err)
+		}
+		return nil, status.Errorf(codes.Internal, "failed to get node: %v", err)
+	}
+	if err := s.checkWINodeLabel(node, pod.Spec.HostNetwork); err != nil {
+		return nil, err
 	}
 
 	volumeID := req.GetVolumeId()
@@ -1030,28 +1035,22 @@ func (s *nodeServer) executeNodeStageVolume(ctx context.Context, req *csi.NodeSt
 		args.fuseMountOptions = joinMountOptions(args.fuseMountOptions, []string{util.EnableGCSFuseKernelParams + "=true"})
 	}
 
+	disallowedFlags := s.driver.generateDisallowedFlagsMap(podImage)
+	args.fuseMountOptions = removeDisallowedMountOptions(args.fuseMountOptions, disallowedFlags)
+
 	// Make the staging path.
 	klog.Infof("NodeStageVolume attempting mkdir for staging path %q", stagingPath)
 	if err := os.MkdirAll(stagingPath, 0750); err != nil {
 		return nil, status.Errorf(codes.Internal, "mkdir failed for path %q: %v", stagingPath, err)
 	}
 
-	// Fetch the node to pass its labels for auto-config
-	node, err := s.k8sClients.GetNode(s.driver.config.NodeID)
-	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
-	}
-	if node == nil {
-		return nil, status.Errorf(codes.Internal, "Node %q not found", s.driver.config.NodeID)
-	}
-
-	// Only pass mountOptions flags for defaulting if sidecar container is managed and satisfies min version requirement
+	// Only pass mountOptions flags for defaulting if mounter pod container is managed and satisfies min version requirement
 	if err := s.populateDriverFlagsForDefaulting(node, podImage, emptyDirBasePath); err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
 	// Wait for the mounter pod grpc server to be ready.
-	if err := waitForMounterServer(ctx, clientset, podNamespace, podName, podUID, s.driver.config.FeatureOptions.SharedMountOptions.EmptyDirBasePath); err != nil {
+	if err := waitForMounterServer(ctx, s.k8sClients, podNamespace, podName, podUID, s.driver.config.FeatureOptions.SharedMountOptions.EmptyDirBasePath); err != nil {
 		return nil, err
 	}
 
@@ -1186,6 +1185,24 @@ func (s *nodeServer) cleanupStagingPath(stagingPath string) error {
 	// Cleanup the mount point.
 	if err := mount.CleanupMountPoint(stagingPath, s.mounter, false /* bind mount */); err != nil {
 		return status.Errorf(codes.Internal, "failed to cleanup the mount point %q: %v", stagingPath, err)
+	}
+
+	return nil
+}
+
+func (s *nodeServer) checkWINodeLabel(node *corev1.Node, isHostNetwork bool) error {
+	if node == nil {
+		return status.Errorf(codes.Internal, "Node %q not found", s.driver.config.NodeID)
+	}
+	if !s.driver.config.WINodeLabelCheck {
+		return nil
+	}
+
+	val, ok := node.Labels[clientset.GkeMetaDataServerKey]
+	// If Workload Identity is not enabled, the key should be missing; the check for "val == false" is just for extra caution
+	isWorkloadIdentityDisabled := val != "true" || !ok
+	if isWorkloadIdentityDisabled && !isHostNetwork {
+		return status.Errorf(codes.FailedPrecondition, "Workload Identity Federation is not enabled on node. Please make sure this is enabled on both cluster and node pool level (https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity)")
 	}
 
 	return nil

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -206,6 +206,49 @@ func createErrorFile(t *testing.T, emptyDirPath, content string) {
 	}
 }
 
+func setupSharedMountOptions(t *testing.T, podUID types.UID) (*SharedMountOptions, *fakeMounterServer) {
+	t.Helper()
+	tmpDir, err := os.MkdirTemp("/tmp", "s_nsv")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(tmpDir) })
+
+	socketDir := filepath.Join(tmpDir, "s")
+	emptyDirBasePath := filepath.Join(tmpDir, "e")
+	sockFile := filepath.Join(emptyDirBasePath, string(podUID), MounterPodSocketFile)
+
+	mounterServer := startFakeMounterServer(t, sockFile)
+
+	return &SharedMountOptions{
+		Enabled:       true,
+		FuseSocketDir: socketDir,
+		EmptyDirBasePath: func(podUID string) string {
+			return filepath.Join(emptyDirBasePath, podUID)
+		},
+	}, mounterServer
+}
+
+func newTestNodeStageVolumeRequest(stagingPath, podName, podNamespace string, extraVolContext map[string]string) *csi.NodeStageVolumeRequest {
+	volContext := map[string]string{
+		VolumeContextSharedNodeMount: "true",
+		util.VolumeContextKeyPVName:  testVolumeID,
+	}
+	for k, v := range extraVolContext {
+		volContext[k] = v
+	}
+	return &csi.NodeStageVolumeRequest{
+		VolumeId:          testVolumeID,
+		StagingTargetPath: stagingPath,
+		VolumeCapability:  testVolumeCapability,
+		VolumeContext:     volContext,
+		PublishContext: map[string]string{
+			PublishContextKeyMounterPodName:      podName,
+			PublishContextKeyMounterPodNamespace: podNamespace,
+		},
+	}
+}
+
 func TestNodePublishVolume(t *testing.T) {
 	testTargetPath, cleanup := setupTestTargetPath(t)
 	defer cleanup()
@@ -2718,16 +2761,7 @@ func TestNodeStageVolumeEnableAutoGoMemLimit(t *testing.T) {
 			testStagingPath, cleanupStaging := setupTestStagingPath(t)
 			defer cleanupStaging()
 
-			tmpDir, err := os.MkdirTemp("/tmp", "s")
-			if err != nil {
-				t.Fatalf("failed to create temp dir: %v", err)
-			}
-			t.Cleanup(func() { os.RemoveAll(tmpDir) })
-			socketDir := filepath.Join(tmpDir, "s")
-			emptyDirBasePath := filepath.Join(tmpDir, "e")
-
-			sockFile := filepath.Join(emptyDirBasePath, string(podUID), MounterPodSocketFile)
-			mounterServer := startFakeMounterServer(t, sockFile)
+			sharedMountOptions, mounterServer := setupSharedMountOptions(t, podUID)
 
 			fc := clientset.NewFakeClientset()
 			fc.CreatePod(clientset.FakePodConfig{
@@ -2752,34 +2786,15 @@ func TestNodeStageVolumeEnableAutoGoMemLimit(t *testing.T) {
 				AutoGoMemLimitRatio:  tc.autoGoMemLimitRatio,
 			}
 			ns.driver.config.AssumeGoodSidecarVersion = tc.assumeGoodSidecarVersion
-			ns.driver.config.FeatureOptions.SharedMountOptions = &SharedMountOptions{
-				Enabled:       true,
-				FuseSocketDir: socketDir,
-				EmptyDirBasePath: func(podUID string) string {
-					return filepath.Join(emptyDirBasePath, podUID)
-				},
-			}
+			ns.driver.config.FeatureOptions.SharedMountOptions = sharedMountOptions
 
-			vc := map[string]string{
-				VolumeContextSharedNodeMount: "true",
-				util.VolumeContextKeyPVName:  volID,
-			}
+			var extraVC map[string]string
 			if tc.userMountOptions != "" {
-				vc[VolumeContextKeyMountOptions] = tc.userMountOptions
+				extraVC = map[string]string{VolumeContextKeyMountOptions: tc.userMountOptions}
 			}
+			stageReq := newTestNodeStageVolumeRequest(testStagingPath, podName, podNamespace, extraVC)
 
-			stageReq := &csi.NodeStageVolumeRequest{
-				VolumeId:          volID,
-				StagingTargetPath: testStagingPath,
-				VolumeCapability:  testVolumeCapability,
-				VolumeContext:     vc,
-				PublishContext: map[string]string{
-					PublishContextKeyMounterPodName:      podName,
-					PublishContextKeyMounterPodNamespace: podNamespace,
-				},
-			}
-
-			_, err = ns.NodeStageVolume(context.Background(), stageReq)
+			_, err := ns.NodeStageVolume(context.Background(), stageReq)
 			if err != nil {
 				t.Fatalf("NodeStageVolume failed: %v", err)
 			}
@@ -2844,17 +2859,7 @@ func TestNodeStageVolumeEnableGCSFuseKernelParams(t *testing.T) {
 			testStagingPath, cleanupStaging := setupTestStagingPath(t)
 			defer cleanupStaging()
 
-			// Use a short base dir to avoid hitting the 108-character limit for Unix domain sockets.
-			tmpDir, err := os.MkdirTemp("/tmp", "s")
-			if err != nil {
-				t.Fatalf("failed to create temp dir: %v", err)
-			}
-			t.Cleanup(func() { os.RemoveAll(tmpDir) })
-			socketDir := filepath.Join(tmpDir, "s")
-			emptyDirBasePath := filepath.Join(tmpDir, "e")
-
-			sockFile := filepath.Join(emptyDirBasePath, string(podUID), MounterPodSocketFile)
-			mounterServer := startFakeMounterServer(t, sockFile)
+			sharedMountOptions, mounterServer := setupSharedMountOptions(t, podUID)
 
 			fc := clientset.NewFakeClientset()
 			fc.CreatePod(clientset.FakePodConfig{
@@ -2876,29 +2881,11 @@ func TestNodeStageVolumeEnableGCSFuseKernelParams(t *testing.T) {
 
 			ns.driver.config.FeatureOptions.EnableGCSFuseKernelParams = tc.enableKernelParamsFileFlag
 			ns.driver.config.AssumeGoodSidecarVersion = tc.assumeGoodSidecarVersion
-			ns.driver.config.FeatureOptions.SharedMountOptions = &SharedMountOptions{
-				Enabled:       true,
-				FuseSocketDir: socketDir,
-				EmptyDirBasePath: func(podUID string) string {
-					return filepath.Join(emptyDirBasePath, podUID)
-				},
-			}
+			ns.driver.config.FeatureOptions.SharedMountOptions = sharedMountOptions
 
-			stageReq := &csi.NodeStageVolumeRequest{
-				VolumeId:          volID,
-				StagingTargetPath: testStagingPath,
-				VolumeCapability:  testVolumeCapability,
-				VolumeContext: map[string]string{
-					VolumeContextSharedNodeMount: "true",
-					util.VolumeContextKeyPVName:  volID,
-				},
-				PublishContext: map[string]string{
-					PublishContextKeyMounterPodName:      podName,
-					PublishContextKeyMounterPodNamespace: podNamespace,
-				},
-			}
+			stageReq := newTestNodeStageVolumeRequest(testStagingPath, podName, podNamespace, nil)
 
-			_, err = ns.NodeStageVolume(context.Background(), stageReq)
+			_, err := ns.NodeStageVolume(context.Background(), stageReq)
 			if err != nil {
 				t.Fatalf("NodeStageVolume failed: %v", err)
 			}
@@ -2953,16 +2940,7 @@ func TestNodeStageVolumeHostNetwork(t *testing.T) {
 			testStagingPath, cleanupStaging := setupTestStagingPath(t)
 			defer cleanupStaging()
 
-			tmpDir, err := os.MkdirTemp("/tmp", "s_hnw")
-			if err != nil {
-				t.Fatalf("failed to create temp dir: %v", err)
-			}
-			t.Cleanup(func() { os.RemoveAll(tmpDir) })
-			socketDir := filepath.Join(tmpDir, "s")
-			emptyDirBasePath := filepath.Join(tmpDir, "e")
-
-			sockFile := filepath.Join(emptyDirBasePath, string(podUID), MounterPodSocketFile)
-			mounterServer := startFakeMounterServer(t, sockFile)
+			sharedMountOptions, mounterServer := setupSharedMountOptions(t, podUID)
 
 			fc := clientset.NewFakeClientset()
 			fc.CreatePod(clientset.FakePodConfig{
@@ -2987,35 +2965,15 @@ func TestNodeStageVolumeHostNetwork(t *testing.T) {
 			ns.mounter = fakeMounter
 
 			ns.driver.config.AssumeGoodSidecarVersion = true
-			ns.driver.config.FeatureOptions.SharedMountOptions = &SharedMountOptions{
-				Enabled:       true,
-				FuseSocketDir: socketDir,
-				EmptyDirBasePath: func(podUID string) string {
-					return filepath.Join(emptyDirBasePath, podUID)
-				},
-			}
+			ns.driver.config.FeatureOptions.SharedMountOptions = sharedMountOptions
 
-			volContext := map[string]string{
-				VolumeContextSharedNodeMount:      "true",
-				VolumeContextKeyHostNetworkPodKSA: "true",
-				util.VolumeContextKeyPVName:       volID,
-			}
+			extraVC := map[string]string{VolumeContextKeyHostNetworkPodKSA: "true"}
 			if tc.userSpecifiedIDP != "" {
-				volContext[VolumeContextKeyIdentityProvider] = tc.userSpecifiedIDP
+				extraVC[VolumeContextKeyIdentityProvider] = tc.userSpecifiedIDP
 			}
+			stageReq := newTestNodeStageVolumeRequest(testStagingPath, podName, podNamespace, extraVC)
 
-			stageReq := &csi.NodeStageVolumeRequest{
-				VolumeId:          volID,
-				StagingTargetPath: testStagingPath,
-				VolumeCapability:  testVolumeCapability,
-				VolumeContext:     volContext,
-				PublishContext: map[string]string{
-					PublishContextKeyMounterPodName:      podName,
-					PublishContextKeyMounterPodNamespace: podNamespace,
-				},
-			}
-
-			_, err = ns.NodeStageVolume(context.Background(), stageReq)
+			_, err := ns.NodeStageVolume(context.Background(), stageReq)
 			if err != nil {
 				t.Fatalf("NodeStageVolume failed: %v", err)
 			}
@@ -3078,16 +3036,7 @@ func TestNodeStageVolumeMachineTypeDefaulting(t *testing.T) {
 			testStagingPath, cleanupStaging := setupTestStagingPath(t)
 			defer cleanupStaging()
 
-			tmpDir, err := os.MkdirTemp("/tmp", "s")
-			if err != nil {
-				t.Fatalf("failed to create temp dir: %v", err)
-			}
-			t.Cleanup(func() { os.RemoveAll(tmpDir) })
-			socketDir := filepath.Join(tmpDir, "s")
-			emptyDirBaseRoot := filepath.Join(tmpDir, "e")
-
-			sockFile := filepath.Join(emptyDirBaseRoot, string(podUID), MounterPodSocketFile)
-			_ = startFakeMounterServer(t, sockFile)
+			sharedMountOptions, _ := setupSharedMountOptions(t, podUID)
 
 			fc := clientset.NewFakeClientset()
 			fc.CreatePod(clientset.FakePodConfig{
@@ -3106,29 +3055,11 @@ func TestNodeStageVolumeMachineTypeDefaulting(t *testing.T) {
 			ns.mounter = mount.NewFakeMounter([]mount.MountPoint{})
 			ns.driver.config.AssumeGoodSidecarVersion = tc.assumeGoodSidecarVersion
 			ns.driver.config.DisableAutoconfig = tc.disableAutoconfig
-			ns.driver.config.FeatureOptions.SharedMountOptions = &SharedMountOptions{
-				Enabled:       true,
-				FuseSocketDir: socketDir,
-				EmptyDirBasePath: func(uid string) string {
-					return filepath.Join(emptyDirBaseRoot, uid)
-				},
-			}
+			ns.driver.config.FeatureOptions.SharedMountOptions = sharedMountOptions
 
-			stageReq := &csi.NodeStageVolumeRequest{
-				VolumeId:          volID,
-				StagingTargetPath: testStagingPath,
-				VolumeCapability:  testVolumeCapability,
-				VolumeContext: map[string]string{
-					VolumeContextSharedNodeMount: "true",
-					util.VolumeContextKeyPVName:  volID,
-				},
-				PublishContext: map[string]string{
-					PublishContextKeyMounterPodName:      podName,
-					PublishContextKeyMounterPodNamespace: podNamespace,
-				},
-			}
+			stageReq := newTestNodeStageVolumeRequest(testStagingPath, podName, podNamespace, nil)
 
-			_, err = ns.NodeStageVolume(context.Background(), stageReq)
+			_, err := ns.NodeStageVolume(context.Background(), stageReq)
 			if err != nil {
 				t.Fatalf("NodeStageVolume failed: %v", err)
 			}
@@ -3140,7 +3071,7 @@ func TestNodeStageVolumeMachineTypeDefaulting(t *testing.T) {
 				}
 			}()
 
-			emptyDirPath := ns.driver.config.FeatureOptions.SharedMountOptions.EmptyDirBasePath(string(podUID))
+			emptyDirPath := sharedMountOptions.EmptyDirBasePath(string(podUID))
 			flagFilePath := filepath.Join(emptyDirPath, FlagFileForDefaultingPath)
 			content, readErr := os.ReadFile(flagFilePath)
 
@@ -3158,6 +3089,79 @@ func TestNodeStageVolumeMachineTypeDefaulting(t *testing.T) {
 			} else {
 				if readErr == nil {
 					t.Errorf("expected no flags-for-defaulting file to be written, but found one with content: %q", string(content))
+				}
+			}
+		})
+	}
+}
+
+func TestNodeStageVolumeWILabelCheck(t *testing.T) {
+	t.Parallel()
+
+	testStagingPath, cleanup := setupTestStagingPath(t)
+	defer cleanup()
+
+	nodeID := "test-node"
+	volID := testVolumeID
+	podNamespace := "test-ns"
+	podName := createMounterPodName(nodeID, volID)
+	podUID := types.UID(podName)
+
+	sharedMountOptions, _ := setupSharedMountOptions(t, podUID)
+
+	req := newTestNodeStageVolumeRequest(testStagingPath, podName, podNamespace, nil)
+
+	cases := []struct {
+		name                          string
+		wiNodeLabelCheck              bool
+		workloadIdentityEnabledOnNode bool
+		expectErr                     error
+	}{
+		{
+			name:                          "WI node label check is disabled, WI is disabled on node, should succeed",
+			wiNodeLabelCheck:              false,
+			workloadIdentityEnabledOnNode: false,
+		},
+		{
+			name:                          "WI node label check is enabled, WI is disabled on node, should fail",
+			wiNodeLabelCheck:              true,
+			workloadIdentityEnabledOnNode: false,
+			expectErr:                     status.Errorf(codes.FailedPrecondition, "Workload Identity Federation is not enabled on node. Please make sure this is enabled on both cluster and node pool level (https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity)"),
+		},
+		{
+			name:                          "WI node label check is enabled, WI is enabled on node, should succeed",
+			wiNodeLabelCheck:              true,
+			workloadIdentityEnabledOnNode: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeClientSet := &clientset.FakeClientset{}
+			fakeClientSet.CreateNode(clientset.FakeNodeConfig{IsWorkloadIdentityEnabled: tc.workloadIdentityEnabledOnNode})
+			fakeClientSet.CreatePod(clientset.FakePodConfig{
+				Name:         podName,
+				Namespace:    podNamespace,
+				UID:          podUID,
+				PodStatus:    &corev1.PodStatus{Phase: corev1.PodRunning},
+				IsMounterPod: true,
+			})
+			testEnv := initTestNodeServerWithCustomClientset(t, fakeClientSet, tc.wiNodeLabelCheck)
+			ns, ok := testEnv.ns.(*nodeServer)
+			if !ok {
+				t.Fatalf("Failed to cast NodeServer to *nodeServer")
+			}
+			ns.driver.config.FeatureOptions.SharedMountOptions = sharedMountOptions
+
+			_, err := testEnv.ns.NodeStageVolume(context.TODO(), req)
+			if tc.expectErr == nil && err != nil {
+				t.Errorf("got error %q, expected error nil", err)
+			}
+			if tc.expectErr != nil && !errors.Is(err, tc.expectErr) {
+				t.Errorf("got error %q, expected error %q", err, tc.expectErr)
+			}
+			if vs, ok := ns.volumeStateStore.Load(testStagingPath); ok && vs != nil {
+				if vs.GCSFuseKernelMonitorState.CancelFunc != nil {
+					vs.GCSFuseKernelMonitorState.CancelFunc()
 				}
 			}
 		})


### PR DESCRIPTION
…ount

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:

This PR refactors Workload Identity validation into a reusable helper method to align `NodeStageVolume` behavior with standard sidecar `NodePublishVolume` mode.
* WI Node Label Check: Extracted `checkWINodeLabel` helper method in node.go and used it in NSV to align with sidecar NPV's Workload Identity node label verification.
* Disallowed Flag Filtering: Added `removeDisallowedMountOptions` step in NSV to align with sidecar NPV's disallowed flag filtering behavior.
* Unit Test Helper Methods: Extracted helper methods (`setupSharedMountOptions` and `newTestNodeStageVolumeRequest`) in node_test.go to simplify NSV test cases set up.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```