### PR TITLE
[Shared Mount] Pass default mount options

### DIFF
--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -1105,8 +1105,13 @@ func (s *nodeServer) executeNodeStageVolume(ctx context.Context, req *csi.NodeSt
 		return nil, err
 	}
 
+	// Prepare mount options specifically for shared node mount architecture before sending to mounter pod.
+	preparedMountOptions := prepareSharedNodeMountOptions(args.fuseMountOptions)
+
+	// TODO(FUECHR): Pass read_ahead_kb and node_fuse_max_request_limit_kb to gcsfuse config correctly for shared node mounts.
+
 	// Send GRPC to mounter pod to start GCSFuse.
-	if err := s.mountToNode(ctx, podUID, stagingPath, volumeID, args.fuseMountOptions); err != nil {
+	if err := s.mountToNode(ctx, podUID, stagingPath, volumeID, preparedMountOptions); err != nil {
 		klog.Errorf("Failed to mount volume %q to staging path %q: %v", volumeID, stagingPath, err)
 		if code, err := checkMounterPodErrorFile(emptyDirBasePath); err != nil {
 			return nil, status.Error(code, err.Error())

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -1066,6 +1066,8 @@ func TestNodeStageVolume(t *testing.T) {
 
 	fakeServer := startFakeMounterServer(t, validSocketFile)
 
+	defaultSharedOpts := []string{"o=allow_other,default_permissions"}
+
 	cases := []struct {
 		name                 string
 		req                  *csi.NodeStageVolumeRequest
@@ -1244,14 +1246,14 @@ func TestNodeStageVolume(t *testing.T) {
 				},
 			},
 			profilesEnabled: true,
-			expectedMountOptions: []string{
+			expectedMountOptions: append([]string{
 				"implicit-dirs",
 				"file-cache:max-size-mb:1",
 				"file-cache:cache-file-for-range-read:true",
 				"log-severity=trace",
 				"metadata-cache:stat-cache-max-size-mb:34",
 				"file-cache-medium=ram",
-			},
+			}, defaultSharedOpts...),
 			pvConfig: &clientset.FakePVConfig{
 				Name:         testVolumeID,
 				VolumeHandle: testVolumeID,
@@ -1289,11 +1291,11 @@ func TestNodeStageVolume(t *testing.T) {
 					PublishContextKeyMounterPodNamespace: "test-ns",
 				},
 			},
-			expectedMountOptions: []string{
+			expectedMountOptions: append([]string{
 				util.EnableCloudProfilerForSidecarConst + "=true",
 				util.PodNameConst + "=" + createMounterPodName("test-node", testVolumeID),
 				util.PodUIDConst + "=" + createMounterPodName("test-node", testVolumeID),
-			},
+			}, defaultSharedOpts...),
 		},
 	}
 
@@ -2639,6 +2641,116 @@ func TestNodePublishVolumeForSharedMount(t *testing.T) {
 			targetPathMounted: false,
 			expectErrCode:     codes.OK,
 			expectedBindOpts:  []string{"bind", "ro"},
+		},
+		{
+			name: "target path not mounted - ro in mountOptions does not override pod spec readOnly false",
+			reqBuilder: func(t *testing.T, targetPath, stagingPath string) *csi.NodePublishVolumeRequest {
+				return &csi.NodePublishVolumeRequest{
+					VolumeId:          testVolumeID,
+					VolumeCapability:  testVolumeCapability,
+					TargetPath:        targetPath,
+					StagingTargetPath: stagingPath,
+					Readonly:          false,
+					VolumeContext: map[string]string{
+						VolumeContextSharedNodeMount: "true",
+						VolumeContextKeyMountOptions: "ro,implicit-dirs",
+					},
+					PublishContext: map[string]string{
+						PublishContextKeyMounterPodName:      podName,
+						PublishContextKeyMounterPodNamespace: podNamespace,
+					},
+				}
+			},
+			setupClient: func() *clientset.FakeClientset {
+				fc := clientset.NewFakeClientset()
+				fc.CreatePod(clientset.FakePodConfig{
+					Name:         podName,
+					Namespace:    podNamespace,
+					UID:          podUID,
+					PodStatus:    &corev1.PodStatus{Phase: corev1.PodRunning},
+					IsMounterPod: true,
+				})
+				return fc
+			},
+			targetPathMounted: false,
+			expectErrCode:     codes.OK,
+			expectedBindOpts:  []string{"bind"},
+		},
+		{
+			name: "target path not mounted - mount option rw does not override pod spec readOnly true",
+			reqBuilder: func(t *testing.T, targetPath, stagingPath string) *csi.NodePublishVolumeRequest {
+				return &csi.NodePublishVolumeRequest{
+					VolumeId:          testVolumeID,
+					VolumeCapability:  testVolumeCapability,
+					TargetPath:        targetPath,
+					StagingTargetPath: stagingPath,
+					Readonly:          true,
+					VolumeContext: map[string]string{
+						VolumeContextSharedNodeMount: "true",
+						VolumeContextKeyMountOptions: "rw,implicit-dirs",
+					},
+					PublishContext: map[string]string{
+						PublishContextKeyMounterPodName:      podName,
+						PublishContextKeyMounterPodNamespace: podNamespace,
+					},
+				}
+			},
+			setupClient: func() *clientset.FakeClientset {
+				fc := clientset.NewFakeClientset()
+				fc.CreatePod(clientset.FakePodConfig{
+					Name:         podName,
+					Namespace:    podNamespace,
+					UID:          podUID,
+					PodStatus:    &corev1.PodStatus{Phase: corev1.PodRunning},
+					IsMounterPod: true,
+				})
+				return fc
+			},
+			targetPathMounted: false,
+			expectErrCode:     codes.OK,
+			expectedBindOpts:  []string{"bind", "ro"},
+		},
+		{
+			name: "target path not mounted - ro in volumeCapability mountFlags does not override pod spec readOnly false",
+			reqBuilder: func(t *testing.T, targetPath, stagingPath string) *csi.NodePublishVolumeRequest {
+				return &csi.NodePublishVolumeRequest{
+					VolumeId: testVolumeID,
+					VolumeCapability: &csi.VolumeCapability{
+						AccessType: &csi.VolumeCapability_Mount{
+							Mount: &csi.VolumeCapability_MountVolume{
+								MountFlags: []string{"ro"},
+							},
+						},
+						AccessMode: &csi.VolumeCapability_AccessMode{
+							Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
+						},
+					},
+					TargetPath:        targetPath,
+					StagingTargetPath: stagingPath,
+					Readonly:          false,
+					VolumeContext: map[string]string{
+						VolumeContextSharedNodeMount: "true",
+					},
+					PublishContext: map[string]string{
+						PublishContextKeyMounterPodName:      podName,
+						PublishContextKeyMounterPodNamespace: podNamespace,
+					},
+				}
+			},
+			setupClient: func() *clientset.FakeClientset {
+				fc := clientset.NewFakeClientset()
+				fc.CreatePod(clientset.FakePodConfig{
+					Name:         podName,
+					Namespace:    podNamespace,
+					UID:          podUID,
+					PodStatus:    &corev1.PodStatus{Phase: corev1.PodRunning},
+					IsMounterPod: true,
+				})
+				return fc
+			},
+			targetPathMounted: false,
+			expectErrCode:     codes.OK,
+			expectedBindOpts:  []string{"bind"},
 		},
 	}
 

--- a/pkg/csi_driver/utils.go
+++ b/pkg/csi_driver/utils.go
@@ -796,3 +796,21 @@ func getInternalMountOptionValue(options []string, key string) string {
 	}
 	return ""
 }
+
+// prepareSharedNodeMountOptions processes and filters mount options to be directly passed to the gcsfuse process during shared node mounts.
+// Unlike prepareMountOptions (which splits options between those used to open fuse device and those passed to gcsfuse).
+func prepareSharedNodeMountOptions(options []string) []string {
+	// TODO(FUECHR): Investigate if we should only allow "allowedOptions" from prepareMountOptions for shared node mount.
+
+	csiMountOptions := []string{"o=allow_other,default_permissions"}
+	for _, o := range options {
+		// Strip read_ahead_kb and node_fuse_max_request_limit_kb flags so they are not passed to gcsfuse (which would reject them as unknown flags).
+		if strings.HasPrefix(o, "read_ahead_kb=") || strings.HasPrefix(o, "node_fuse_max_request_limit_kb=") {
+			continue
+		}
+
+		csiMountOptions = append(csiMountOptions, o)
+	}
+
+	return csiMountOptions
+}

--- a/pkg/csi_driver/utils_test.go
+++ b/pkg/csi_driver/utils_test.go
@@ -1298,3 +1298,57 @@ func TestParseFlagMapFromFlagFile(t *testing.T) {
 		})
 	}
 }
+
+func TestPrepareSharedNodeMountOptions(t *testing.T) {
+	t.Parallel()
+	defaultOpts := []string{
+		"o=allow_other,default_permissions",
+	}
+
+	testCases := []struct {
+		name     string
+		options  []string
+		expected []string
+	}{
+		{
+			name:     "empty options - should inject default CSI mount options",
+			options:  []string{},
+			expected: defaultOpts,
+		},
+		{
+			name:     "pass through raw rw and ro flags",
+			options:  []string{"rw", "ro", "implicit-dirs"},
+			expected: append(append([]string{}, defaultOpts...), "rw", "ro", "implicit-dirs"),
+		},
+		{
+			name:     "pass through o=rw and keep default options",
+			options:  []string{"o=rw", "implicit-dirs"},
+			expected: append(append([]string{}, defaultOpts...), "o=rw", "implicit-dirs"),
+		},
+		{
+			name:     "strip read_ahead_kb flags",
+			options:  []string{"read_ahead_kb=1024", "read_ahead_kb=4096", "file-cache:max-size-mb:1"},
+			expected: append(append([]string{}, defaultOpts...), "file-cache:max-size-mb:1"),
+		},
+		{
+			name:     "strip node_fuse_max_request_limit_kb flags",
+			options:  []string{"node_fuse_max_request_limit_kb=8192", "node_fuse_max_request_limit_kb=16384", "file-cache:max-size-mb:1"},
+			expected: append(append([]string{}, defaultOpts...), "file-cache:max-size-mb:1"),
+		},
+		{
+			name:     "mixed options with existing o= flags and stripped flags",
+			options:  []string{"o=noexec", "rw", "ro", "read_ahead_kb=100", "node_fuse_max_request_limit_kb=8192", "enable-cloud-profiler=true"},
+			expected: append(append([]string{}, defaultOpts...), "o=noexec", "rw", "ro", "enable-cloud-profiler=true"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			actual := prepareSharedNodeMountOptions(tc.options)
+			if diff := cmp.Diff(actual, tc.expected); diff != "" {
+				t.Errorf("test %q failed: got %v, want %v\nDiff (-want +got):\n%s", tc.name, actual, tc.expected, diff)
+			}
+		})
+	}
+}

--- a/pkg/sidecar_mounter/sidecar_mounter_config.go
+++ b/pkg/sidecar_mounter/sidecar_mounter_config.go
@@ -290,9 +290,13 @@ func (mc *MountConfig) prepareMountArgs() {
 
 		flag := argPair[0]
 		if _, ok := DisallowedFlags[flag]; ok {
-			invalidArgs = append(invalidArgs, arg)
-
-			continue
+			// Reject all disallowed flags EXCEPT "-o" when SharedMountPoint is set.
+			// SharedMountPoint is set when the shared mount feature is enabled, during which the "-o" flag is needed to pass mount options to gcsfuse.
+			isAllowedOFlag := flag == "o" && mc.SharedMountPoint != ""
+			if !isAllowedOFlag {
+				invalidArgs = append(invalidArgs, arg)
+				continue
+			}
 		}
 
 		value := ""
@@ -376,7 +380,18 @@ func (mc *MountConfig) prepareMountArgs() {
 			value = GCSFuseAppName + "-" + value
 		}
 
-		flagMap[flag] = value
+		// The "-o" flag can be passed multiple times, and gcsfuse expects them to be comma-separated.
+		if flag == "o" {
+			if value != "" {
+				if existing, ok := flagMap["o"]; ok && existing != "" {
+					flagMap["o"] = existing + "," + value
+				} else {
+					flagMap["o"] = value
+				}
+			}
+		} else {
+			flagMap[flag] = value
+		}
 	}
 
 	if len(invalidArgs) > 0 {

--- a/pkg/sidecar_mounter/sidecar_mounter_config_test.go
+++ b/pkg/sidecar_mounter/sidecar_mounter_config_test.go
@@ -166,6 +166,27 @@ func TestPrepareMountArgs(t *testing.T) {
 			expectedConfigMapArgs: defaultConfigFileFlagMap,
 		},
 		{
+			name: "should concatenate multiple o= flags for shared node mount",
+			mc: &MountConfig{
+				BucketName:       "test-bucket",
+				BufferDir:        "test-buffer-dir",
+				CacheDir:         "test-cache-dir",
+				ConfigFile:       "test-config-file",
+				SharedMountPoint: "/shared-mount",
+				Options:          []string{"o=allow_other,default_permissions", "o=ro", "o=noexec"},
+			},
+			expectedArgs: map[string]string{
+				"app-name":    GCSFuseAppName,
+				"temp-dir":    "test-buffer-dir/temp-dir",
+				"config-file": "test-config-file",
+				"foreground":  "",
+				"uid":         "0",
+				"gid":         "0",
+				"o":           "allow_other,default_permissions,ro,noexec",
+			},
+			expectedConfigMapArgs: defaultConfigFileFlagMap,
+		},
+		{
 			name: "should return valid args when file cache is disabled",
 			mc: &MountConfig{
 				BucketName: "test-bucket",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:
 In the sidecar architecture, the CSI driver manually opens the FUSE device via /bin/mount using a 
  set of default mount arguments (see prepareMountOptions). These arguments, along with stripped user-
  provided options, are passed to mount the FUSE device and are removed from the list of arguments    
  passed to the gcsfuse process itself.                                                               
                                                                                                      
In Shared Node Mount mode, gcsfuse opens its own FUSE device directly because the mounter pod runs
  as root (UID 0). Consequently, we do not need to filter out "o=" mount options or construct low-    
  level kernel mount flags. Instead, we use prepareSharedNodeMountOptions to generate a streamlined   
  list of default parameters (e.g., {"o=allow_other,default_permissions"}).
  
Explanation of FUSE Parameters (Needed vs. Unneeded)[https://docs.google.com/document/d/1RW3tyswe0PWAKk6mN8K2zWU94Ln-xNB87RA5qTrduJs/edit?tab=t.0]

 ### Summary of Changes
  
  1. Options Processing Helper (pkg/csi_driver/utils.go):
      • Created prepareSharedNodeMountOptions() to process mount options for Shared Node Mount mode:  
          • Automatically prepends mandatory FUSE options: o=allow_other,default_permissions.         
          • Strips read_ahead_kb= options (preventing gcsfuse flag validation errors).
  2. Node Server Staging Integration (pkg/csi_driver/node.go):
      • Updated executeNodeStageVolume() to pass "o=" options through prepareSharedNodeMountOptions() 
      before invoking s.mountToNode().
  3. Sidecar Mounter Flag Handling (pkg/sidecar_mounter/sidecar_mounter_config.go):
      • Bypassed the -o flag restriction in DisallowedFlags when SharedMountPoint is active (allowing 
      -o flags in Shared Node Mount mode).
      • Updated flag parsing to concatenate multiple -o options with commas, this prevents o= args from overwriting eachother (e.g., merging            
      o=allow_other,default_permissions and o=ro into -o allow_other,default_permissions,ro instead of o=ro being the final value) 
    4.  rw and ro options are directly passed to the host mount and any pod spec rw/ro is applied at bind mount. This facilitates different levels of access across pods using the same mount.
  
  
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```