### PR TITLE
Automated cherry pick of #1512: filter Node driver PV cache to profile-managed volumes only to prevent OOMs
#1523: test: update PV listing in clientset tests to use pvLister directly with labels

### DIFF
--- a/cmd/csi_driver/main.go
+++ b/cmd/csi_driver/main.go
@@ -160,7 +160,7 @@ func main() {
 		}()
 	}
 
-	clientset, err := clientset.New(*kubeconfigPath, *informerResyncDurationSec)
+	clientset, err := clientset.New(*kubeconfigPath, *informerResyncDurationSec, *runController)
 	if err != nil {
 		klog.Fatalf("Failed to configure k8s client: %v", err)
 	}

--- a/pkg/cloud_provider/clientset/clientset.go
+++ b/pkg/cloud_provider/clientset/clientset.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/webhook"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -68,6 +69,7 @@ type Clientset struct {
 	pvcLister                 listersv1.PersistentVolumeClaimLister
 	scLister                  storagelisters.StorageClassLister
 	informerResyncDurationSec int
+	runController             bool
 }
 
 const (
@@ -242,7 +244,7 @@ func (c *Clientset) ConfigureSCLister(ctx context.Context) {
 	c.scLister = scLister
 }
 
-func New(kubeconfigPath string, informerResyncDurationSec int) (Interface, error) {
+func New(kubeconfigPath string, informerResyncDurationSec int, runController bool) (Interface, error) {
 	var err error
 	var rc *rest.Config
 	if kubeconfigPath != "" {
@@ -262,7 +264,7 @@ func New(kubeconfigPath string, informerResyncDurationSec int) (Interface, error
 		return nil, fmt.Errorf("failed to configure k8s client: %w", err)
 	}
 
-	return &Clientset{k8sClients: clientset, informerResyncDurationSec: informerResyncDurationSec}, nil
+	return &Clientset{k8sClients: clientset, informerResyncDurationSec: informerResyncDurationSec, runController: runController}, nil
 }
 
 func (c *Clientset) ConfigurePodLister(ctx context.Context, nodeName string) {

--- a/pkg/cloud_provider/clientset/clientset.go
+++ b/pkg/cloud_provider/clientset/clientset.go
@@ -165,6 +165,13 @@ func (c *Clientset) ConfigurePVLister(ctx context.Context) {
 	informerFactory := informers.NewSharedInformerFactoryWithOptions(
 		c.k8sClients,
 		time.Duration(c.informerResyncDurationSec)*time.Second,
+		// To prevent OOMs, the Node driver uses a server-side filter to cache only profile-managed PVs since profiles is the only feature using GetPV.
+		// Leaving the Controller unfiltered to discover and patch legacy volumes.
+		informers.WithTweakListOptions(func(options *metav1.ListOptions) {
+			if !c.runController {
+				options.LabelSelector = fmt.Sprintf("%s=%s", webhook.GcsfuseProfilesManagedLabel, util.TrueStr)
+			}
+		}),
 		informers.WithTransform(trim),
 	)
 	pvLister := informerFactory.Core().V1().PersistentVolumes().Lister()
@@ -347,6 +354,12 @@ func (c *Clientset) GetNode(name string) (*corev1.Node, error) {
 	return c.nodeLister.Get(name)
 }
 
+// GetPV retrieves a PersistentVolume from the informer cache by name.
+// IMPORTANT: In the Node driver, the PV informer cache is intentionally filtered down
+// to ONLY track PVs that utilize the GCS Fuse profiles feature (via the gke-gcsfuse/profile-managed label)
+// to minimize the memory footprint in large-scale clusters.
+// Do not attempt to use this function from the Node driver to look up generic PVs or non-profile GCS Fuse PVs,
+// as they are explicitly prevented from entering the Node's cache.
 func (c *Clientset) GetPV(name string) (*corev1.PersistentVolume, error) {
 	if c.pvLister == nil {
 		return nil, errors.New("pv informer is not ready")

--- a/pkg/cloud_provider/clientset/clientset_test.go
+++ b/pkg/cloud_provider/clientset/clientset_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clientset
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util"
+	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/webhook"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestConfigurePVLister(t *testing.T) {
+	t.Parallel()
+
+	labeledPV := &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "labeled-gcsfuse-pv",
+			Labels: map[string]string{
+				webhook.GcsfuseProfilesManagedLabel: util.TrueStr,
+			},
+		},
+		Spec: corev1.PersistentVolumeSpec{
+			PersistentVolumeSource: corev1.PersistentVolumeSource{
+				CSI: &corev1.CSIPersistentVolumeSource{
+					Driver: "gcsfuse.csi.storage.gke.io",
+				},
+			},
+		},
+	}
+
+	unlabeledPV := &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "unlabeled-pv",
+		},
+		Spec: corev1.PersistentVolumeSpec{
+			PersistentVolumeSource: corev1.PersistentVolumeSource{
+				CSI: &corev1.CSIPersistentVolumeSource{
+					Driver: "pd.csi.storage.gke.io",
+				},
+			},
+		},
+	}
+
+	multiLabeledPV := &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "multi-labeled-gcsfuse-pv",
+			Labels: map[string]string{
+				webhook.GcsfuseProfilesManagedLabel: util.TrueStr,
+				"some-label":                        "some-value",
+			},
+		},
+		Spec: corev1.PersistentVolumeSpec{
+			PersistentVolumeSource: corev1.PersistentVolumeSource{
+				CSI: &corev1.CSIPersistentVolumeSource{
+					Driver: "gcsfuse.csi.storage.gke.io",
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewSimpleClientset(labeledPV, unlabeledPV, multiLabeledPV)
+	c := &Clientset{
+		k8sClients: fakeClient,
+		// We want to test the Node driver behavior (which filters the PV), so we set runController to false.
+		runController: false,
+	}
+
+	c.ConfigurePVLister(t.Context())
+
+	pvs, err := c.ListPVs()
+	if err != nil {
+		t.Fatalf("ListPVs() unexpected error: %v", err)
+	}
+
+	var gotPVNames []string
+	for _, pv := range pvs {
+		gotPVNames = append(gotPVNames, pv.Name)
+	}
+
+	wantPVNames := []string{"labeled-gcsfuse-pv", "multi-labeled-gcsfuse-pv"}
+	less := func(a, b string) bool { return a < b }
+	if diff := cmp.Diff(wantPVNames, gotPVNames, cmpopts.SortSlices(less)); diff != "" {
+		t.Errorf("ListPVs() PV names mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/pkg/cloud_provider/clientset/clientset_test.go
+++ b/pkg/cloud_provider/clientset/clientset_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/webhook"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
@@ -86,7 +87,7 @@ func TestConfigurePVLister(t *testing.T) {
 
 	c.ConfigurePVLister(t.Context())
 
-	pvs, err := c.ListPVs()
+	pvs, err := c.pvLister.List(labels.Everything())
 	if err != nil {
 		t.Fatalf("ListPVs() unexpected error: %v", err)
 	}

--- a/pkg/profiles/scanner.go
+++ b/pkg/profiles/scanner.go
@@ -1544,6 +1544,39 @@ func defaultScanBucketWithDataflux(ctx context.Context, gcsClient *storage.Clien
 	}
 }
 
+// ensurePVTrackingLabel applies the PV tracking label if it's currently missing.
+func (s *Scanner) ensurePVTrackingLabel(ctx context.Context, pv *v1.PersistentVolume) error {
+	if err := ctx.Err(); err != nil {
+		return status.Errorf(codes.Canceled, "context cancelled: %v", err)
+	}
+	if pv == nil {
+		return status.Error(codes.Internal, "persistent volume is nil")
+	}
+	if _, hasTrackedLabel := pv.Labels[profileManagedLabelKey]; hasTrackedLabel {
+		return nil
+	}
+
+	patchData := map[string]any{
+		"metadata": map[string]any{"labels": map[string]string{profileManagedLabelKey: util.TrueStr}},
+	}
+	patchBytes, marshalErr := json.Marshal(patchData)
+	if marshalErr != nil {
+		return status.Errorf(codes.Internal, "failed to marshal label patch data for PV %q: %v", pv.Name, marshalErr)
+	}
+	klog.V(6).Infof("PV %q is missing the tracking label. Patching it with: %q", pv.Name, string(patchBytes))
+	_, patchErr := s.kubeClient.CoreV1().PersistentVolumes().Patch(ctx, pv.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+	if patchErr != nil {
+		if apierrors.IsNotFound(patchErr) {
+			klog.Warningf("Failed to patch PV %q because it was not found", pv.Name)
+			return nil
+		}
+		return status.Errorf(codes.Internal, "failed to patch PV %q with label: %v", pv.Name, patchErr)
+	}
+
+	klog.V(6).Infof("Successfully added %s=%s label to PV %q", profileManagedLabelKey, util.TrueStr, pv.Name)
+	return nil
+}
+
 // patchPVAnnotations updates the annotations for a given PV.
 // annotationsToUpdate should contain the desired state of the annotations to be patched.
 func (s *Scanner) patchPVAnnotations(ctx context.Context, pvName string, annotationsToUpdate map[string]*string) error {
@@ -1637,6 +1670,14 @@ func (s *Scanner) checkPVRelevance(ctx context.Context, pv *v1.PersistentVolume,
 	if !profilesutil.IsProfile(sc) {
 		klog.Warningf("profile label was not found in StorageClass %q for PV %q", sc.Name, pv.Name)
 		return nil, false, nil
+	}
+
+	// We intentionally only patch the tracking label onto PVs that utilize the GCS Fuse Profiles feature.
+	// This ensures that the Node driver (which filters its informer cache based on this label)
+	// only loads precisely the metadata it needs for profiling, preventing OOM crashes in large clusters
+	// that have thousands of generic GCS Fuse PVs or PDCSI PVs.
+	if err := s.ensurePVTrackingLabel(ctx, pv); err != nil {
+		return nil, false, fmt.Errorf("failed to ensure tracking label for PV %q: %w", pv.Name, err)
 	}
 
 	// ---- At this stage, there is clearly a customer intent to use the scanner feature, so we start logging warnings -----

--- a/pkg/profiles/scanner_test.go
+++ b/pkg/profiles/scanner_test.go
@@ -46,6 +46,7 @@ import (
 
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/metrics"
 	putil "github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/profiles/util"
+	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util"
 	compute "google.golang.org/api/compute/v1"
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -291,6 +292,7 @@ func createStorageClass(name string, params map[string]string) *storagev1.Storag
 // createPV is a helper function to create a PersistentVolume object.
 func createPV(name, scName, volumeHandle, driver string, mountOptions []string, annotations map[string]string, volAttributes map[string]string) *v1.PersistentVolume {
 	return &v1.PersistentVolume{
+		TypeMeta:   metav1.TypeMeta{Kind: "PersistentVolume", APIVersion: "v1"},
 		ObjectMeta: metav1.ObjectMeta{Name: name, Annotations: annotations},
 		Spec: v1.PersistentVolumeSpec{
 			StorageClassName: scName,
@@ -606,6 +608,8 @@ func TestSyncPV(t *testing.T) {
 	scName := testSCName
 	bucketName := testBucketName
 	basePV := createPV(pvName, scName, bucketName, csiDriverName, nil, nil, nil)
+	basePVTracked := basePV.DeepCopy()
+	basePVTracked.Labels = map[string]string{profileManagedLabelKey: util.TrueStr}
 	relevantSC := createStorageClass(scName, validSCParams)
 	irrelevantSC := createStorageClass("irrelevant-sc", map[string]string{"some": "param"})
 	irrelevantSC.Labels = nil
@@ -719,9 +723,17 @@ func TestSyncPV(t *testing.T) {
 			expectScanCall: true,
 		},
 		{
-			name:           "Patch Error",
+			name:           "Tracking Label Patch Error",
 			key:            pvName,
 			initialObjects: []runtime.Object{basePV.DeepCopy(), relevantSC},
+			patchErr:       fmt.Errorf("patch failed"),
+			wantErr:        true,
+			expectScanCall: false,
+		},
+		{
+			name:           "Patch Error",
+			key:            pvName,
+			initialObjects: []runtime.Object{basePVTracked.DeepCopy(), relevantSC},
 			bucketI:        scanResult,
 			patchErr:       fmt.Errorf("patch failed"),
 			wantErr:        true,
@@ -1399,6 +1411,57 @@ func TestPatchPVAnnotations(t *testing.T) {
 	expectedAnnotations := map[string]string{newAnnotationKey: newAnnotationVal}
 	if !reflect.DeepEqual(updatedPV.Annotations, expectedAnnotations) {
 		t.Errorf("Annotations: got %v, want %v", updatedPV.Annotations, expectedAnnotations)
+	}
+}
+
+func TestEnsurePVTrackingLabel(t *testing.T) {
+	tests := []struct {
+		name           string
+		initialLabels  map[string]string
+		expectedLabels map[string]string
+	}{
+		{
+			name:           "No Labels",
+			initialLabels:  nil,
+			expectedLabels: map[string]string{profileManagedLabelKey: util.TrueStr},
+		},
+		{
+			name:           "Labels exist, but not tracked",
+			initialLabels:  map[string]string{"env": "dev"},
+			expectedLabels: map[string]string{"env": "dev", profileManagedLabelKey: util.TrueStr},
+		},
+		{
+			name:           "Tracked label explicitly FALSE",
+			initialLabels:  map[string]string{profileManagedLabelKey: util.FalseStr},
+			expectedLabels: map[string]string{profileManagedLabelKey: util.FalseStr},
+		},
+		{
+			name:           "Tracked label explicitly TRUE (no-op expected)",
+			initialLabels:  map[string]string{profileManagedLabelKey: util.TrueStr},
+			expectedLabels: map[string]string{profileManagedLabelKey: util.TrueStr},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pv := createPV(testPVName, testSCName, testBucketName, csiDriverName, nil, nil, nil)
+			pv.Labels = tc.initialLabels
+			f := newTestFixture(t, pv)
+
+			if err := f.scanner.ensurePVTrackingLabel(context.Background(), pv); err != nil {
+				t.Fatalf("ensurePVTrackingLabel() returned error: %v", err)
+			}
+
+			// Get the updated PV.
+			updatedPV, err := f.kubeClient.CoreV1().PersistentVolumes().Get(context.Background(), testPVName, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("Failed to get PV: %v", err)
+			}
+
+			if !reflect.DeepEqual(updatedPV.Labels, tc.expectedLabels) {
+				t.Errorf("Labels: got %v, want %v", updatedPV.Labels, tc.expectedLabels)
+			}
+		})
 	}
 }
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -63,7 +63,7 @@ var _ = func() bool {
 	flag.Parse()
 	framework.AfterReadingAllFlags(&framework.TestContext)
 
-	c, err = clientset.New(framework.TestContext.KubeConfig, 0)
+	c, err = clientset.New(framework.TestContext.KubeConfig, 0, false)
 	if err != nil {
 		klog.Fatalf("Failed to configure k8s client: %v", err)
 	}


### PR DESCRIPTION
Cherry pick of #1512 #1523 on release-1.22.

#1512: filter Node driver PV cache to profile-managed volumes only to prevent OOMs
#1523: test: update PV listing in clientset tests to use pvLister directly with labels

The cherry-pick from `main` did not compile out-of-the-box on `release-1.22` because the `clientset` initialization signature differs between versions. To fix compilation and ensure tests pass, this PR includes the following manual backport adaptations:

* Updated the `Clientset` struct in `pkg/cloud_provider/clientset/clientset.go` to add the `runController` boolean, which is required on this older version to toggle the caching feature.
* Updated the `clientset.New()` instantiation footprint in `cmd/csi_driver/main.go` and `test/e2e/e2e_test.go` to pass the required boolean argument (`*runController` and `false` respectively).

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixed an issue where the GCS Fuse CSI Node driver would OOM in clusters with tens of thousands of unrelated PersistentVolumes.
```