### PR TITLE
Add e2e test resource and timeout support for rapid_operations while …

### DIFF
--- a/test/e2e/testsuites/gcsfuse_integration.go
+++ b/test/e2e/testsuites/gcsfuse_integration.go
@@ -60,6 +60,7 @@ const (
 	testNameBufferedReads         = "buffered_read"
 	testNameRenameSymlink         = "rename_symlink"
 	testNameRapidAppends          = "rapid_appends"
+	testNameRapidOperations       = "rapid_operations"
 	testNameCloudProfiler         = "cloud_profiler"
 	testNameBenchmarking          = "benchmarking"
 	testNameUnsupportedPath       = "unsupported_path"
@@ -87,6 +88,7 @@ var testPackageTimeoutMap = map[string]int{
 	testNameWriteLargeFiles: 60,
 	testNameReadLargeFiles:  60,
 	testNameRapidAppends:    60,
+	testNameRapidOperations: 60,
 	testNameCloudProfiler:   30,
 }
 
@@ -400,8 +402,8 @@ func generateTestCommand(opts TestCommandConfig) string {
 }
 
 // configureLargeFileResources configures the pod and sidecar resources for memory-intensive large file tests.
-// Note: We only increase memory limits for specific tests like testNameWriteLargeFiles, testNameReadLargeFiles
-// and testNameRapidAppends. Other test cases run stable within the default memory for now
+// Note: We only increase memory limits for specific tests like testNameWriteLargeFiles, testNameReadLargeFiles,
+// testNameRapidAppends and testNameRapidOperations. Other test cases run stable within the default memory for now
 // limits and do not require additional resources.
 func configureLargeFileResources(tPod *specs.TestPod, testNameOrPkg string, driver storageframework.TestDriver) (string, string) {
 	sidecarMemoryLimit := defaultSidecarMemoryLimit
@@ -415,7 +417,7 @@ func configureLargeFileResources(tPod *specs.TestPod, testNameOrPkg string, driv
 			sidecarMemoryLimit = "2Gi"
 		}
 	}
-	if testNameOrPkg == testNameRapidAppends {
+	if testNameOrPkg == testNameRapidAppends || testNameOrPkg == testNameRapidOperations {
 		tPod.SetResource("1", "3Gi", "5Gi")
 		sidecarMemoryRequest = "2Gi"
 		sidecarMemoryLimit = "3Gi"


### PR DESCRIPTION
…preserving rapid_appends

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

In GCSFuse E2E integration tests, the test package `rapid_appends` was renamed to `rapid_operations` in [PR#4824](https://github.com/GoogleCloudPlatform/gcsfuse/pull/4824). This PR adds special resource and timeout handling for `rapid_operations` while retaining `rapid_appends` for backward compatibility with older GCSFuse versions and branches.

Modified `test/e2e/testsuites/gcsfuse_integration.go`:
- Defined `testNameRapidOperations = "rapid_operations"` in the const block (`test/e2e/testsuites/gcsfuse_integration.go:63`).
- Added `testNameRapidOperations: 60` to `testPackageTimeoutMap` to enforce `-timeout 60m` during `go test ./rapid_operations/...` execution (`test/e2e/testsuites/gcsfuse_integration.go:91`).
- Updated `configureLargeFileResources` (`test/e2e/testsuites/gcsfuse_integration.go:405-420`) to check `if testNameOrPkg == testNameRapidAppends || testNameOrPkg == testNameRapidOperations`, allocating `3Gi` pod memory limit (`tPod.SetResource("1", "3Gi", "5Gi")`) and `2Gi`/`3Gi` sidecar container memory request/limit to prevent cgroup OOM kills.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
I have verified locally by running:
```
E2E_TEST_USE_GKE_MANAGED_DRIVER=false \
REGISTRY=us-central1-docker.pkg.dev/yaozile-gke-dev/gcs-fuse-csi-driver \
STAGINGVERSION=prow-gob-internal-boskos-fix-zb-tests \
ENABLE_ZB=true \
E2E_TEST_FOCUS="rapid_operations" \

Ran 21 of 517 Specs in 1441.702 seconds
  FAIL! -- 19 Passed | 2 Failed | 0 Pending | 496 Skipped


  Ginkgo ran 1 suite in 24m18.873715415s

  Test Suite Failed
```

There were two newly added test failed, which will be fixed by GCSFuse team by another PR.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```