### PR TITLE
Implement multi-nic for shared node mount

### DIFF
--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -1044,6 +1044,12 @@ func (s *nodeServer) executeNodeStageVolume(ctx context.Context, req *csi.NodeSt
 		return &csi.NodeStageVolumeResponse{}, nil
 	}
 
+	// Unlike other features, we'll assume multi NIC can be used unless we know for certain we have a version mismatch.
+	canUseMultiNIC := !isManagedSidecarImage(podImage) || s.driver.isSidecarVersionSupportedForGivenFeature(podImage, MultiNICMinVersion)
+	if err := s.setupMultiNIC(&args, pod, canUseMultiNIC); err != nil {
+		return nil, err
+	}
+
 	// Pass kernel params file flag to GCSFuse iff GCSFuse Kernel Params feature is supported.
 	if s.isGcsFuseKernelParamsFeatureSupported(podImage, vs) {
 		args.fuseMountOptions = joinMountOptions(args.fuseMountOptions, []string{util.EnableGCSFuseKernelParams + "=true"})

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -2836,6 +2836,149 @@ func TestNodeStageVolumeEnableAutoGoMemLimit(t *testing.T) {
 	}
 }
 
+func TestNodeStageVolumeMultiNIC(t *testing.T) {
+	nodeID := "test-node"
+	volID := testVolumeID
+	podNamespace := "test-ns"
+	podName := createMounterPodName(nodeID, volID)
+	podUID := types.UID(podName)
+
+	for _, tc := range []struct {
+		name              string
+		poisonedIP        string
+		rules             []Rule
+		routes            []Route
+		rtTables          string
+		extraVC           map[string]string
+		expectedNewRules  []Rule
+		expectedNewRoutes []Route
+		expectedOpts      []string
+	}{
+		{
+			name: "use nic 1",
+			extraVC: map[string]string{
+				VolumeContextKeyMultiNICIndex: "1",
+			},
+			expectedNewRules:  []Rule{{Source: "10.144.0.8/32", Table: 50}},
+			expectedNewRoutes: []Route{{Device: "eth1", Gateway: "10.144.0.1", Table: 50}},
+			expectedOpts:      []string{"gcs-fuse-numa-node=1", "experimental-local-socket-address=10.144.0.8"},
+		},
+		{
+			name: "existing network",
+			extraVC: map[string]string{
+				VolumeContextKeyMultiNICIndex: "1",
+			},
+			rtTables:     "45 gcsfusecsi_eth1",
+			rules:        []Rule{{Source: "10.144.0.8/32", Table: 45}},
+			routes:       []Route{{Device: "eth1", Gateway: "10.144.0.1", Table: 45}},
+			expectedOpts: []string{"gcs-fuse-numa-node=1", "experimental-local-socket-address=10.144.0.8"},
+		},
+		{
+			name: "partial network",
+			extraVC: map[string]string{
+				VolumeContextKeyMultiNICIndex: "1",
+			},
+			rules:             []Rule{{Source: "10.144.0.8/32", Table: 50}},
+			expectedNewRoutes: []Route{{Device: "eth1", Gateway: "10.144.0.1", Table: 50}},
+			expectedOpts:      []string{"gcs-fuse-numa-node=1", "experimental-local-socket-address=10.144.0.8"},
+		},
+		{
+			name: "invalid node",
+			extraVC: map[string]string{
+				VolumeContextKeyMultiNICIndex: "3",
+			},
+			expectedOpts: []string{},
+		},
+		{
+			name:       "failed route",
+			poisonedIP: "10.128.0.6",
+			extraVC: map[string]string{
+				VolumeContextKeyMultiNICIndex: "0",
+			},
+			expectedOpts: []string{},
+		},
+		{
+			name: "source address override",
+			extraVC: map[string]string{
+				VolumeContextKeyMultiNICIndex: "1",
+				VolumeContextKeyMountOptions:  "experimental-local-socket-address=151.101.129.164",
+			},
+			expectedNewRules:  []Rule{{Source: "10.144.0.8/32", Table: 50}},
+			expectedNewRoutes: []Route{{Device: "eth1", Gateway: "10.144.0.1", Table: 50}},
+			expectedOpts:      []string{"gcs-fuse-numa-node=1", "experimental-local-socket-address=151.101.129.164"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			testStagingPath, cleanupStaging := setupTestStagingPath(t)
+			defer cleanupStaging()
+
+			sharedMountOptions, mounterServer := setupSharedMountOptions(t, podUID)
+
+			fc := clientset.NewFakeClientset()
+			fc.CreatePod(clientset.FakePodConfig{
+				Name:         podName,
+				Namespace:    podNamespace,
+				UID:          podUID,
+				PodStatus:    &corev1.PodStatus{Phase: corev1.PodRunning},
+				IsMounterPod: true,
+			})
+
+			fakeMounter := mount.NewFakeMounter([]mount.MountPoint{})
+
+			testEnv := initTestNodeServerWithCustomClientset(t, fc, false)
+			testEnv.nwMgr.poisonedIP = tc.poisonedIP
+			testEnv.nwMgr.devices = []LinkDevice{
+				{Name: "eth0", Driver: "gve", NumaNode: 0},
+				{Name: "eth1", Driver: "gve", NumaNode: 1},
+			}
+			testEnv.nwMgr.rules = append([]Rule{}, tc.rules...)
+			testEnv.nwMgr.routes = append([]Route{
+				{Device: "eth0", Gateway: "10.128.0.1", Source: "10.128.0.6", Table: 254},
+				{Device: "eth1", Gateway: "10.144.0.1", Source: "10.144.0.8", Table: 254},
+			}, tc.routes...)
+			testEnv.nwMgr.rtTables = tc.rtTables
+			expectedRules := append([]Rule{}, testEnv.nwMgr.rules...)
+			expectedRules = append(expectedRules, tc.expectedNewRules...)
+			expectedRoutes := append([]Route{}, testEnv.nwMgr.routes...)
+			expectedRoutes = append(expectedRoutes, tc.expectedNewRoutes...)
+
+			ns, ok := testEnv.ns.(*nodeServer)
+			if !ok {
+				t.Fatalf("Failed to cast NodeServer to *nodeServer")
+			}
+			ns.mounter = fakeMounter
+			ns.driver.config.AssumeGoodSidecarVersion = true
+			ns.driver.config.FeatureOptions.SharedMountOptions = sharedMountOptions
+
+			stageReq := newTestNodeStageVolumeRequest(testStagingPath, podName, podNamespace, tc.extraVC)
+
+			_, err := ns.NodeStageVolume(context.Background(), stageReq)
+			if err != nil {
+				t.Fatalf("NodeStageVolume failed: %v", err)
+			}
+			defer func() {
+				if vs, ok := ns.volumeStateStore.Load(testStagingPath); ok && vs != nil {
+					if vs.GCSFuseKernelMonitorState.CancelFunc != nil {
+						vs.GCSFuseKernelMonitorState.CancelFunc()
+					}
+				}
+			}()
+
+			if !reflect.DeepEqual(testEnv.nwMgr.routes, expectedRoutes) {
+				t.Errorf("Bad routes, expected %+v, got %+v", expectedRoutes, testEnv.nwMgr.routes)
+			}
+			if !reflect.DeepEqual(testEnv.nwMgr.rules, expectedRules) {
+				t.Errorf("Bad rules, expected %+v, got %+v", expectedRules, testEnv.nwMgr.rules)
+			}
+
+			if mounterServer.req == nil {
+				t.Fatalf("expected mounterServer.req to be non-nil, but got nil")
+			}
+			validateMountOptions(t, mounterServer.req.MountOptions, tc.expectedOpts, nil)
+		})
+	}
+}
+
 func TestNodeStageVolumeEnableGCSFuseKernelParams(t *testing.T) {
 	nodeID := "test-node"
 	volID := testVolumeID


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:

Integrates multi-NIC support into shared node mount in`NodeStageVolume`. Previously, `setupMultiNIC` was only called in `NodePublishVolume`  for non-shared mounts. This PR invokes `setupMultiNIC` in `executeNodeStageVolume` so multi-NIC work when shared node mount is enabled.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
I have tested locally by writing separately to two shared-mount volumes configured with different NIC indices. I have confirmed that I/O flows exclusively through each volume's designated eth interface.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```