### PR TITLE
feat: Improve test skips based on gke version for fuse max pages e2e tests

### DIFF
--- a/test/e2e/specs/specs.go
+++ b/test/e2e/specs/specs.go
@@ -1141,12 +1141,10 @@ func GKEClusterVersion() *version.Version {
 
 // GKEClusterVersionAtLeast returns true if the GKE cluster version is at least minVersionStr.
 func GKEClusterVersionAtLeast(minVersionStr string) bool {
-	vStr := GetGKEClusterVersion()
-	if vStr == "" {
+	v := GKEClusterVersion()
+	if v == nil {
 		return true
 	}
-	v, err := version.ParseGeneric(vStr)
-	framework.ExpectNoError(err, "Failed to parse GKE Cluster version string %s into version.Version", vStr)
 
 	minV, err := version.ParseGeneric(minVersionStr)
 	framework.ExpectNoError(err, "Failed to parse minimum GKE Cluster version string %s into version.Version", minVersionStr)

--- a/test/e2e/specs/specs.go
+++ b/test/e2e/specs/specs.go
@@ -1122,6 +1122,40 @@ func GCSFuseVersionAndBranch() (*version.Version, string) {
 	return v, branch
 }
 
+// GetGKEClusterVersion returns the GKE cluster version being tested.
+// The env var is set by handler.go before running the tests.
+func GetGKEClusterVersion() string {
+	return os.Getenv(utils.GkeClusterVersionVarName)
+}
+
+// GKEClusterVersion returns the parsed semantic version of the GKE cluster.
+func GKEClusterVersion() *version.Version {
+	vStr := GetGKEClusterVersion()
+	if vStr == "" {
+		return nil
+	}
+	v, err := version.ParseGeneric(vStr)
+	framework.ExpectNoError(err, "Failed to parse GKE Cluster version string %s into version.Version", vStr)
+	return v
+}
+
+// GKEClusterVersionAtLeast returns true if the GKE cluster version is at least minVersionStr.
+func GKEClusterVersionAtLeast(minVersionStr string) bool {
+	vStr := GetGKEClusterVersion()
+	if vStr == "" {
+		return true
+	}
+	v, err := version.ParseGeneric(vStr)
+	if err != nil {
+		return false
+	}
+	minV, err := version.ParseGeneric(minVersionStr)
+	if err != nil {
+		return false
+	}
+	return v.AtLeast(minV)
+}
+
 func DeployIstioSidecar(namespace string) {
 	runKubectlOrDie(namespace, "apply", "--filename", "./specs/istio-sidecar.yaml")
 }

--- a/test/e2e/specs/specs.go
+++ b/test/e2e/specs/specs.go
@@ -1146,13 +1146,11 @@ func GKEClusterVersionAtLeast(minVersionStr string) bool {
 		return true
 	}
 	v, err := version.ParseGeneric(vStr)
-	if err != nil {
-		return false
-	}
+	framework.ExpectNoError(err, "Failed to parse GKE Cluster version string %s into version.Version", vStr)
+
 	minV, err := version.ParseGeneric(minVersionStr)
-	if err != nil {
-		return false
-	}
+	framework.ExpectNoError(err, "Failed to parse minimum GKE Cluster version string %s into version.Version", minVersionStr)
+
 	return v.AtLeast(minV)
 }
 

--- a/test/e2e/testsuites/kernel_params.go
+++ b/test/e2e/testsuites/kernel_params.go
@@ -153,13 +153,14 @@ func skipIfKernelParamsNotSupported() {
 func skipIfFuseMaxRequestSizeNotSupported() {
 	gcsfuseVersion, branch := specs.GCSFuseVersionAndBranch()
 
-	// Running since we are on master branch.
-	if branch == utils.MasterBranchName {
-		return
-	}
 	// fuse-max-request-size-kb was introduced in v3.11.2-gke.0.
-	if !gcsfuseVersion.AtLeast(version.MustParseSemantic(utils.MinGCSFuseFuseMaxRequestSizeVersion)) {
+	if branch != utils.MasterBranchName && !gcsfuseVersion.AtLeast(version.MustParseSemantic(utils.MinGCSFuseFuseMaxRequestSizeVersion)) {
 		e2eskipper.Skipf("skip fuse max request size test for unsupported gcsfuse version %s", gcsfuseVersion.String())
+	}
+
+	// GKE version 1.34+ is required for /proc/sys/fs/fuse/max_pages_limit kernel support.
+	if !specs.GKEClusterVersionAtLeast("1.34.0-gke.0") {
+		e2eskipper.Skipf("skip fuse max request size test for unsupported GKE cluster version %s (requires GKE >= 1.34)", specs.GetGKEClusterVersion())
 	}
 }
 

--- a/test/e2e/utils/handler.go
+++ b/test/e2e/utils/handler.go
@@ -338,6 +338,23 @@ func Handle(testParams *TestParameters) error {
 		}
 	}
 
+	if testParams.GkeClusterVersion != "" {
+		if err := os.Setenv(GkeClusterVersionVarName, testParams.GkeClusterVersion); err != nil {
+			return fmt.Errorf("failed to set %s env var: %w", GkeClusterVersionVarName, err)
+		}
+	} else {
+		gkeVersion, err := FetchGKEClusterVersion(k8sclientset)
+		if err != nil {
+			klog.Warningf("Failed to fetch GKE cluster version from APIServer: %v", err)
+		} else {
+			testParams.GkeClusterVersion = gkeVersion
+			klog.Infof("Fetched GKE cluster version from APIServer: %s", gkeVersion)
+			if err := os.Setenv(GkeClusterVersionVarName, gkeVersion); err != nil {
+				return fmt.Errorf("failed to set %s env var: %w", GkeClusterVersionVarName, err)
+			}
+		}
+	}
+
 	//nolint:gosec
 	cmd := exec.Command("ginkgo", "run", "-v",
 		"--procs", testParams.GinkgoProcs,

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -542,9 +542,15 @@ func FetchGCSFuseVersion(ctx context.Context, cl clientset.Interface) (string, e
 
 // FetchGKEClusterVersion retrieves the Kubernetes master version directly from the cluster APIServer.
 func FetchGKEClusterVersion(cl clientset.Interface) (string, error) {
+	if cl == nil {
+		return "", fmt.Errorf("clientset interface is nil")
+	}
 	serverVersion, err := cl.Discovery().ServerVersion()
 	if err != nil {
 		return "", fmt.Errorf("failed to fetch server version from cluster: %w", err)
+	}
+	if serverVersion == nil {
+		return "", fmt.Errorf("failed to fetch server version from cluster: serverVersion is nil")
 	}
 	return serverVersion.GitVersion, nil
 }

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -50,7 +50,8 @@ const (
 	MinGCSFuseGrpcMetricsVersion             = "v3.8.0-gke.0"
 	MinGCSFuseFuseMaxRequestSizeVersion      = "v3.11.2-gke.0"
 
-	GcsfuseVersionVarName = "gcsfuse-version"
+	GcsfuseVersionVarName    = "gcsfuse-version"
+	GkeClusterVersionVarName = "gke-cluster-version"
 
 	testConfigUrlFormat                  = "https://raw.githubusercontent.com/GoogleCloudPlatform/gcsfuse/%s/tools/integration_tests/test_config.yaml"
 	flagFileCacheCapacity                = "file-cache-max-size-mb"
@@ -537,6 +538,15 @@ func FetchGCSFuseVersion(ctx context.Context, cl clientset.Interface) (string, e
 		return "", fmt.Errorf("unexpected version output format: %s", output)
 	}
 	return l[2], nil
+}
+
+// FetchGKEClusterVersion retrieves the Kubernetes master version directly from the cluster APIServer.
+func FetchGKEClusterVersion(cl clientset.Interface) (string, error) {
+	serverVersion, err := cl.Discovery().ServerVersion()
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch server version from cluster: %w", err)
+	}
+	return serverVersion.GitVersion, nil
 }
 
 // ExpandFlagVariables allows for the expansion of custom parameterized fields


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation

kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Fixes failing fuse max pages test by skipping when a v3.11.2 GCSFuse version is installed on lower version GKE Clusters.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```