### PR TITLE
Cleanup staging path

### DIFF
--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -965,7 +965,10 @@ func (s *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolu
 	resp, err := s.executeNodeStageVolume(ctx, req)
 
 	if err != nil {
-		klog.Errorf("NodeStageVolume failed on staging path %q for volume %q: %v)", stagingPath, volumeID, err)
+		klog.Errorf("NodeStageVolume failed on staging path %q for volume %q: %v, cleaning up", stagingPath, volumeID, err)
+		if cleanupErr := s.cleanupStagingPath(stagingPath); cleanupErr != nil {
+			klog.Errorf("Failed to clean up staging path %q for volume %q, err: %v", stagingPath, volumeID, cleanupErr)
+		}
 	}
 
 	return resp, err

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -3414,3 +3414,52 @@ func TestAppendCloudProfilerOptions(t *testing.T) {
 		})
 	}
 }
+
+func TestNodeStageVolumeCleanupStagingPathOnFailure(t *testing.T) {
+	t.Parallel()
+
+	stagingPath, cleanup := setupTestStagingPath(t)
+	defer cleanup()
+
+	nodeID := "test-node"
+	volID := testVolumeID
+	podName := createMounterPodName(nodeID, volID)
+
+	// Simulate an error in executeNodeStageVolume by simulating a non-existent mounter pod.
+	fakeClientset := clientset.NewFakeClientset()
+	fakeClientset.GetPodErr = apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, podName)
+
+	// Pretend the path is mounted initially on the fake mounter.
+	fakeMounter := mount.NewFakeMounter([]mount.MountPoint{
+		{Path: stagingPath, Device: "fuse"},
+	})
+
+	testEnv := initTestNodeServerWithCustomClientset(t, fakeClientset, false /*wiNodeLabelCheck*/)
+	ns, ok := testEnv.ns.(*nodeServer)
+	if !ok {
+		t.Fatalf("Failed to cast NodeServer to *nodeServer")
+	}
+	ns.mounter = fakeMounter
+
+	req := newTestNodeStageVolumeRequest(stagingPath, podName, "test-ns", nil)
+
+	// Call NodeStageVolume, which should fail due to missing mounter pod.
+	_, err := ns.NodeStageVolume(context.Background(), req)
+	if err == nil {
+		t.Fatal("Expected NodeStageVolume to fail, but it returned success")
+	}
+
+	// Verify that the fake mounter processed the Unmount call.
+	if len(fakeMounter.MountPoints) > 0 {
+		for _, mp := range fakeMounter.MountPoints {
+			if mp.Path == stagingPath {
+				t.Errorf("Expected staging path %q to be unmounted in fake mounter, but it is still mounted", stagingPath)
+			}
+		}
+	}
+
+	// Verify that the directory was physically removed by mount.CleanupMountPoint to prevent leakage.
+	if _, err := os.Stat(stagingPath); !os.IsNotExist(err) {
+		t.Errorf("Expected staging path directory %q to be deleted to prevent leakage, but it still exists", stagingPath)
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**: If NodeStageVolume creates the staging path dir, or mounts to the staging path, and fails, it's not guaranteed that Kubelet will call NodeUnstageVolume, since NodeStageVolume didn't succeed. Therefore, we must cleanup the staging path ourselves, so that on the next NodeStageVolume, we start in a clean state, or in case that we delete the workloads, NodeStageVolume doesn't leak the mountpoint.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```