### PR TITLE
Skip cleanupSocket on staging paths and remove shared mount metrics s…

### DIFF
--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -591,6 +591,10 @@ func (s *nodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpub
 		s.volumeStateStore.Delete(targetPath)
 	}
 
+	if c, ok := s.mounter.(interface{ CleanupSocket(string) }); ok {
+		c.CleanupSocket(targetPath)
+	}
+
 	// Check if the target path is already mounted
 	if mounted, err := s.isDirMounted(targetPath); mounted || err != nil {
 		if err != nil {
@@ -1208,6 +1212,19 @@ func (s *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstage
 		// It is idempotent to unregister the same collector.
 		if s.driver.config.MetricsManager != nil {
 			s.driver.config.MetricsManager.UnregisterMetricsCollector(stagingPath, s.driver.config.NodeID, vs.MounterPodUID, vs.VolumeName)
+			if s.driver.config.FeatureOptions != nil && s.driver.config.FeatureOptions.SharedMountOptions != nil {
+				fuseSocketDir := s.driver.config.FeatureOptions.SharedMountOptions.FuseSocketDir
+				if vs.MounterPodUID != "" && vs.VolumeName != "" && fuseSocketDir != "" {
+					socketBasePath := util.GetSocketBasePath(vs.MounterPodUID, vs.VolumeName, fuseSocketDir)
+					if err := os.Remove(socketBasePath); err != nil && !os.IsNotExist(err) {
+						klog.Errorf("failed to remove metrics collector symlink %q: %v", socketBasePath, err)
+					}
+				} else {
+					// TODO(yaozile): Implement a long-term solution to prevent leaking metrics collector
+					// symlinks when NodeUnstageVolume is called after a driver restart
+					klog.Errorf("failed to remove metrics collector symlink for staging path %q: empty podUID, volumeName, or fuseSocketDir, symlink leaked", stagingPath)
+				}
+			}
 		}
 
 		// Stop GCSFuse Kernel Params monitoring.

--- a/pkg/csi_mounter/csi_mounter.go
+++ b/pkg/csi_mounter/csi_mounter.go
@@ -242,14 +242,10 @@ func updateSysfsConfig(targetMountPath string, sysfsBDI map[string]int64) error 
 }
 
 func (m *Mounter) UnmountWithForce(target string, umountTimeout time.Duration) error {
-	m.cleanupSocket(target)
-
 	return m.MounterForceUnmounter.UnmountWithForce(target, umountTimeout)
 }
 
 func (m *Mounter) Unmount(target string) error {
-	m.cleanupSocket(target)
-
 	return m.MounterForceUnmounter.Unmount(target)
 }
 
@@ -347,10 +343,11 @@ func (m *Mounter) createSocket(target string, logPrefix string) (net.Listener, e
 	return l, nil
 }
 
-func (m *Mounter) cleanupSocket(target string) {
+func (m *Mounter) CleanupSocket(target string) {
 	podUID, volumeName, err := util.ParsePodIDVolumeFromTargetpath(target)
 	if err != nil {
 		klog.Warningf("Failed to parse pod ID and volume name from target path %q: %v.", target, err)
+		return
 	}
 	socketBasePath := util.GetSocketBasePath(podUID, volumeName, m.fuseSocketDir)
 	socketPath := filepath.Join(socketBasePath, socketName)

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -356,6 +356,7 @@ func TestPrepareEmptyDir(t *testing.T) {
 }
 
 func TestGetSocketBasePath(t *testing.T) {
+	t.Parallel()
 	fuseSocketDir := "/tmp/fuse-sockets"
 
 	testCases := []struct {


### PR DESCRIPTION
…ymlink

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:
This PR did two things:

- **Socket cleanup:** Decoupled `CleanupSocket` from general filesystem unmounting (`Mounter.Unmount` / `Mounter.UnmountWithForce`) and invoked it explicitly in `NodeUnpublishVolume` before unmounting Pod target paths. This prevents `NodeUnstageVolume` (which unstages PV Shared Node Mount staging paths) from ever triggering socket cleanup, avoiding invalid Pod ID parsing and erroneous `_` socket removal attempts.
- **Symlink cleanup:** While standard sidecar mount symlinks continue to be removed by `CleanupSocket(targetPath)` during `NodeUnpublishVolume`, Shared Mount metric collector symlinks are now explicitly removed immediately after calling `UnregisterMetricsCollector` in `NodeUnstageVolume` to prevent leakage without conditional staging path checks.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

I have verified locally by deploying a workload pod with shared mount volume and delete it, and Node Unstage Volume went successfully.
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```