### PR TITLE
Restrict private sidecar images in shared mount mode.

### DIFF
--- a/cmd/csi_driver/main.go
+++ b/cmd/csi_driver/main.go
@@ -81,7 +81,8 @@ var (
 	enableGCSFuseKernelParams = flag.Bool("enable-gcsfuse-kernel-params", false, "Enable gcsfuse kernel params feature.")
 
 	// GCSFuse shared mount flags.
-	enableSharedMount = flag.Bool("enable-shared-mount", false, "Enable the shared mount feature.")
+	enableSharedMount        = flag.Bool("enable-shared-mount", false, "Enable the shared mount feature.")
+	allowCustomMounterImages = flag.Bool("allow-custom-mounter-images", false, "Allow arbitrary non-GKE-managed images to be used for mounter pods.")
 
 	// GCSFuse profiles flags.
 	enableGCSFuseProfiles         = flag.Bool("enable-gcsfuse-profiles", false, "Enable the gcsfuse profiles feature.")
@@ -247,9 +248,10 @@ func main() {
 			AutoGoMemLimitRatio:  *autoGoMemLimitRatio,
 		},
 		SharedMountOptions: &driver.SharedMountOptions{
-			Enabled:         *enableSharedMount,
-			FuseSocketDir:   *fuseSocketDir,
-			DriverNamespace: *driverNamespace,
+			Enabled:                  *enableSharedMount,
+			FuseSocketDir:            *fuseSocketDir,
+			DriverNamespace:          *driverNamespace,
+			AllowCustomMounterImages: *allowCustomMounterImages,
 			EmptyDirBasePath: func(podUID string) string {
 				return filepath.Join(util.KubeletDir, "pods", podUID, "volumes", "kubernetes.io~empty-dir", util.SidecarContainerTmpVolumeName)
 			},

--- a/pkg/csi_driver/controller.go
+++ b/pkg/csi_driver/controller.go
@@ -226,7 +226,12 @@ func (s *controllerServer) ControllerPublishVolume(ctx context.Context, req *csi
 		if container.Image != "" && container.Image != mounterPodManagedImageKeyword {
 			// If the image isn't the placeholder managed keyword, the user is trying to
 			// override the mounter pod's image.
-			// TODO(urielguzman): Somehow validate image so that only trustworthy repositories are allowed.
+			// Validate that the image is trustworthy (either it is an official GKE-managed image,
+			// or the cluster administrator has explicitly allowed custom mounter images).
+			imageOverrideAllowed := s.features.SharedMountOptions.AllowCustomMounterImages || isStrictManagedSidecarImage(container.Image)
+			if !imageOverrideAllowed {
+				return nil, status.Errorf(codes.InvalidArgument, "image %q is not allowed. Only GKE managed images are allowed", container.Image)
+			}
 			containerImage = container.Image
 		}
 		break

--- a/pkg/csi_driver/controller_test.go
+++ b/pkg/csi_driver/controller_test.go
@@ -253,16 +253,17 @@ func TestControllerPublishVolume(t *testing.T) {
 	defer func() { mounterPodPollInterval = oldInterval }()
 
 	cases := []struct {
-		name               string
-		req                *csi.ControllerPublishVolumeRequest
-		setupFake          func() *clientset.FakeClientset
-		podGetErr          error
-		podCreateErr       error
-		expectErr          bool
-		expectErrCode      codes.Code
-		podTemplateGetErr  error
-		wantPublishContext map[string]string
-		verifyCreatedPod   func(t *testing.T, pod *corev1.Pod)
+		name                     string
+		req                      *csi.ControllerPublishVolumeRequest
+		setupFake                func() *clientset.FakeClientset
+		podGetErr                error
+		podCreateErr             error
+		expectErr                bool
+		expectErrCode            codes.Code
+		podTemplateGetErr        error
+		wantPublishContext       map[string]string
+		verifyCreatedPod         func(t *testing.T, pod *corev1.Pod)
+		allowCustomMounterImages bool
 	}{
 		{
 			name: "empty volume ID - should return error",
@@ -498,6 +499,78 @@ func TestControllerPublishVolume(t *testing.T) {
 
 				if !reflect.DeepEqual(container.Image, expectedImage) {
 					t.Errorf("Mounter pod image does not match expected overrides.\nGot: %+v\nWant: %+v", container.Image, expectedImage)
+				}
+			},
+			allowCustomMounterImages: true,
+		},
+		{
+			name: "sharedMount true - mounter pod with untrusted image override - should return error when AllowCustomMounterImages is false",
+			req: &csi.ControllerPublishVolumeRequest{
+				VolumeId:         testVolumeID,
+				NodeId:           testNodeID,
+				VolumeCapability: testVolumeCapability,
+				VolumeContext: map[string]string{
+					"sharedMount":               "true",
+					util.VolumeContextKeyPVName: testPV,
+				},
+			},
+			setupFake: func() *clientset.FakeClientset {
+				cfg := getDefaultFakeClientsetConfig()
+				cfg.ptConfig.Template = corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  util.MounterPodNamePrefix,
+								Image: "gcr.io/some-project/some-random-image/v1.2.3",
+							},
+						},
+					},
+				}
+				return setupFakeBase(cfg)
+			},
+			podGetErr:     apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "pods"}, ""),
+			expectErr:     true,
+			expectErrCode: codes.InvalidArgument,
+		},
+		{
+			name: "sharedMount true - mounter pod with GKE managed image override - should succeed when AllowCustomMounterImages is false",
+			req: &csi.ControllerPublishVolumeRequest{
+				VolumeId:         testVolumeID,
+				NodeId:           testNodeID,
+				VolumeCapability: testVolumeCapability,
+				VolumeContext: map[string]string{
+					"sharedMount":               "true",
+					util.VolumeContextKeyPVName: testPV,
+				},
+			},
+			setupFake: func() *clientset.FakeClientset {
+				cfg := getDefaultFakeClientsetConfig()
+				cfg.ptConfig.Template = corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  util.MounterPodNamePrefix,
+								Image: "gke.gcr.io/gcs-fuse-csi-driver-sidecar-mounter:v1.23.0-gke.1",
+							},
+						},
+					},
+				}
+				return setupFakeBase(cfg)
+			},
+			wantPublishContext: map[string]string{
+				PublishContextKeyMounterPodNamespace: testNamespace,
+				PublishContextKeyMounterPodName:      createMounterPodName(testNodeID, testVolumeID),
+			},
+			podGetErr: apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "pods"}, ""),
+			expectErr: false,
+			verifyCreatedPod: func(t *testing.T, pod *corev1.Pod) {
+				if len(pod.Spec.Containers) != 1 {
+					t.Fatalf("Expected 1 container in created pod, got %d", len(pod.Spec.Containers))
+				}
+				container := pod.Spec.Containers[0]
+				expectedImage := "gke.gcr.io/gcs-fuse-csi-driver-sidecar-mounter:v1.23.0-gke.1"
+				if container.Image != expectedImage {
+					t.Errorf("Expected image %q, got %q", expectedImage, container.Image)
 				}
 			},
 		},
@@ -902,6 +975,13 @@ func TestControllerPublishVolume(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			fc := test.setupFake()
 			s := initTestController(t, fc)
+			if test.allowCustomMounterImages {
+				if cs, ok := s.(*controllerServer); ok {
+					if cs.features != nil && cs.features.SharedMountOptions != nil {
+						cs.features.SharedMountOptions.AllowCustomMounterImages = true
+					}
+				}
+			}
 
 			fakeK8sClient := fc.K8sClient().(*fake.Clientset)
 			var createdPod *corev1.Pod

--- a/pkg/csi_driver/gcs_fuse_driver.go
+++ b/pkg/csi_driver/gcs_fuse_driver.go
@@ -52,9 +52,10 @@ type GoMemLimitOptions struct {
 }
 
 type SharedMountOptions struct {
-	Enabled         bool
-	FuseSocketDir   string
-	DriverNamespace string
+	Enabled                  bool
+	FuseSocketDir            string
+	DriverNamespace          string
+	AllowCustomMounterImages bool
 	// Needed to override the mounter pods emptydir base path, otherwise tests will try to write to var/lib/kubelet which it won't have access to.
 	EmptyDirBasePath func(podUID string) string
 }

--- a/pkg/csi_driver/utils.go
+++ b/pkg/csi_driver/utils.go
@@ -101,6 +101,10 @@ var (
 	managedSidecarRegexAR    = regexp.MustCompile(managedSidecarPatternAR)
 	managedSidecarPatternGCR = `^(gke|staging-gke|master-gke)\.gcr\.io/gcs-fuse-csi-driver-sidecar-mounter:v\d+\.\d+\.\d+-gke\.\d+.*`
 	managedSidecarRegexGCR   = regexp.MustCompile(managedSidecarPatternGCR)
+
+	strictManagedSidecarPatternAR = `^(gcr\.io|[^/]*\.gcr\.io|[^/]*-docker\.pkg\.dev)/gke-release(-staging)?(/gke-release)?/gcs-fuse-csi-driver-sidecar-mounter:v\d+\.\d+\.\d+-gke\.\d+.*`
+	strictManagedSidecarRegexAR   = regexp.MustCompile(strictManagedSidecarPatternAR)
+
 	// Regex to detect deprecated flag error messages from gcsfuse. Should match the flags using .MarkDeprecated() in https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/cfg/config.go
 	deprecatedFlagPatterns = regexp.MustCompile(`Flag .*? has been deprecated`)
 	// Regex to detect invalid argument error messages from gcsfuse. Should match the flags using InvalidValueError in https://github.com/spf13/pflag/blob/b85eb9e15911a41cd7c05d955503542e9befadf4/errors.go#L116,
@@ -649,6 +653,10 @@ func getSidecarContainerStatus(isInitContainer bool, pod *corev1.Pod) (*corev1.C
 
 func isManagedSidecarImage(imageName string) bool {
 	return managedSidecarRegexAR.MatchString(imageName) || managedSidecarRegexGCR.MatchString(imageName)
+}
+
+func isStrictManagedSidecarImage(imageName string) bool {
+	return strictManagedSidecarRegexAR.MatchString(imageName) || managedSidecarRegexGCR.MatchString(imageName)
 }
 
 func (d *GCSDriver) isSidecarVersionSupportedForGivenFeature(imageName string, sidecarMinSupportedVersion string) bool {

--- a/pkg/csi_driver/utils_test.go
+++ b/pkg/csi_driver/utils_test.go
@@ -437,6 +437,71 @@ func TestIsSidecarVersionSupportedForGivenFeature(t *testing.T) {
 	})
 }
 
+func TestIsStrictManagedSidecarImage(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name      string
+		imageName string
+		want      bool
+	}{
+		{
+			name:      "official regional GCR - should return true",
+			imageName: "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gcs-fuse-csi-driver-sidecar-mounter:v1.23.0-gke.1",
+			want:      true,
+		},
+		{
+			name:      "official strict staging GCR - should return true",
+			imageName: "gcr.io/gke-release-staging/gcs-fuse-csi-driver-sidecar-mounter:v1.23.0-gke.1",
+			want:      true,
+		},
+		{
+			name:      "official strict regional docker pkg dev - should return true",
+			imageName: "us-central1-docker.pkg.dev/gke-release/gke-release/gcs-fuse-csi-driver-sidecar-mounter:v1.23.0-gke.1",
+			want:      true,
+		},
+		{
+			name:      "official strict regional docker pkg dev staging - should return true",
+			imageName: "us-central1-docker.pkg.dev/gke-release-staging/gcs-fuse-csi-driver-sidecar-mounter:v1.23.0-gke.1",
+			want:      true,
+		},
+		{
+			name:      "official gke.gcr.io host - should return true",
+			imageName: "gke.gcr.io/gcs-fuse-csi-driver-sidecar-mounter:v1.23.0-gke.1",
+			want:      true,
+		},
+		{
+			name:      "malicious suffix bypass AR - should return false",
+			imageName: "docker.io/attacker/gke-release/gcs-fuse-csi-driver-sidecar-mounter:v1.23.0-gke.1",
+			want:      false,
+		},
+		{
+			name:      "malicious suffix bypass GCR - should return false",
+			imageName: "docker.io/attacker/gke.gcr.io/gcs-fuse-csi-driver-sidecar-mounter:v1.23.0-gke.1",
+			want:      false,
+		},
+		{
+			name:      "customer GCR - should return false",
+			imageName: "customer.gcr.io/dir/gcs-fuse-csi-driver-sidecar-mounter:v1.23.0-gke.1",
+			want:      false,
+		},
+		{
+			name:      "malicious suffix bypass AR with gcr.io in path - should return false",
+			imageName: "docker.io/attacker/something.gcr.io/gke-release/gcs-fuse-csi-driver-sidecar-mounter:v1.23.0-gke.1",
+			want:      false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := isStrictManagedSidecarImage(tc.imageName)
+			if got != tc.want {
+				t.Errorf("isStrictManagedSidecarImage(%q) = %v; want %v", tc.imageName, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestParseVolumeAttributes(t *testing.T) {
 	testCases := []struct {
 		name                                  string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**: 
# Why this is a risk now (compared to gke-gcsfuse-sidecar)
 1. Standard Sidecar (gke-gcsfuse-sidecar) is Securely Jailed:
      - In pkg/webhook/sidecar_spec.go (GetSecurityContext), the standard sidecar container runs under the Restricted Pod Security Standard:
        - RunAsNonRoot: true
        - RunAsUser: NobodyUID (65534)
        - Capabilities.Drop: ["ALL"]
        - ReadOnlyRootFilesystem: true
      - Because it is severely restricted, allowing an arbitrary/custom image is safe: the user can only run custom code within their own isolated namespace boundaries under a restricted
        user profile. They cannot access host devices or other pods' volumes.

   2. Shared Mounter Pod (gcsfusecsi-mount) is Fully Privileged:
      - In pkg/csi_driver/shared_mount.go (createMounterPodSpec), the shared mounter container named gcsfusecsi-mount runs with:
        - Privileged: ptr.To(true)
      - Running a container as privileged gives it full host kernel capabilities, raw access to all host devices (/dev), and makes it trivial to escape to the host node (e.g., mounting
        raw disks, using nsenter, or injecting host cronjobs).
      - If pkg/csi_driver/controller.go (line 223) accepts a custom user-supplied image override from the PVC's annotated PodTemplate, the driver will create this privileged pod with
        that arbitrary image.

# How to addresss the security concern
We should implement a balanced option to eliminate the privilege escalation risk while preserving necessary flexibility:

   1. pkg/csi_driver/gcs_fuse_driver.go:
     Added AllowCustomMounterImages bool field to the SharedMountOptions struct to pass the configuration parameter into the CSI controller.
   2. cmd/csi_driver/main.go:
     Introduced a new flag --allow-custom-mounter-images (defaulting to false) to control whether untrusted images are permitted.
   3. pkg/csi_driver/controller.go:
     Added strict validation for the mounter container image override. If a custom image is provided:
      * It is allowed if it is a GKE-managed image (verified using isManagedSidecarImage). This allows users to quickly pin/adopt official GKE fixes or mitigations before a full driver
        rollout.
      * It is allowed if the cluster administrator explicitly opted-in by setting --allow-custom-mounter-images=true.
      * Otherwise, the publish request is rejected with codes.InvalidArgument to prevent execution of arbitrary untrusted binaries as root.
   4. pkg/csi_driver/controller_test.go:
      * Update the existing image override test case to include allowCustomMounterImages: true so that advanced/admin override scenarios continue to pass.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```