### PR TITLE
Check container termination and OOM for mounter pods

### DIFF
--- a/pkg/cloud_provider/clientset/fake.go
+++ b/pkg/cloud_provider/clientset/fake.go
@@ -177,7 +177,12 @@ func (c *FakeClientset) CreatePod(podConfig FakePodConfig) {
 		Status: corev1.PodStatus{
 			ContainerStatuses: []corev1.ContainerStatus{
 				{
-					Name: webhook.GcsFuseSidecarName,
+					Name: func() string {
+						if podConfig.IsMounterPod {
+							return util.MounterPodNamePrefix
+						}
+						return webhook.GcsFuseSidecarName
+					}(),
 					State: corev1.ContainerState{
 						Running: &corev1.ContainerStateRunning{},
 					},
@@ -195,7 +200,11 @@ func (c *FakeClientset) CreatePod(podConfig FakePodConfig) {
 	}
 
 	if podConfig.PodStatus != nil {
+		containerStatuses := c.fakePod.Status.ContainerStatuses
 		c.fakePod.Status = *podConfig.PodStatus
+		if len(c.fakePod.Status.ContainerStatuses) == 0 {
+			c.fakePod.Status.ContainerStatuses = containerStatuses
+		}
 	}
 
 	if podConfig.NodeName != "" {

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -173,6 +173,15 @@ func (s *nodeServer) NodePublishVolumeForSharedMount(_ context.Context, req *csi
 		return nil, status.Error(code, err.Error())
 	}
 
+	cs, err := getMounterPodContainerStatus(mounterPod)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	code, err = checkContainerStatusErr(cs)
+	if code != codes.OK {
+		return nil, status.Error(code, err.Error())
+	}
+
 	// We ignore the pod UID parsed from the target path, since we register the mounter pod's UID instead.
 	_, volumeName, err := util.ParsePodIDVolumeFromTargetpath(targetPath)
 	if err != nil {
@@ -461,7 +470,11 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 		}
 
 		// Check if there is any error from the sidecar container
-		code, err = checkSidecarContainerErr(isInitContainer, pod)
+		cs, err := getSidecarContainerStatus(isInitContainer, pod)
+		if err != nil {
+			return nil, status.Error(codes.Internal, err.Error())
+		}
+		code, err = checkContainerStatusErr(cs)
 		if code != codes.OK {
 			return nil, status.Error(code, err.Error())
 		}
@@ -1120,8 +1133,25 @@ func (s *nodeServer) executeNodeStageVolume(ctx context.Context, req *csi.NodeSt
 	// Send GRPC to mounter pod to start GCSFuse.
 	if err := s.mountToNode(ctx, podUID, stagingPath, volumeID, preparedMountOptions); err != nil {
 		klog.Errorf("Failed to mount volume %q to staging path %q: %v", volumeID, stagingPath, err)
-		if code, err := checkMounterPodErrorFile(emptyDirBasePath); err != nil {
-			return nil, status.Error(code, err.Error())
+		if code, fileErr := checkMounterPodErrorFile(emptyDirBasePath); fileErr != nil {
+			return nil, status.Error(code, fileErr.Error())
+		}
+		cs, csErr := func() (*corev1.ContainerStatus, error) {
+			// Re-fetch the mounter pod to get the updated container termination status
+			// (e.g. OOMKilled or crash) that occurred during mountToNode.
+			mounterPod, getErr := s.k8sClients.GetPod(podNamespace, podName)
+			if getErr != nil {
+				return nil, fmt.Errorf("failed to get mounter pod %s/%s: %w", podNamespace, podName, getErr)
+			}
+			if mounterPod == nil {
+				return nil, fmt.Errorf("mounter pod %s/%s cannot be nil", podNamespace, podName)
+			}
+			return getMounterPodContainerStatus(mounterPod)
+		}()
+		if csErr != nil {
+			klog.Warningf("Failed to inspect mounter pod container status: %v", csErr)
+		} else if code, cErr := checkContainerStatusErr(cs); code != codes.OK {
+			return nil, status.Error(code, cErr.Error())
 		}
 		return nil, err
 	}

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -2546,6 +2546,90 @@ func TestNodePublishVolumeForSharedMount(t *testing.T) {
 			expectErrCode:    codes.NotFound,
 		},
 		{
+			name: "mounter pod container oom killed - should return ResourceExhausted error",
+			reqBuilder: func(t *testing.T, targetPath, stagingPath string) *csi.NodePublishVolumeRequest {
+				return &csi.NodePublishVolumeRequest{
+					VolumeId:          testVolumeID,
+					VolumeCapability:  testVolumeCapability,
+					TargetPath:        targetPath,
+					StagingTargetPath: stagingPath,
+					VolumeContext: map[string]string{
+						VolumeContextSharedNodeMount: "true",
+					},
+					PublishContext: map[string]string{
+						PublishContextKeyMounterPodName:      podName,
+						PublishContextKeyMounterPodNamespace: podNamespace,
+					},
+				}
+			},
+			setupClient: func() *clientset.FakeClientset {
+				fc := clientset.NewFakeClientset()
+				fc.CreatePod(clientset.FakePodConfig{
+					Name:      podName,
+					Namespace: podNamespace,
+					UID:       podUID,
+					PodStatus: &corev1.PodStatus{
+						Phase: corev1.PodRunning,
+						ContainerStatuses: []corev1.ContainerStatus{
+							{
+								Name: util.MounterPodNamePrefix,
+								State: corev1.ContainerState{
+									Terminated: &corev1.ContainerStateTerminated{
+										ExitCode: 137,
+										Reason:   "OOMKilled",
+									},
+								},
+							},
+						},
+					},
+				})
+				return fc
+			},
+			expectErrCode: codes.ResourceExhausted,
+		},
+		{
+			name: "mounter pod container crashed - should return Internal error",
+			reqBuilder: func(t *testing.T, targetPath, stagingPath string) *csi.NodePublishVolumeRequest {
+				return &csi.NodePublishVolumeRequest{
+					VolumeId:          testVolumeID,
+					VolumeCapability:  testVolumeCapability,
+					TargetPath:        targetPath,
+					StagingTargetPath: stagingPath,
+					VolumeContext: map[string]string{
+						VolumeContextSharedNodeMount: "true",
+					},
+					PublishContext: map[string]string{
+						PublishContextKeyMounterPodName:      podName,
+						PublishContextKeyMounterPodNamespace: podNamespace,
+					},
+				}
+			},
+			setupClient: func() *clientset.FakeClientset {
+				fc := clientset.NewFakeClientset()
+				fc.CreatePod(clientset.FakePodConfig{
+					Name:      podName,
+					Namespace: podNamespace,
+					UID:       podUID,
+					PodStatus: &corev1.PodStatus{
+						Phase: corev1.PodRunning,
+						ContainerStatuses: []corev1.ContainerStatus{
+							{
+								Name: util.MounterPodNamePrefix,
+								State: corev1.ContainerState{
+									Terminated: &corev1.ContainerStateTerminated{
+										ExitCode: 1,
+										Reason:   "Error",
+									},
+								},
+							},
+						},
+					},
+				})
+				return fc
+			},
+			expectErrCode: codes.Internal,
+		},
+		{
 			name: "target path already mounted - should return early success",
 			reqBuilder: func(t *testing.T, targetPath, stagingPath string) *csi.NodePublishVolumeRequest {
 				return &csi.NodePublishVolumeRequest{
@@ -3573,5 +3657,76 @@ func TestNodeStageVolumeCleanupStagingPathOnFailure(t *testing.T) {
 	// Verify that the directory was physically removed by mount.CleanupMountPoint to prevent leakage.
 	if _, err := os.Stat(stagingPath); !os.IsNotExist(err) {
 		t.Errorf("Expected staging path directory %q to be deleted to prevent leakage, but it still exists", stagingPath)
+	}
+}
+
+func TestNodeStageVolumeMounterPodOOM(t *testing.T) {
+	t.Parallel()
+
+	stagingPath, cleanup := setupTestStagingPath(t)
+	defer cleanup()
+	nodeID := "test-node"
+	volID := testVolumeID
+	podName := createMounterPodName(nodeID, volID)
+
+	kubeletDir := t.TempDir()
+	mounterSocketDirValid := filepath.Join(kubeletDir, "pods", podName, "volumes", "kubernetes.io~empty-dir", util.SidecarContainerTmpVolumeName)
+	if err := os.MkdirAll(mounterSocketDirValid, 0755); err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	validSocketFile := filepath.Join(mounterSocketDirValid, MounterPodSocketFile)
+
+	if f, err := os.Create(validSocketFile); err != nil {
+		t.Fatalf("failed to create socket file: %v", err)
+	} else {
+		f.Close()
+	}
+
+	fakeClientset := clientset.NewFakeClientset()
+	fakeClientset.CreateNode(clientset.FakeNodeConfig{
+		Status: corev1.NodeStatus{
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("16Gi"),
+			},
+		},
+	})
+	fakeClientset.CreatePod(clientset.FakePodConfig{
+		Name:         podName,
+		Namespace:    "test-ns",
+		UID:          types.UID(podName),
+		IsMounterPod: true,
+		PodStatus: &corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name: util.MounterPodNamePrefix,
+					State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							ExitCode: 137,
+							Reason:   "OOMKilled",
+						},
+					},
+				},
+			},
+		},
+	})
+
+	testEnv := initTestNodeServerWithCustomClientset(t, fakeClientset, false)
+	ns, ok := testEnv.ns.(*nodeServer)
+	if !ok {
+		t.Fatalf("Failed to cast NodeServer to *nodeServer")
+	}
+	ns.driver.config.FeatureOptions.SharedMountOptions.EmptyDirBasePath = func(uid string) string {
+		return filepath.Join(kubeletDir, "pods", uid, "volumes", "kubernetes.io~empty-dir", util.SidecarContainerTmpVolumeName)
+	}
+
+	req := newTestNodeStageVolumeRequest(stagingPath, podName, "test-ns", nil)
+	_, err := ns.NodeStageVolume(context.Background(), req)
+	if err == nil {
+		t.Fatal("Expected NodeStageVolume to fail with OOM error, got nil")
+	}
+	st, ok := status.FromError(err)
+	if !ok || st.Code() != codes.ResourceExhausted {
+		t.Fatalf("Expected error code ResourceExhausted, got %v (err: %v)", st.Code(), err)
 	}
 }

--- a/pkg/csi_driver/shared_mount.go
+++ b/pkg/csi_driver/shared_mount.go
@@ -478,6 +478,17 @@ func waitForMounterServer(ctx context.Context, clientset clientset.Interface, mo
 			return false, nil
 		}
 
+		// Retry if container status is not yet available.
+		cs, err := getMounterPodContainerStatus(pod)
+		if err != nil {
+			klog.V(4).Infof("Mounter pod %s/%s container status not yet available: %v. Retrying...", mounterPodNamespace, mounterPodName, err)
+			return false, nil
+		}
+		// Fail fast if the mounter container terminates with an error or OOM.
+		if code, err := checkContainerStatusErr(cs); code != codes.OK {
+			return false, status.Error(code, err.Error())
+		}
+
 		// Mounter pod is running, check if the socket file is available.
 		// TODO(FUECHR): Investigate symlink traversal vulnerabilities for os.Stat vs os.Lstat.
 		if _, err = os.Stat(mounterSocketFilePath); err == nil {

--- a/pkg/csi_driver/shared_mount_test.go
+++ b/pkg/csi_driver/shared_mount_test.go
@@ -180,13 +180,77 @@ func TestWaitForMounterServer(t *testing.T) {
 			expectErr:    true,
 			expectedCode: codes.DeadlineExceeded,
 		},
+		{
+			name: "pod running but container oom killed - should return resource exhausted",
+			podStatus: &corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name: util.MounterPodNamePrefix,
+						State: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{
+								ExitCode: 137,
+								Reason:   "OOMKilled",
+							},
+						},
+					},
+				},
+			},
+			podUID:       testPod,
+			timeout:      200 * time.Millisecond,
+			expectErr:    true,
+			expectedCode: codes.ResourceExhausted,
+		},
+		{
+			name: "pod running but container restarted due to oom - should return resource exhausted",
+			podStatus: &corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name:         util.MounterPodNamePrefix,
+						RestartCount: 1,
+						LastTerminationState: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{
+								ExitCode: 137,
+								Reason:   "OOMKilled",
+							},
+						},
+					},
+				},
+			},
+			podUID:       testPod,
+			timeout:      200 * time.Millisecond,
+			expectErr:    true,
+			expectedCode: codes.ResourceExhausted,
+		},
+		{
+			name: "pod running but container terminated with error - should return internal",
+			podStatus: &corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name: util.MounterPodNamePrefix,
+						State: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{
+								ExitCode: 1,
+								Reason:   "Error",
+							},
+						},
+					},
+				},
+			},
+			podUID:       testPod,
+			timeout:      200 * time.Millisecond,
+			expectErr:    true,
+			expectedCode: codes.Internal,
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			fc := clientset.NewFakeClientset()
 			if tc.podStatus != nil {
-				fc.CreatePod(clientset.FakePodConfig{PodStatus: tc.podStatus})
+				fc.CreatePod(clientset.FakePodConfig{PodStatus: tc.podStatus, IsMounterPod: true})
 			}
 			if tc.getPodErr != nil {
 				fc.GetPodErr = tc.getPodErr

--- a/pkg/csi_driver/utils.go
+++ b/pkg/csi_driver/utils.go
@@ -605,13 +605,12 @@ func extractErrorFromGcsFuseErrorFile(errMsg []byte) (codes.Code, error) {
 	return codes.OK, nil
 }
 
-func checkSidecarContainerErr(isInitContainer bool, pod *corev1.Pod) (codes.Code, error) {
-	code := codes.Internal
-	cs, err := getSidecarContainerStatus(isInitContainer, pod)
-	if err != nil {
-		return code, err
+func checkContainerStatusErr(cs *corev1.ContainerStatus) (codes.Code, error) {
+	if cs == nil {
+		return codes.Internal, errors.New("container status is nil")
 	}
 
+	code := codes.Internal
 	var reason string
 	var exitCode int32
 	if cs.RestartCount > 0 && cs.LastTerminationState.Terminated != nil {
@@ -627,13 +626,28 @@ func checkSidecarContainerErr(isInitContainer bool, pod *corev1.Pod) (codes.Code
 			code = codes.ResourceExhausted
 		}
 
-		return code, fmt.Errorf("the sidecar container terminated due to %v, exit code: %v", reason, exitCode)
+		return code, fmt.Errorf("the %q container terminated due to %v, exit code: %v", cs.Name, reason, exitCode)
 	}
 
 	return codes.OK, nil
 }
 
+func getMounterPodContainerStatus(pod *corev1.Pod) (*corev1.ContainerStatus, error) {
+	if pod == nil {
+		return nil, errors.New("pod is nil")
+	}
+	for i := range pod.Status.ContainerStatuses {
+		if strings.HasPrefix(pod.Status.ContainerStatuses[i].Name, util.MounterPodNamePrefix) {
+			return &pod.Status.ContainerStatuses[i], nil
+		}
+	}
+	return nil, errors.New("the mounter pod container was not found")
+}
+
 func getSidecarContainerStatus(isInitContainer bool, pod *corev1.Pod) (*corev1.ContainerStatus, error) {
+	if pod == nil {
+		return nil, errors.New("pod is nil")
+	}
 	var containerStatusList []corev1.ContainerStatus
 	// Use ContainerStatuses or InitContainerStatuses
 	if isInitContainer {
@@ -642,9 +656,9 @@ func getSidecarContainerStatus(isInitContainer bool, pod *corev1.Pod) (*corev1.C
 		containerStatusList = pod.Status.ContainerStatuses
 	}
 
-	for _, cs := range containerStatusList {
-		if cs.Name == webhook.GcsFuseSidecarName {
-			return &cs, nil
+	for i := range containerStatusList {
+		if containerStatusList[i].Name == webhook.GcsFuseSidecarName {
+			return &containerStatusList[i], nil
 		}
 	}
 

--- a/pkg/csi_driver/utils_test.go
+++ b/pkg/csi_driver/utils_test.go
@@ -29,7 +29,9 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/clientset"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util"
+	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/webhook"
 	"google.golang.org/grpc/codes"
+	corev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -1413,6 +1415,311 @@ func TestPrepareSharedNodeMountOptions(t *testing.T) {
 			actual := prepareSharedNodeMountOptions(tc.options)
 			if diff := cmp.Diff(actual, tc.expected); diff != "" {
 				t.Errorf("test %q failed: got %v, want %v\nDiff (-want +got):\n%s", tc.name, actual, tc.expected, diff)
+			}
+		})
+	}
+}
+
+func TestCheckContainerStatusErr(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name         string
+		cs           *corev1.ContainerStatus
+		expectedCode codes.Code
+		expectErr    bool
+		expectedErr  string
+	}{
+		{
+			name:         "nil container status - should return Internal error",
+			cs:           nil,
+			expectedCode: codes.Internal,
+			expectErr:    true,
+			expectedErr:  "container status is nil",
+		},
+		{
+			name: "running container - should return OK",
+			cs: &corev1.ContainerStatus{
+				Name: "gke-gcsfuse-sidecar",
+				State: corev1.ContainerState{
+					Running: &corev1.ContainerStateRunning{},
+				},
+			},
+			expectedCode: codes.OK,
+			expectErr:    false,
+		},
+		{
+			name: "terminated with exit code 0 - should return OK",
+			cs: &corev1.ContainerStatus{
+				Name: "gke-gcsfuse-sidecar",
+				State: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{
+						ExitCode: 0,
+					},
+				},
+			},
+			expectedCode: codes.OK,
+			expectErr:    false,
+		},
+		{
+			name: "terminated with OOMKilled - should return ResourceExhausted",
+			cs: &corev1.ContainerStatus{
+				Name: "gke-gcsfuse-sidecar",
+				State: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{
+						ExitCode: 137,
+						Reason:   "OOMKilled",
+					},
+				},
+			},
+			expectedCode: codes.ResourceExhausted,
+			expectErr:    true,
+			expectedErr:  `the "gke-gcsfuse-sidecar" container terminated due to OOMKilled, exit code: 137`,
+		},
+		{
+			name: "terminated with exit code 137 - should return ResourceExhausted",
+			cs: &corev1.ContainerStatus{
+				Name: "gcsfusecsi-mount-test",
+				State: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{
+						ExitCode: 137,
+						Reason:   "Error",
+					},
+				},
+			},
+			expectedCode: codes.ResourceExhausted,
+			expectErr:    true,
+			expectedErr:  `the "gcsfusecsi-mount-test" container terminated due to Error, exit code: 137`,
+		},
+		{
+			name: "terminated with non-zero exit code - should return Internal",
+			cs: &corev1.ContainerStatus{
+				Name: "gke-gcsfuse-sidecar",
+				State: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{
+						ExitCode: 1,
+						Reason:   "Error",
+					},
+				},
+			},
+			expectedCode: codes.Internal,
+			expectErr:    true,
+			expectedErr:  `the "gke-gcsfuse-sidecar" container terminated due to Error, exit code: 1`,
+		},
+		{
+			name: "restarted container with OOM in LastTerminationState - should return ResourceExhausted",
+			cs: &corev1.ContainerStatus{
+				Name:         "gke-gcsfuse-sidecar",
+				RestartCount: 1,
+				LastTerminationState: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{
+						ExitCode: 137,
+						Reason:   "OOMKilled",
+					},
+				},
+			},
+			expectedCode: codes.ResourceExhausted,
+			expectErr:    true,
+			expectedErr:  `the "gke-gcsfuse-sidecar" container terminated due to OOMKilled, exit code: 137`,
+		},
+		{
+			name: "restarted container with non-zero exit in LastTerminationState - should return Internal",
+			cs: &corev1.ContainerStatus{
+				Name:         "gcsfusecsi-mount-test",
+				RestartCount: 1,
+				LastTerminationState: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{
+						ExitCode: 2,
+						Reason:   "Error",
+					},
+				},
+			},
+			expectedCode: codes.Internal,
+			expectErr:    true,
+			expectedErr:  `the "gcsfusecsi-mount-test" container terminated due to Error, exit code: 2`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			code, err := checkContainerStatusErr(tc.cs)
+			if tc.expectErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if code != tc.expectedCode {
+					t.Errorf("expected code %v, got %v", tc.expectedCode, code)
+				}
+				if tc.expectedErr != "" && err.Error() != tc.expectedErr {
+					t.Errorf("expected error %q, got %q", tc.expectedErr, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+				if code != tc.expectedCode {
+					t.Errorf("expected code %v, got %v", tc.expectedCode, code)
+				}
+			}
+		})
+	}
+}
+
+func TestGetMounterPodContainerStatus(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name         string
+		pod          *corev1.Pod
+		expectErr    bool
+		expectedName string
+	}{
+		{
+			name:      "nil pod - should return error",
+			pod:       nil,
+			expectErr: true,
+		},
+		{
+			name: "pod with no container statuses - should return error",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{},
+			},
+			expectErr: true,
+		},
+		{
+			name: "pod with sidecar container only - should return error",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{Name: "gke-gcsfuse-sidecar"},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "pod with exact mounter container name - should succeed",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{Name: util.MounterPodNamePrefix},
+					},
+				},
+			},
+			expectErr:    false,
+			expectedName: util.MounterPodNamePrefix,
+		},
+		{
+			name: "pod with prefixed mounter container name - should succeed",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{Name: util.MounterPodNamePrefix + "-12345"},
+					},
+				},
+			},
+			expectErr:    false,
+			expectedName: util.MounterPodNamePrefix + "-12345",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cs, err := getMounterPodContainerStatus(tc.pod)
+			if tc.expectErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+				if cs.Name != tc.expectedName {
+					t.Errorf("expected container name %q, got %q", tc.expectedName, cs.Name)
+				}
+			}
+		})
+	}
+}
+
+func TestGetSidecarContainerStatus(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name            string
+		isInitContainer bool
+		pod             *corev1.Pod
+		expectErr       bool
+		expectedName    string
+	}{
+		{
+			name:            "nil pod - should return error",
+			isInitContainer: false,
+			pod:             nil,
+			expectErr:       true,
+		},
+		{
+			name:            "pod with no container statuses - should return error",
+			isInitContainer: false,
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{},
+			},
+			expectErr: true,
+		},
+		{
+			name:            "regular sidecar container found - should succeed",
+			isInitContainer: false,
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{Name: webhook.GcsFuseSidecarName},
+					},
+				},
+			},
+			expectErr:    false,
+			expectedName: webhook.GcsFuseSidecarName,
+		},
+		{
+			name:            "init sidecar container found - should succeed",
+			isInitContainer: true,
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					InitContainerStatuses: []corev1.ContainerStatus{
+						{Name: webhook.GcsFuseSidecarName},
+					},
+				},
+			},
+			expectErr:    false,
+			expectedName: webhook.GcsFuseSidecarName,
+		},
+		{
+			name:            "init sidecar requested but only regular exists - should return error",
+			isInitContainer: true,
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{Name: webhook.GcsFuseSidecarName},
+					},
+				},
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cs, err := getSidecarContainerStatus(tc.isInitContainer, tc.pod)
+			if tc.expectErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+				if cs.Name != tc.expectedName {
+					t.Errorf("expected container name %q, got %q", tc.expectedName, cs.Name)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:
In shared mount mode, the CSI driver only checked the `/error` file and `pod.Status.Phase`.
When a mounter container terminated because of an OOM event:
- The container did not write an error to the `/error` file.
- The driver returned `codes.Internal`.
- This behavior triggered false SLO alerts.
- When the container restarted, `pod.Status.Phase` remained `PodRunning`. The driver did not detect the terminated GCSFuse process.

To solve this issue, this PR did the following things:
- Refactored GCSFuse container inspection into `checkContainerStatusErr` for shared use.
- Added container status inspection to `waitForMounterServer`, `executeNodeStageVolume`, and `NodePublishVolumeForSharedMount`.
- Returns `codes.ResourceExhausted` when the container terminates with `OOMKilled` or exit code 137.
- Returns `codes.Internal` with the exit code and reason when the container terminates with a non-zero exit code or restarts.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```