### PR TITLE
Cherry-pick #1497 onto release-1.22: Retry NodeUnpublishVolume upon failure

### DIFF
--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -35,6 +35,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	mount "k8s.io/mount-utils"
 )
@@ -46,6 +47,18 @@ const (
 	GCSFuseKernelParamsFilePollInterval = time.Second * 5
 	FuseMountType                       = "fuse"
 	maxGCSFuseVolumesForMetrics         = 10
+	unmountRetryInterval                = 100 * time.Millisecond
+	unmountRetryBackoffFactor           = 2.0
+	unmountRetryJitter                  = 0.1
+	// Standard unmount has no built-in timeout, so we use a short timeout to fail fast.
+	standardUnmountRetryTimeout = 2 * time.Second
+	standardUnmountRetrySteps   = 5
+	// Force unmount attempts include an initial non-force unmount with a
+	// 5 second timeout (as defined in vendor/k8s.io/mount-utils/mount_linux.go).
+	// We then retry force unmounting for 2 seconds.
+	// Thus the full timeout is 7 seconds.
+	forceUnmountRetryTimeout = 7 * time.Second
+	forceUnmountRetrySteps   = 6
 )
 
 // nodeServer handles mounting and unmounting of GCS FUSE volumes on a node.
@@ -378,7 +391,7 @@ func (s *nodeServer) isGcsFuseKernelParamsFeatureSupported(gcsFuseSidecarImage s
 		s.driver.isSidecarVersionSupportedForGivenFeature(gcsFuseSidecarImage, GCSFuseKernelParamsMinVersion)
 }
 
-func (s *nodeServer) NodeUnpublishVolume(_ context.Context, req *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
+func (s *nodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
 	// Validate arguments
 	targetPath := req.GetTargetPath()
 	if len(targetPath) == 0 {
@@ -415,12 +428,16 @@ func (s *nodeServer) NodeUnpublishVolume(_ context.Context, req *csi.NodeUnpubli
 		// mount.CleanupMountPoint() call will hang.
 		forceUnmounter, ok := s.mounter.(mount.MounterForceUnmounter)
 		if ok {
-			if err = forceUnmounter.UnmountWithForce(targetPath, UmountTimeout); err != nil {
+			if err = s.unmountWithRetry(ctx, targetPath, forceUnmountRetryTimeout, forceUnmountRetrySteps, func() error {
+				return forceUnmounter.UnmountWithForce(targetPath, UmountTimeout)
+			}); err != nil {
 				return nil, status.Errorf(codes.Internal, "failed to force unmount target path %q: %v", targetPath, err)
 			}
 		} else {
 			klog.Warningf("failed to cast the mounter to a forceUnmounter, proceed with the default mounter Unmount")
-			if err = s.mounter.Unmount(targetPath); err != nil {
+			if err = s.unmountWithRetry(ctx, targetPath, standardUnmountRetryTimeout, standardUnmountRetrySteps, func() error {
+				return s.mounter.Unmount(targetPath)
+			}); err != nil {
 				return nil, status.Errorf(codes.Internal, "failed to unmount target path %q: %v", targetPath, err)
 			}
 		}
@@ -449,6 +466,43 @@ func (s *nodeServer) isDirMounted(targetPath string) (bool, error) {
 	}
 
 	return false, nil
+}
+
+// unmountWithRetry retries the unmount operation using exponential backoff.
+// It uses a child context with a timeout to limit the total retry duration,
+// in addition to being limited to the defined number of steps.
+//
+// If the OS unmount system call itself hangs, this function will block
+// on the hung call. It won't be able to interrupt the hung call until the Kubelet cancels the parent
+// context (NodeUnpublishVolume context) and retries the entire operation.
+func (s *nodeServer) unmountWithRetry(ctx context.Context, targetPath string, timeout time.Duration, steps int, unmountFn func() error) error {
+	var lastErr error
+	childCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	backoff := wait.Backoff{
+		Duration: unmountRetryInterval,
+		Factor:   unmountRetryBackoffFactor,
+		Jitter:   unmountRetryJitter,
+		Steps:    steps,
+	}
+
+	pollErr := wait.ExponentialBackoffWithContext(childCtx, backoff, func(ctx context.Context) (bool, error) {
+		lastErr = unmountFn()
+		if lastErr == nil {
+			return true, nil
+		}
+		klog.Warningf("Failed to unmount %q: %v. Retrying...", targetPath, lastErr)
+		return false, nil
+	})
+
+	if pollErr != nil {
+		if lastErr != nil {
+			return lastErr
+		}
+		return pollErr
+	}
+	return nil
 }
 
 // setupMultiNIC updates args with options for multi NIC configuration.

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -19,6 +19,7 @@ package driver
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -26,6 +27,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/clientset"
@@ -56,9 +58,39 @@ type nodeServerTestEnv struct {
 }
 
 func initTestNodeServer(t *testing.T) *nodeServerTestEnv {
+	return initTestNodeServerWithMounter(t, mount.NewFakeMounter([]mount.MountPoint{}))
+}
+
+type fakeForceUnmounter struct {
+	*mount.FakeMounter
+	unmountWithForceFunc func(target string, umountTimeout time.Duration) error
+}
+
+func (f *fakeForceUnmounter) UnmountWithForce(target string, umountTimeout time.Duration) error {
+	if f.unmountWithForceFunc != nil {
+		return f.unmountWithForceFunc(target, umountTimeout)
+	}
+	return f.FakeMounter.Unmount(target)
+}
+
+func initTestNodeServerWithForceMounter(t *testing.T) (*nodeServerTestEnv, *fakeForceUnmounter) {
+	fakeMounter := mount.NewFakeMounter([]mount.MountPoint{})
+	mounter := &fakeForceUnmounter{
+		FakeMounter: fakeMounter,
+	}
+	return initTestNodeServerWithMounter(t, mounter), mounter
+}
+
+func initTestNodeServerWithMounter(t *testing.T, mounter mount.Interface) *nodeServerTestEnv {
 	t.Helper()
-	mounter := mount.NewFakeMounter([]mount.MountPoint{})
-	driver := initTestDriver(t, mounter)
+	var fakeMounter *mount.FakeMounter
+	if fm, ok := mounter.(*mount.FakeMounter); ok {
+		fakeMounter = fm
+	} else if ffm, ok := mounter.(*fakeForceUnmounter); ok {
+		fakeMounter = ffm.FakeMounter
+	}
+
+	driver := initTestDriver(t, fakeMounter)
 	s, _ := driver.config.StorageServiceManager.SetupService(context.TODO(), nil)
 	if _, err := s.CreateBucket(context.Background(), &storage.ServiceBucket{Name: testVolumeID}); err != nil {
 		t.Fatalf("failed to create the fake bucket: %v", err)
@@ -66,7 +98,7 @@ func initTestNodeServer(t *testing.T) *nodeServerTestEnv {
 
 	return &nodeServerTestEnv{
 		ns:    newNodeServer(driver, mounter),
-		fm:    mounter,
+		fm:    fakeMounter,
 		nwMgr: driver.config.NetworkManager.(*fakeNetworkManager),
 	}
 }
@@ -407,7 +439,9 @@ func TestNodeUnpublishVolume(t *testing.T) {
 		mounts        []mount.MountPoint // already existing mounts
 		req           *csi.NodeUnpublishVolumeRequest
 		actions       []mount.FakeAction
+		unmountFunc   func(path string) error
 		expectedMount *mount.MountPoint
+		ctx           context.Context
 		expectErr     error
 	}{
 		{
@@ -439,6 +473,41 @@ func TestNodeUnpublishVolume(t *testing.T) {
 				TargetPath: testTargetPath,
 			},
 		},
+		{
+			name:   "retry unmount succeeds eventually",
+			mounts: []mount.MountPoint{{Device: testVolumeID, Path: testTargetPath}},
+			req: &csi.NodeUnpublishVolumeRequest{
+				VolumeId:   testVolumeID,
+				TargetPath: testTargetPath,
+			},
+			unmountFunc: func() func(path string) error {
+				calls := 0
+				return func(path string) error {
+					calls++
+					if calls < 3 {
+						return fmt.Errorf("umount: %s: target is busy", path)
+					}
+					return nil
+				}
+			}(),
+		},
+		{
+			name:   "retry unmount fails after max retries",
+			mounts: []mount.MountPoint{{Device: testVolumeID, Path: testTargetPath}},
+			req: &csi.NodeUnpublishVolumeRequest{
+				VolumeId:   testVolumeID,
+				TargetPath: testTargetPath,
+			},
+			unmountFunc: func(path string) error {
+				return fmt.Errorf("umount: %s: target is busy", path)
+			},
+			expectedMount: &mount.MountPoint{Device: testVolumeID, Path: testTargetPath},
+			ctx: func() context.Context {
+				ctx, _ := context.WithTimeout(context.Background(), 500*time.Millisecond)
+				return ctx
+			}(),
+			expectErr: status.Errorf(codes.Internal, "failed to unmount target path %q: umount: %s: target is busy", testTargetPath, testTargetPath),
+		},
 	}
 
 	for _, test := range cases {
@@ -447,8 +516,95 @@ func TestNodeUnpublishVolume(t *testing.T) {
 			if test.mounts != nil {
 				testEnv.fm.MountPoints = test.mounts
 			}
+			if test.unmountFunc != nil {
+				testEnv.fm.UnmountFunc = test.unmountFunc
+			}
 
-			_, err := testEnv.ns.NodeUnpublishVolume(context.TODO(), test.req)
+			ctx := context.TODO()
+			if test.ctx != nil {
+				ctx = test.ctx
+			}
+
+			_, err := testEnv.ns.NodeUnpublishVolume(ctx, test.req)
+			if test.expectErr == nil && err != nil {
+				t.Errorf("got error %q, expected error nil", err)
+			}
+			if test.expectErr != nil && !errors.Is(err, test.expectErr) {
+				t.Errorf("got error %q, expected error %q", err, test.expectErr)
+			}
+
+			validateMountPoint(t, testEnv.fm, test.expectedMount, nil)
+		})
+	}
+}
+
+func TestNodeUnpublishVolumeForceUnmount(t *testing.T) {
+	t.Parallel()
+	testTargetPath, cleanup := setupMountTarget(t)
+	defer cleanup()
+
+	cases := []struct {
+		name                 string
+		mounts               []mount.MountPoint
+		req                  *csi.NodeUnpublishVolumeRequest
+		unmountWithForceFunc func(target string, umountTimeout time.Duration) error
+		expectedMount        *mount.MountPoint
+		ctx                  context.Context
+		expectErr            error
+	}{
+		{
+			name:   "retry force unmount succeeds eventually",
+			mounts: []mount.MountPoint{{Device: testVolumeID, Path: testTargetPath}},
+			req: &csi.NodeUnpublishVolumeRequest{
+				VolumeId:   testVolumeID,
+				TargetPath: testTargetPath,
+			},
+			unmountWithForceFunc: func() func(target string, umountTimeout time.Duration) error {
+				calls := 0
+				return func(target string, umountTimeout time.Duration) error {
+					calls++
+					if calls < 3 {
+						return fmt.Errorf("umount: %s: target is busy", target)
+					}
+					return nil
+				}
+			}(),
+		},
+		{
+			name:   "retry force unmount fails after max retries",
+			mounts: []mount.MountPoint{{Device: testVolumeID, Path: testTargetPath}},
+			req: &csi.NodeUnpublishVolumeRequest{
+				VolumeId:   testVolumeID,
+				TargetPath: testTargetPath,
+			},
+			unmountWithForceFunc: func(target string, umountTimeout time.Duration) error {
+				return fmt.Errorf("umount: %s: target is busy", target)
+			},
+			expectedMount: &mount.MountPoint{Device: testVolumeID, Path: testTargetPath},
+			ctx: func() context.Context {
+				ctx, _ := context.WithTimeout(context.Background(), 500*time.Millisecond)
+				return ctx
+			}(),
+			expectErr: status.Errorf(codes.Internal, "failed to force unmount target path %q: umount: %s: target is busy", testTargetPath, testTargetPath),
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			testEnv, forceMounter := initTestNodeServerWithForceMounter(t)
+			if test.mounts != nil {
+				testEnv.fm.MountPoints = test.mounts
+			}
+			if test.unmountWithForceFunc != nil {
+				forceMounter.unmountWithForceFunc = test.unmountWithForceFunc
+			}
+
+			ctx := context.TODO()
+			if test.ctx != nil {
+				ctx = test.ctx
+			}
+
+			_, err := testEnv.ns.NodeUnpublishVolume(ctx, test.req)
 			if test.expectErr == nil && err != nil {
 				t.Errorf("got error %q, expected error nil", err)
 			}


### PR DESCRIPTION
Cherry-pick of #1497 onto `release-1.22`.

### Summary
Backports the unmount retry logic for `NodeUnpublishVolume` to `release-1.22` (GKE 1.35).

### Changes
* Retries unmounting in `NodeUnpublishVolume` upon transient "target is busy" errors.
* Added unit tests for standard and force unmount retries.

### Verification
* Ran `go test ./pkg/csi_driver/ -run "TestNodeUnpublishVolume"`.