### PR TITLE
Verify fsGroup and SA name in NPV for shared mount

### DIFF
--- a/pkg/cloud_provider/clientset/clientset.go
+++ b/pkg/cloud_provider/clientset/clientset.go
@@ -561,13 +561,17 @@ func (c *Clientset) ConfigurePodLister(ctx context.Context, nodeName string, eve
 		volumes := podObj.Spec.Volumes
 		restartPolicy := podObj.Spec.RestartPolicy
 		hostNetwork := podObj.Spec.HostNetwork
+		securityContext := podObj.Spec.SecurityContext
+		serviceAccountName := podObj.Spec.ServiceAccountName
 		podObj.Spec = corev1.PodSpec{
-			NodeName:       nodeName,
-			Volumes:        volumes,
-			Containers:     newContainers,
-			InitContainers: newInitContainers,
-			RestartPolicy:  restartPolicy,
-			HostNetwork:    hostNetwork,
+			NodeName:           nodeName,
+			Volumes:            volumes,
+			Containers:         newContainers,
+			InitContainers:     newInitContainers,
+			RestartPolicy:      restartPolicy,
+			HostNetwork:        hostNetwork,
+			SecurityContext:    securityContext,
+			ServiceAccountName: serviceAccountName,
 		}
 
 		return obj, nil

--- a/pkg/cloud_provider/clientset/clientset_test.go
+++ b/pkg/cloud_provider/clientset/clientset_test.go
@@ -27,7 +27,50 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/utils/ptr"
 )
+
+func TestConfigurePodLister(t *testing.T) {
+	t.Parallel()
+
+	var wantFSGroup int64 = 1000
+	wantSA := "custom-sa"
+
+	testPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "test-ns",
+		},
+		Spec: corev1.PodSpec{
+			NodeName:           "test-node",
+			ServiceAccountName: wantSA,
+			SecurityContext: &corev1.PodSecurityContext{
+				FSGroup: ptr.To(wantFSGroup),
+			},
+		},
+	}
+
+	fakeClient := fake.NewSimpleClientset(testPod)
+	c := &Clientset{
+		k8sClients:    fakeClient,
+		runController: false,
+	}
+
+	c.ConfigurePodLister(t.Context(), "test-node", nil)
+
+	gotPod, err := c.GetPod("test-ns", "test-pod")
+	if err != nil {
+		t.Fatalf("c.GetPod unexpected error: %v", err)
+	}
+
+	if gotPod.Spec.ServiceAccountName != wantSA {
+		t.Errorf("got ServiceAccountName %q, want %q", gotPod.Spec.ServiceAccountName, wantSA)
+	}
+
+	if gotPod.Spec.SecurityContext == nil || gotPod.Spec.SecurityContext.FSGroup == nil || *gotPod.Spec.SecurityContext.FSGroup != wantFSGroup {
+		t.Errorf("got SecurityContext %+v, want FSGroup %d", gotPod.Spec.SecurityContext, wantFSGroup)
+	}
+}
 
 func TestConfigurePVLister(t *testing.T) {
 	t.Parallel()

--- a/pkg/cloud_provider/clientset/fake.go
+++ b/pkg/cloud_provider/clientset/fake.go
@@ -49,6 +49,8 @@ type FakePodConfig struct {
 	PodStatus          *corev1.PodStatus
 	NodeName           string
 	IsMounterPod       bool
+	SecurityContext    *corev1.PodSecurityContext
+	ServiceAccountName string
 }
 
 type FakePVConfig struct {
@@ -209,6 +211,14 @@ func (c *FakeClientset) CreatePod(podConfig FakePodConfig) {
 
 	if podConfig.NodeName != "" {
 		c.fakePod.Spec.NodeName = podConfig.NodeName
+	}
+
+	if podConfig.SecurityContext != nil {
+		c.fakePod.Spec.SecurityContext = podConfig.SecurityContext
+	}
+
+	if podConfig.ServiceAccountName != "" {
+		c.fakePod.Spec.ServiceAccountName = podConfig.ServiceAccountName
 	}
 
 	c.fakePods = append(c.fakePods, c.fakePod)

--- a/pkg/csi_driver/controller.go
+++ b/pkg/csi_driver/controller.go
@@ -277,6 +277,7 @@ func (s *controllerServer) ControllerPublishVolume(ctx context.Context, req *csi
 		hostNetworkEnabled: hostNetworkEnabled,
 		tokenAudience:      tokenAudience,
 		dnsPolicy:          podTemplate.Template.Spec.DNSPolicy,
+		securityContext:    podTemplate.Template.Spec.SecurityContext,
 	}
 
 	if err := createMounterPod(clientset, ctx, podConfig); err != nil {

--- a/pkg/csi_driver/controller_test.go
+++ b/pkg/csi_driver/controller_test.go
@@ -38,17 +38,19 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
+	"k8s.io/utils/ptr"
 )
 
 const (
-	testVolumeID           = "test-volume-id"
-	testNodeID             = "test-node-id"
-	testPV                 = "test-pv"
-	testPVC                = "test-pvc"
-	testMounterPodTemplate = "test-mounter-pod-template"
-	testNamespace          = "test-namespace"
-	testPod                = "test-pod"
-	testImage              = "k8s.gcr.io/pause"
+	testVolumeID                 = "test-volume-id"
+	testNodeID                   = "test-node-id"
+	testPV                       = "test-pv"
+	testPVC                      = "test-pvc"
+	testMounterPodTemplate       = "test-mounter-pod-template"
+	testNamespace                = "test-namespace"
+	testPod                      = "test-pod"
+	testImage                    = "k8s.gcr.io/pause"
+	testFSGroup            int64 = 1000
 )
 
 func initTestController(t *testing.T, clientset clientset.Interface) csi.ControllerServer {
@@ -639,6 +641,42 @@ func TestControllerPublishVolume(t *testing.T) {
 			verifyCreatedPod: func(t *testing.T, pod *corev1.Pod) {
 				if pod.Spec.DNSPolicy != corev1.DNSClusterFirstWithHostNet {
 					t.Errorf("Expected DNSPolicy %q, got %q", corev1.DNSClusterFirstWithHostNet, pod.Spec.DNSPolicy)
+				}
+			},
+		},
+		{
+			name: "sharedMount true - mounter pod with SecurityContext override - should create pod with overridden SecurityContext",
+			req: &csi.ControllerPublishVolumeRequest{
+				VolumeId:         testVolumeID,
+				NodeId:           testNodeID,
+				VolumeCapability: testVolumeCapability,
+				VolumeContext: map[string]string{
+					"sharedMount":               "true",
+					util.VolumeContextKeyPVName: testPV,
+				},
+			},
+			setupFake: func() *clientset.FakeClientset {
+				cfg := getDefaultFakeClientsetConfig()
+				cfg.ptConfig.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
+					RunAsUser:    ptr.To(int64(2000)),
+					RunAsGroup:   ptr.To(int64(2000)),
+					RunAsNonRoot: ptr.To(true),
+					FSGroup:      ptr.To(testFSGroup),
+				}
+				return setupFakeBase(cfg)
+			},
+			wantPublishContext: map[string]string{
+				PublishContextKeyMounterPodNamespace: testNamespace,
+				PublishContextKeyMounterPodName:      createMounterPodName(testNodeID, testVolumeID),
+			},
+			podGetErr: apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "pods"}, ""),
+			expectErr: false,
+			verifyCreatedPod: func(t *testing.T, pod *corev1.Pod) {
+				expectedSC := &corev1.PodSecurityContext{
+					FSGroup: ptr.To(testFSGroup),
+				}
+				if !reflect.DeepEqual(pod.Spec.SecurityContext, expectedSC) {
+					t.Errorf("Expected SecurityContext %+v, got %+v", expectedSC, pod.Spec.SecurityContext)
 				}
 			},
 		},

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -159,6 +159,25 @@ func (s *nodeServer) NodePublishVolumeForSharedMount(_ context.Context, req *csi
 		return nil, status.Errorf(codes.Internal, "mounter pod %s/%s cannot be nil", mounterPodNamespace, mounterPodName)
 	}
 
+	// Verify workload service account name matches mounter pod.
+	// If neither the workload nor the mounter pod specifies a service account, the Kubernetes ServiceAccount
+	// admission controller defaults both to "default", so the equality check passes as expected.
+	targetDesc := "mounter pod"
+	vc := req.GetVolumeContext()
+	if err := webhook.ValidateServiceAccountName(vc[VolumeContextKeyServiceAccountName], mounterPod.Spec.ServiceAccountName, targetDesc); err != nil {
+		return nil, status.Error(codes.PermissionDenied, err.Error())
+	}
+
+	// Verify workload fsGroup matches mounter pod.
+	var mounterFSGroup string
+	if mounterPod.Spec.SecurityContext != nil && mounterPod.Spec.SecurityContext.FSGroup != nil {
+		mounterFSGroup = strconv.FormatInt(*mounterPod.Spec.SecurityContext.FSGroup, 10)
+	}
+	workloadFSGroup := req.GetVolumeCapability().GetMount().GetVolumeMountGroup()
+	if err := webhook.ValidateFSGroup(workloadFSGroup, mounterFSGroup, targetDesc); err != nil {
+		return nil, status.Error(codes.PermissionDenied, err.Error())
+	}
+
 	// Surface any GCSFuse error to the user.
 	if s.driver.config.FeatureOptions == nil || s.driver.config.FeatureOptions.SharedMountOptions == nil {
 		return nil, status.Error(codes.Internal, "shared mount options can't be nil")

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -47,6 +47,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	mount "k8s.io/mount-utils"
+	"k8s.io/utils/ptr"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -2835,6 +2836,153 @@ func TestNodePublishVolumeForSharedMount(t *testing.T) {
 			targetPathMounted: false,
 			expectErrCode:     codes.OK,
 			expectedBindOpts:  []string{"bind"},
+		},
+		{
+			name: "workload SA matches mounter SA and both have matching fsGroup - should succeed",
+			reqBuilder: func(t *testing.T, targetPath, stagingPath string) *csi.NodePublishVolumeRequest {
+				return &csi.NodePublishVolumeRequest{
+					VolumeId: testVolumeID,
+					VolumeCapability: &csi.VolumeCapability{
+						AccessType: &csi.VolumeCapability_Mount{
+							Mount: &csi.VolumeCapability_MountVolume{
+								VolumeMountGroup: "1000",
+							},
+						},
+						AccessMode: testVolumeCapability.AccessMode,
+					},
+					TargetPath:        targetPath,
+					StagingTargetPath: stagingPath,
+					VolumeContext: map[string]string{
+						VolumeContextSharedNodeMount:       "true",
+						VolumeContextKeyServiceAccountName: "custom-sa",
+					},
+					PublishContext: map[string]string{
+						PublishContextKeyMounterPodName:      podName,
+						PublishContextKeyMounterPodNamespace: podNamespace,
+					},
+				}
+			},
+			setupClient: func() *clientset.FakeClientset {
+				fc := clientset.NewFakeClientset()
+				fc.CreatePod(clientset.FakePodConfig{
+					Name:               podName,
+					Namespace:          podNamespace,
+					UID:                podUID,
+					PodStatus:          &corev1.PodStatus{Phase: corev1.PodRunning},
+					IsMounterPod:       true,
+					ServiceAccountName: "custom-sa",
+					SecurityContext: &corev1.PodSecurityContext{
+						FSGroup: ptr.To(int64(1000)),
+					},
+				})
+				return fc
+			},
+			expectErrCode: codes.OK,
+		},
+		{
+			name: "workload SA mismatches mounter SA - should return PermissionDenied error",
+			reqBuilder: func(t *testing.T, targetPath, stagingPath string) *csi.NodePublishVolumeRequest {
+				return &csi.NodePublishVolumeRequest{
+					VolumeId:          testVolumeID,
+					VolumeCapability:  testVolumeCapability,
+					TargetPath:        targetPath,
+					StagingTargetPath: stagingPath,
+					VolumeContext: map[string]string{
+						VolumeContextSharedNodeMount:       "true",
+						VolumeContextKeyServiceAccountName: "sa-1",
+					},
+					PublishContext: map[string]string{
+						PublishContextKeyMounterPodName:      podName,
+						PublishContextKeyMounterPodNamespace: podNamespace,
+					},
+				}
+			},
+			setupClient: func() *clientset.FakeClientset {
+				fc := clientset.NewFakeClientset()
+				fc.CreatePod(clientset.FakePodConfig{
+					Name:               podName,
+					Namespace:          podNamespace,
+					UID:                podUID,
+					PodStatus:          &corev1.PodStatus{Phase: corev1.PodRunning},
+					IsMounterPod:       true,
+					ServiceAccountName: "sa-2",
+				})
+				return fc
+			},
+			expectErrCode: codes.PermissionDenied,
+		},
+		{
+			name: "workload fsGroup mismatches mounter fsGroup - should return PermissionDenied error",
+			reqBuilder: func(t *testing.T, targetPath, stagingPath string) *csi.NodePublishVolumeRequest {
+				return &csi.NodePublishVolumeRequest{
+					VolumeId: testVolumeID,
+					VolumeCapability: &csi.VolumeCapability{
+						AccessType: &csi.VolumeCapability_Mount{
+							Mount: &csi.VolumeCapability_MountVolume{
+								VolumeMountGroup: "2000",
+							},
+						},
+						AccessMode: testVolumeCapability.AccessMode,
+					},
+					TargetPath:        targetPath,
+					StagingTargetPath: stagingPath,
+					VolumeContext: map[string]string{
+						VolumeContextSharedNodeMount: "true",
+					},
+					PublishContext: map[string]string{
+						PublishContextKeyMounterPodName:      podName,
+						PublishContextKeyMounterPodNamespace: podNamespace,
+					},
+				}
+			},
+			setupClient: func() *clientset.FakeClientset {
+				fc := clientset.NewFakeClientset()
+				fc.CreatePod(clientset.FakePodConfig{
+					Name:         podName,
+					Namespace:    podNamespace,
+					UID:          podUID,
+					PodStatus:    &corev1.PodStatus{Phase: corev1.PodRunning},
+					IsMounterPod: true,
+					SecurityContext: &corev1.PodSecurityContext{
+						FSGroup: ptr.To(int64(1000)),
+					},
+				})
+				return fc
+			},
+			expectErrCode: codes.PermissionDenied,
+		},
+		{
+			name: "mounter has fsGroup, workload has no fsGroup - should return PermissionDenied error",
+			reqBuilder: func(t *testing.T, targetPath, stagingPath string) *csi.NodePublishVolumeRequest {
+				return &csi.NodePublishVolumeRequest{
+					VolumeId:          testVolumeID,
+					VolumeCapability:  testVolumeCapability,
+					TargetPath:        targetPath,
+					StagingTargetPath: stagingPath,
+					VolumeContext: map[string]string{
+						VolumeContextSharedNodeMount: "true",
+					},
+					PublishContext: map[string]string{
+						PublishContextKeyMounterPodName:      podName,
+						PublishContextKeyMounterPodNamespace: podNamespace,
+					},
+				}
+			},
+			setupClient: func() *clientset.FakeClientset {
+				fc := clientset.NewFakeClientset()
+				fc.CreatePod(clientset.FakePodConfig{
+					Name:         podName,
+					Namespace:    podNamespace,
+					UID:          podUID,
+					PodStatus:    &corev1.PodStatus{Phase: corev1.PodRunning},
+					IsMounterPod: true,
+					SecurityContext: &corev1.PodSecurityContext{
+						FSGroup: ptr.To(int64(1000)),
+					},
+				})
+				return fc
+			},
+			expectErrCode: codes.PermissionDenied,
 		},
 	}
 

--- a/pkg/csi_driver/shared_mount.go
+++ b/pkg/csi_driver/shared_mount.go
@@ -66,6 +66,7 @@ type mounterPodConfig struct {
 	hostNetworkEnabled bool                         // Whether hostNetwork is enabled for the mounter pod.
 	tokenAudience      string                       // Token audience for projected service account volume.
 	dnsPolicy          corev1.DNSPolicy             // The DNS policy for the mounter pod.
+	securityContext    *corev1.PodSecurityContext   // The pod-level security context for the mounter pod.
 }
 
 // sharedMount checks if the VolumeContext enables the shared node mount feature
@@ -235,6 +236,12 @@ func createMounterPodSpec(config *mounterPodConfig) *corev1.Pod {
 
 	if config.dnsPolicy != "" {
 		spec.Spec.DNSPolicy = config.dnsPolicy
+	}
+
+	if config.securityContext != nil && config.securityContext.FSGroup != nil {
+		spec.Spec.SecurityContext = &corev1.PodSecurityContext{
+			FSGroup: config.securityContext.FSGroup,
+		}
 	}
 
 	spec.Spec.Containers[0].Resources = *mounterPodResources(config)

--- a/pkg/csi_driver/shared_mount_test.go
+++ b/pkg/csi_driver/shared_mount_test.go
@@ -825,6 +825,60 @@ func TestCreateMounterPodSpec(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "config with securityContext - should propagate only fsGroup",
+			config: &mounterPodConfig{
+				podName:            "my-mounter-pod",
+				namespace:          "my-namespace",
+				serviceAccountName: "my-ksa",
+				nodeID:             "node-123",
+				image:              "gcr.io/my-project/my-image:v1.0.0",
+				securityContext: &corev1.PodSecurityContext{
+					RunAsUser: ptr.To(int64(2000)),
+					FSGroup:   ptr.To(testFSGroup),
+				},
+			},
+			want: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-mounter-pod",
+					Namespace: "my-namespace",
+					Labels: map[string]string{
+						"gke-gcsfuse/shared-mount": "true",
+					},
+				},
+				Spec: corev1.PodSpec{
+					NodeSelector: map[string]string{
+						"kubernetes.io/hostname": "node-123",
+						"kubernetes.io/os":       "linux",
+					},
+					ServiceAccountName: "my-ksa",
+					SecurityContext: &corev1.PodSecurityContext{
+						FSGroup: ptr.To(testFSGroup),
+					},
+					PriorityClassName: mounterPodPriorityClass,
+					Containers: []corev1.Container{
+						{
+							Name:            util.MounterPodNamePrefix,
+							Image:           "gcr.io/my-project/my-image:v1.0.0",
+							ImagePullPolicy: corev1.PullAlways,
+							Args:            []string{"--enable-shared-mount"},
+							SecurityContext: &corev1.SecurityContext{
+								Privileged: ptr.To(true),
+							},
+							Resources:    defaultResources,
+							VolumeMounts: expectedVolumeMounts,
+						},
+					},
+					Volumes: []corev1.Volume{
+						testBuffVolume,
+						testCacheVolume,
+						testTmpVolume,
+						kubeletHostPathVolume,
+					},
+					Tolerations: []corev1.Toleration{{Operator: corev1.TolerationOpExists}},
+				},
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/webhook/mutatingwebhook.go
+++ b/pkg/webhook/mutatingwebhook.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 
 	"cloud.google.com/go/compute/metadata"
@@ -188,13 +189,22 @@ func (si *SidecarInjector) Handle(ctx context.Context, req admission.Request) ad
 				}
 
 				// Validate that Pod fsGroup matches the requirements of the referenced PVC PodTemplate.
-				if err := si.validateFSGroup(pod, podTemplate); err != nil {
+				var workloadFSGroup string
+				if pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.FSGroup != nil {
+					workloadFSGroup = strconv.FormatInt(*pod.Spec.SecurityContext.FSGroup, 10)
+				}
+				var templateFSGroup string
+				if podTemplate.Template.Spec.SecurityContext != nil && podTemplate.Template.Spec.SecurityContext.FSGroup != nil {
+					templateFSGroup = strconv.FormatInt(*podTemplate.Template.Spec.SecurityContext.FSGroup, 10)
+				}
+				targetDesc := fmt.Sprintf("volume's PodTemplate %q", podTemplate.Name)
+				if err := ValidateFSGroup(workloadFSGroup, templateFSGroup, targetDesc); err != nil {
 					klog.Errorf("fsGroup validation failed: %v", err)
 					return admission.Errored(http.StatusBadRequest, err)
 				}
 
 				// Validate that Pod serviceAccountName matches the requirements of the referenced PVC PodTemplate.
-				if err := si.validateServiceAccountName(pod, podTemplate); err != nil {
+				if err := ValidateServiceAccountName(pod.Spec.ServiceAccountName, podTemplate.Template.Spec.ServiceAccountName, targetDesc); err != nil {
 					klog.Errorf("serviceAccountName validation failed: %v", err)
 					return admission.Errored(http.StatusBadRequest, err)
 				}
@@ -692,45 +702,36 @@ func (si *SidecarInjector) getMounterPodTemplate(namespace string, pvc *corev1.P
 	return podTemplate, nil
 }
 
-// validateFSGroup checks if the Pod's fsGroup matches the one specified in the volume's referenced mounter PodTemplate.
-func (si *SidecarInjector) validateFSGroup(pod *corev1.Pod, podTemplate *corev1.PodTemplate) error {
-	templateName := podTemplate.Name
-	templateHasFSGroup := podTemplate.Template.Spec.SecurityContext != nil && podTemplate.Template.Spec.SecurityContext.FSGroup != nil
-	podHasFSGroup := pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.FSGroup != nil
-
-	// Enforce strict matching between Pod and PodTemplate fsGroup settings to prevent shared mount permission conflicts.
-	if templateHasFSGroup {
-		expectedFSGroup := *podTemplate.Template.Spec.SecurityContext.FSGroup
-		if !podHasFSGroup {
-			return fmt.Errorf("Pod fsGroup is not set, but volume's PodTemplate %q requires fsGroup %d", templateName, expectedFSGroup)
+// ValidateFSGroup checks if the workload fsGroup matches the target fsGroup.
+func ValidateFSGroup(workloadFSGroup, targetFSGroup, targetDesc string) error {
+	if targetFSGroup != "" {
+		if workloadFSGroup == "" {
+			return fmt.Errorf("Pod fsGroup is not set, but %s requires fsGroup %s", targetDesc, targetFSGroup)
 		}
-		actualFSGroup := *pod.Spec.SecurityContext.FSGroup
-		if actualFSGroup != expectedFSGroup {
-			return fmt.Errorf("Pod fsGroup %d does not match the one specified in volume's PodTemplate %q (%d)", actualFSGroup, templateName, expectedFSGroup)
+		if workloadFSGroup != targetFSGroup {
+			return fmt.Errorf("Pod fsGroup %s does not match the one specified in %s (%s)", workloadFSGroup, targetDesc, targetFSGroup)
 		}
 		return nil
 	}
 
-	if podHasFSGroup {
-		return fmt.Errorf("Pod has fsGroup set, but volume's PodTemplate %q does not specify one (not allowed for shared node mount)", templateName)
+	if workloadFSGroup != "" {
+		return fmt.Errorf("Pod has fsGroup set, but %s does not specify one (not allowed for shared node mount)", targetDesc)
 	}
 
 	return nil
 }
 
-// validateServiceAccountName checks if the Pod's serviceAccountName matches the one specified in the volume's referenced mounter PodTemplate.
-func (si *SidecarInjector) validateServiceAccountName(pod *corev1.Pod, podTemplate *corev1.PodTemplate) error {
-	templateSA := podTemplate.Template.Spec.ServiceAccountName
-	if templateSA == "" {
-		templateSA = "default"
+// ValidateServiceAccountName checks if the workload serviceAccountName matches the target's serviceAccountName.
+func ValidateServiceAccountName(workloadSA, targetSA, targetDesc string) error {
+	if targetSA == "" {
+		targetSA = "default"
 	}
-	podSA := pod.Spec.ServiceAccountName
-	if podSA == "" {
-		podSA = "default"
+	if workloadSA == "" {
+		workloadSA = "default"
 	}
 
-	if templateSA != podSA {
-		return fmt.Errorf("Pod serviceAccountName %q does not match the one specified in volume's PodTemplate %q (%q)", podSA, podTemplate.Name, templateSA)
+	if targetSA != workloadSA {
+		return fmt.Errorf("Pod serviceAccountName %q does not match the one specified in %s (%q)", workloadSA, targetDesc, targetSA)
 	}
 
 	return nil

--- a/pkg/webhook/mutatingwebhook_test.go
+++ b/pkg/webhook/mutatingwebhook_test.go
@@ -2682,3 +2682,155 @@ func TestHandleEviction(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateFSGroup(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name            string
+		workloadFSGroup string
+		targetFSGroup   string
+		targetDesc      string
+		wantErr         bool
+		wantErrMsg      string
+	}{
+		{
+			name:            "both workload and target have no fsGroup - should succeed",
+			workloadFSGroup: "",
+			targetFSGroup:   "",
+			targetDesc:      "volume's PodTemplate \"mounter-template\"",
+			wantErr:         false,
+		},
+		{
+			name:            "workload and target have matching fsGroup - should succeed",
+			workloadFSGroup: "1000",
+			targetFSGroup:   "1000",
+			targetDesc:      "volume's PodTemplate \"mounter-template\"",
+			wantErr:         false,
+		},
+		{
+			name:            "target has fsGroup, workload has no fsGroup - should return error",
+			workloadFSGroup: "",
+			targetFSGroup:   "1000",
+			targetDesc:      "volume's PodTemplate \"mounter-template\"",
+			wantErr:         true,
+			wantErrMsg:      "Pod fsGroup is not set, but volume's PodTemplate \"mounter-template\" requires fsGroup 1000",
+		},
+		{
+			name:            "target and workload have different fsGroups - should return error",
+			workloadFSGroup: "2000",
+			targetFSGroup:   "1000",
+			targetDesc:      "volume's PodTemplate \"mounter-template\"",
+			wantErr:         true,
+			wantErrMsg:      "Pod fsGroup 2000 does not match the one specified in volume's PodTemplate \"mounter-template\" (1000)",
+		},
+		{
+			name:            "workload has fsGroup, target has no fsGroup - should return error",
+			workloadFSGroup: "1000",
+			targetFSGroup:   "",
+			targetDesc:      "volume's PodTemplate \"mounter-template\"",
+			wantErr:         true,
+			wantErrMsg:      "Pod has fsGroup set, but volume's PodTemplate \"mounter-template\" does not specify one (not allowed for shared node mount)",
+		},
+		{
+			name:            "mounter pod targetDesc formatting",
+			workloadFSGroup: "2000",
+			targetFSGroup:   "1000",
+			targetDesc:      "mounter pod",
+			wantErr:         true,
+			wantErrMsg:      "Pod fsGroup 2000 does not match the one specified in mounter pod (1000)",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateFSGroup(tc.workloadFSGroup, tc.targetFSGroup, tc.targetDesc)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("ValidateFSGroup(%q, %q, %q) expected error, got nil", tc.workloadFSGroup, tc.targetFSGroup, tc.targetDesc)
+				}
+				if tc.wantErrMsg != "" && !strings.Contains(err.Error(), tc.wantErrMsg) {
+					t.Errorf("ValidateFSGroup(%q, %q, %q) error = %q, want substring %q", tc.workloadFSGroup, tc.targetFSGroup, tc.targetDesc, err.Error(), tc.wantErrMsg)
+				}
+			} else if err != nil {
+				t.Fatalf("ValidateFSGroup(%q, %q, %q) unexpected error: %v", tc.workloadFSGroup, tc.targetFSGroup, tc.targetDesc, err)
+			}
+		})
+	}
+}
+
+func TestValidateServiceAccountName(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		workloadSA string
+		targetSA   string
+		targetDesc string
+		wantErr    bool
+		wantErrMsg string
+	}{
+		{
+			name:       "both SA empty - should succeed (default to default)",
+			workloadSA: "",
+			targetSA:   "",
+			targetDesc: "volume's PodTemplate \"mounter-template\"",
+			wantErr:    false,
+		},
+		{
+			name:       "workload specifies default, target empty - should succeed",
+			workloadSA: "default",
+			targetSA:   "",
+			targetDesc: "volume's PodTemplate \"mounter-template\"",
+			wantErr:    false,
+		},
+		{
+			name:       "workload empty, target specifies default - should succeed",
+			workloadSA: "",
+			targetSA:   "default",
+			targetDesc: "volume's PodTemplate \"mounter-template\"",
+			wantErr:    false,
+		},
+		{
+			name:       "both specify matching custom SA - should succeed",
+			workloadSA: "custom-sa",
+			targetSA:   "custom-sa",
+			targetDesc: "volume's PodTemplate \"mounter-template\"",
+			wantErr:    false,
+		},
+		{
+			name:       "SA mismatch with PodTemplate targetDesc - should return error",
+			workloadSA: "wrong-sa",
+			targetSA:   "mounter-sa",
+			targetDesc: "volume's PodTemplate \"mounter-template\"",
+			wantErr:    true,
+			wantErrMsg: "Pod serviceAccountName \"wrong-sa\" does not match the one specified in volume's PodTemplate \"mounter-template\" (\"mounter-sa\")",
+		},
+		{
+			name:       "SA mismatch with mounter pod targetDesc - should return error",
+			workloadSA: "sa-1",
+			targetSA:   "sa-2",
+			targetDesc: "mounter pod",
+			wantErr:    true,
+			wantErrMsg: "Pod serviceAccountName \"sa-1\" does not match the one specified in mounter pod (\"sa-2\")",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateServiceAccountName(tc.workloadSA, tc.targetSA, tc.targetDesc)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("ValidateServiceAccountName(%q, %q, %q) expected error, got nil", tc.workloadSA, tc.targetSA, tc.targetDesc)
+				}
+				if tc.wantErrMsg != "" && !strings.Contains(err.Error(), tc.wantErrMsg) {
+					t.Errorf("ValidateServiceAccountName(%q, %q, %q) error = %q, want substring %q", tc.workloadSA, tc.targetSA, tc.targetDesc, err.Error(), tc.wantErrMsg)
+				}
+			} else if err != nil {
+				t.Fatalf("ValidateServiceAccountName(%q, %q, %q) unexpected error: %v", tc.workloadSA, tc.targetSA, tc.targetDesc, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:
During concurrent resource creation, the mutating webhook skips validation if the referenced PodTemplate is not yet found, allowing workload pods with mismatched permissions to bypass webhook checks. To prevent unauthorized shared mount access, this change enforces defense-in-depth ServiceAccount and FSGroup validation directly in `NodePublishVolumeForSharedMount` before performing the bind-mount. Any mismatch between the workload and the target mounter Pod is rejected with `PermissionDenied`.

### Changes
- **`pkg/csi_driver/controller.go`**: Propagate `PodTemplate.Template.Spec.SecurityContext` to the mounter Pod in `ControllerPublishVolume`.
- **`pkg/csi_driver/shared_mount.go`**: Add `securityContext` to `mounterPodConfig`, populate `spec.Spec.SecurityContext` in `createMounterPodSpec`, and add `validateFSGroup` helper.
- **`pkg/csi_driver/node.go`**: Validate workload pod's SA name and fsGroup against the mounter Pod in `NodePublishVolumeForSharedMount`.
- **`pkg/cloud_provider/clientset/clientset.go`**: Retain `SecurityContext` and `ServiceAccountName` in `ConfigurePodLister` transform so the node-local informer cache preserves mounter pod security settings.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```