### PR TITLE
[Shared Mount] Implement read_ahead_kb

### DIFF
--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -1145,12 +1145,12 @@ func (s *nodeServer) executeNodeStageVolume(ctx context.Context, req *csi.NodeSt
 	}
 
 	// Prepare mount options specifically for shared node mount architecture before sending to mounter pod.
-	gcsfuseMO, _, _, err := util.PrepareSharedMountOptions(args.fuseMountOptions)
+	gcsfuseMO, sysfsBDI, _, err := util.PrepareSharedMountOptions(args.fuseMountOptions)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "failed to prepare mount options: %v", err)
 	}
 
-	// TODO(FUECHR): Pass read_ahead_kb and node_fuse_max_request_limit_kb to gcsfuse config correctly for shared node mounts.
+	// TODO(FUECHR): Pass node_fuse_max_request_limit_kb to gcsfuse config correctly for shared node mounts.
 
 	// Send GRPC to mounter pod to start GCSFuse.
 	if err := s.mountToNode(ctx, podUID, stagingPath, volumeID, gcsfuseMO); err != nil {
@@ -1177,6 +1177,9 @@ func (s *nodeServer) executeNodeStageVolume(ctx context.Context, req *csi.NodeSt
 		}
 		return nil, err
 	}
+
+	logPrefix := fmt.Sprintf("[Pod %v, Volume %v, Bucket %v]", podUID, pvName, args.bucketName)
+	util.ApplySysfsConfig(stagingPath, sysfsBDI, args.fuseMountOptions, logPrefix)
 
 	klog.Infof("Mounter pod %s/%s is running and staging path %s is mounted", podNamespace, podName, stagingPath)
 

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -1298,6 +1298,60 @@ func TestNodeStageVolume(t *testing.T) {
 				util.PodUIDConst + "=" + createMounterPodName("test-node", testVolumeID),
 			}, defaultSharedOpts...),
 		},
+		{
+			name: "valid request with sharedMount true and sysfsBDI mount option",
+			req: &csi.NodeStageVolumeRequest{
+				VolumeId:          testVolumeID,
+				StagingTargetPath: stagingPath,
+				VolumeCapability:  testVolumeCapability,
+				VolumeContext: map[string]string{
+					VolumeContextSharedNodeMount: "true",
+					util.VolumeContextKeyPVName:  testVolumeID,
+					VolumeContextKeyMountOptions: "read_ahead_kb=1024",
+				},
+				PublishContext: map[string]string{
+					PublishContextKeyMounterPodName:      createMounterPodName("test-node", testVolumeID),
+					PublishContextKeyMounterPodNamespace: "test-ns",
+				},
+			},
+			expectedMountOptions: defaultSharedOpts,
+		},
+		{
+			name: "invalid request with sharedMount true and negative sysfsBDI mount option",
+			req: &csi.NodeStageVolumeRequest{
+				VolumeId:          testVolumeID,
+				StagingTargetPath: stagingPath,
+				VolumeCapability:  testVolumeCapability,
+				VolumeContext: map[string]string{
+					VolumeContextSharedNodeMount: "true",
+					util.VolumeContextKeyPVName:  testVolumeID,
+					VolumeContextKeyMountOptions: "read_ahead_kb=-1",
+				},
+				PublishContext: map[string]string{
+					PublishContextKeyMounterPodName:      createMounterPodName("test-node", testVolumeID),
+					PublishContextKeyMounterPodNamespace: "test-ns",
+				},
+			},
+			expectErr: status.Errorf(codes.InvalidArgument, "failed to prepare mount options: invalid negative value for read_ahead_kb mount flag: %q", "read_ahead_kb=-1"),
+		},
+		{
+			name: "invalid request with sharedMount true and non-integer sysfsBDI mount option",
+			req: &csi.NodeStageVolumeRequest{
+				VolumeId:          testVolumeID,
+				StagingTargetPath: stagingPath,
+				VolumeCapability:  testVolumeCapability,
+				VolumeContext: map[string]string{
+					VolumeContextSharedNodeMount: "true",
+					util.VolumeContextKeyPVName:  testVolumeID,
+					VolumeContextKeyMountOptions: "read_ahead_kb=abc",
+				},
+				PublishContext: map[string]string{
+					PublishContextKeyMounterPodName:      createMounterPodName("test-node", testVolumeID),
+					PublishContextKeyMounterPodNamespace: "test-ns",
+				},
+			},
+			expectErr: status.Errorf(codes.InvalidArgument, "failed to prepare mount options: invalid read_ahead_kb mount flag %q: strconv.ParseInt: parsing \"abc\": invalid syntax", "read_ahead_kb=abc"),
+		},
 	}
 
 	for _, test := range cases {

--- a/pkg/csi_mounter/csi_mounter.go
+++ b/pkg/csi_mounter/csi_mounter.go
@@ -24,10 +24,7 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"slices"
-	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -114,19 +111,7 @@ func (m *Mounter) Mount(source string, target string, fstype string, options []s
 		return fmt.Errorf("failed to mount the fuse filesystem: %w", err)
 	}
 
-	if len(sysfsBDI) != 0 {
-		go func() {
-			if slices.Contains(sidecarMountOptions, fmt.Sprintf("%s=true", util.EnableGCSFuseKernelParams)) {
-				klog.Warning("The mount option read_ahead_kb is soft deprecated for zonal buckets. GCSFuse automatically applies appropriate Read Ahead Kb kernel setting for best performance by default for Zonal Buckets.")
-			}
-			// updateSysfsConfig may hang until the file descriptor (fd) is either consumed or canceled.
-			// It will succeed once dfuse finishes the mount process, or it will fail if dfuse fails
-			// or the mount point is cleaned up due to mounting failures.
-			if err := updateSysfsConfig(target, sysfsBDI); err != nil {
-				klog.Errorf("%v failed to update kernel parameters: %v", logPrefix, err)
-			}
-		}()
-	}
+	util.ApplySysfsConfig(target, sysfsBDI, sidecarMountOptions, logPrefix)
 
 	listener, err := m.createSocket(target, logPrefix)
 	if err != nil {
@@ -179,45 +164,6 @@ func (m *Mounter) Mount(source string, target string, fstype string, options []s
 
 	// Asynchronously waiting for the sidecar container to connect to the listener
 	go startAcceptConn(listener, logPrefix, msg, fd, cancel)
-
-	return nil
-}
-
-// updateSysfsConfig modifies the kernel page cache settings based on the read_ahead_kb provided in the mountOption,
-// and verifies that the values are successfully updated after the operation completes.
-func updateSysfsConfig(targetMountPath string, sysfsBDI map[string]int64) error {
-	// Command will hang until mount completes.
-	cmd := exec.Command("mountpoint", "-d", targetMountPath)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		klog.Errorf("Error executing mountpoint command on target path %s: %v", targetMountPath, err)
-		var exitError *exec.ExitError
-		if errors.As(err, &exitError) {
-			klog.Errorf("Exit code: %d", exitError.ExitCode())
-		}
-
-		return err
-	}
-
-	targetDevice := strings.TrimSpace(string(output))
-	klog.Infof("Output of mountpoint for target mount path %s: %s", targetMountPath, output)
-
-	for key, value := range sysfsBDI {
-		// Update the target value.
-		sysfsBDIPath := filepath.Join("/sys/class/bdi/", targetDevice, key)
-		file, err := os.OpenFile(sysfsBDIPath, os.O_WRONLY|os.O_TRUNC, 0o644)
-		if err != nil {
-			return fmt.Errorf("failed to open file %q: %w", sysfsBDIPath, err)
-		}
-		defer file.Close()
-
-		_, err = file.WriteString(fmt.Sprintf("%d\n", value))
-		if err != nil {
-			return fmt.Errorf("failed to write to file %q: %w", "echo", err)
-		}
-
-		klog.Infof("Updated %s to %d", sysfsBDIPath, value)
-	}
 
 	return nil
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -24,9 +24,11 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -523,4 +525,59 @@ func prepareMountOptions(options []string, csiMountOptions []string) ([]string, 
 	}
 
 	return csiMountOptions, optionSet.List(), sysfsBDI, fuseMaxPagesLimit, nil
+}
+
+// updateSysfsConfig modifies the kernel page cache settings based on the read_ahead_kb provided in the mountOption,
+// and verifies that the values are successfully updated after the operation completes.
+func updateSysfsConfig(targetMountPath string, sysfsBDI map[string]int64) error {
+	// Command will hang until mount completes.
+	cmd := exec.Command("mountpoint", "-d", targetMountPath)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		klog.Errorf("Error executing mountpoint command on target path %s: %v", targetMountPath, err)
+		var exitError *exec.ExitError
+		if errors.As(err, &exitError) {
+			klog.Errorf("Exit code: %d", exitError.ExitCode())
+		}
+
+		return err
+	}
+
+	targetDevice := strings.TrimSpace(string(output))
+	klog.Infof("Output of mountpoint for target mount path %s: %s", targetMountPath, output)
+
+	for key, value := range sysfsBDI {
+		// Update the target value.
+		sysfsBDIPath := filepath.Join("/sys/class/bdi/", targetDevice, key)
+		file, err := os.OpenFile(sysfsBDIPath, os.O_WRONLY|os.O_TRUNC, 0o644)
+		if err != nil {
+			return fmt.Errorf("failed to open file %q: %w", sysfsBDIPath, err)
+		}
+		defer file.Close()
+
+		_, err = file.WriteString(fmt.Sprintf("%d\n", value))
+		if err != nil {
+			return fmt.Errorf("failed to write to file %q: %w", sysfsBDIPath, err)
+		}
+
+		klog.Infof("Updated %s to %d", sysfsBDIPath, value)
+	}
+
+	return nil
+}
+
+func ApplySysfsConfig(targetMountPath string, sysfsBDI map[string]int64, mountOptions []string, logPrefix string) {
+	if len(sysfsBDI) != 0 {
+		go func() {
+			if slices.Contains(mountOptions, fmt.Sprintf("%s=true", EnableGCSFuseKernelParams)) {
+				klog.Warning("The mount option read_ahead_kb is soft deprecated for zonal buckets. GCSFuse automatically applies appropriate Read Ahead Kb kernel setting for best performance by default for Zonal Buckets.")
+			}
+			// updateSysfsConfig may hang until the file descriptor (fd) is either consumed or canceled.
+			// It will succeed once gcsfuse finishes the mount process, or it will fail if gcsfuse fails
+			// or the mount point is cleaned up due to mounting failures.
+			if err := updateSysfsConfig(targetMountPath, sysfsBDI); err != nil {
+				klog.Errorf("%v failed to update kernel parameters: %v", logPrefix, err)
+			}
+		}()
+	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:
Implements read ahead in shared node mount
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```