### PR TITLE
Update Readme to add more details for the new test flags

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -103,8 +103,9 @@ You can control the test through the following make parameters, eg `make e2e-tes
 - `E2E_TEST_MANAGE_CLUSTER_LIFECYCLE`: default value is `false`. Change it to `true` if you want the test runner to create and destroy the GKE cluster for the test.
 - `USE_CAPACITY_ADVISOR`: default value is `false` (defaults to `true` in Prow CI). Whether to use GCE Capacity Advisor to select node locations and fallback regions. Only used when `E2E_TEST_MANAGE_CLUSTER_LIFECYCLE=true`; ignored when running on an existing cluster.
 - `E2E_TEST_GKE_CLUSTER_VERSION`: It denotes the GKE cluster master and node version. If `E2E_TEST_MANAGE_CLUSTER_LIFECYCLE` is `true`, it specifies the version of the cluster to be created (defaults to `latest` if not provided). If `E2E_TEST_MANAGE_CLUSTER_LIFECYCLE` is `false`, it auto-detects the version of the existing cluster (can be overridden by setting this parameter). The version is used by the test framework to check for feature compatibility.
-- `E2E_TEST_USE_BOSKOS`: default value is `false`. Change it to `true` if you want to use Boskos to acquire a project. Useful for debugging Boskos infrastructure locally.
+- `E2E_TEST_USE_BOSKOS`: default value is `false`. Change it to `true` if you want to use Boskos to acquire a project. Useful for debugging Boskos infrastructure locally.  More details around boskos debugging are available [here](https://gke-internal.googlesource.com/test-infra/+/refs/heads/master/deployments/gke-managed-storage-team/boskos/README.md) (for internal use only).
 - `E2E_TEST_PROJECT_ID`: default value is empty. GCP project ID to run E2E tests. Required when managing cluster lifecycle without Boskos.
+- `E2E_TEST_GKE_GCLOUD_ARGS` (or `GKE_GCLOUD_ARGS`): default value is empty. Additional arguments passed to underlying `gcloud` commands executed during cluster lifecycle management (e.g. `--impersonate-service-account=<sa-email>`). This is especially required during local Boskos debugging to impersonate a service account with IAM permissions on the leased project.
 ```bash
 # Run the test on an Autopilot cluster with the GcsFuseCsiDriver add-on enabled.
 make e2e-test E2E_TEST_USE_GKE_MANAGED_DRIVER=true E2E_TEST_USE_GKE_AUTOPILOT=true
@@ -119,15 +120,39 @@ make e2e-test E2E_TEST_USE_GKE_MANAGED_DRIVER=false E2E_TEST_BUILD_DRIVER=true \
 # Run the test with customized Ginkgo flags.
 make e2e-test E2E_TEST_FOCUS=gcsfuseIntegration E2E_TEST_SKIP=failedMount E2E_TEST_GINKGO_PROCS=3 E2E_TEST_GINKGO_TIMEOUT=20m E2E_TEST_GINKGO_FLAKE_ATTEMPTS=1
 
-# Boskos Debugging: Test Boskos leasing and cluster lifecycle management locally.
-# This requires a Boskos server running in your current cluster context (e.g. port-forwarded to localhost:8080).
+# You can optionally create and tear down a GKE cluster through E2E_TEST_MANAGE_CLUSTER_LIFECYCLE; whether the GCS Fuse CSI driver is enabled in the cluster is controlled by E2E_TEST_USE_GKE_MANAGED_DRIVER. Refer to Managed Cluster Configuration for more details.
+
+# Fixed Project Automation (Non-Managed Driver): Automatically provision and tear down a GKE cluster in a specific GCP project, and install the driver from source.
+make e2e-test \
+  E2E_TEST_USE_GKE_MANAGED_DRIVER=false \
+  REGISTRY=us-central1-docker.pkg.dev/$PROJECT_ID/gcs-fuse-csi-driver \
+  STAGINGVERSION=prow-gob-internal-boskos-1 \
+  E2E_TEST_MANAGE_CLUSTER_LIFECYCLE=true \
+  E2E_TEST_PROJECT_ID=$PROJECT_ID
+
+# Fixed Project Automation (Managed Driver): Automatically provision and tear down a GKE cluster in a specific GCP project, using the GKE-managed driver.
+# You can optionally specify a cluster version using E2E_TEST_GKE_CLUSTER_VERSION (defaults to 'latest').
+make e2e-test \
+  E2E_TEST_USE_GKE_MANAGED_DRIVER=true \
+  E2E_TEST_MANAGE_CLUSTER_LIFECYCLE=true \
+  E2E_TEST_PROJECT_ID=$PROJECT_ID \
+  E2E_TEST_GKE_CLUSTER_VERSION=1.36
+
+# To debug boskos infrastructure locally, you can use E2E_TEST_USE_BOSKOS=true which would try to lease a project from boskos pool. But this is to be used only for debugging boskos infrastructure. It needs a running boskos server and is currently access restricted to the repo owners. Refer internal test-infra repo for more details on boskos debugging.
 export BOSKOS_URL=http://localhost:8080
-make e2e-test E2E_TEST_USE_BOSKOS=true E2E_TEST_MANAGE_CLUSTER_LIFECYCLE=true E2E_TEST_GKE_CLUSTER_VERSION=latest GKE_CLUSTER_REGION=us-central1
+make e2e-test \
+  E2E_TEST_USE_BOSKOS=true \
+  E2E_TEST_MANAGE_CLUSTER_LIFECYCLE=true \
+  E2E_TEST_GKE_CLUSTER_VERSION=latest \
+  GKE_CLUSTER_REGION=us-central1 \
+  E2E_TEST_GKE_GCLOUD_ARGS="--impersonate-service-account=<sa-email>"
 ```
 
 #### Managed Cluster Configuration
 
-When `E2E_TEST_MANAGE_CLUSTER_LIFECYCLE` is set to `true`, the test runner provisions a GKE cluster with the same configurations as used by the prow job. THese can be updated as needed through the below parameters:
+You can optionally create and tear down a GKE cluster through `E2E_TEST_MANAGE_CLUSTER_LIFECYCLE` (defaulted to `false`). Whether the GCS Fuse CSI driver is enabled in the cluster is controlled by `E2E_TEST_USE_GKE_MANAGED_DRIVER`.
+
+When `E2E_TEST_MANAGE_CLUSTER_LIFECYCLE` is set to `true`, the test runner provisions a GKE cluster with the same configurations as used by the prow job. These can be updated as needed through the below parameters:
 - **Cluster Type**: Standard GKE Cluster (default) or Autopilot (if `E2E_TEST_USE_GKE_AUTOPILOT=true`).
 - **Release Channel**: `rapid` (can be overridden by `GKE_RELEASE_CHANNEL` environment variable).
 - **Version**: Determined by `E2E_TEST_GKE_CLUSTER_VERSION` (local) or `GKE_CLUSTER_VERSION` (CI).
@@ -140,6 +165,7 @@ When `E2E_TEST_MANAGE_CLUSTER_LIFECYCLE` is set to `true`, the test runner provi
   - **Image Type**: `cos_containerd` (Container-Optimized OS with containerd).
 - **Workload Identity**: Enabled by default using the GCP project's workload pool (`<project-id>.svc.id.goog`).
 - **CSI Driver**: Installs the GKE-managed GCS FUSE CSI Driver addon by default (can be disabled by setting `E2E_TEST_USE_GKE_MANAGED_DRIVER=false`).
+- **Custom gcloud Arguments**: Extra arguments passed to underlying `gcloud` commands via `E2E_TEST_GKE_GCLOUD_ARGS` or `GKE_GCLOUD_ARGS` (e.g. `--impersonate-service-account=<sa-email>`).
 
 ## Performance test
 

--- a/test/e2e/run-e2e-local.sh
+++ b/test/e2e/run-e2e-local.sh
@@ -36,6 +36,7 @@ readonly build_gcsfuse_from_source="${BUILD_GCSFUSE_FROM_SOURCE:-false}"
 readonly manage_cluster_lifecycle="${E2E_TEST_MANAGE_CLUSTER_LIFECYCLE:-false}"
 readonly use_boskos="${E2E_TEST_USE_BOSKOS:-false}"
 readonly project_id="${E2E_TEST_PROJECT_ID:-}"
+readonly gke_gcloud_args="${E2E_TEST_GKE_GCLOUD_ARGS:-${GKE_GCLOUD_ARGS:-}}" # This is needed to pass SA credentials or extra flags with gcloud command (e.g. during boskos debugging).
 readonly num_nodes="${E2E_TEST_NUM_NODES:-${NUMBER_NODES:-9}}"
 readonly boskos_resource_type="${E2E_TEST_BOSKOS_RESOURCE_TYPE:-${GCE_PD_BOSKOS_RESOURCE_TYPE:-gke-internal-project}}"
 
@@ -102,6 +103,7 @@ base_cmd="${PKGDIR}/bin/e2e-test-ci \
             --gke-cluster-region=${gke_cluster_region} \
             --use-gke-autopilot=${use_gke_autopilot} \
             --api-endpoint-override=${cloudsdk_api_endpoint_overrides_container} \
+            --gke-gcloud-args=\"${gke_gcloud_args}\" \
             --image-registry=${REGISTRY} \
             --build-gcs-fuse-csi-driver=${build_gcs_fuse_csi_driver} \
             --build-gcs-fuse-from-source=${build_gcsfuse_from_source} \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design

 /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR updates the README to add some sample usage for the newly added flags (#1565 ). This does not change behavior for any of the old test commands but adds in additional capability to spin up and tear down GKE cluster as part of E2E test run.

This PR also adds a new variable `GKE_GCLOUD_ARGS`, this is already added in the CI pipeline now we add it to the local pipeline too. This helps to send additional required details with gcloud commands during boskos debugging. Example, to run E2E tests with boskos server locally you would need to impersonate a service account that access for some gcloud commands. This param allows the workflow to run the commands with impersonation.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```