### PR TITLE
Bump gcsfuse to v2.5.4-gke.4 to FIX CVEs

### DIFF
--- a/cmd/sidecar_mounter/gcsfuse_binary
+++ b/cmd/sidecar_mounter/gcsfuse_binary
@@ -1,1 +1,1 @@
-gs://gke-release-staging/gcsfuse/v2.5.3-gke.0/gcsfuse_bin
+gs://gke-release-staging/gcsfuse/v2.5.4-gke.4/gcsfuse_bin


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Bump gcsfuse to v2.5.4-gke.4 to FIX CVEs. See https://github.com/GoogleCloudPlatform/gcsfuse/releases/tag/v2.5.4 for list of CVEs fixed. 

The louhi release flow had to be rerun several times to fix issues, which is why the release iteration is gke.4.

```
gcloud storage ls gs://gke-release-staging/gcsfuse/ | grep v2.5.
gs://gke-release-staging/gcsfuse/v2.5.0-gke.0/
gs://gke-release-staging/gcsfuse/v2.5.1-gke.0/
gs://gke-release-staging/gcsfuse/v2.5.2-gke.0/
gs://gke-release-staging/gcsfuse/v2.5.2-gke.1/
gs://gke-release-staging/gcsfuse/v2.5.3-gke.0/
gs://gke-release-staging/gcsfuse/v2.5.4-gke.4/
```



**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Bump gcsfuse to v2.5.4-gke.4 to FIX CVEs
```

