### PR TITLE
fix TestReadDriverFlagsForDefaulting failure when running as root

### DIFF
--- a/pkg/sidecar_mounter/sidecar_mounter_config_test.go
+++ b/pkg/sidecar_mounter/sidecar_mounter_config_test.go
@@ -990,7 +990,6 @@ func TestReadDriverFlagsForDefaulting(t *testing.T) {
 		},
 		{
 			name:        "File exists but is unreadable",
-			fileExists:  true,
 			unreadable:  true,
 			fileContent: "machine-type:e2-standard-4\n",
 			expectErr:   true,
@@ -1002,12 +1001,15 @@ func TestReadDriverFlagsForDefaulting(t *testing.T) {
 			t.Parallel()
 			flagFilePath := filepath.Join(t.TempDir(), "flags-for-defaulting")
 
-			if tc.fileExists {
+			if tc.unreadable {
+				// Create a directory to fail os.ReadFile with EISDIR.
+				// This simulates an unreadable file consistently across root and non-root environments.
+				if err := os.MkdirAll(flagFilePath, 0755); err != nil {
+					t.Fatalf("Failed to create dir: %v", err)
+				}
+			} else if tc.fileExists {
 				if err := os.WriteFile(flagFilePath, []byte(tc.fileContent), 0644); err != nil {
 					t.Fatalf("Failed to write mock flag file: %v", err)
-				}
-				if tc.unreadable {
-					_ = os.Chmod(flagFilePath, 0000)
 				}
 			}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation

/kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
In environments where unit tests run as root (e.g. Louhi containerized CI), restricting file permissions to 0000 does not prevent os.ReadFile from succeeding because UID 0 bypasses DAC permission checks.

Replace the permission-based unreadable file test case with a directory path test case. Passing a directory to os.ReadFile returns EISDIR regardless of user privileges, ensuring non-ErrNotExist error propagation is deterministically tested.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
I have tested locally by using `sudo` and make sure it succeed in current version.
```
sudo $(which go) test -count=1 -v ./pkg/sidecar_mounter -run TestReadDriverFlagsForDefaulting

=== RUN   TestReadDriverFlagsForDefaulting
=== PAUSE TestReadDriverFlagsForDefaulting
=== CONT  TestReadDriverFlagsForDefaulting
=== RUN   TestReadDriverFlagsForDefaulting/File_does_not_exist
=== PAUSE TestReadDriverFlagsForDefaulting/File_does_not_exist
=== RUN   TestReadDriverFlagsForDefaulting/File_exists_and_contains_flags
=== PAUSE TestReadDriverFlagsForDefaulting/File_exists_and_contains_flags
=== RUN   TestReadDriverFlagsForDefaulting/File_exists_but_is_unreadable
=== PAUSE TestReadDriverFlagsForDefaulting/File_exists_but_is_unreadable
=== CONT  TestReadDriverFlagsForDefaulting/File_does_not_exist
=== CONT  TestReadDriverFlagsForDefaulting/File_exists_but_is_unreadable
=== CONT  TestReadDriverFlagsForDefaulting/File_exists_and_contains_flags
--- PASS: TestReadDriverFlagsForDefaulting (0.00s)
    --- PASS: TestReadDriverFlagsForDefaulting/File_does_not_exist (0.00s)
    --- PASS: TestReadDriverFlagsForDefaulting/File_exists_but_is_unreadable (0.00s)
    --- PASS: TestReadDriverFlagsForDefaulting/File_exists_and_contains_flags (0.00s)
PASS
ok      github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/sidecar_mounter  0.079s
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```