### PR TITLE
Automated cherry pick of #1589: fix TestReadDriverFlagsForDefaulting failure when running as root

### DIFF
--- a/pkg/sidecar_mounter/sidecar_mounter_config_test.go
+++ b/pkg/sidecar_mounter/sidecar_mounter_config_test.go
@@ -990,7 +990,6 @@ func TestReadDriverFlagsForDefaulting(t *testing.T) {
 		},
 		{
 			name:        "File exists but is unreadable",
-			fileExists:  true,
 			unreadable:  true,
 			fileContent: "machine-type:e2-standard-4\n",
 			expectErr:   true,
@@ -1002,12 +1001,15 @@ func TestReadDriverFlagsForDefaulting(t *testing.T) {
 			t.Parallel()
 			flagFilePath := filepath.Join(t.TempDir(), "flags-for-defaulting")
 
-			if tc.fileExists {
+			if tc.unreadable {
+				// Create a directory to fail os.ReadFile with EISDIR.
+				// This simulates an unreadable file consistently across root and non-root environments.
+				if err := os.MkdirAll(flagFilePath, 0755); err != nil {
+					t.Fatalf("Failed to create dir: %v", err)
+				}
+			} else if tc.fileExists {
 				if err := os.WriteFile(flagFilePath, []byte(tc.fileContent), 0644); err != nil {
 					t.Fatalf("Failed to write mock flag file: %v", err)
-				}
-				if tc.unreadable {
-					_ = os.Chmod(flagFilePath, 0000)
 				}
 			}
 


### PR DESCRIPTION
Cherry pick of #1589 on release-1.24.

#1589: fix TestReadDriverFlagsForDefaulting failure when running as root

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```