### PR TITLE
Integrate existing test suites for shared node mount

### DIFF
--- a/pkg/sidecar_mounter/sidecar_mounter_config_test.go
+++ b/pkg/sidecar_mounter/sidecar_mounter_config_test.go
@@ -989,10 +989,9 @@ func TestReadDriverFlagsForDefaulting(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			name:        "File exists but is unreadable",
-			unreadable:  true,
-			fileContent: "machine-type:e2-standard-4\n",
-			expectErr:   true,
+			name:       "File exists but is unreadable",
+			unreadable: true,
+			expectErr:  true,
 		},
 	}
 

--- a/test/e2e/specs/specs.go
+++ b/test/e2e/specs/specs.go
@@ -42,6 +42,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/kubernetes/pkg/kubelet/events"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2eevents "k8s.io/kubernetes/test/e2e/framework/events"
@@ -49,12 +50,15 @@ import (
 	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2epodooutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
+	e2epv "k8s.io/kubernetes/test/e2e/framework/pv"
+	e2evolume "k8s.io/kubernetes/test/e2e/framework/volume"
 	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 	"k8s.io/utils/ptr"
 )
 
 const (
+	SharedMountTag                = "shared-mount"
 	TesterContainerName           = "volume-tester"
 	K8sServiceAccountName         = "gcsfuse-csi-sa"
 	DefaultMounterPodTemplateName = "default-mounter-pod-template"
@@ -590,21 +594,158 @@ func (t *TestPod) setupVolumeMount(name, mountPath string, readOnly bool, subPat
 	}
 }
 
+// CreateVolumeResource wraps storageframework.CreateVolumeResource for E2E tests.
+// For shared-mount PreprovisionedPV, it creates the PV with an explicit name instead of
+// GenerateName, because upstream's GenerateName leaves pv.Name empty during webhook CREATE
+// admission, preventing the webhook from populating csi.storage.k8s.io/pv/name.
+func CreateVolumeResource(ctx context.Context, driver storageframework.TestDriver, config *storageframework.PerTestConfig, pattern storageframework.TestPattern, testVolumeSizeRange e2evolume.SizeRange) *storageframework.VolumeResource {
+	gcsDriver, ok := driver.(*GCSFuseCSITestDriver)
+	if !ok || !gcsDriver.EnableSharedMount || pattern.VolType != storageframework.PreprovisionedPV {
+		return storageframework.CreateVolumeResource(ctx, driver, config, pattern, testVolumeSizeRange)
+	}
+
+	r := &storageframework.VolumeResource{
+		Config:  config,
+		Pattern: pattern,
+	}
+	f := config.Framework
+	cs := f.ClientSet
+
+	r.Volume = storageframework.CreateVolume(ctx, driver, config, pattern.VolType)
+	pDriver, ok := driver.(storageframework.PreprovisionedPVTestDriver)
+	if !ok {
+		framework.Failf("Driver %s does not implement PreprovisionedPVTestDriver", driver.GetDriverInfo().Name)
+	}
+
+	pvSource, volumeNodeAffinity := pDriver.GetPersistentVolumeSource(false /* readOnly */, pattern.FsType, r.Volume)
+	if pvSource == nil {
+		framework.Failf("Failed to get PersistentVolumeSource for volume")
+	}
+
+	pvName := fmt.Sprintf("gcsfuse-shared-pv-%s", rand.String(8))
+	pvcName := fmt.Sprintf("pvc-%s", rand.String(8))
+
+	accessModes := driver.GetDriverInfo().RequiredAccessModes
+	if len(accessModes) == 0 {
+		accessModes = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany}
+	}
+
+	var success bool
+	defer func() {
+		if !success {
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			_ = r.CleanupResource(cleanupCtx)
+		}
+	}()
+
+	// 1. Create PVC
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pvcName,
+			Namespace: f.Namespace.Name,
+			Annotations: map[string]string{
+				webhook.MounterPodTemplateAnnotation: DefaultMounterPodTemplateName,
+			},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: accessModes,
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("2Gi"),
+				},
+			},
+			StorageClassName: ptr.To(""),
+		},
+	}
+	if pattern.VolMode != "" {
+		pvc.Spec.VolumeMode = &pattern.VolMode
+	}
+
+	var err error
+	r.Pvc, err = cs.CoreV1().PersistentVolumeClaims(f.Namespace.Name).Create(ctx, pvc, metav1.CreateOptions{})
+	framework.ExpectNoError(err, "failed to create PVC %s", pvcName)
+
+	// 2. Create PV with explicit Name (not GenerateName)
+	pv := &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: pvName,
+		},
+		Spec: corev1.PersistentVolumeSpec{
+			Capacity: corev1.ResourceList{
+				corev1.ResourceStorage: resource.MustParse("2Gi"),
+			},
+			PersistentVolumeSource: *pvSource,
+			AccessModes:            accessModes,
+			ClaimRef: &corev1.ObjectReference{
+				Kind:       "PersistentVolumeClaim",
+				APIVersion: "v1",
+				Name:       r.Pvc.Name,
+				Namespace:  r.Pvc.Namespace,
+				UID:        r.Pvc.UID,
+			},
+			PersistentVolumeReclaimPolicy: corev1.PersistentVolumeReclaimRetain,
+			StorageClassName:              "",
+			NodeAffinity:                  volumeNodeAffinity,
+		},
+	}
+	if pattern.VolMode != "" {
+		pv.Spec.VolumeMode = &pattern.VolMode
+	}
+
+	r.Pv, err = cs.CoreV1().PersistentVolumes().Create(ctx, pv, metav1.CreateOptions{})
+	framework.ExpectNoError(err, "failed to create PV %s", pvName)
+
+	// 3. Wait for PV and PVC to be Bound
+	err = e2epv.WaitOnPVandPVC(ctx, cs, f.Timeouts, f.Namespace.Name, r.Pv, r.Pvc)
+	framework.ExpectNoError(err, "PVC, PV failed to bind")
+
+	r.VolSource = &corev1.VolumeSource{
+		PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+			ClaimName: r.Pvc.Name,
+			ReadOnly:  false,
+		},
+	}
+
+	success = true
+	return r
+}
+
 // ensureMounterPodTemplateAnnotation ensures that when shared node mount is enabled,
 // the PVC references a mounter PodTemplate via the gke-gcsfuse/mounter-pod-template annotation.
 // If absent, it defaults to the default mounter PodTemplate provisioned during PrepareTest.
 func (t *TestPod) ensureMounterPodTemplateAnnotation(volumeResource *storageframework.VolumeResource) {
-	if volumeResource.Pvc != nil && volumeResource.Pv != nil && volumeResource.Pv.Spec.CSI != nil && volumeResource.Pv.Spec.CSI.VolumeAttributes[driver.VolumeContextSharedNodeMount] == util.TrueStr {
-		if volumeResource.Pvc.Annotations == nil {
-			volumeResource.Pvc.Annotations = make(map[string]string)
-		}
-		if _, ok := volumeResource.Pvc.Annotations[webhook.MounterPodTemplateAnnotation]; !ok {
-			volumeResource.Pvc.Annotations[webhook.MounterPodTemplateAnnotation] = DefaultMounterPodTemplateName
-			updatedPVC, err := t.client.CoreV1().PersistentVolumeClaims(volumeResource.Pvc.Namespace).Update(context.Background(), volumeResource.Pvc, metav1.UpdateOptions{})
-			framework.ExpectNoError(err)
-			volumeResource.Pvc = updatedPVC
-		}
+	if volumeResource == nil || volumeResource.Pvc == nil || volumeResource.Pv == nil || volumeResource.Pv.Spec.CSI == nil {
+		return
 	}
+	if volumeResource.Pv.Spec.CSI.VolumeAttributes[driver.VolumeContextSharedNodeMount] != util.TrueStr {
+		return
+	}
+
+	pvc := volumeResource.Pvc
+	if pvc.Annotations != nil && pvc.Annotations[webhook.MounterPodTemplateAnnotation] != "" {
+		return
+	}
+
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest, err := t.client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(context.Background(), pvc.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if latest.Annotations == nil {
+			latest.Annotations = make(map[string]string)
+		}
+		if latest.Annotations[webhook.MounterPodTemplateAnnotation] == "" {
+			latest.Annotations[webhook.MounterPodTemplateAnnotation] = DefaultMounterPodTemplateName
+			updated, err := t.client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Update(context.Background(), latest, metav1.UpdateOptions{})
+			if err == nil {
+				volumeResource.Pvc = updated
+			}
+			return err
+		}
+		return nil
+	})
+	framework.ExpectNoError(err, "failed to update PVC with mounter pod template annotation")
 }
 
 func (t *TestPod) setupVolume(volumeResource *storageframework.VolumeResource, name string, readOnly bool, mountOptions ...string) {

--- a/test/e2e/specs/testdriver.go
+++ b/test/e2e/specs/testdriver.go
@@ -137,6 +137,9 @@ func (n *GCSFuseCSITestDriver) SkipUnsupportedTest(pattern storageframework.Test
 	if n.EnableSharedMount && (pattern.VolType == storageframework.CSIInlineVolume || pattern.VolType == storageframework.DynamicPV) {
 		e2eskipper.Skipf("Shared node mount does not support %s -- skipping", pattern.VolType)
 	}
+	if isSharedMountTest() && !n.EnableSharedMount {
+		e2eskipper.Skipf("Shared node mount is not enabled -- skipping")
+	}
 }
 
 func (n *GCSFuseCSITestDriver) PrepareTest(ctx context.Context, f *e2eframework.Framework) *storageframework.PerTestConfig {
@@ -734,4 +737,9 @@ func isProfilerTest() bool {
 func isBillingTest() bool {
 	report := ginkgo.CurrentSpecReport()
 	return strings.Contains(report.FullText(), "billing-project")
+}
+
+func isSharedMountTest() bool {
+	report := ginkgo.CurrentSpecReport()
+	return strings.Contains(report.FullText(), SharedMountTag)
 }

--- a/test/e2e/testsuites/multivolume.go
+++ b/test/e2e/testsuites/multivolume.go
@@ -88,7 +88,7 @@ func (t *gcsFuseCSIMultiVolumeTestSuite) DefineTests(driver storageframework.Tes
 
 		l.volumeResourceList = []*storageframework.VolumeResource{}
 		for range volumeNumber {
-			l.volumeResourceList = append(l.volumeResourceList, storageframework.CreateVolumeResource(ctx, driver, l.config, pattern, e2evolume.SizeRange{}))
+			l.volumeResourceList = append(l.volumeResourceList, specs.CreateVolumeResource(ctx, driver, l.config, pattern, e2evolume.SizeRange{}))
 		}
 	}
 
@@ -163,6 +163,30 @@ func (t *gcsFuseCSIMultiVolumeTestSuite) DefineTests(driver storageframework.Tes
 		}
 	}
 
+	testOnePodMultipleBuckets := func() {
+		ginkgo.By("Configuring the pod")
+		tPod := specs.NewTestPod(f.ClientSet, f.Namespace)
+		tPod.SetupVolume(l.volumeResourceList[0], volumeName, mountPath, false)
+
+		ginkgo.By("Sleeping 2 minutes for the service account being propagated")
+		time.Sleep(time.Minute * 2)
+
+		ginkgo.By("Deploying the pod")
+		tPod.Create(ctx)
+		defer tPod.Cleanup(ctx)
+
+		ginkgo.By("Checking that the pod is running")
+		tPod.WaitForRunning(ctx)
+
+		ginkgo.By("Checking that the pod command exits with no error")
+		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("mount | grep %v | grep rw,", mountPath))
+
+		// The test driver uses config.Prefix to pass the bucket names back to the test suite.
+		for i, bucketName := range strings.Split(l.config.Prefix, ",") {
+			tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("echo 'hello world' > %v/%v/data-%v && grep 'hello world' %v/%v/data-%v", mountPath, bucketName, i, mountPath, bucketName, i))
+		}
+	}
+
 	// This tests below configuration:
 	//          [node1]
 	//          /    \
@@ -205,7 +229,7 @@ func (t *gcsFuseCSIMultiVolumeTestSuite) DefineTests(driver storageframework.Tes
 		init(1)
 		defer cleanup()
 
-		testTwoPodsSameBucket(false /* same volume */, false /* same node */)
+		testTwoPodsSameBucket(false /* same volume */, true /* same node */)
 	})
 
 	// This tests below configuration:
@@ -301,26 +325,75 @@ func (t *gcsFuseCSIMultiVolumeTestSuite) DefineTests(driver storageframework.Tes
 		init(1, specs.MultipleBucketsPrefix)
 		defer cleanup()
 
-		ginkgo.By("Configuring the pod")
-		tPod := specs.NewTestPod(f.ClientSet, f.Namespace)
-		tPod.SetupVolume(l.volumeResourceList[0], volumeName, mountPath, false)
+		testOnePodMultipleBuckets()
+	})
 
-		ginkgo.By("Sleeping 2 minutes for the service account being propagated")
-		time.Sleep(time.Minute * 2)
+	// ---- [shared-mount] test duplicates ----
+	// Each test below mirrors an existing test case above but is tagged with [shared-mount]
+	// so that ginkgo --focus="shared-mount" selects only these. When shared mount is not
+	// enabled, the driver automatically skips them via SkipUnsupportedTest.
 
-		ginkgo.By("Deploying the pod")
-		tPod.Create(ctx)
-		defer tPod.Cleanup(ctx)
+	ginkgo.It("[shared-mount] should access multiple volumes backed by the same bucket from different Pods on the same node", func() {
+		init(2)
+		defer cleanup()
 
-		ginkgo.By("Checking that the pod is running")
-		tPod.WaitForRunning(ctx)
+		testTwoPodsSameBucket(true /* different volumes */, true /* same node */)
+	})
 
-		ginkgo.By("Checking that the pod command exits with no error")
-		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("mount | grep %v | grep rw,", mountPath))
+	ginkgo.It("[shared-mount] should access multiple volumes backed by the same bucket from different Pods on different nodes", func() {
+		init(2)
+		defer cleanup()
 
-		// The test driver uses config.Prefix to pass the bucket names back to the test suite.
-		for i, bucketName := range strings.Split(l.config.Prefix, ",") {
-			tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("echo 'hello world' > %v/%v/data-%v && grep 'hello world' %v/%v/data-%v", mountPath, bucketName, i, mountPath, bucketName, i))
+		testTwoPodsSameBucket(true /* different volumes */, false /* different nodes */)
+	})
+
+	ginkgo.It("[shared-mount] should access one volume backed by the same bucket from different Pods on the same node", func() {
+		init(1)
+		defer cleanup()
+
+		testTwoPodsSameBucket(false /* same volume */, true /* same node */)
+	})
+
+	ginkgo.It("[shared-mount] should access one volume backed by the same bucket from different Pods on different nodes", func() {
+		init(1)
+		defer cleanup()
+
+		testTwoPodsSameBucket(false /* same volume */, false /* different nodes */)
+	})
+
+	ginkgo.It("[shared-mount] should access multiple volumes backed by the same bucket from the same Pod", func() {
+		if pattern.VolType == storageframework.PreprovisionedPV {
+			e2eskipper.Skipf("skip for volume type %v", storageframework.PreprovisionedPV)
 		}
+
+		init(2)
+		defer cleanup()
+
+		testOnePodTwoVols()
+	})
+
+	ginkgo.It("[shared-mount] should access multiple volumes backed by different buckets from the same Pod", func() {
+		init(2, specs.ForceNewBucketPrefix)
+		defer cleanup()
+
+		testOnePodTwoVols()
+	})
+
+	ginkgo.It("[shared-mount] should access different directories in the same GCS bucket via different volumes", func() {
+		if pattern.VolType == storageframework.PreprovisionedPV {
+			e2eskipper.Skipf("skip for volume type %v", storageframework.PreprovisionedPV)
+		}
+
+		init(2, specs.SubfolderInBucketPrefix)
+		defer cleanup()
+
+		testOnePodTwoVols()
+	})
+
+	ginkgo.It("[shared-mount] should access multiple GCS buckets via the same volume", func() {
+		init(1, specs.MultipleBucketsPrefix)
+		defer cleanup()
+
+		testOnePodMultipleBuckets()
 	})
 }

--- a/test/e2e/testsuites/subpath.go
+++ b/test/e2e/testsuites/subpath.go
@@ -76,7 +76,7 @@ func (t *gcsFuseCSISubPathTestSuite) DefineTests(driver storageframework.TestDri
 		if len(configPrefix) > 0 {
 			l.config.Prefix = configPrefix[0]
 		}
-		l.volumeResource = storageframework.CreateVolumeResource(ctx, driver, l.config, pattern, e2evolume.SizeRange{})
+		l.volumeResource = specs.CreateVolumeResource(ctx, driver, l.config, pattern, e2evolume.SizeRange{})
 	}
 
 	cleanup := func() {
@@ -86,10 +86,7 @@ func (t *gcsFuseCSISubPathTestSuite) DefineTests(driver storageframework.TestDri
 		framework.ExpectNoError(err, "while cleaning up")
 	}
 
-	ginkgo.It("should support non-existent paths", func() {
-		init()
-		defer cleanup()
-
+	testNonExistentPaths := func() {
 		ginkgo.By("Configuring the first pod")
 		tPod1 := specs.NewTestPod(f.ClientSet, f.Namespace)
 		tPod1.SetupVolumeWithSubPath(l.volumeResource, volumeName, mountPath+"1", false, "subpath1", false /* add the first volume */)
@@ -125,12 +122,9 @@ func (t *gcsFuseCSISubPathTestSuite) DefineTests(driver storageframework.TestDri
 		tPod2.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("mount | grep %v | grep rw,", mountPath))
 		tPod2.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("grep 'hello world' %v/subpath1/data", mountPath))
 		tPod2.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("grep 'hello world' %v/subpath2/data", mountPath))
-	})
+	}
 
-	ginkgo.It("should support existing paths", func() {
-		init()
-		defer cleanup()
-
+	testExistingPaths := func() {
 		// The test driver uses config.Prefix to pass the bucket names back to the test suite.
 		bucketName := l.config.Prefix
 
@@ -161,12 +155,9 @@ func (t *gcsFuseCSISubPathTestSuite) DefineTests(driver storageframework.TestDri
 		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("echo 'hello world' > %v/data && grep 'hello world' %v/data", mountPath+"1", mountPath+"1"))
 		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("mount | grep %v | grep rw,", mountPath+"2"))
 		tPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("echo 'hello world' > %v/data && grep 'hello world' %v/data", mountPath+"2", mountPath+"2"))
-	})
+	}
 
-	ginkgo.It("should support files as paths", func(ctx context.Context) {
-		init()
-		defer cleanup()
-
+	testFilesAsPaths := func(ctx context.Context) {
 		// The test driver uses config.Prefix to pass the bucket names back to the test suite.
 		bucketName := l.config.Prefix
 
@@ -197,12 +188,9 @@ func (t *gcsFuseCSISubPathTestSuite) DefineTests(driver storageframework.TestDri
 		tPod1.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("echo 'hello world' > %v && grep 'hello world' %v", mountPath+"1", mountPath+"1"))
 		tPod1.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("mount | grep %v | grep rw,", mountPath+"2"))
 		tPod1.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("echo 'hello world' > %v && grep 'hello world' %v", mountPath+"2", mountPath+"2"))
-	})
+	}
 
-	ginkgo.It("[read-only] should fail when write", func() {
-		init()
-		defer cleanup()
-
+	testReadOnlyFailWhenWrite := func() {
 		ginkgo.By("Configuring the writer pod")
 		tPod := specs.NewTestPod(f.ClientSet, f.Namespace)
 		tPod.SetName("gcsfuse-volume-tester-writer")
@@ -246,5 +234,66 @@ func (t *gcsFuseCSISubPathTestSuite) DefineTests(driver storageframework.TestDri
 		ginkgo.By("Expecting error when write to read-only volumes")
 		tPod.VerifyExecInPodFail(f, specs.TesterContainerName, fmt.Sprintf("echo 'hello world' > %v/data", mountPath+"1"), 1)
 		tPod.VerifyExecInPodFail(f, specs.TesterContainerName, fmt.Sprintf("echo 'hello world' > %v", mountPath+"2"), 1)
+	}
+
+	ginkgo.It("should support non-existent paths", func() {
+		init()
+		defer cleanup()
+
+		testNonExistentPaths()
+	})
+
+	ginkgo.It("should support existing paths", func() {
+		init()
+		defer cleanup()
+
+		testExistingPaths()
+	})
+
+	ginkgo.It("should support files as paths", func(ctx context.Context) {
+		init()
+		defer cleanup()
+
+		testFilesAsPaths(ctx)
+	})
+
+	ginkgo.It("[read-only] should fail when write", func() {
+		init()
+		defer cleanup()
+
+		testReadOnlyFailWhenWrite()
+	})
+
+	// ---- [shared-mount] test duplicates ----
+	// Each test below mirrors an existing test case above but is tagged with [shared-mount]
+	// so that ginkgo --focus="shared-mount" selects only these. When shared mount is not
+	// enabled, the driver automatically skips them via SkipUnsupportedTest.
+
+	ginkgo.It("[shared-mount] should support non-existent paths", func() {
+		init()
+		defer cleanup()
+
+		testNonExistentPaths()
+	})
+
+	ginkgo.It("[shared-mount] should support existing paths", func() {
+		init()
+		defer cleanup()
+
+		testExistingPaths()
+	})
+
+	ginkgo.It("[shared-mount] should support files as paths", func(ctx context.Context) {
+		init()
+		defer cleanup()
+
+		testFilesAsPaths(ctx)
+	})
+
+	ginkgo.It("[shared-mount] [read-only] should fail when write", func() {
+		init()
+		defer cleanup()
+
+		testReadOnlyFailWhenWrite()
 	})
 }

--- a/test/e2e/testsuites/volumes.go
+++ b/test/e2e/testsuites/volumes.go
@@ -95,7 +95,7 @@ func (t *gcsFuseCSIVolumesTestSuite) DefineTests(driver storageframework.TestDri
 		if len(configPrefix) > 0 {
 			l.config.Prefix = configPrefix[0]
 		}
-		l.volumeResource = storageframework.CreateVolumeResource(ctx, driver, l.config, pattern, e2evolume.SizeRange{})
+		l.volumeResource = specs.CreateVolumeResource(ctx, driver, l.config, pattern, e2evolume.SizeRange{})
 	}
 
 	cleanup := func() {
@@ -203,6 +203,9 @@ func (t *gcsFuseCSIVolumesTestSuite) DefineTests(driver storageframework.TestDri
 	}
 
 	ginkgo.It("[read-only] should fail when write", func() {
+		testCaseReadOnlyFailedWrite("")
+	})
+	ginkgo.It("[shared-mount] [read-only] should fail when write", func() {
 		testCaseReadOnlyFailedWrite("")
 	})
 	ginkgo.It("[read-only][csi-skip-bucket-access-check] should fail when write", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:

Integrate existing E2E test suites (multivolume, subpath, and volumes) to support shared node mount, and create new `specs.CreateVolumeResource helper` to resolve PreprovisionedPV webhook admission issues during test volume creation. Previously, [CreateVolumeResource uses generateName would leaving pv.Name empty](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/framework/pv/pv.go#L609-L614) during webhook admission review and failing our pv name injection

Key changes:
- Extended multivolume, subpath, and volumes test suites with [shared-mount] test cases.
- Added `specs.CreateVolumeResource` helper to replace upstream storageframework.CreateVolumeResource for shared mount PreprovisionedPV tests. This assigns an explicit PV metadata.name on creation instead of GenerateName, allowing the mutating webhook to receive a valid pv.Name during CREATE admission and automatically populate the shared-mount label and pv name volume attribute.
- Added skip logic in `SkipUnsupportedTest()` to automatically skip `shared-mount` tests when shared mount is not enabled.
- Fixed `sameNode` parameter in `multivolume` from `false` to `true` to match the test's same-node specification.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
I have tested locally, all of the test cases passed
```
E2E_TEST_USE_GKE_MANAGED_DRIVER=false \
REGISTRY=us-central1-docker.pkg.dev/yaozile-gke-dev/gcs-fuse-csi-driver \
STAGINGVERSION=prow-gob-internal-boskos-dev \
ENABLE_SHARED_MOUNT=true \
E2E_TEST_FOCUS="shared-mount" \
make e2e-test

Ran 11 of 694 Specs in 347.029 seconds
SUCCESS! -- 11 Passed | 0 Failed | 0 Pending | 683 Skipped
Ginkgo ran 1 suite in 5m52.818579224s
Test Suite Passed
```

The shared mount related tests also skipped if we didn't enable shared mount
```
ENABLE_SHARED_MOUNT=false E2E_TEST_SKIP_CSI_DRIVER_INSTALL=true E2E_TEST_USE_GKE_MANAGED_DRIVER=false E2E_TEST_FOCUS="shared-mount" make e2e-test

Ran 0 of 694 Specs in 0.441 seconds
SUCCESS! -- 0 Passed | 0 Failed | 0 Pending | 694 Skipped
Ginkgo ran 1 suite in 5.378952402s
Test Suite Passed
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```