### PR TITLE
Fix Go 1.25 covdata bug on pkg/csi_mounter

### DIFF
--- a/pkg/csi_mounter/dummy_test.go
+++ b/pkg/csi_mounter/dummy_test.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package csimounter
+
+import "testing"
+
+func TestDummy(t *testing.T) {
+	// Dummy test to work around Go 1.25 covdata bug on empty test dirs (https://github.com/golang/go/issues/75031)
+}


### PR DESCRIPTION
Adds dummy_test.go to pkg/csi_mounter to bypass Go 1.25 covdata coverage failure on empty test package.