### PR TITLE
[Shared Mount] Disallow Unused Bucket Access MO 

### DIFF
--- a/test/e2e/specs/specs.go
+++ b/test/e2e/specs/specs.go
@@ -73,6 +73,7 @@ const (
 	ForceNewBucketPrefix                                       = "gcsfuse-csi-force-new-bucket"
 	SubfolderInBucketPrefix                                    = "gcsfuse-csi-subfolder-in-bucket"
 	MultipleBucketsPrefix                                      = "gcsfuse-csi-multiple-buckets"
+	SingleBucketDiffVolWithSuffixPrefix                        = "gcsfuse-csi-single-bucket-diff-with-suffix-vol"
 	EnableFileCacheForceNewBucketPrefix                        = "gcsfuse-csi-enable-file-cache-force-new-bucket"
 	EnableFileCacheForceNewBucketAndMetricsPrefix              = "gcsfuse-csi-enable-file-cache-force-new-bucket-and-metrics"
 	EnableFileCachePrefix                                      = "gcsfuse-csi-enable-file-cache"
@@ -598,7 +599,7 @@ func (t *TestPod) setupVolumeMount(name, mountPath string, readOnly bool, subPat
 // For shared-mount PreprovisionedPV, it creates the PV with an explicit name instead of
 // GenerateName, because upstream's GenerateName leaves pv.Name empty during webhook CREATE
 // admission, preventing the webhook from populating csi.storage.k8s.io/pv/name.
-func CreateVolumeResource(ctx context.Context, driver storageframework.TestDriver, config *storageframework.PerTestConfig, pattern storageframework.TestPattern, testVolumeSizeRange e2evolume.SizeRange) *storageframework.VolumeResource {
+func CreateVolumeResource(ctx context.Context, driver storageframework.TestDriver, config *storageframework.PerTestConfig, pattern storageframework.TestPattern, testVolumeSizeRange e2evolume.SizeRange, customVolumeHandleSuffix ...string) *storageframework.VolumeResource {
 	gcsDriver, ok := driver.(*GCSFuseCSITestDriver)
 	if !ok || !gcsDriver.EnableSharedMount || pattern.VolType != storageframework.PreprovisionedPV {
 		return storageframework.CreateVolumeResource(ctx, driver, config, pattern, testVolumeSizeRange)
@@ -620,6 +621,10 @@ func CreateVolumeResource(ctx context.Context, driver storageframework.TestDrive
 	pvSource, volumeNodeAffinity := pDriver.GetPersistentVolumeSource(false /* readOnly */, pattern.FsType, r.Volume)
 	if pvSource == nil {
 		framework.Failf("Failed to get PersistentVolumeSource for volume")
+	}
+
+	if len(customVolumeHandleSuffix) > 0 && customVolumeHandleSuffix[0] != "" && pvSource.CSI != nil {
+		pvSource.CSI.VolumeHandle += customVolumeHandleSuffix[0]
 	}
 
 	pvName := fmt.Sprintf("gcsfuse-shared-pv-%s", rand.String(8))

--- a/test/e2e/testsuites/multivolume.go
+++ b/test/e2e/testsuites/multivolume.go
@@ -25,7 +25,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util"
+	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/webhook"
 	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -87,8 +91,16 @@ func (t *gcsFuseCSIMultiVolumeTestSuite) DefineTests(driver storageframework.Tes
 		}
 
 		l.volumeResourceList = []*storageframework.VolumeResource{}
-		for range volumeNumber {
-			l.volumeResourceList = append(l.volumeResourceList, specs.CreateVolumeResource(ctx, driver, l.config, pattern, e2evolume.SizeRange{}))
+		for i := range volumeNumber {
+			suffix := ""
+			if len(configPrefix) > 0 && configPrefix[0] == specs.SameBucketDiffVolPrefix {
+				if i == 0 {
+					suffix = ":rwx"
+				} else if i == 1 {
+					suffix = ":rox"
+				}
+			}
+			l.volumeResourceList = append(l.volumeResourceList, specs.CreateVolumeResource(ctx, driver, l.config, pattern, e2evolume.SizeRange{}, suffix))
 		}
 	}
 
@@ -395,5 +407,61 @@ func (t *gcsFuseCSIMultiVolumeTestSuite) DefineTests(driver storageframework.Tes
 		defer cleanup()
 
 		testOnePodMultipleBuckets()
+	})
+
+	// This tests mounting two volumes via a unique suffix using shared mount as seen in https://docs.cloud.google.com/kubernetes-engine/docs/how-to/cloud-storage-fuse-csi-driver-pv#mount-same-bucket-different-pv.
+	ginkgo.It("[shared-mount] should access the same bucket via different PV's with deduplicated volumeHandles from different Pods on the same node", func() {
+		if pattern.VolType != storageframework.PreprovisionedPV {
+			e2eskipper.Skipf("skip for volume type %v", pattern.VolType)
+		}
+
+		init(2, specs.SameBucketDiffVolWithSuffixPrefix)
+		l.volumeResourceList[1].VolSource.PersistentVolumeClaim.ReadOnly = true
+		defer cleanup()
+
+		// 1. Deploy Pod 1 (ReadWriteMany).
+		ginkgo.By("Configuring the first pod (ReadWriteMany)")
+		tPod1 := specs.NewTestPod(f.ClientSet, f.Namespace)
+		tPod1.SetupVolume(l.volumeResourceList[0], volumeName, mountPath, false /* readOnly */)
+
+		ginkgo.By("Deploying the first pod")
+		tPod1.Create(ctx)
+		defer tPod1.Cleanup(ctx)
+
+		ginkgo.By("Checking that the first pod is running")
+		tPod1.WaitForRunning(ctx)
+		nodeName := tPod1.GetNode()
+
+		// 2. Deploy Pod 2 (ReadOnlyMany) on the same node.
+		ginkgo.By("Configuring the second pod (ReadOnlyMany) on the same node")
+		tPod2 := specs.NewTestPod(f.ClientSet, f.Namespace)
+		tPod2.SetupVolume(l.volumeResourceList[1], volumeName, mountPath, true /* readOnly */)
+		tPod2.SetNodeAffinity(nodeName, true /* sameNode */)
+
+		ginkgo.By("Deploying the second pod")
+		tPod2.Create(ctx)
+		defer tPod2.Cleanup(ctx)
+
+		ginkgo.By("Checking that the second pod is running")
+		tPod2.WaitForRunning(ctx)
+
+		// 3. Verify distinct Mounter Pods exist for each volumeHandle in our ns.
+		ginkgo.By("Verifying distinct Mounter Pods exist for each volumeHandle")
+		mounterPods, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).List(ctx, metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("%s=%s", webhook.SharedMountLabel, util.TrueStr),
+		})
+		framework.ExpectNoError(err, "failed to list mounter pods")
+		gomega.Expect(len(mounterPods.Items)).To(gomega.Equal(2), "expected 2 distinct Mounter Pods for unique volumeHandles")
+
+		// 4. Verify Pod 1 (RWX) operations.
+		ginkgo.By("Verifying RWX pod read and write operations")
+		tPod1.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("mount | grep %v | grep rw,", mountPath))
+		tPod1.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("echo 'hello world rwx' > %v/data-rwx && grep 'hello world rwx' %v/data-rwx", mountPath, mountPath))
+
+		// 5. Verify Pod 2 (ROX) operations and access mode enforcement.
+		ginkgo.By("Verifying ROX pod read operation and write restriction enforcement")
+		tPod2.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("mount | grep %v | grep ro,", mountPath))
+		tPod2.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("grep 'hello world rwx' %v/data-rwx", mountPath))
+		tPod2.VerifyExecInPodFail(f, specs.TesterContainerName, fmt.Sprintf("echo 'hello world rox' > %v/data-rox", mountPath), 1)
 	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:
Disable and injection of sidecar bucket access check options for shared mounts.                                                                             

Previously, when the CSI driver had EnableSidecarBucketAccessCheck enabled globally, populateTokenAndBucketAccessCheckOptions was injecting sidecar bucket access check and token identity parameters (enable-sidecar-bucket-access-check=true, pod-namespace, service-account-name, and token-server-identity-pool) into args.fuseMountOptions these are unused and are confusing to users as mount options that are being passed.             

Changes                           
                                                                                                                                                                        
1. Directly Disable in `populateTokenAndBucketAccessCheckOptions                  
Check `s.driver.sharedMount(vc)` directly from the volume context.                  
If sidecar bucket access check is enabled and the volume is a shared mount, log a   
  warning and disable `enableBucketAccessCheckForVersion`, avoiding the generation and       
  injection of `pod-namespace`, `service-account-name`, `token-server-identity-pool`, and    
  `enable-sidecar-bucket-access-check=true`.                                                 
                                                                                             
2. Disallow enable-sidecar-bucket-access-check in executeNodeStageVolume
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```