### PR TITLE
fix: fix webhook script syntax and prevent mount options bounds panic

### DIFF
--- a/deploy/base/webhook/manage-validating_admission_policy.sh
+++ b/deploy/base/webhook/manage-validating_admission_policy.sh
@@ -41,8 +41,8 @@ while [[ $# -gt 0 ]]; do
     shift
 done
 
-[ -z ${install} ] && install=false
-[ -z ${uninstall} ] && uninstall=false
+[[ -z "${install}" ]] && install=false
+[[ -z "${uninstall}" ]] && uninstall=false
 
 versionStr=$(kubectl version | sed -n '3p' | cut -d " " -f 3)
 
@@ -57,12 +57,12 @@ if [[ $versionStr =~ $versionRegex ]]; then
         echo "Cluster version is greater than or equal to 1.30"
         script_path=$(dirname "$(realpath "$0")")
         
-        if ( $install == "true" ); then
+        if [[ "${install}" == "true" ]]; then
             echo "Installing ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding"
             kubectl apply -f "${script_path}/validating_admission_policy.yaml"
         fi
 
-        if ( $uninstall == "true" ); then
+        if [[ "${uninstall}" == "true" ]]; then
             echo "Uninstalling ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding"
             kubectl delete -f "${script_path}/validating_admission_policy.yaml"
         fi

--- a/pkg/csi_driver/utils.go
+++ b/pkg/csi_driver/utils.go
@@ -768,6 +768,11 @@ func removeDisallowedMountOptions(fuseMountOptions []string, disallowedFlags map
 		parts := strings.FieldsFunc(item, func(r rune) bool {
 			return r == ':' || r == '='
 		})
+		if len(parts) == 0 {
+			fuseMountOptions[n] = item
+			n++
+			continue
+		}
 		key := parts[0]
 
 		if !disallowedFlags[key] {

--- a/pkg/csi_driver/utils_test.go
+++ b/pkg/csi_driver/utils_test.go
@@ -973,6 +973,18 @@ func TestRemoveDisallowedMountOptions(t *testing.T) {
 			disallowedFlags: map[string]bool{"debug_fuse": true},
 			expected:        []string{"uid:1001", "gid=1002"},
 		},
+		{
+			name:            "delimiter-only mount options with disallowed flags, results in mountOptions stripped of disallowed flags",
+			mountOptions:    []string{"=", ":", ":=", ":::=", "debug_fuse"},
+			disallowedFlags: map[string]bool{"debug_fuse": true},
+			expected:        []string{"=", ":", ":=", ":::="},
+		},
+		{
+			name:            "mixed delimiter-only and normal mount options with disallowed flags, results in mountOptions stripped of disallowed flags",
+			mountOptions:    []string{"=", "uid:1001", ":", "debug_fuse", ":=", "implicit-dirs", ":::", "gid=1002"},
+			disallowedFlags: map[string]bool{"debug_fuse": true},
+			expected:        []string{"=", "uid:1001", ":", ":=", "implicit-dirs", ":::", "gid=1002"},
+		},
 	}
 
 	// Run test cases


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
- In `manage-validating_admission_policy.sh`:
  - `( $install == "true" )` and `( $uninstall == "true" )` execute `$install` / `$uninstall` in a subshell rather than evaluating boolean conditions.
  - Unquoted `${install}` and `${uninstall}` in `[ -z ... ]` can cause word splitting / syntax errors if the variables contain spaces.
  - I have replaced `( $install == "true" )` / `( $uninstall == "true" )` with standard test expressions `[ "$install" = "true" ]` / `[ "$uninstall" = "true" ]`, and quoted `${install}` / `${uninstall}` in `[ -z ... ]` to prevent word splitting.
- In `removeDisallowedMountOptions`:
  - Passing mount options with only delimiters (e.g. `"="`, `":"`) causes `strings.FieldsFunc` to return an empty slice, leading to an index-out-of-range panic on `parts[0]`.
  - I have added a `len(parts) == 0` bounds check in `removeDisallowedMountOptions` to safely retain delimiter-only options without panicking, along with unit tests in `pkg/csi_driver/utils_test.go`.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```