### PR TITLE
fix(metrics): filter conflicting metric labels to prevent descriptor …

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -321,7 +321,13 @@ func (c *metricsCollector) emitMetricFamily(metricFamily *dto.MetricFamily, ch c
 	var cachedLabelNames []string
 
 	for _, metric := range metricFamily.GetMetric() {
-		labels := metric.GetLabel()
+		rawLabels := metric.GetLabel()
+		labels := make([]*dto.LabelPair, 0, len(rawLabels))
+		for _, label := range rawLabels {
+			if _, exists := c.constLabels[label.GetName()]; !exists {
+				labels = append(labels, label)
+			}
+		}
 
 		var desc *prometheus.Desc
 		// Reuse cached prometheus.Desc assuming identical label ordering.

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/cloud_provider/clientset"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
@@ -261,6 +262,131 @@ gcs_request_count{gcs_method="StatObject"} 6
 	}
 	if count != 2 {
 		t.Errorf("expected 2 metric families, got %d", count)
+	}
+}
+
+func TestEmitMetricFamily(t *testing.T) {
+	t.Parallel()
+
+	counterType := dto.MetricType_COUNTER
+	val := float64(42.0)
+	name := "test_metric"
+	help := "test help string"
+
+	strPtr := func(s string) *string { return &s }
+
+	defaultConstLabels := map[string]string{
+		"pod_name":       "test-pod",
+		"namespace_name": "default",
+		"volume_name":    "vol-1",
+		"bucket_name":    "bucket-1",
+		"pod_uid":        "",
+	}
+
+	testCases := []struct {
+		name           string
+		constLabels    map[string]string
+		metricFamily   *dto.MetricFamily
+		expectedEmits  int
+		expectedLabels map[string]string
+	}{
+		{
+			name:        "counter without label conflicts",
+			constLabels: defaultConstLabels,
+			metricFamily: &dto.MetricFamily{
+				Name: &name,
+				Help: &help,
+				Type: &counterType,
+				Metric: []*dto.Metric{
+					{
+						Label: []*dto.LabelPair{
+							{Name: strPtr("fs_op"), Value: strPtr("read")},
+						},
+						Counter: &dto.Counter{Value: &val},
+					},
+				},
+			},
+			expectedEmits: 1,
+			expectedLabels: map[string]string{
+				"fs_op":          "read",
+				"pod_name":       "test-pod",
+				"namespace_name": "default",
+				"volume_name":    "vol-1",
+				"bucket_name":    "bucket-1",
+				"pod_uid":        "",
+			},
+		},
+		{
+			name:        "counter with conflicting labels matching constLabels",
+			constLabels: defaultConstLabels,
+			metricFamily: &dto.MetricFamily{
+				Name: &name,
+				Help: &help,
+				Type: &counterType,
+				Metric: []*dto.Metric{
+					{
+						Label: []*dto.LabelPair{
+							{Name: strPtr("pod_name"), Value: strPtr("malicious_pod")},
+							{Name: strPtr("fs_op"), Value: strPtr("write")},
+							{Name: strPtr("pod_uid"), Value: strPtr("malicious_uid")},
+						},
+						Counter: &dto.Counter{Value: &val},
+					},
+				},
+			},
+			expectedEmits: 1,
+			expectedLabels: map[string]string{
+				"fs_op":          "write",
+				"pod_name":       "test-pod",
+				"namespace_name": "default",
+				"volume_name":    "vol-1",
+				"bucket_name":    "bucket-1",
+				"pod_uid":        "",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			c := &metricsCollector{
+				constLabels: tc.constLabels,
+			}
+
+			ch := make(chan prometheus.Metric, tc.expectedEmits+5)
+			c.emitMetricFamily(tc.metricFamily, ch)
+			close(ch)
+
+			var emittedMetrics []prometheus.Metric
+			for m := range ch {
+				if m == nil {
+					t.Errorf("received nil metric")
+					continue
+				}
+				emittedMetrics = append(emittedMetrics, m)
+			}
+
+			if len(emittedMetrics) != tc.expectedEmits {
+				t.Fatalf("emitted metrics count = %d, want %d", len(emittedMetrics), tc.expectedEmits)
+			}
+
+			if len(emittedMetrics) > 0 {
+				var pb dto.Metric
+				if err := emittedMetrics[0].Write(&pb); err != nil {
+					t.Fatalf("failed to write metric to dto.Metric: %v", err)
+				}
+
+				gotLabels := make(map[string]string)
+				for _, lp := range pb.GetLabel() {
+					gotLabels[lp.GetName()] = lp.GetValue()
+				}
+
+				if diff := cmp.Diff(tc.expectedLabels, gotLabels); diff != "" {
+					t.Errorf("labels mismatch (-want +got):\n%s", diff)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
…panics

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
When the CSI Node Driver scrapes Prometheus metrics from the sidecar over `metrics.sock`, if the payload contains dynamic metric labels that share the same key names with the driver's predefined `constLabels`, `prometheus.NewDesc` fails due to label name collision. Subsequent calls to `prometheus.MustNewConstMetric` panic on the invalid descriptor and crash the CSI Node Driver process.

This PR fixed this issue by filtering out any dynamic labels that collide with `c.constLabels` before constructing the Prometheus descriptor and extracting label values.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```