### PR TITLE
test(e2e): skip host max_pages_limit revert test on GKE Autopilot

### DIFF
--- a/test/e2e/utils/handler.go
+++ b/test/e2e/utils/handler.go
@@ -412,7 +412,9 @@ func generateTestSkip(testParams *TestParameters) string {
 	}
 
 	if testParams.UseGKEAutopilot {
-		skipTests = append(skipTests, "OOM", "high.resource.usage", "gcsfuseIntegration", "istio")
+		skipTests = append(skipTests, "OOM", "high.resource.usage", "gcsfuseIntegration", "istio", "hostnetwork.enabled.pods")
+		// TODO(yaozile): Remove skip once GCW supports mounting /proc/sys/fs/fuse hostPath on Autopilot clusters.
+		skipTests = append(skipTests, "reverted.back.to.its.original.default.value")
 	}
 
 	if testParams.EnableGcsFuseProfiles {
@@ -434,10 +436,6 @@ func generateTestSkip(testParams *TestParameters) string {
 	supportsLongMountOptions, _ := ClusterAtLeastMinVersion(testParams.GkeClusterVersion, testParams.GkeNodeVersion, longMountOptionsMinimumVersion)
 	if !supportsLongMountOptions {
 		skipTests = append(skipTests, "long.mount.options")
-	}
-
-	if testParams.UseGKEAutopilot {
-		skipTests = append(skipTests, "hostnetwork.enabled.pods")
 	}
 
 	if testParams.UseGKEManagedDriver {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation

/kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

The test [should verify that once the GCSFuse mount is done the FUSE max_pages_limit on the host is reverted back to its original default value](https://github.com/GoogleCloudPlatform/gcs-fuse-csi-driver/blob/bff96c0e3195ae48b59175fd9d6d4d0c2d0507aa/test/e2e/testsuites/kernel_params.go#L549) mounts `/proc/sys/fs/fuse` via a hostPath volume to verify the host sysctl parameter.
On GKE Autopilot clusters, GCW strictly restricts hostPath volume paths to `/var/log/` and rejects workloads mounting `/proc/sys/fs/fuse` (violating `autogke-no-write-mode-hostpath`).
This change skips the test when running against Autopilot clusters in `test/e2e/utils/handler.go`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
I have tested manually to make sure the test got skipped in autopilot:
```
E2E_TEST_USE_GKE_AUTOPILOT=true E2E_TEST_USE_GKE_MANAGED_DRIVER=true E2E_TEST_PROJECT_ID=yaozile-gke-dev E2E_TEST_FOCUS="should verify that once the GCSFuse mount is done the FUSE max_pages_limit on the host is reverted back to its original default value" 
make e2e-test

Ran 0 of 694 Specs in 0.446 seconds
  SUCCESS! -- 0 Passed | 0 Failed | 0 Pending | 694 Skipped


  Ginkgo ran 1 suite in 10.71837308s
  Test Suite Passed
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```