### PR TITLE
[Shared Mount] E2E Same Bucket Different Volume

### DIFF
--- a/test/e2e/specs/specs.go
+++ b/test/e2e/specs/specs.go
@@ -73,6 +73,7 @@ const (
 	ForceNewBucketPrefix                                       = "gcsfuse-csi-force-new-bucket"
 	SubfolderInBucketPrefix                                    = "gcsfuse-csi-subfolder-in-bucket"
 	MultipleBucketsPrefix                                      = "gcsfuse-csi-multiple-buckets"
+	BucketWithTwoUniqueVolSuffixPrefix                         = "gcsfuse-csi-bucket-with-two-unique-vol-suffix"
 	EnableFileCacheForceNewBucketPrefix                        = "gcsfuse-csi-enable-file-cache-force-new-bucket"
 	EnableFileCacheForceNewBucketAndMetricsPrefix              = "gcsfuse-csi-enable-file-cache-force-new-bucket-and-metrics"
 	EnableFileCachePrefix                                      = "gcsfuse-csi-enable-file-cache"
@@ -598,7 +599,7 @@ func (t *TestPod) setupVolumeMount(name, mountPath string, readOnly bool, subPat
 // For shared-mount PreprovisionedPV, it creates the PV with an explicit name instead of
 // GenerateName, because upstream's GenerateName leaves pv.Name empty during webhook CREATE
 // admission, preventing the webhook from populating csi.storage.k8s.io/pv/name.
-func CreateVolumeResource(ctx context.Context, driver storageframework.TestDriver, config *storageframework.PerTestConfig, pattern storageframework.TestPattern, testVolumeSizeRange e2evolume.SizeRange) *storageframework.VolumeResource {
+func CreateVolumeResource(ctx context.Context, driver storageframework.TestDriver, config *storageframework.PerTestConfig, pattern storageframework.TestPattern, testVolumeSizeRange e2evolume.SizeRange, customVolumeHandleSuffix ...string) *storageframework.VolumeResource {
 	gcsDriver, ok := driver.(*GCSFuseCSITestDriver)
 	if !ok || !gcsDriver.EnableSharedMount || pattern.VolType != storageframework.PreprovisionedPV {
 		return storageframework.CreateVolumeResource(ctx, driver, config, pattern, testVolumeSizeRange)
@@ -620,6 +621,13 @@ func CreateVolumeResource(ctx context.Context, driver storageframework.TestDrive
 	pvSource, volumeNodeAffinity := pDriver.GetPersistentVolumeSource(false /* readOnly */, pattern.FsType, r.Volume)
 	if pvSource == nil {
 		framework.Failf("Failed to get PersistentVolumeSource for volume")
+	}
+
+	if len(customVolumeHandleSuffix) > 0 && customVolumeHandleSuffix[0] != "" {
+		if pvSource.CSI == nil || pvSource.CSI.VolumeHandle == "" {
+			framework.Failf("Failed to apply custom volume handle suffix")
+		}
+		pvSource.CSI.VolumeHandle += customVolumeHandleSuffix[0]
 	}
 
 	pvName := fmt.Sprintf("gcsfuse-shared-pv-%s", rand.String(8))
@@ -757,6 +765,7 @@ func (t *TestPod) setupVolume(volumeResource *storageframework.VolumeResource, n
 		volume.VolumeSource = corev1.VolumeSource{
 			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 				ClaimName: volumeResource.Pvc.Name,
+				ReadOnly:  readOnly,
 			},
 		}
 	} else if volumeResource.VolSource != nil {

--- a/test/e2e/testsuites/multivolume.go
+++ b/test/e2e/testsuites/multivolume.go
@@ -25,7 +25,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util"
+	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/webhook"
 	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -87,8 +91,12 @@ func (t *gcsFuseCSIMultiVolumeTestSuite) DefineTests(driver storageframework.Tes
 		}
 
 		l.volumeResourceList = []*storageframework.VolumeResource{}
-		for range volumeNumber {
-			l.volumeResourceList = append(l.volumeResourceList, specs.CreateVolumeResource(ctx, driver, l.config, pattern, e2evolume.SizeRange{}))
+		for i := range volumeNumber {
+			suffix := ""
+			if len(configPrefix) > 0 && configPrefix[0] == specs.BucketWithTwoUniqueVolSuffixPrefix {
+				suffix = fmt.Sprintf(":%d", i)
+			}
+			l.volumeResourceList = append(l.volumeResourceList, specs.CreateVolumeResource(ctx, driver, l.config, pattern, e2evolume.SizeRange{}, suffix))
 		}
 	}
 
@@ -395,5 +403,64 @@ func (t *gcsFuseCSIMultiVolumeTestSuite) DefineTests(driver storageframework.Tes
 		defer cleanup()
 
 		testOnePodMultipleBuckets()
+	})
+
+	// This tests mounting two volumes via a unique suffix using shared mount as seen in https://docs.cloud.google.com/kubernetes-engine/docs/how-to/cloud-storage-fuse-csi-driver-pv#mount-same-bucket-different-pv.
+	ginkgo.It("[shared-mount] should access the same bucket via different PV's with unique volumeHandles from different Pods on the same node", func() {
+		if pattern.VolType != storageframework.PreprovisionedPV {
+			e2eskipper.Skipf("skip for volume type %v", pattern.VolType)
+		}
+
+		init(2, specs.BucketWithTwoUniqueVolSuffixPrefix)
+		defer cleanup()
+
+		gomega.Expect(l.volumeResourceList).To(gomega.HaveLen(2))
+		gomega.Expect(l.volumeResourceList[0]).ToNot(gomega.BeNil())
+		gomega.Expect(l.volumeResourceList[1]).ToNot(gomega.BeNil())
+
+		// 1. Deploy Pod 1 (ReadWriteMany).
+		ginkgo.By("Configuring the first pod (ReadWriteMany)")
+		tPod1 := specs.NewTestPod(f.ClientSet, f.Namespace)
+		tPod1.SetupVolume(l.volumeResourceList[0], volumeName, mountPath, false /* readOnly */)
+
+		ginkgo.By("Deploying the first pod")
+		tPod1.Create(ctx)
+		defer tPod1.Cleanup(ctx)
+
+		ginkgo.By("Checking that the first pod is running")
+		tPod1.WaitForRunning(ctx)
+		nodeName := tPod1.GetNode()
+
+		// 2. Deploy Pod 2 (ReadOnlyMany) on the same node.
+		ginkgo.By("Configuring the second pod (ReadOnlyMany) on the same node")
+		tPod2 := specs.NewTestPod(f.ClientSet, f.Namespace)
+		tPod2.SetupVolume(l.volumeResourceList[1], volumeName, mountPath, true /* readOnly */)
+		tPod2.SetNodeAffinity(nodeName, true /* sameNode */)
+
+		ginkgo.By("Deploying the second pod")
+		tPod2.Create(ctx)
+		defer tPod2.Cleanup(ctx)
+
+		ginkgo.By("Checking that the second pod is running")
+		tPod2.WaitForRunning(ctx)
+
+		// 3. Verify distinct Mounter Pods exist for each volumeHandle in our ns.
+		ginkgo.By("Verifying distinct Mounter Pods exist for each volumeHandle")
+		mounterPods, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).List(ctx, metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("%s=%s", webhook.SharedMountLabel, util.TrueStr),
+		})
+		framework.ExpectNoError(err, "failed to list mounter pods")
+		gomega.Expect(mounterPods.Items).To(gomega.HaveLen(2), "expected 2 distinct Mounter Pods for unique volumeHandles")
+
+		// 4. Verify Pod 1 (RWX) operations.
+		ginkgo.By("Verifying RWX pod read and write operations")
+		tPod1.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("mount | grep %v | grep rw,", mountPath))
+		tPod1.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("echo 'hello world rwx' > %v/data-rwx && grep 'hello world rwx' %v/data-rwx", mountPath, mountPath))
+
+		// 5. Verify Pod 2 (ROX) operations and access mode enforcement.
+		ginkgo.By("Verifying ROX pod read operation and write restriction enforcement")
+		tPod2.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("mount | grep %v | grep ro,", mountPath))
+		tPod2.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("grep 'hello world rwx' %v/data-rwx", mountPath))
+		tPod2.VerifyExecInPodFail(f, specs.TesterContainerName, fmt.Sprintf("echo 'hello world rox' > %v/data-rox", mountPath), 1)
 	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:
Adds test for verifying that the CSI driver correctly handles de-duplicating multiple PVs pointing to the same bucket with different access modes (ReadWriteMany vs ReadOnlyMany) or mount options using [de-duplicated volumeHandles](https://docs.cloud.google.com/kubernetes-engine/docs/how-to/cloud-storage-fuse-csi-driver-pv#mount-same-bucket-different-pv), creating distinct Mounter Pods for each volume
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
This change was tested by running e2e on the multivolume test package with both Shared Mount enabled and disabled. The Shared mount tests is successfully skipped when its not enabled. During the test run i manually check pantheon logs to verify both mounter pods were created and CPV and NSV succeed as expected.
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```