### PR TITLE
Integrate GCE Capacity Advisor for E2E test cluster set up

### DIFF
--- a/test/e2e/main.go
+++ b/test/e2e/main.go
@@ -50,6 +50,8 @@ var (
 	enableSharedMount              = flag.Bool("enable-shared-mount", false, "enables shared mount overlay and features in e2e tests")
 	skipCSIDriverInstall           = flag.Bool("skip-csi-driver-install", false, "skips the install of the driver. You must have manually deployed the driver and webhook.")
 	gcsFusePrNumber                = flag.String("gcsfuse-pr-number", "", "PR number for gcsfuse to test against")
+	// Only works for zonal clusters by pinning nodes to a single advised zone, set to false if want to create regional cluster.
+	useCapacityAdvisor = flag.Bool("use-capacity-advisor", false, "whether to use GCE Capacity Advisor to select node locations")
 
 	// Test infrastructure flags.
 	inProw                 = flag.Bool("run-in-prow", false, "whether or not to run the test in PROW")
@@ -164,6 +166,7 @@ func main() {
 		EnableSharedMount:              *enableSharedMount,
 		SkipCSIDriverInstall:           *skipCSIDriverInstall,
 		GCSFusePRNumber:                *gcsFusePrNumber,
+		UseCapacityAdvisor:             *useCapacityAdvisor,
 	}
 
 	if strings.Contains(testParams.GinkgoFocus, "performance") {

--- a/test/e2e/run-e2e-ci.sh
+++ b/test/e2e/run-e2e-ci.sh
@@ -39,7 +39,13 @@ readonly gke_cluster_version=${GKE_CLUSTER_VERSION:-latest}
 readonly gke_release_channel=${GKE_RELEASE_CHANNEL:-rapid}
 readonly gke_node_version=${GKE_NODE_VERSION:-}
 readonly node_machine_type=${MACHINE_TYPE:-n2-standard-8}
-readonly number_nodes=${NUMBER_NODES:-3}
+readonly use_capacity_advisor=${USE_CAPACITY_ADVISOR:-true}
+if [ "${use_capacity_advisor}" = true ]; then
+  default_number_nodes=9
+else
+  default_number_nodes=3
+fi
+readonly number_nodes=${NUMBER_NODES:-$default_number_nodes}
 readonly gcsfuse_client_protocol=${GCSFUSE_CLIENT_PROTOCOL:-http1}
 readonly build_gcsfuse_from_source=${BUILD_GCSFUSE_FROM_SOURCE:-false}
 readonly enable_zb=${ENABLE_ZB:-false}
@@ -115,5 +121,6 @@ base_cmd="${PKGDIR}/bin/e2e-test-ci \
             --gke-gcloud-command='${gke_gcloud_command}' \
             --gke-gcloud-args='${gke_gcloud_args}'\
             --deploy-overlay-name=${overlay} \
+            --use-capacity-advisor=${use_capacity_advisor} \
             ${gcsfuse_pr_number:+--gcsfuse-pr-number=${gcsfuse_pr_number}}"
 eval "$base_cmd"

--- a/test/e2e/utils/cluster.go
+++ b/test/e2e/utils/cluster.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/klog/v2"
@@ -72,6 +73,68 @@ func clusterDownGKE(testParams *TestParameters) error {
 	return nil
 }
 
+// queryRegionalStandardZones retrieves standard compute zones for a region from 'gcloud compute regions describe',
+// which naturally excludes AI-only zones, so they can be passed to Capacity Advisor via --zones.
+func queryRegionalStandardZones(testParams *TestParameters) string {
+	regionArgs := []string{
+		"compute", "regions", "describe", testParams.GkeClusterRegion,
+		"--format=value(zones.basename())",
+	}
+	if testParams.ProjectID != "" {
+		regionArgs = append(regionArgs, "--project="+testParams.ProjectID)
+	}
+
+	regionOut, err := gcloudCommand(testParams, regionArgs...).Output()
+	if err != nil {
+		klog.Warningf("Failed to query standard regional compute zones for %s: %v", testParams.GkeClusterRegion, err)
+		return ""
+	}
+
+	// gcloud formats list projections with semicolons, commas, or whitespace; normalize into a comma-separated list for --zones.
+	zones := strings.FieldsFunc(string(regionOut), func(r rune) bool {
+		return r == ';' || r == ',' || unicode.IsSpace(r)
+	})
+	return strings.Join(zones, ",")
+}
+
+// queryCapacityAdvisedZone calls queryRegionalStandardZones to get all standard GKE zones,
+// and queries Capacity Advisor to select the best zone with sufficient compute capacity.
+func queryCapacityAdvisedZone(testParams *TestParameters) (string, error) {
+	// Note: Capacity Advisor requires --provisioning-model (supports only SPOT or FLEX_START).
+	// We use SPOT as a proxy for regional resource availability.
+	// See: https://cloud.google.com/sdk/gcloud/reference/beta/compute/advice/capacity
+	cmdArgs := []string{
+		"beta", "compute", "advice", "capacity",
+		"--region=" + testParams.GkeClusterRegion,
+		"--provisioning-model=SPOT",
+		"--size=" + strconv.Itoa(testParams.NumNodes),
+		"--instance-selection-machine-types=" + testParams.NodeMachineType,
+		"--target-distribution-shape=any-single-zone",
+		"--format=value(recommendations[0].shards[0].zone.basename())",
+	}
+
+	// Restrict capacity search to standard regional compute zones to avoid non-GKE AI zones.
+	if zonesFilter := queryRegionalStandardZones(testParams); zonesFilter != "" {
+		cmdArgs = append(cmdArgs, "--zones="+zonesFilter)
+	}
+	if testParams.ProjectID != "" {
+		cmdArgs = append(cmdArgs, "--project="+testParams.ProjectID)
+	}
+
+	out, err := gcloudCommand(testParams, cmdArgs...).Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return "", fmt.Errorf("failed to query capacity advice: %w, stderr: %s", err, string(exitErr.Stderr))
+		}
+		return "", fmt.Errorf("failed to query capacity advice: %w", err)
+	}
+	zone := strings.TrimSpace(string(out))
+	if zone == "" {
+		return "", fmt.Errorf("no zone returned in capacity advice")
+	}
+	return zone, nil
+}
+
 func clusterUpGKE(testParams *TestParameters) error {
 	//nolint:gosec
 	out, err := gcloudCommand(testParams, "container", "clusters", "list", "--region", testParams.GkeClusterRegion, "--project", testParams.ProjectID, "--verbosity", "none", "--filter", "name="+testParams.GkeClusterName).CombinedOutput()
@@ -102,6 +165,22 @@ func clusterUpGKE(testParams *TestParameters) error {
 		cmdParams = append(cmdParams, "--cluster-version", testParams.GkeClusterVersion)
 	}
 
+	// Query Capacity Advisor to select a stockout-free zone for Standard clusters.
+	// gcloud interprets --num-nodes as a per-zone count. When the advisor pins a
+	// single zone, NumNodes is the total; on failure we fall back to GKE's default
+	// 3-zone regional layout, so scale NumNodes down (minimum 1) to keep the total consistent.
+	var nodeLocations string
+	if !testParams.UseGKEAutopilot && testParams.UseCapacityAdvisor {
+		advisedZone, err := queryCapacityAdvisedZone(testParams)
+		if err != nil {
+			klog.Warningf("Capacity Advisor query failed, falling back to default regional node allocation: %v", err)
+			testParams.NumNodes = max(1, testParams.NumNodes/3)
+		} else {
+			klog.Infof("Using Capacity Advised zone %q for cluster node locations", advisedZone)
+			nodeLocations = advisedZone
+		}
+	}
+
 	standardClusterFlags := []string{
 		"--num-nodes", strconv.Itoa(testParams.NumNodes), "--image-type", testParams.NodeImageType,
 		"--machine-type", testParams.NodeMachineType,
@@ -116,20 +195,7 @@ func clusterUpGKE(testParams *TestParameters) error {
 		standardClusterFlags = append(standardClusterFlags, "--node-version", testParams.GkeNodeVersion)
 	}
 
-	// For supported regions/zones for ARM nodes, see https://cloud.google.com/kubernetes-engine/docs/concepts/arm-on-gke#arm-requirements-limitations
-	if strings.HasPrefix(testParams.NodeMachineType, "t2a-standard") {
-		var nodeLocations string
-		switch testParams.GkeClusterRegion {
-		case "us-central1":
-			nodeLocations = "us-central1-a,us-central1-b,us-central1-f"
-		case "europe-west4":
-			nodeLocations = "europe-west4-a,europe-west4-b"
-		case "asia-southeast1":
-			nodeLocations = "asia-southeast1-b,asia-southeast1-c"
-		default:
-			return fmt.Errorf("got invalid region %q for ARM node type %q", testParams.GkeClusterRegion, testParams.NodeMachineType)
-		}
-
+	if nodeLocations != "" {
 		standardClusterFlags = append(standardClusterFlags, "--node-locations", nodeLocations)
 	}
 

--- a/test/e2e/utils/handler.go
+++ b/test/e2e/utils/handler.go
@@ -86,6 +86,7 @@ type TestParameters struct {
 	EnableGcsFuseProfiles          bool
 	EnableGCSFuseKernelParams      bool
 	EnableSharedMount              bool
+	UseCapacityAdvisor             bool
 
 	GkeGcloudCommand string
 	GkeGcloudArgs    string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:
Previously, when spinning up regional GKE test clusters in `us-central1` during Prow CI runs, GKE automatically distributed the node pool across three default zones (allocating 3 nodes per zone). If any single zone experienced a capacity stockout, the entire cluster provisioning step failed, causing flaky CI runs.

To mitigate stockout failures, we integrate GCE Capacity Advisor (`gcloud beta compute advice capacity`) into the E2E cluster provisioning workflow. The test runner queries Capacity Advisor for the optimal standard compute zone with sufficient spot capacity within the target region, then sets `--node-locations` to that advised single zone to provision all 9 nodes in one place.

Additionally, this change removes deprecated ARM (`t2a-standard`) node placement logic, as ARM test suites have been removed from Prow TestGrid.

### Changes
- **Capacity Advisor integration**: Added `queryCapacityAdvisedZone` and `queryRegionalStandardZones` in `test/e2e/utils/cluster.go` to query GCE Capacity Advisor and filter out non-GKE / AI-only zones.
- **E2E CLI flags & parameter wiring**: Added `--use-capacity-advisor` flag in `test/e2e/main.go` and threaded `UseCapacityAdvisor` through `TestParameters` in `test/e2e/utils/handler.go`.
- **CI runner script update**: Updated `test/e2e/run-e2e-ci.sh` to enable `use_capacity_advisor` by default and set the default node count to 9 when enabled.
- **Clean up deprecated ARM logic**: Removed legacy `t2a-standard` hardcoded region/zone mapping in `test/e2e/utils/cluster.go` since ARM tests are no longer run in Prow TestGrid.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
Manually verified against a Boskos test project across both standard and ZB-enabled (`ENABLE_ZB=true`) test suites. In both runs, Capacity Advisor successfully selected an optimal stockout-free zone and cluster provisioning completed without issue.
```
I0821 22:06:11.306605 1723743 cluster.go:180] Using Capacity Advised zone "us-central1-c" for cluster node locations
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```