### PR TITLE
use static vendor mode in sanity-test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -389,11 +389,15 @@ unit-test:
 	go test -v -mod=vendor -timeout 30s "./pkg/..." -cover
 
 sanity-test:
-	cd test && go mod tidy && go test -mod=readonly -v -timeout 30s "./sanity/" -run TestSanity
+	# Note: Any go commands inside the test/ directory must explicitly specify -mod=readonly.
+	# This prevents Go from defaulting to -mod=vendor and compiling against stale snapshots.
+	cd test && go test -mod=readonly -v -timeout 30s "./sanity/" -run TestSanity
 
+# Note: Any go commands inside the test/ directory must explicitly specify -mod=readonly.
+# This prevents Go from defaulting to -mod=vendor and compiling against stale snapshots.
 build-e2e-test:
-	cd test && go build -o ../bin/e2e-test-ci ./e2e
-	cd test && go test -c -o ../bin/e2e-test ./e2e
+	cd test && go build -mod=readonly -o ../bin/e2e-test-ci ./e2e
+	cd test && go test -mod=readonly -c -o ../bin/e2e-test ./e2e
 
 e2e-test:
 	./test/e2e/run-e2e-local.sh

--- a/docs/development.md
+++ b/docs/development.md
@@ -145,6 +145,8 @@ Refer to [Test](../test/README.md) documentation.
 
 Follow the following steps to update go modules:
 
+### Root Module (`go.mod`)
+
 1. Open the [go.mod](../go.mod) file in Visual Studio Code.
 2. Click "Check for upgrades" above the first `require` block.
 3. Hover over the module with available upgrade. Click "Quick Fix" to apply the upgrade.
@@ -152,6 +154,17 @@ Follow the following steps to update go modules:
 5. Run `go mod tidy` to ensure that the listed dependencies are really still needed.
 6. Run `go mod vendor` to update vendor directory.
 7. Resolve any issues that may be introduced by the new modules.
+
+### Test Module (`test/go.mod`)
+
+The `test/` directory maintains its own Go module. Tests run with `-mod=readonly`:
+
+1. Add or update dependencies in [`test/go.mod`](../test/go.mod).
+2. Tidy the test module dependencies:
+   ```bash
+   cd test && go mod tidy
+   ```
+3. Commit the updated `test/go.mod` and `test/go.sum`.
 
 ## Troubleshooting
 

--- a/test/e2e/run-e2e-ci.sh
+++ b/test/e2e/run-e2e-ci.sh
@@ -80,7 +80,7 @@ cd "${PKGDIR}"
 
 # Build e2e-test CLI
 pushd test
-go build -o ${PKGDIR}/bin/e2e-test-ci ./e2e
+go build -mod=readonly -o ${PKGDIR}/bin/e2e-test-ci ./e2e
 popd
 chmod +x ${PKGDIR}/bin/e2e-test-ci
 

--- a/test/e2e/run-e2e-local.sh
+++ b/test/e2e/run-e2e-local.sh
@@ -85,7 +85,7 @@ cd "${PKGDIR}"
 
 # Build e2e-test CLI
 pushd ./test
-go build -o ${PKGDIR}/bin/e2e-test-ci ./e2e
+go build -mod=readonly -o ${PKGDIR}/bin/e2e-test-ci ./e2e
 popd
 chmod +x "${PKGDIR}/bin/e2e-test-ci"
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Auto-VC configuration manifests drive two independent vulnerability remediation pipelines per repository:
* **Go Module Patches** (Enabled globally via `goModVulnerabilityUpdate: enabled: true`): Scans dependencies via `govulncheck` to patch CVEs.
* **Base Image Updates** (Defined via custom hooks under `commits: - name: baseimages`): Bumps compilers and OS bases in Dockerfiles.

Because pipelines are decoupled, they concurrently generate independent PRs. Previously, the `sanity-test` Makefile target  executed `go mod tidy` dynamically on every test run. When base image remediation hooks ran sanity tests to verify Dockerfile updates,`test/go.mod` and `test/go.sum` were automatically modified and bundled into the base image PR. Merging one PR made the other stale,  
  causing merge conflicts and requiring manual reconciliation.                                                                          
                                                                                                                                        
    Additionally, in Go 1.14+, executing `go` commands inside `test/` automatically defaults to `-mod=vendor` due to the presence of    
  `test/vendor/modules.txt`. Under `-mod=vendor`, Go ignores the `replace ... => ../` directive in `test/go.mod` and compiles against   
  stale static snapshots in `test/vendor/` rather than the live `pkg/` codebase.                                                        
                                                                                                                                        
    This PR:                                                                                                                            
    1. Removes dynamic `go mod tidy` from `make sanity-test` to prevent unintended dependency file mutations during test runs.          
    2. Explicitly specifies `-mod=readonly` across all `test/` targets (`sanity-test`, `build-e2e-test`, `test/e2e/run-e2e-local.sh`,   
  and `test/e2e/run-e2e-ci.sh`). This forces Go to respect the local `replace` directive and compile against the live `pkg/` code.      
    3. Updates `docs/development.md` with the workflow for updating `test/go.mod` dependencies.     

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
After making the code change I ran go mod vendor in the test dir and ran sanity tests at root. Also verified e2e runs as expected.
```
cd test && go mod vendor
make sanity-test
Ran 28 of 92 Specs in 0.407 seconds
SUCCESS! -- 28 Passed | 0 Failed | 1 Pending | 63 Skipped
--- PASS: TestSanity (0.42s)
```

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

