### PR TITLE
perf(shared-mount): bypass NodePublishVolume rate limiter for shared mounts

### DIFF
--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -311,11 +311,6 @@ func (s *nodeServer) populateDriverFlagsForDefaulting(node *corev1.Node, mounter
 }
 
 func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
-	// Rate limit NodePublishVolume calls to avoid kube API throttling.
-	if err := s.limiter.Wait(ctx); err != nil {
-		return nil, status.Errorf(codes.Aborted, "NodePublishVolume request is aborted due to rate limit: %v", err)
-	}
-
 	// Validate the target path.
 	targetPath := req.GetTargetPath()
 	if len(targetPath) == 0 {
@@ -326,6 +321,11 @@ func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublish
 	vc := req.GetVolumeContext()
 	if s.driver.sharedMount(vc) {
 		return s.NodePublishVolumeForSharedMount(ctx, req)
+	}
+
+	// Rate limit NodePublishVolume calls to avoid kube API throttling for sidecar mode.
+	if err := s.limiter.Wait(ctx); err != nil {
+		return nil, status.Errorf(codes.Aborted, "NodePublishVolume request is aborted due to rate limit: %v", err)
 	}
 
 	// Get the Pod object.


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In `NodePublishVolume`, a global rate limiter (1 request/second with a burst of 10) was previously invoked at the very beginning of the function before evaluating the volume context:
```go
func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
	if err := s.limiter.Wait(ctx); err != nil {
		return nil, status.Errorf(codes.Aborted, "NodePublishVolume request is aborted due to rate limit: %v", err)
	}
    ...
	if s.driver.sharedMount(vc) {
		return s.NodePublishVolumeForSharedMount(ctx, req)
	}
```

### Why this change is needed:
* **Sidecar Mode:** Requires rate limiting because each sidecar pod runs its own gcsfuse and as a result requires WI token exchanges and bucket access checks against Cloud Storage / `kube-apiserver`, which can throttle under high concurrency bursts.
* **Shared Mount Mode:** The GCSFuse process runs in a dedicated mounter pod, GCS bucket access checks, or remote API calls. `NodePublishVolumeForSharedMount` only looks up the mounter pod from client-go's in-memory Informer cache and performs a local filesystem `mount --bind` to the target path.
* **The Bottleneck:** Because the rate limiter was called unconditionally before checking `s.driver.sharedMount(vc)`, large concurrent shared mount workloads (e.g. 110 pods) were throttled to 1 pod per second. This artificial serialization pushed tail pods beyond Kubelet volume manager deadlines, triggering exponential backoff retries and extending 110-pod startup to **409s (6m 49s)**.

### Solution:
Validate `targetPath` and route shared mount requests to `NodePublishVolumeForSharedMount` **before** calling `s.limiter.Wait(ctx)`. This allows shared mount volume publish requests to complete immediately (1–2 ms per pod) without throttling, while preserving rate limiting for standard sidecar mode.

### Benchmark Results (110 Concurrent Pods on GKE `n2-highmem-16`):
* **Before Fix (Rate-limited):** 409.0s (6m 49s) to reach 110/110 running pods (throughput: 0.27 pods/sec).
* **After Fix (Rate-limiter bypassed):** **48.47s** to reach 110/110 running pods (throughput: 2.27 pods/sec) — **8.44x speedup**.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

TAG=agy
CONV=8f4b3bd8-b6ca-4ea4-8955-7b08badc8462
