### PR TITLE
[Shared Mount] Dynamic Mount Test

### DIFF
--- a/test/e2e/specs/specs.go
+++ b/test/e2e/specs/specs.go
@@ -97,6 +97,7 @@ const (
 	SkipCSIBucketAccessCheckAndImplicitDirsVolumePrefix        = "gcsfuse-csi-skip-bucket-access-check-implicit-dirs-volume"
 	EnableKernelParamsPrefix                                   = "gcsfuse-csi-enable-kernel-params"
 	SidecarAndSharedMountCoexistencePrefix                     = "gcsfuse-csi-sidecar-and-shared-mount-coexistence"
+	SharedDynamicMountPrefix                                   = "gcsfuse-csi-shared-dynamic-mount"
 
 	expectedTrainingProfileFlag   = "--profile=aiml-training"
 	expectedTrainingProfileConfig = `map\[.*profile:aiml-training.*\]`
@@ -183,6 +184,21 @@ func CreateMounterPodTemplate(ctx context.Context, c clientset.Interface, namesp
 		},
 	}
 	return c.CoreV1().PodTemplates(namespace).Create(ctx, template, metav1.CreateOptions{})
+}
+
+// VerifyMounterPods verifies the expected count of Mounter Pods scheduled on expectedNodeName in the namespace.
+func VerifyMounterPods(ctx context.Context, c clientset.Interface, namespace string, expectedCount int, expectedNodeName string) {
+	if expectedNodeName == "" {
+		framework.Failf("expectedNodeName must be provided to verify Mounter Pods")
+	}
+	listOpts := metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", webhook.SharedMountLabel, util.TrueStr),
+		FieldSelector: fmt.Sprintf("spec.nodeName=%s", expectedNodeName),
+	}
+
+	mounterPods, err := c.CoreV1().Pods(namespace).List(ctx, listOpts)
+	framework.ExpectNoError(err, "failed to list mounter pods")
+	gomega.Expect(mounterPods.Items).To(gomega.HaveLen(expectedCount), fmt.Sprintf("expected %d Mounter Pod(s) on node %s", expectedCount, expectedNodeName))
 }
 
 type TestPod struct {
@@ -327,6 +343,28 @@ func (t *TestPod) VerifyExecInPodFail(f *framework.Framework, containerName, shE
 	stdout, stderr, err := execCommandInContainerWithFullOutputWithRetry(f, t.pod.Name, containerName, "/bin/sh", "-c", shExec)
 	gomega.Expect(err).Should(gomega.HaveOccurred(),
 		fmt.Sprintf("%q should fail with exit code %d, but exit without error\nstdout: %s\nstderr: %s", shExec, exitCode, stdout, stderr))
+}
+
+// VerifyRWMount verifies that the mount point is mounted read-write in the target pod.
+func (t *TestPod) VerifyRWMount(f *framework.Framework, mountPath string) {
+	t.VerifyExecInPodSucceed(f, TesterContainerName, fmt.Sprintf("mount | grep %s | grep rw,", mountPath))
+}
+
+// VerifyROMount verifies that the mount point is mounted read-only in the target pod.
+func (t *TestPod) VerifyROMount(f *framework.Framework, mountPath string) {
+	t.VerifyExecInPodSucceed(f, TesterContainerName, fmt.Sprintf("mount | grep %s | grep ro,", mountPath))
+}
+
+// VerifyWriteAndReadFile writes content to filePath and verifies that reading it back returns the same content.
+func (t *TestPod) VerifyWriteAndReadFile(f *framework.Framework, filePath, content string) {
+	escapedContent := strings.ReplaceAll(content, "'", "'\\''")
+	t.VerifyExecInPodSucceed(f, TesterContainerName, fmt.Sprintf("echo '%s' > %s && grep '%s' %s", escapedContent, filePath, escapedContent, filePath))
+}
+
+// VerifyReadFile verifies that reading filePath returns the expected content.
+func (t *TestPod) VerifyReadFile(f *framework.Framework, filePath, expectedContent string) {
+	escapedContent := strings.ReplaceAll(expectedContent, "'", "'\\''")
+	t.VerifyExecInPodSucceed(f, TesterContainerName, fmt.Sprintf("grep '%s' %s", escapedContent, filePath))
 }
 
 // execCommandInContainerWithFullOutputWithRetry executes a command in a target pod and retries with gradual back until timeout(10 min) or success.

--- a/test/e2e/specs/testdriver.go
+++ b/test/e2e/specs/testdriver.go
@@ -262,7 +262,7 @@ func (n *GCSFuseCSITestDriver) CreateVolume(ctx context.Context, config *storage
 				n.RemoveIAMPolicy(ctx, serviceBucketobj, config.Framework.Namespace.Name, K8sServiceAccountName)
 			})
 
-		case MultipleBucketsPrefix:
+		case MultipleBucketsPrefix, SharedDynamicMountPrefix:
 			isMultipleBucketsPrefix = true
 			l := []string{}
 			for range 2 {

--- a/test/e2e/testsuites/multivolume.go
+++ b/test/e2e/testsuites/multivolume.go
@@ -25,11 +25,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util"
-	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/webhook"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -444,13 +441,9 @@ func (t *gcsFuseCSIMultiVolumeTestSuite) DefineTests(driver storageframework.Tes
 		ginkgo.By("Checking that the second pod is running")
 		tPod2.WaitForRunning(ctx)
 
-		// 3. Verify distinct Mounter Pods exist for each volumeHandle in our ns.
+		// 3. Verify distinct Mounter Pods exist for each volumeHandle in our ns and on the node.
 		ginkgo.By("Verifying distinct Mounter Pods exist for each volumeHandle")
-		mounterPods, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).List(ctx, metav1.ListOptions{
-			LabelSelector: fmt.Sprintf("%s=%s", webhook.SharedMountLabel, util.TrueStr),
-		})
-		framework.ExpectNoError(err, "failed to list mounter pods")
-		gomega.Expect(mounterPods.Items).To(gomega.HaveLen(2), "expected 2 distinct Mounter Pods for unique volumeHandles")
+		specs.VerifyMounterPods(ctx, f.ClientSet, f.Namespace.Name, 2, nodeName)
 
 		// 4. Verify Pod 1 (RWX) operations.
 		ginkgo.By("Verifying RWX pod read and write operations")

--- a/test/e2e/testsuites/shared_mount.go
+++ b/test/e2e/testsuites/shared_mount.go
@@ -20,12 +20,10 @@ package testsuites
 import (
 	"context"
 	"fmt"
+	"strings"
 
-	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util"
-	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/webhook"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2evolume "k8s.io/kubernetes/test/e2e/framework/volume"
@@ -162,24 +160,92 @@ func (t *gcsFuseCSISharedMountTestSuite) DefineTests(driver storageframework.Tes
 		sharedMountTestPod.VerifySidecarPresence(false /* expectPresent */)
 
 		ginkgo.By("Verifying a single Mounter Pod is created for sharedMountTestPod on the same node")
-		mounterPods, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).List(ctx, metav1.ListOptions{
-			LabelSelector: fmt.Sprintf("%s=%s", webhook.SharedMountLabel, util.TrueStr),
-		})
-		framework.ExpectNoError(err, "failed to list mounter pods")
-		gomega.Expect(mounterPods.Items).To(gomega.HaveLen(1), "expected exactly 1 Mounter Pod for the shared mount volume")
-		gomega.Expect(mounterPods.Items[0].Spec.NodeName).To(gomega.Equal(nodeName), "expected Mounter Pod to be scheduled on the same node")
+		specs.VerifyMounterPods(ctx, f.ClientSet, f.Namespace.Name, 1, nodeName)
 
 		// 5. Verify that both pods can successfully read and write to their respective volumes without conflicts.
 		ginkgo.By("Verifying sidecarTestPod can write and read from its sidecar-mounted volume")
-		sidecarTestPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("mount | grep %s | grep rw,", sidecarMountPath))
-		sidecarTestPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("echo 'hello from sidecar pod' > %s/data-sidecar && grep 'hello from sidecar pod' %s/data-sidecar", sidecarMountPath, sidecarMountPath))
+		sidecarTestPod.VerifyRWMount(f, sidecarMountPath)
+		sidecarTestPod.VerifyWriteAndReadFile(f, fmt.Sprintf("%s/data-sidecar", sidecarMountPath), "hello from sidecar pod")
 
 		ginkgo.By("Verifying sharedMountTestPod can write and read from its shared-mounted volume")
-		sharedMountTestPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("mount | grep %s | grep rw,", sharedMountPath))
-		sharedMountTestPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("echo 'hello from shared mount pod' > %s/data-shared && grep 'hello from shared mount pod' %s/data-shared", sharedMountPath, sharedMountPath))
+		sharedMountTestPod.VerifyRWMount(f, sharedMountPath)
+		sharedMountTestPod.VerifyWriteAndReadFile(f, fmt.Sprintf("%s/data-shared", sharedMountPath), "hello from shared mount pod")
 
 		ginkgo.By("Verifying data persistence and isolation on both volumes")
-		sidecarTestPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("grep 'hello from sidecar pod' %s/data-sidecar", sidecarMountPath))
-		sharedMountTestPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("grep 'hello from shared mount pod' %s/data-shared", sharedMountPath))
+		sidecarTestPod.VerifyReadFile(f, fmt.Sprintf("%s/data-sidecar", sidecarMountPath), "hello from sidecar pod")
+		sharedMountTestPod.VerifyReadFile(f, fmt.Sprintf("%s/data-shared", sharedMountPath), "hello from shared mount pod")
+	})
+
+	// TC: Dynamic Mounting Test
+	// Verify that dynamic mounting works with the shared node mount architecture.
+	// Create a PV with volumeHandle: _ and sharedMount: true.
+	// Create multiple Pods referencing the PVC.
+	// Verify the Mounter Pod is created.
+	// Verify all pods can successfully read from and write to any buckets their KSA is authorized to access.
+	ginkgo.It("[shared-mount] should verify dynamic mounting across multiple pods with volumeHandle _", func() {
+		init(1, specs.SharedDynamicMountPrefix)
+		defer cleanup()
+
+		gomega.Expect(l.volumeResourceList).To(gomega.HaveLen(1))
+		gomega.Expect(l.volumeResourceList[0]).ToNot(gomega.BeNil())
+
+		sharedVR := l.volumeResourceList[0]
+		buckets := strings.Split(l.config.Prefix, ",")
+		gomega.Expect(buckets).To(gomega.HaveLen(2), "expected 2 buckets created for dynamic mounting")
+
+		// 1. Configure and deploy Pod 1 referencing the dynamic shared-mount PVC.
+		ginkgo.By("Configuring and deploying the first pod referencing the dynamic shared-mount PVC")
+		tPod1 := specs.NewTestPod(f.ClientSet, f.Namespace)
+		tPod1.SetupVolume(sharedVR, sharedVolName, sharedMountPath, false /* readOnly */)
+		tPod1.Create(ctx)
+		defer tPod1.Cleanup(ctx)
+
+		ginkgo.By("Waiting for the first pod to be running and getting its node")
+		tPod1.WaitForRunning(ctx)
+		nodeName := tPod1.GetNode()
+
+		// 2. Configure and deploy Pod 2 on the same node referencing the same PVC.
+		ginkgo.By(fmt.Sprintf("Configuring and deploying the second pod on node %s referencing the same PVC", nodeName))
+		tPod2 := specs.NewTestPod(f.ClientSet, f.Namespace)
+		tPod2.SetupVolume(sharedVR, sharedVolName, sharedMountPath, false /* readOnly */)
+		tPod2.SetNodeAffinity(nodeName, true /* sameNode */)
+		tPod2.Create(ctx)
+		defer tPod2.Cleanup(ctx)
+
+		ginkgo.By("Waiting for the second pod to be running")
+		tPod2.WaitForRunning(ctx)
+		gomega.Expect(tPod2.GetNode()).To(gomega.Equal(nodeName), "expected second pod to run on the same node as first pod")
+
+		// 3. Verify sidecar absence on client pods and exactly 1 Mounter Pod created on the node.
+		ginkgo.By("Verifying client pods do NOT have sidecar containers injected")
+		tPod1.VerifySidecarPresence(false /* expectPresent */)
+		tPod2.VerifySidecarPresence(false /* expectPresent */)
+
+		ginkgo.By("Verifying exactly 1 Mounter Pod is created for the dynamic shared-mount volume on the node")
+		specs.VerifyMounterPods(ctx, f.ClientSet, f.Namespace.Name, 1, nodeName)
+
+		// 4. Verify RW mount point in both pods.
+		ginkgo.By("Verifying RW mount point in both pods")
+		tPod1.VerifyRWMount(f, sharedMountPath)
+		tPod2.VerifyRWMount(f, sharedMountPath)
+
+		// 5. Verify dynamic multi-bucket read and write operations across both pods.
+		ginkgo.By("Verifying both pods can read and write across all authorized buckets")
+		for _, bucket := range buckets {
+			pod1File := fmt.Sprintf("%s/%s/pod1-data.txt", sharedMountPath, bucket)
+			pod2File := fmt.Sprintf("%s/%s/pod2-data.txt", sharedMountPath, bucket)
+			pod1Content := fmt.Sprintf("hello from pod1 in bucket %s", bucket)
+			pod2Content := fmt.Sprintf("hello from pod2 in bucket %s", bucket)
+
+			// Pod 1 writes and reads its own file in this bucket
+			tPod1.VerifyWriteAndReadFile(f, pod1File, pod1Content)
+
+			// Pod 2 writes and reads its own file in this bucket
+			tPod2.VerifyWriteAndReadFile(f, pod2File, pod2Content)
+
+			// Cross-pod read: Pod 1 reads Pod 2's file, Pod 2 reads Pod 1's file
+			tPod1.VerifyReadFile(f, pod2File, pod2Content)
+			tPod2.VerifyReadFile(f, pod1File, pod1Content)
+		}
 	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:
This test adds the Shared Mount Dynamic Mount E2E Test. It verifies that dynamic mounting works seamlessly with the shared node mount architecture by creating a PV with volumeHandle: `_` and `sharedMount: true`. It creates multiple Pods referencing the PVC and verifies the Mounter Pod is succesfully created. Finally it verifies all pods can successfully read from and write to any buckets their KSA is authorized to access (This test creates 2).
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```