### PR TITLE
Update gcloud components before querying Capacity Advisor in prow e2e

### DIFF
--- a/test/e2e/utils/cluster.go
+++ b/test/e2e/utils/cluster.go
@@ -136,6 +136,19 @@ func queryCapacityAdvisedZone(testParams *TestParameters) (string, error) {
 }
 
 func clusterUpGKE(testParams *TestParameters) error {
+	var cmd *exec.Cmd
+
+	// Update gcloud to latest version in Prow.
+	if testParams.InProw {
+		cmd = gcloudCommand(testParams, "components", "update", "--quiet")
+		if err := runCommand("Updating gcloud to the latest version", cmd); err != nil {
+			return fmt.Errorf("failed to update gcloud to latest version: %w", err)
+		}
+	} else {
+		// This is skipped only to ensure command doesn't fail for 'apt' package installed gcloud in local runs.
+		klog.Infof("Skipping gcloud components update for local run.")
+	}
+
 	//nolint:gosec
 	out, err := gcloudCommand(testParams, "container", "clusters", "list", "--region", testParams.GkeClusterRegion, "--project", testParams.ProjectID, "--verbosity", "none", "--filter", "name="+testParams.GkeClusterName).CombinedOutput()
 	if err != nil {
@@ -148,7 +161,6 @@ func clusterUpGKE(testParams *TestParameters) error {
 		}
 	}
 
-	var cmd *exec.Cmd
 	createCmd := "create"
 	if testParams.UseGKEAutopilot {
 		createCmd = "create-auto"
@@ -202,17 +214,6 @@ func clusterUpGKE(testParams *TestParameters) error {
 	// If using standard cluster, add required flags.
 	if !testParams.UseGKEAutopilot {
 		cmdParams = append(cmdParams, standardClusterFlags...)
-
-		// Update gcloud to latest version in Prow.
-		if testParams.InProw {
-			cmd = exec.Command("gcloud", "components", "update")
-			if err := runCommand("Updating gcloud to the latest version", cmd); err != nil {
-				return fmt.Errorf("failed to update gcloud to latest version: %w", err)
-			}
-		} else {
-			// This is skipped only to ensure command doesn't fail for 'apt' package installed gcloud in local runs.
-			klog.Infof("Skipping gcloud components update for local run.")
-		}
 	}
 
 	cmd = gcloudCommand(testParams, cmdParams...)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
In Prow E2E test environments, the pre-installed gcloud version in the container image lacks the `gcloud beta compute advice capacity` subcommand, causing Capacity Advisor queries to fail with:
`ERROR: (gcloud.beta.compute.advice) Invalid choice: 'capacity'`.

Previously, `gcloud components update` was executed after `queryCapacityAdvisedZone` during the standard cluster flag configuration step. This change relocates `gcloud components update` to the beginning of `clusterUpGKE`
prior to `queryCapacityAdvisedZone`, ensuring that `gcloud` is updated to the latest version before any Capacity Advisor queries are executed.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```