### PR TITLE
Add pre-flight Capacity Advisor region evaluation to mitigate cluster stockouts

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -101,6 +101,7 @@ You can control the test through the following make parameters, eg `make e2e-tes
 - `ENABLE_ZB`: default value is `false`. Change it to `true` if you want the bucket used during testing to be a Zonal Bucket created in the zone -> "$(location provided)" + "-c".
 - `GCSFUSE_CLIENT_PROTOCOL`: default value is 'http1'. Change to 'grpc' to alter the type of protocol gcsfuse uses to communicate with gcs
 - `E2E_TEST_MANAGE_CLUSTER_LIFECYCLE`: default value is `false`. Change it to `true` if you want the test runner to create and destroy the GKE cluster for the test.
+- `USE_CAPACITY_ADVISOR`: default value is `false` (defaults to `true` in Prow CI). Whether to use GCE Capacity Advisor to select node locations and fallback regions. Only used when `E2E_TEST_MANAGE_CLUSTER_LIFECYCLE=true`; ignored when running on an existing cluster.
 - `E2E_TEST_GKE_CLUSTER_VERSION`: It denotes the GKE cluster master and node version. If `E2E_TEST_MANAGE_CLUSTER_LIFECYCLE` is `true`, it specifies the version of the cluster to be created (defaults to `latest` if not provided). If `E2E_TEST_MANAGE_CLUSTER_LIFECYCLE` is `false`, it auto-detects the version of the existing cluster (can be overridden by setting this parameter). The version is used by the test framework to check for feature compatibility.
 - `E2E_TEST_USE_BOSKOS`: default value is `false`. Change it to `true` if you want to use Boskos to acquire a project. Useful for debugging Boskos infrastructure locally.
 - `E2E_TEST_PROJECT_ID`: default value is empty. GCP project ID to run E2E tests. Required when managing cluster lifecycle without Boskos.
@@ -130,9 +131,11 @@ When `E2E_TEST_MANAGE_CLUSTER_LIFECYCLE` is set to `true`, the test runner provi
 - **Cluster Type**: Standard GKE Cluster (default) or Autopilot (if `E2E_TEST_USE_GKE_AUTOPILOT=true`).
 - **Release Channel**: `rapid` (can be overridden by `GKE_RELEASE_CHANNEL` environment variable).
 - **Version**: Determined by `E2E_TEST_GKE_CLUSTER_VERSION` (local) or `GKE_CLUSTER_VERSION` (CI).
-- **Region**: Determined by `GKE_CLUSTER_REGION` (default: `us-central1`).
+- **Region & Capacity Selection**: Determined by `GKE_CLUSTER_REGION` (default: `us-central1`).
+  - **Dynamic Fallback & Capacity Checks**: When `USE_CAPACITY_ADVISOR=true`, as enabled by default in Prow, the test runner pre-flights compute availability across candidate fallback regions using the Compute Engine Capacity Advisor API. It evaluates obtainability scores, stack-ranks candidate regions from highest to lowest score, and attempts cluster creation in the top-ranked region to mitigate regional stockouts. Note that `USE_CAPACITY_ADVISOR` is only used when `E2E_TEST_MANAGE_CLUSTER_LIFECYCLE=true`, and is ignored when running tests against an existing cluster.
+  - **Bucket Co-location**: Selecting a fallback region also implicitly updates the `--test-bucket-location` passed to Ginkgo, ensuring test GCS buckets are co-located in the same region as the cluster to prevent cross-region data transfer.
 - **Node Pool Configuration** (Standard cluster only):
-  - **Node Count**: 3 nodes (can be overridden by `E2E_TEST_NUM_NODES` or `NUMBER_NODES` env var).
+  - **Node Count**: 9 nodes (can be overridden by `E2E_TEST_NUM_NODES` or `NUMBER_NODES` env var).
   - **Machine Type**: `n2-standard-8` (can be overridden by `MACHINE_TYPE` env var).
   - **Image Type**: `cos_containerd` (Container-Optimized OS with containerd).
 - **Workload Identity**: Enabled by default using the GCP project's workload pool (`<project-id>.svc.id.goog`).

--- a/test/e2e/main.go
+++ b/test/e2e/main.go
@@ -31,12 +31,12 @@ var (
 	pkgDir = flag.String("pkg-dir", "", "the package directory")
 
 	// Kubernetes cluster flags.
-	gkeClusterRegion               = flag.String("gke-cluster-region", "", "region that gke regional cluster should be created in")
+	gkeClusterRegion               = flag.String("gke-cluster-region", "", "region that gke regional cluster should be created in, which also sets --test-bucket-location for Ginkgo")
 	gkeClusterVersion              = flag.String("gke-cluster-version", "", "GKE cluster worker master and node version")
 	gkeReleaseChannel              = flag.String("gke-release-channel", "rapid", "GKE cluster release channel")
 	gkeNodeVersion                 = flag.String("gke-node-version", "", "GKE cluster worker node version")
 	nodeMachineType                = flag.String("node-machine-type", "n2-standard-8", "GKE cluster worker node machine type")
-	numNodes                       = flag.Int("number-nodes", 3, "number of nodes in the test cluster")
+	numNodes                       = flag.Int("number-nodes", 9, "number of nodes in the test cluster")
 	useGKEAutopilot                = flag.Bool("use-gke-autopilot", false, "use GKE Autopilot cluster for the tests")
 	apiEndpointOverride            = flag.String("api-endpoint-override", "https://container.googleapis.com/", "CloudSDK API endpoint override to use for the cluster environment")
 	nodeImageType                  = flag.String("node-image-type", "cos_containerd", "image type to use for the cluster")
@@ -51,7 +51,7 @@ var (
 	skipCSIDriverInstall           = flag.Bool("skip-csi-driver-install", false, "skips the install of the driver. You must have manually deployed the driver and webhook.")
 	gcsFusePrNumber                = flag.String("gcsfuse-pr-number", "", "PR number for gcsfuse to test against")
 	// Only works for zonal clusters by pinning nodes to a single advised zone, set to false if want to create regional cluster.
-	useCapacityAdvisor = flag.Bool("use-capacity-advisor", false, "whether to use GCE Capacity Advisor to select node locations")
+	useCapacityAdvisor = flag.Bool("use-capacity-advisor", false, "whether to use GCE Capacity Advisor to select node locations. Only used when --manage-cluster-lifecycle=true; ignored for existing clusters.")
 
 	// Test infrastructure flags.
 	inProw                 = flag.Bool("run-in-prow", false, "whether or not to run the test in PROW")
@@ -106,6 +106,11 @@ func main() {
 			*gkeClusterVersion = "latest"
 		}
 		utils.EnsureVariable(gkeReleaseChannel, true, "'gke-release-channel' must be set when managing cluster lifecycle")
+	}
+
+	if !*manageClusterLifecycle && *useCapacityAdvisor {
+		klog.Infof("Ignoring --use-capacity-advisor because --manage-cluster-lifecycle is false (tests are running on an existing cluster)")
+		*useCapacityAdvisor = false
 	}
 
 	if *useBoskos {

--- a/test/e2e/run-e2e-ci.sh
+++ b/test/e2e/run-e2e-ci.sh
@@ -39,13 +39,8 @@ readonly gke_cluster_version=${GKE_CLUSTER_VERSION:-latest}
 readonly gke_release_channel=${GKE_RELEASE_CHANNEL:-rapid}
 readonly gke_node_version=${GKE_NODE_VERSION:-}
 readonly node_machine_type=${MACHINE_TYPE:-n2-standard-8}
+readonly number_nodes=${NUMBER_NODES:-9}
 readonly use_capacity_advisor=${USE_CAPACITY_ADVISOR:-true}
-if [ "${use_capacity_advisor}" = true ]; then
-  default_number_nodes=9
-else
-  default_number_nodes=3
-fi
-readonly number_nodes=${NUMBER_NODES:-$default_number_nodes}
 readonly gcsfuse_client_protocol=${GCSFUSE_CLIENT_PROTOCOL:-http1}
 readonly build_gcsfuse_from_source=${BUILD_GCSFUSE_FROM_SOURCE:-false}
 readonly enable_zb=${ENABLE_ZB:-false}

--- a/test/e2e/run-e2e-local.sh
+++ b/test/e2e/run-e2e-local.sh
@@ -36,7 +36,7 @@ readonly build_gcsfuse_from_source="${BUILD_GCSFUSE_FROM_SOURCE:-false}"
 readonly manage_cluster_lifecycle="${E2E_TEST_MANAGE_CLUSTER_LIFECYCLE:-false}"
 readonly use_boskos="${E2E_TEST_USE_BOSKOS:-false}"
 readonly project_id="${E2E_TEST_PROJECT_ID:-}"
-readonly num_nodes="${E2E_TEST_NUM_NODES:-3}"
+readonly num_nodes="${E2E_TEST_NUM_NODES:-${NUMBER_NODES:-9}}"
 readonly boskos_resource_type="${E2E_TEST_BOSKOS_RESOURCE_TYPE:-${GCE_PD_BOSKOS_RESOURCE_TYPE:-gke-internal-project}}"
 
 ginkgo_focus="${E2E_TEST_FOCUS:-}"
@@ -51,6 +51,7 @@ readonly enable_sidecar_bucket_access_check=${ENABLE_SIDECAR_BUCKET_ACCESS_CHECK
 readonly enable_gcsfuse_profiles=${ENABLE_GCSFUSE_PROFILES:-true}
 readonly enable_gcsfuse_kernel_params=${ENABLE_GCSFUSE_KERNEL_PARAMS:-true}
 readonly enable_shared_mount=${ENABLE_SHARED_MOUNT:-false}
+readonly use_capacity_advisor=${USE_CAPACITY_ADVISOR:-false}
 # TODO(yaozile): Remove overlay default once shared-mount overlay is promoted to stable.
 if [ "${enable_shared_mount}" = true ]; then
   if [ -z "${E2E_TEST_FOCUS:-}" ]; then
@@ -120,5 +121,6 @@ base_cmd="${PKGDIR}/bin/e2e-test-ci \
             --enable-gcsfuse-profiles=${enable_gcsfuse_profiles} \
             --enable-gcsfuse-kernel-params=${enable_gcsfuse_kernel_params} \
             --enable-shared-mount=${enable_shared_mount} \
+            --use-capacity-advisor=${use_capacity_advisor} \
             ${gcsfuse_pr_number:+--gcsfuse-pr-number=${gcsfuse_pr_number}}"
 eval "$base_cmd"

--- a/test/e2e/testsuites/profiles.go
+++ b/test/e2e/testsuites/profiles.go
@@ -538,14 +538,25 @@ func modifyPVForProfiles(testScenario string, pv *v1.PersistentVolume, sc string
 		mo = append(mo, fmt.Sprintf("%s:%s", fileCacheSizeMiBMountOptionKey, "30"))
 
 		if sc == "gcsfusecsi-serving" {
-			// We are hardcoding the zones for ac to be us-central1-c because one of the available zones is an ai
-			// specific zone which has limited quota, we should not make caches in this zone.
+			// TODO(yaozile): Create the ANyC in the same zone as the compute (or skip the test
+			// if the zone is not supported for AnyC), rather than hardcoding to <cluster-region>-c.
+			// We are hardcoding the zones for ac to be <cluster-region>-c because some available zones are AI-specific
+			// zones which have limited quota, we should not make caches in those zones.
 			va[anywhereCacheTTLKey] = "2h"
 			va[anywhereCacheAdmissionPolicyKey] = "admit-on-second-miss"
 			isZBEnabled := os.Getenv(utils.IsZBEnabledEnvVar)
 			if isZBEnabled == "false" {
 				// AC is not supported for zb, so we only use AC for non zb tests.
-				va[anywhereCacheZonesKey] = "us-central1-c"
+				clusterLocation := os.Getenv(utils.ClusterLocationEnvVar)
+				if clusterLocation == "" {
+					clusterLocation = "us-central1"
+				}
+				// If clusterLocation is a zone (e.g. "us-central1-a"), extract the region prefix ("us-central1").
+				parts := strings.Split(clusterLocation, "-")
+				if len(parts) > 2 && len(parts[len(parts)-1]) == 1 {
+					clusterLocation = strings.Join(parts[:len(parts)-1], "-")
+				}
+				va[anywhereCacheZonesKey] = clusterLocation + "-c"
 			}
 
 		}

--- a/test/e2e/utils/cluster.go
+++ b/test/e2e/utils/cluster.go
@@ -20,6 +20,7 @@ package utils
 import (
 	"fmt"
 	"os/exec"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -75,9 +76,9 @@ func clusterDownGKE(testParams *TestParameters) error {
 
 // queryRegionalStandardZones retrieves standard compute zones for a region from 'gcloud compute regions describe',
 // which naturally excludes AI-only zones, so they can be passed to Capacity Advisor via --zones.
-func queryRegionalStandardZones(testParams *TestParameters) string {
+func queryRegionalStandardZones(testParams *TestParameters, region string) string {
 	regionArgs := []string{
-		"compute", "regions", "describe", testParams.GkeClusterRegion,
+		"compute", "regions", "describe", region,
 		"--format=value(zones.basename())",
 	}
 	if testParams.ProjectID != "" {
@@ -86,7 +87,7 @@ func queryRegionalStandardZones(testParams *TestParameters) string {
 
 	regionOut, err := gcloudCommand(testParams, regionArgs...).Output()
 	if err != nil {
-		klog.Warningf("Failed to query standard regional compute zones for %s: %v", testParams.GkeClusterRegion, err)
+		klog.Warningf("Failed to query standard regional compute zones for %s: %v", region, err)
 		return ""
 	}
 
@@ -97,24 +98,24 @@ func queryRegionalStandardZones(testParams *TestParameters) string {
 	return strings.Join(zones, ",")
 }
 
-// queryCapacityAdvisedZone calls queryRegionalStandardZones to get all standard GKE zones,
-// and queries Capacity Advisor to select the best zone with sufficient compute capacity.
-func queryCapacityAdvisedZone(testParams *TestParameters) (string, error) {
+// queryCapacityAdvice calls queryRegionalStandardZones to get standard GKE zones in the given region,
+// and queries Capacity Advisor to return the recommended zone and obtainability score.
+func queryCapacityAdvice(testParams *TestParameters, region string) (string, float64, error) {
 	// Note: Capacity Advisor requires --provisioning-model (supports only SPOT or FLEX_START).
 	// We use SPOT as a proxy for regional resource availability.
 	// See: https://cloud.google.com/sdk/gcloud/reference/beta/compute/advice/capacity
 	cmdArgs := []string{
 		"beta", "compute", "advice", "capacity",
-		"--region=" + testParams.GkeClusterRegion,
+		"--region=" + region,
 		"--provisioning-model=SPOT",
 		"--size=" + strconv.Itoa(testParams.NumNodes),
 		"--instance-selection-machine-types=" + testParams.NodeMachineType,
 		"--target-distribution-shape=any-single-zone",
-		"--format=value(recommendations[0].shards[0].zone.basename())",
+		"--format=value(recommendations[0].scores.obtainability,recommendations[0].shards[0].zone.basename())",
 	}
 
 	// Restrict capacity search to standard regional compute zones to avoid non-GKE AI zones.
-	if zonesFilter := queryRegionalStandardZones(testParams); zonesFilter != "" {
+	if zonesFilter := queryRegionalStandardZones(testParams, region); zonesFilter != "" {
 		cmdArgs = append(cmdArgs, "--zones="+zonesFilter)
 	}
 	if testParams.ProjectID != "" {
@@ -124,15 +125,21 @@ func queryCapacityAdvisedZone(testParams *TestParameters) (string, error) {
 	out, err := gcloudCommand(testParams, cmdArgs...).Output()
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
-			return "", fmt.Errorf("failed to query capacity advice: %w, stderr: %s", err, string(exitErr.Stderr))
+			return "", 0, fmt.Errorf("failed to query capacity advice: %w, stderr: %s", err, string(exitErr.Stderr))
 		}
-		return "", fmt.Errorf("failed to query capacity advice: %w", err)
+		return "", 0, fmt.Errorf("failed to query capacity advice: %w", err)
 	}
-	zone := strings.TrimSpace(string(out))
-	if zone == "" {
-		return "", fmt.Errorf("no zone returned in capacity advice")
+	klog.Infof("Capacity Advisor output for region %s: %s", region, string(out))
+	fields := strings.Fields(string(out))
+	if len(fields) < 2 {
+		return "", 0, fmt.Errorf("no zone or score returned in capacity advice: %q", string(out))
 	}
-	return zone, nil
+	score, err := strconv.ParseFloat(fields[0], 64)
+	if err != nil {
+		return "", 0, fmt.Errorf("failed to parse obtainability score %q: %w", fields[0], err)
+	}
+	zone := fields[1]
+	return zone, score, nil
 }
 
 func clusterUpGKE(testParams *TestParameters) error {
@@ -149,10 +156,91 @@ func clusterUpGKE(testParams *TestParameters) error {
 		klog.Infof("Skipping gcloud components update for local run.")
 	}
 
+	// Fall back across candidate regions to mitigate stockouts; Zonal Buckets
+	// are pinned to testParams.GkeClusterRegion (which defaults to us-central1).
+	// For standard clusters, testParams.GkeClusterRegion is prioritized first,
+	// followed by candidate fallback regions with typically lower contention.
+	candidateRegions := []string{testParams.GkeClusterRegion}
+	if !testParams.EnableZB {
+		fallbackRegions := []string{
+			"us-east4",
+			"us-east1",
+			"us-west1",
+			"us-west4",
+			"europe-west1",
+			"europe-west3",
+		}
+		for _, r := range fallbackRegions {
+			if r != testParams.GkeClusterRegion {
+				candidateRegions = append(candidateRegions, r)
+			}
+		}
+	}
+
+	var nodeLocations string
+
+	// Use Capacity Advisor to select an unconstrained region for both Standard and Autopilot clusters.
+	if testParams.UseCapacityAdvisor {
+		type capacityResult struct {
+			region string
+			zone   string
+			score  float64
+		}
+		var results []capacityResult
+
+		for _, region := range candidateRegions {
+			zone, score, err := queryCapacityAdvice(testParams, region)
+			if err != nil {
+				klog.Warningf("Capacity Advisor query failed for region %q: %v", region, err)
+				continue
+			}
+			klog.Infof("Capacity Advisor for region %q: zone=%q, obtainability=%.2f", region, zone, score)
+			results = append(results, capacityResult{region: region, zone: zone, score: score})
+		}
+
+		if len(results) > 0 {
+			// Sort descending by obtainability score. Stable sort preserves priority for earlier candidate regions on ties.
+			sort.SliceStable(results, func(i, j int) bool {
+				return results[i].score > results[j].score
+			})
+
+			best := results[0]
+			klog.Infof("Stack-ranked candidate regions:")
+			for idx, r := range results {
+				klog.Infof("  #%d: region=%q zone=%q score=%.2f", idx+1, r.region, r.zone, r.score)
+			}
+			klog.Infof("Selecting highest-scoring region %q (zone: %q, score: %.2f)", best.region, best.zone, best.score)
+
+			// Note: Updating GkeClusterRegion here implicitly updates the
+			// --test-bucket-location passed to Ginkgo. This ensures that the
+			// GCS buckets created during tests are co-located in this fallback
+			// region, preventing cross-region data transfer.
+			testParams.GkeClusterRegion = best.region
+			// Autopilot manages node placement dynamically across zones within the region,
+			// so --node-locations is only applied to Standard clusters.
+			if !testParams.UseGKEAutopilot {
+				nodeLocations = best.zone
+			}
+		} else {
+			klog.Warningf("All Capacity Advisor queries failed, falling back to default regional node allocation in %s", testParams.GkeClusterRegion)
+		}
+	}
+
+	// gcloud interprets --num-nodes as a per-zone count. When node-locations pins a
+	// single zone, numNodes is the total count across the cluster. Without pinned node-locations,
+	// GKE defaults to allocating nodes across all zones in the region (typically 3 zones),
+	// so scale numNodes down (minimum 1) to keep the total cluster node count consistent.
+	numNodes := testParams.NumNodes
+	if !testParams.UseGKEAutopilot && nodeLocations == "" {
+		numNodes = max(1, testParams.NumNodes/3)
+	}
+
+	klog.Infof("Attempting to create cluster %q in region %q (zone: %q)...", testParams.GkeClusterName, testParams.GkeClusterRegion, nodeLocations)
+
 	//nolint:gosec
-	out, err := gcloudCommand(testParams, "container", "clusters", "list", "--region", testParams.GkeClusterRegion, "--project", testParams.ProjectID, "--verbosity", "none", "--filter", "name="+testParams.GkeClusterName).CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("failed to check for previous test cluster: output: %v, err: %w", out, err)
+	out, listErr := gcloudCommand(testParams, "container", "clusters", "list", "--region", testParams.GkeClusterRegion, "--project", testParams.ProjectID, "--verbosity", "none", "--filter", "name="+testParams.GkeClusterName).CombinedOutput()
+	if listErr != nil {
+		return fmt.Errorf("failed to check for previous test cluster: output: %v, err: %w", out, listErr)
 	}
 	if len(out) > 0 {
 		klog.Infof("Detected previous cluster %s. Deleting it so a new one can be created...", testParams.GkeClusterName)
@@ -177,24 +265,8 @@ func clusterUpGKE(testParams *TestParameters) error {
 		cmdParams = append(cmdParams, "--cluster-version", testParams.GkeClusterVersion)
 	}
 
-	// Query Capacity Advisor to select a stockout-free zone for Standard clusters.
-	// gcloud interprets --num-nodes as a per-zone count. When the advisor pins a
-	// single zone, NumNodes is the total; on failure we fall back to GKE's default
-	// 3-zone regional layout, so scale NumNodes down (minimum 1) to keep the total consistent.
-	var nodeLocations string
-	if !testParams.UseGKEAutopilot && testParams.UseCapacityAdvisor {
-		advisedZone, err := queryCapacityAdvisedZone(testParams)
-		if err != nil {
-			klog.Warningf("Capacity Advisor query failed, falling back to default regional node allocation: %v", err)
-			testParams.NumNodes = max(1, testParams.NumNodes/3)
-		} else {
-			klog.Infof("Using Capacity Advised zone %q for cluster node locations", advisedZone)
-			nodeLocations = advisedZone
-		}
-	}
-
 	standardClusterFlags := []string{
-		"--num-nodes", strconv.Itoa(testParams.NumNodes), "--image-type", testParams.NodeImageType,
+		"--num-nodes", strconv.Itoa(numNodes), "--image-type", testParams.NodeImageType,
 		"--machine-type", testParams.NodeMachineType,
 		"--workload-pool", testParams.ProjectID + ".svc.id.goog",
 	}
@@ -224,9 +296,9 @@ func clusterUpGKE(testParams *TestParameters) error {
 	// Call update because --add-maintenance-exclusion is not an available flag during cluster creation.
 	startExclusionTime := time.Now().UTC()
 
-	exclusionDuration, err := time.ParseDuration(testParams.GinkgoTimeout)
-	if err != nil {
-		klog.Warningf("failed to parse ginkgo timeout %q, using default 4h for maintenance exclusion: %v", testParams.GinkgoTimeout, err)
+	exclusionDuration, parseErr := time.ParseDuration(testParams.GinkgoTimeout)
+	if parseErr != nil {
+		klog.Warningf("failed to parse ginkgo timeout %q, using default 4h for maintenance exclusion: %v", testParams.GinkgoTimeout, parseErr)
 		exclusionDuration = 4 * time.Hour
 	}
 

--- a/test/e2e/utils/handler.go
+++ b/test/e2e/utils/handler.go
@@ -44,6 +44,8 @@ var envAPIMap = map[string]string{
 type TestParameters struct {
 	PkgDir string
 
+	// GkeClusterRegion specifies the target GKE cluster region and implicitly sets
+	// Ginkgo's --test-bucket-location to co-locate test GCS buckets with the cluster.
 	GkeClusterRegion    string
 	GkeClusterVersion   string
 	GkeReleaseChannel   string
@@ -86,7 +88,10 @@ type TestParameters struct {
 	EnableGcsFuseProfiles          bool
 	EnableGCSFuseKernelParams      bool
 	EnableSharedMount              bool
-	UseCapacityAdvisor             bool
+	// UseCapacityAdvisor indicates whether to use GCE Capacity Advisor to select
+	// node locations and fallback regions. Only used when ManageClusterLifecycle is true;
+	// ignored on existing clusters.
+	UseCapacityAdvisor bool
 
 	GkeGcloudCommand string
 	GkeGcloudArgs    string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
After introducing GCE Capacity Advisor to select the best zone, we still encounter stockout issues (`GCE_STOCKOUT` / `ZONE_RESOURCE_POOL_EXHAUSTED`) in `us-central1` when creating 9-node `n2-standard-8` clusters because the entire region frequently runs out of available N2 capacity.
This PR addresses this by:
1. **Pre-flight Capacity Advisor evaluation across candidate regions**: Before initiating cluster creation (for both Standard and Autopilot clusters), queries the GCE Capacity Advisor across candidate fallback regions when Zonal Buckets (`EnableZB`) are disabled.
2. **Stack-ranked region & zone selection**: Stack-ranks all evaluated candidate regions by obtainability score and selects the highest-scoring region for a single cluster creation attempt. For Standard clusters, pins `--node-locations` to the advisor-recommended single zone.
3. Updates `modifyPVForProfiles` in `profiles.go` to dynamically derive Anywhere Cache zones (`<region>-c`) from `CLUSTER_LOCATION` instead of hardcoding `us-central1-c`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
I verified manually in a boskos project and  successfully provisioned a 9-node `n2-standard-8` cluster in `us-east4` (`us-east4-c`) without stockouts

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```