### PR TITLE
Bump GCSFuse binary to v2.5.5 to fix CVEs

### DIFF
--- a/cmd/sidecar_mounter/gcsfuse_binary
+++ b/cmd/sidecar_mounter/gcsfuse_binary
@@ -1,1 +1,1 @@
-gs://gke-release-staging/gcsfuse/v2.5.4-gke.4/gcsfuse_bin
+gs://gke-release-staging/gcsfuse/v2.5.5-gke.0/gcsfuse_bin


### PR DESCRIPTION
Update the GCSFuse binary to v2.5.5-gke.0 to address vulnerabilities.

BUG=b/552341736