### PR TITLE
[Shared Mount] Kernel Parameters Test

### DIFF
--- a/test/e2e/specs/specs.go
+++ b/test/e2e/specs/specs.go
@@ -211,6 +211,22 @@ func VerifyMounterPods(ctx context.Context, c clientset.Interface, namespace str
 	return mounterPods
 }
 
+// GetMounterPod returns the Mounter Pod scheduled on expectedNodeName in the namespace.
+func GetMounterPod(ctx context.Context, c clientset.Interface, namespace string, expectedNodeName string) *corev1.Pod {
+	if expectedNodeName == "" {
+		framework.Failf("expectedNodeName must be provided to get Mounter Pod")
+	}
+	listOpts := metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", webhook.SharedMountLabel, util.TrueStr),
+		FieldSelector: fmt.Sprintf("spec.nodeName=%s", expectedNodeName),
+	}
+
+	mounterPods, err := c.CoreV1().Pods(namespace).List(ctx, listOpts)
+	framework.ExpectNoError(err, "failed to list mounter pods")
+	gomega.Expect(mounterPods.Items).To(gomega.HaveLen(1), fmt.Sprintf("expected 1 Mounter Pod on node %s", expectedNodeName))
+	return &mounterPods.Items[0]
+}
+
 type TestPod struct {
 	client    clientset.Interface
 	pod       *corev1.Pod

--- a/test/e2e/testsuites/shared_mount.go
+++ b/test/e2e/testsuites/shared_mount.go
@@ -514,8 +514,7 @@ func (t *gcsFuseCSISharedMountTestSuite) DefineTests(driver storageframework.Tes
 		gomega.Expect(matches[1]).To(gomega.Equal(specs.ReadAheadCustomReadAheadKb), "expected max-read-ahead-kb in kernel-params.json to match custom value")
 		// Verify kernel-params.json is NOT in the workload pod's volume or filesystem.
 		ginkgo.By("Verifying kernel-params.json is NOT created inside the workload pod")
-		_, _, err := e2epod.ExecCommandInContainerWithFullOutput(f, workloadPod.GetPodName(), specs.TesterContainerName, "/bin/sh", "-c", fmt.Sprintf("[ ! -f %s/kernel-params.json ]", sharedMountPath))
-		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "expected kernel-params.json to not exist inside the shared mount path")
+		workloadPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, fmt.Sprintf("[ ! -f %s/kernel-params.json ]", sharedMountPath))
 
 		// Verify CSI Node driver detects kernel-params.json and updates the host node kernel parameters.
 		ginkgo.By("Verifying host node read_ahead_kb kernel parameter is updated to the custom value")

--- a/test/e2e/testsuites/shared_mount.go
+++ b/test/e2e/testsuites/shared_mount.go
@@ -20,8 +20,10 @@ package testsuites
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 
+	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/util"
 	"github.com/googlecloudplatform/gcs-fuse-csi-driver/pkg/webhook"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -32,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2evolume "k8s.io/kubernetes/test/e2e/framework/volume"
 	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
 	admissionapi "k8s.io/pod-security-admission/api"
@@ -68,6 +71,25 @@ func (t *gcsFuseCSISharedMountTestSuite) GetTestSuiteInfo() storageframework.Tes
 }
 
 func (t *gcsFuseCSISharedMountTestSuite) SkipUnsupportedTests(_ storageframework.TestDriver, _ storageframework.TestPattern) {
+}
+
+func setupAndDeploySharedMountPod(ctx context.Context, f *framework.Framework, vr *storageframework.VolumeResource, nodeAffinity ...string) (*specs.TestPod, *corev1.Pod) {
+	tPod := specs.NewTestPod(f.ClientSet, f.Namespace)
+	tPod.SetupVolume(vr, sharedVolName, sharedMountPath, false /* readOnly */)
+	if len(nodeAffinity) > 0 && nodeAffinity[0] != "" {
+		tPod.SetNodeAffinity(nodeAffinity[0], true /* sameNode */)
+	}
+	tPod.Create(ctx)
+	tPod.WaitForRunning(ctx)
+
+	// Verify client pod does NOT have a sidecar container injected.
+	tPod.VerifySidecarPresence(false /* expectPresent */)
+
+	// Verify a single Mounter Pod is created on the same node.
+	nodeName := tPod.GetNode()
+	mounterPod := specs.GetMounterPod(ctx, f.ClientSet, f.Namespace.Name, nodeName)
+
+	return tPod, mounterPod
 }
 
 func (t *gcsFuseCSISharedMountTestSuite) DefineTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {
@@ -150,26 +172,13 @@ func (t *gcsFuseCSISharedMountTestSuite) DefineTests(driver storageframework.Tes
 		nodeName := sidecarTestPod.GetNode()
 
 		ginkgo.By(fmt.Sprintf("Configuring and deploying sharedMountTestPod referencing the shared mount PVC on node %s", nodeName))
-		sharedMountTestPod := specs.NewTestPod(f.ClientSet, f.Namespace)
-		sharedMountTestPod.SetupVolume(sharedVR, sharedVolName, sharedMountPath, false /* readOnly */)
-		sharedMountTestPod.SetNodeAffinity(nodeName, true /* sameNode */)
-		sharedMountTestPod.Create(ctx)
+		sharedMountTestPod, _ := setupAndDeploySharedMountPod(ctx, f, sharedVR, nodeName)
 		defer sharedMountTestPod.Cleanup(ctx)
-
-		ginkgo.By("Waiting for sharedMountTestPod to be running")
-		sharedMountTestPod.WaitForRunning(ctx)
 		gomega.Expect(sharedMountTestPod.GetNode()).To(gomega.Equal(nodeName), "expected sharedMountTestPod to run on the same node as sidecarTestPod")
 
-		// Verify sidecarTestPod has a sidecar container injected while sharedMountTestPod does not, and a single Mounter Pod is created for sharedMountTestPod.
+		// Verify sidecarTestPod has a sidecar container injected.
 		ginkgo.By("Verifying sidecarTestPod has a sidecar container injected")
 		sidecarTestPod.VerifySidecarPresence(true /* expectPresent */)
-
-		ginkgo.By("Verifying sharedMountTestPod does NOT have a sidecar container injected")
-		sharedMountTestPod.VerifySidecarPresence(false /* expectPresent */)
-
-		ginkgo.By("Verifying a single Mounter Pod is created for sharedMountTestPod on the same node")
-		specs.VerifyMounterPods(ctx, f.ClientSet, f.Namespace.Name, 1, nodeName)
-
 		// Verify that both pods can successfully read and write to their respective volumes without conflicts.
 		ginkgo.By("Verifying sidecarTestPod can write and read from its sidecar-mounted volume")
 		sidecarTestPod.VerifyRWMount(f, sidecarMountPath)
@@ -203,35 +212,15 @@ func (t *gcsFuseCSISharedMountTestSuite) DefineTests(driver storageframework.Tes
 
 		// Configure and deploy Pod 1 referencing the dynamic shared-mount PVC.
 		ginkgo.By("Configuring and deploying the first pod referencing the dynamic shared-mount PVC")
-		tPod1 := specs.NewTestPod(f.ClientSet, f.Namespace)
-		tPod1.SetupVolume(sharedVR, sharedVolName, sharedMountPath, false /* readOnly */)
-		tPod1.Create(ctx)
+		tPod1, _ := setupAndDeploySharedMountPod(ctx, f, sharedVR)
 		defer tPod1.Cleanup(ctx)
-
-		ginkgo.By("Waiting for the first pod to be running and getting its node")
-		tPod1.WaitForRunning(ctx)
 		nodeName := tPod1.GetNode()
 
 		// Configure and deploy Pod 2 on the same node referencing the same PVC.
 		ginkgo.By(fmt.Sprintf("Configuring and deploying the second pod on node %s referencing the same PVC", nodeName))
-		tPod2 := specs.NewTestPod(f.ClientSet, f.Namespace)
-		tPod2.SetupVolume(sharedVR, sharedVolName, sharedMountPath, false /* readOnly */)
-		tPod2.SetNodeAffinity(nodeName, true /* sameNode */)
-		tPod2.Create(ctx)
+		tPod2, _ := setupAndDeploySharedMountPod(ctx, f, sharedVR, nodeName)
 		defer tPod2.Cleanup(ctx)
-
-		ginkgo.By("Waiting for the second pod to be running")
-		tPod2.WaitForRunning(ctx)
 		gomega.Expect(tPod2.GetNode()).To(gomega.Equal(nodeName), "expected second pod to run on the same node as first pod")
-
-		// Verify sidecar absence on client pods and exactly 1 Mounter Pod created on the node.
-		ginkgo.By("Verifying client pods do NOT have sidecar containers injected")
-		tPod1.VerifySidecarPresence(false /* expectPresent */)
-		tPod2.VerifySidecarPresence(false /* expectPresent */)
-
-		ginkgo.By("Verifying exactly 1 Mounter Pod is created for the dynamic shared-mount volume on the node")
-		specs.VerifyMounterPods(ctx, f.ClientSet, f.Namespace.Name, 1, nodeName)
-
 		// Verify RW mount point in both pods.
 		ginkgo.By("Verifying RW mount point in both pods")
 		tPod1.VerifyRWMount(f, sharedMountPath)
@@ -477,5 +466,77 @@ func (t *gcsFuseCSISharedMountTestSuite) DefineTests(driver storageframework.Tes
 		mismatchedKSAPod2.SetServiceAccount(mismatchedKSAName)
 		mismatchedKSAPod2.SetNonRootSecurityContext(0, 0, int(customFSGroup))
 		mismatchedKSAPod2.CreateExpectErrorContaining(ctx, "does not match the one specified in volume's PodTemplate")
+	})
+
+	// TC: Kernel Parameters with Shared Mount Test
+	// Verify that kernel parameters (read_ahead_kb, kernel-params.json) are correctly applied
+	// when using shared mount. The kernel params file should be created in the Mounter Pod's emptyDir,
+	// not the customer Pod's.
+	// Create a PodTemplate and a PV/PVC with sharedMount: true and a custom read_ahead_kb mount option.
+	// Create a workload pod referencing the PVC.
+	// Verify that kernel-params.json is created inside the Mounter Pod's gke-gcsfuse-tmp emptyDir volume
+	// instead of the workload pod's volume.
+	// Verify that the CSI Node driver detects kernel-params.json and updates the host node kernel parameters.
+	// Verify that the workload pod can successfully read and write data to the volume.
+	ginkgo.It("[shared-mount] should verify kernel parameters are applied via mounter pod and host node settings are updated", func() {
+		skipIfKernelParamsNotSupported()
+		init(1, specs.EnableCustomReadAhead)
+		defer cleanup()
+
+		gomega.Expect(l.volumeResourceList).To(gomega.HaveLen(1))
+		gomega.Expect(l.volumeResourceList[0]).ToNot(gomega.BeNil())
+		sharedVR := l.volumeResourceList[0]
+
+		// Configure and deploy the workload pod referencing the PVC.
+		ginkgo.By("Configuring and deploying the workload pod referencing the shared-mount PVC")
+		workloadPod, mounterPod := setupAndDeploySharedMountPod(ctx, f, sharedVR)
+		defer workloadPod.Cleanup(ctx)
+
+		// Verify kernel-params.json is created inside the Mounter Pod's gke-gcsfuse-tmp emptyDir volume.
+		ginkgo.By("Verifying kernel-params.json is created inside the Mounter Pod's gke-gcsfuse-tmp volume")
+		gomega.Expect(sharedVR.Pv).ToNot(gomega.BeNil())
+		mounterKernelParamsPath := fmt.Sprintf("/gcsfuse-tmp/.volumes/%s/kernel-params.json", sharedVR.Pv.Name)
+		var configData string
+		gomega.Eventually(func() error {
+			out, _, execErr := e2epod.ExecCommandInContainerWithFullOutput(f, mounterPod.Name, util.MounterPodNamePrefix, "/bin/sh", "-c", fmt.Sprintf("cat %s", mounterKernelParamsPath))
+			if execErr != nil {
+				return execErr
+			}
+			configData = out
+			return nil
+		}, retryTimeout, retryPolling).Should(gomega.Succeed(), "failed to read kernel-params.json in Mounter Pod")
+
+		// Verify kernel-params.json contains max-read-ahead-kb matching specs.ReadAheadCustomReadAheadKb.
+		pattern := fmt.Sprintf(kernelParamExtractRegex, regexp.QuoteMeta(string(MaxReadAheadKb)))
+		re := regexp.MustCompile(pattern)
+		matches := re.FindStringSubmatch(configData)
+		gomega.Expect(matches).To(gomega.HaveLen(2), "expected to extract max-read-ahead-kb from kernel-params.json")
+		gomega.Expect(matches[1]).To(gomega.Equal(specs.ReadAheadCustomReadAheadKb), "expected max-read-ahead-kb in kernel-params.json to match custom value")
+		// Verify kernel-params.json is NOT in the workload pod's volume or filesystem.
+		ginkgo.By("Verifying kernel-params.json is NOT created inside the workload pod")
+		_, _, err := e2epod.ExecCommandInContainerWithFullOutput(f, workloadPod.GetPodName(), specs.TesterContainerName, "/bin/sh", "-c", fmt.Sprintf("[ ! -f %s/kernel-params.json ]", sharedMountPath))
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "expected kernel-params.json to not exist inside the shared mount path")
+
+		// Verify CSI Node driver detects kernel-params.json and updates the host node kernel parameters.
+		ginkgo.By("Verifying host node read_ahead_kb kernel parameter is updated to the custom value")
+		gomega.Eventually(func() (string, error) {
+			bdi, _, err := e2epod.ExecCommandInContainerWithFullOutput(f, workloadPod.GetPodName(), specs.TesterContainerName, "/bin/sh", "-c", fmt.Sprintf("mountpoint -d \"%s\"", sharedMountPath))
+			if err != nil {
+				return "", err
+			}
+			readAheadPath := fmt.Sprintf("/sys/class/bdi/%s/read_ahead_kb", strings.TrimSpace(bdi))
+			out, _, err := e2epod.ExecCommandInContainerWithFullOutput(f, workloadPod.GetPodName(), specs.TesterContainerName, "/bin/sh", "-c", "cat "+readAheadPath)
+			if err != nil {
+				return "", err
+			}
+			return strings.TrimSpace(out), nil
+		}, retryTimeout, retryPolling).Should(gomega.Equal(specs.ReadAheadCustomReadAheadKb))
+
+		// Verify workload pod can read and write data to the volume.
+		ginkgo.By("Verifying workload pod can write and read from its shared-mounted volume")
+		workloadPod.VerifyRWMount(f, sharedMountPath)
+		testFilePath := fmt.Sprintf("%s/kernel-params-test-data.txt", sharedMountPath)
+		testContent := "hello from shared mount kernel params test"
+		workloadPod.VerifyWriteAndReadFile(f, testFilePath, testContent)
 	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:
This PR adds an E2E test case for kernel parameters (`read_ahead_kb`, `kernel-params.json`) with Shared Mount.

Verifies that:
1. `kernel-params.json` is created inside the Mounter Pod's `gke-gcsfuse-tmp` emptyDir volume rather than the client workload pod.
2. The CSI Node driver updates the host node's BDI kernel parameter.
3. Client workload pods can read and write data to the shared mount volume without issues.

Also refactors `setupAndDeploySharedMountPod` helper in `shared_mount.go` for cleaner shared-mount test pod provisioning.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
NONE
**Special notes for your reviewer**:
NONE
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```