### PR TITLE
Automated cherry pick of #1615: Bump GCSFuse binary to 3.11.3

### DIFF
--- a/cmd/sidecar_mounter/gcsfuse_binary
+++ b/cmd/sidecar_mounter/gcsfuse_binary
@@ -1,1 +1,1 @@
-gs://gke-release-staging/gcsfuse/v3.11.2-gke.0/gcsfuse_bin
+gs://gke-release-staging/gcsfuse/v3.11.3-gke.0/gcsfuse_bin


### PR DESCRIPTION
Cherry pick of #1615 on release-1.24.

#1615: Bump GCSFuse binary to 3.11.3

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Bump GCSFuse binary to 3.11.3
```