### PR TITLE
[Shared-Mount] Update container default resource requests

### DIFF
--- a/pkg/csi_driver/shared_mount.go
+++ b/pkg/csi_driver/shared_mount.go
@@ -369,9 +369,8 @@ func mounterPodResources(config *mounterPodConfig) *corev1.ResourceRequirements 
 	// Instantiate maps to avoid nil map assignment panics
 	resources := corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
-			// TODO: Change the defaults once we profile the feature.
-			corev1.ResourceMemory:           resource.MustParse("768Mi"),
-			corev1.ResourceCPU:              resource.MustParse("750m"),
+			corev1.ResourceMemory:           resource.MustParse("356Mi"),
+			corev1.ResourceCPU:              resource.MustParse("350m"),
 			corev1.ResourceEphemeralStorage: resource.MustParse("15Gi"),
 		},
 		Limits: corev1.ResourceList{},

--- a/pkg/csi_driver/shared_mount_test.go
+++ b/pkg/csi_driver/shared_mount_test.go
@@ -403,8 +403,8 @@ func TestCreateMounterPodSpec(t *testing.T) {
 	// Default resources expected when no overrides are provided
 	defaultResources := corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
-			corev1.ResourceMemory:           resource.MustParse("768Mi"),
-			corev1.ResourceCPU:              resource.MustParse("750m"),
+			corev1.ResourceMemory:           resource.MustParse("356Mi"),
+			corev1.ResourceCPU:              resource.MustParse("350m"),
 			corev1.ResourceEphemeralStorage: resource.MustParse("15Gi"),
 		},
 		Limits: corev1.ResourceList{},
@@ -1525,8 +1525,8 @@ func TestSetResource(t *testing.T) {
 
 func TestMounterPodResources(t *testing.T) {
 	defaultRequests := corev1.ResourceList{
-		corev1.ResourceMemory:           resource.MustParse("768Mi"),
-		corev1.ResourceCPU:              resource.MustParse("750m"),
+		corev1.ResourceMemory:           resource.MustParse("356Mi"),
+		corev1.ResourceCPU:              resource.MustParse("350m"),
 		corev1.ResourceEphemeralStorage: resource.MustParse("15Gi"),
 	}
 
@@ -1591,7 +1591,7 @@ func TestMounterPodResources(t *testing.T) {
 			},
 			want: &corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
-					corev1.ResourceMemory:           resource.MustParse("768Mi"),
+					corev1.ResourceMemory:           resource.MustParse("356Mi"),
 					corev1.ResourceEphemeralStorage: resource.MustParse("15Gi"),
 				},
 				Limits: corev1.ResourceList{},


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:
Update the default resource requests for shared node mounter pods based on fleet profiling data:

- **Memory**: `356Mi` (Increased from `256Mi` Sidecar Default)
  - At the P95 fleet concurrency level (10 pods per node), the shared mounter pod used a P95 memory usage of 306.91 MiB. To ensure a resilient out-of-the-box default, a 15% safety margin is applied (based on the default Vertical Pod Autoscaler safety margin).
- **CPU**: `350m` (Increased from `250m` Sidecar Default)
  - At the P95 fleet concurrency level (10 pods per node), the shared mounter pod exhibited a P95 CPU usage of 314.97 mCPU. Because this exceeds the original 250 mCPU baseline, the CPU request is increased to 350 mCPU applying the same ~15% safety margin.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
NONE
**Special notes for your reviewer**:
NONE
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```