### PR TITLE
[Shared Mount] In-Place Workload Pod Restart E2E Test

### DIFF
--- a/test/e2e/specs/specs.go
+++ b/test/e2e/specs/specs.go
@@ -20,6 +20,7 @@ package specs
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -37,11 +38,13 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/kubernetes/pkg/kubelet/events"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -230,9 +233,10 @@ func GetMounterPod(ctx context.Context, c clientset.Interface, namespace string,
 }
 
 type TestPod struct {
-	client    clientset.Interface
-	pod       *corev1.Pod
-	namespace *corev1.Namespace
+	client                   clientset.Interface
+	pod                      *corev1.Pod
+	namespace                *corev1.Namespace
+	inplacePodRestartEnabled bool
 }
 
 func NewTestPodModifiedSpec(c clientset.Interface, ns *corev1.Namespace, setAutomountServiceAccountToken bool) *TestPod {
@@ -304,11 +308,75 @@ func NewTestPod(c clientset.Interface, ns *corev1.Namespace) *TestPod {
 	}
 }
 
+// InplacePodRestart enables the Kubernetes 1.35+ in-place pod restart feature (RestartAllContainers on exit code 88).
+func (t *TestPod) InplacePodRestart() {
+	framework.Logf("Enabling in-place pod restart (RestartAllContainers)")
+	t.inplacePodRestartEnabled = true
+}
+
 func (t *TestPod) Create(ctx context.Context) {
 	framework.Logf("Creating Pod %s", t.pod.Name)
-	var err error
-	t.pod, err = t.client.CoreV1().Pods(t.namespace.Name).Create(ctx, t.pod, metav1.CreateOptions{})
-	framework.ExpectNoError(err)
+	if !t.inplacePodRestartEnabled {
+		var err error
+		t.pod, err = t.client.CoreV1().Pods(t.namespace.Name).Create(ctx, t.pod, metav1.CreateOptions{})
+		framework.ExpectNoError(err)
+		return
+	}
+
+	// TODO(b/558744868): When k8s.io/api and client-go in test/go.mod are upgraded to >= v0.35.0,
+	// replace this raw JSON injection with typed corev1.Container.RestartPolicyRules fields.
+	// In-place pod restart was introduced in Kubernetes 1.35+.
+	// Because this repository's vendored k8s.io/api and client-go dependencies are pinned to v0.33.3 (K8s 1.33),
+	// the typed Go structs lack Container.RestartPolicyRules and container-level RestartPolicy fields.
+	// To enable the feature without requiring a repo-wide Kubernetes dependency upgrade, we serialize the
+	// pod to a JSON map, inject restartPolicy: "Always" and restartPolicyRules directly into the containers,
+	// and submit the raw JSON payload to the API server via the RESTClient.
+	podBytes, err := json.Marshal(t.pod)
+	framework.ExpectNoError(err, "failed to marshal pod to json")
+
+	var podMap map[string]any
+	err = json.Unmarshal(podBytes, &podMap)
+	framework.ExpectNoError(err, "failed to unmarshal pod json to map")
+
+	// When creating a Pod via raw JSON using RESTClient, the API server and admission
+	// webhooks strictly require apiVersion and kind. Since NewTestPod does not populate
+	// TypeMeta, explicitly inject them here.
+	podMap["apiVersion"] = "v1"
+	podMap["kind"] = "Pod"
+
+	if spec, ok := podMap["spec"].(map[string]any); ok {
+		if containers, ok := spec["containers"].([]any); ok {
+			for _, c := range containers {
+				if containerMap, ok := c.(map[string]any); ok {
+					containerMap["restartPolicy"] = "Always"
+					containerMap["restartPolicyRules"] = []any{
+						map[string]any{
+							"action": "RestartAllContainers",
+							"exitCodes": map[string]any{
+								"operator": "In",
+								"values":   []int{88},
+							},
+						},
+					}
+				}
+			}
+		}
+	}
+
+	updatedBytes, err := json.Marshal(podMap)
+	framework.ExpectNoError(err, "failed to marshal updated pod map")
+
+	result := &corev1.Pod{}
+	err = t.client.CoreV1().RESTClient().Post().
+		Namespace(t.namespace.Name).
+		Resource("pods").
+		VersionedParams(&metav1.CreateOptions{}, scheme.ParameterCodec).
+		SetHeader("Content-Type", "application/json").
+		Body(updatedBytes).
+		Do(ctx).
+		Into(result)
+	framework.ExpectNoError(err, "failed to create pod with in-place restart rules")
+	t.pod = result
 }
 
 func (t *TestPod) CreateExpectError(ctx context.Context) {
@@ -339,6 +407,51 @@ func (t *TestPod) GetPodVols() []corev1.Volume {
 
 func (t *TestPod) GetAutoMountServiceAccountToken() bool {
 	return *t.pod.Spec.AutomountServiceAccountToken
+}
+
+func (t *TestPod) GetUID() types.UID {
+	return t.pod.UID
+}
+
+// RefreshPod fetches the latest Pod from the API server and updates t.pod.
+func (t *TestPod) RefreshPod(ctx context.Context) (*corev1.Pod, error) {
+	pod, err := t.client.CoreV1().Pods(t.namespace.Name).Get(ctx, t.pod.Name, metav1.GetOptions{})
+	if err == nil {
+		t.pod = pod
+	}
+	return pod, err
+}
+
+// GetContainerStatus returns the ContainerStatus for the specified container name from the latest pod status.
+func (t *TestPod) GetContainerStatus(ctx context.Context, containerName string) (*corev1.ContainerStatus, error) {
+	pod, err := t.RefreshPod(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for i := range pod.Status.ContainerStatuses {
+		if pod.Status.ContainerStatuses[i].Name == containerName {
+			return &pod.Status.ContainerStatuses[i], nil
+		}
+	}
+	for i := range pod.Status.InitContainerStatuses {
+		if pod.Status.InitContainerStatuses[i].Name == containerName {
+			return &pod.Status.InitContainerStatuses[i], nil
+		}
+	}
+	return nil, fmt.Errorf("container %q not found in pod %s", containerName, t.pod.Name)
+}
+
+// WaitForContainerRestart waits for the container in the pod to reach expectedRestartCount and be running.
+func (t *TestPod) WaitForContainerRestart(ctx context.Context, containerName string, expectedRestartCount int32) {
+	gomega.Eventually(ctx, func(g gomega.Gomega) {
+		cs, err := t.GetContainerStatus(ctx, containerName)
+		g.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("failed to get container %q status in pod %s", containerName, t.pod.Name))
+		if err != nil || cs == nil {
+			return
+		}
+		g.Expect(cs.RestartCount).To(gomega.Equal(expectedRestartCount), fmt.Sprintf("expected container %q to have restartCount %d, got %d", containerName, expectedRestartCount, cs.RestartCount))
+		g.Expect(cs.State.Running).ToNot(gomega.BeNil(), fmt.Sprintf("expected container %q to be running", containerName))
+	}, "2m", "2s").Should(gomega.Succeed())
 }
 
 // VerifyExecInPodSucceed verifies shell cmd in target pod succeed.

--- a/test/e2e/testsuites/shared_mount.go
+++ b/test/e2e/testsuites/shared_mount.go
@@ -20,6 +20,7 @@ package testsuites
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"local/test/e2e/specs"
@@ -648,5 +649,114 @@ func (t *gcsFuseCSISharedMountTestSuite) DefineTests(driver storageframework.Tes
 		testFilePath := fmt.Sprintf("%s/test-profiler-disabled.txt", sharedMountPath)
 		testContent := "hello from shared mount cloud profiler disabled test"
 		workloadPod.VerifyWriteAndReadFile(f, testFilePath, testContent)
+	})
+
+	// TC: In-Place Pod Restart with Shared Mount Test
+	// Create a PV with sharedMount: true, a PodTemplate, and a PVC referencing the template.
+	// Deploy a workload pod referencing the PVC, configured with container restartPolicyRules:
+	//   restartPolicyRules:
+	//     - action: RestartAllContainers
+	//       exitCodes:
+	//         operator: In
+	//         values:
+	//           - 88
+	// Workload container performs constant I/O (appending heartbeats to the shared mount every 2s).
+	// Confirm that both the workload pod and the external Mounter Pod are created and running (0 restarts).
+	// Trigger an in-place container restart by having the container exit with code 88.
+	// Verify that Kubelet restarts the workload container in-place (restart count increments to 1) while the Mounter Pod remains untouched with 0 restarts.
+	// Verify that the restarted container automatically resumes constant I/O to the shared mount without errors.
+	ginkgo.It("[shared-mount] should verify in-place container restart within workload pod preserves shared mount", func() {
+		init(1)
+		defer cleanup()
+
+		gomega.Expect(l.volumeResourceList).To(gomega.HaveLen(1))
+		gomega.Expect(l.volumeResourceList[0]).ToNot(gomega.BeNil())
+		sharedVR := l.volumeResourceList[0]
+
+		mountPath := "/data/gcs"
+		heartbeatFile := fmt.Sprintf("%s/heartbeat.txt", mountPath)
+
+		ginkgo.By("Configuring and deploying the workload pod referencing the shared-mount PVC with container restartPolicyRules and constant I/O")
+		// Deploy the workload pod directly instead of using setupAndDeploySharedMountPod because NewTestPod
+		// defaults to 'tail -f /dev/null' as PID 1, which ignores SIGTERM. We run a constant I/O heartbeat loop
+		// with a trap on signal 15 (SIGTERM) to exit with code 88 and trigger RestartAllContainers.
+		workloadPod := specs.NewTestPod(f.ClientSet, f.Namespace)
+		workloadPod.InplacePodRestart()
+		workloadPod.SetupVolume(sharedVR, sharedVolName, mountPath, false /* readOnly */)
+		workloadPod.SetCommand(fmt.Sprintf("trap 'exit 88' 15; while true; do echo \"$(date) - heartbeat\" >> %s; sleep 2; done", heartbeatFile))
+		workloadPod.Create(ctx)
+		defer workloadPod.Cleanup(ctx)
+
+		ginkgo.By("Waiting for the workload pod to be running")
+		workloadPod.WaitForRunning(ctx)
+		workloadPod.VerifySidecarPresence(false /* expectPresent */)
+
+		nodeName := workloadPod.GetNode()
+
+		ginkgo.By("Confirming both the workload pod and the external Mounter Pod are created and running with 0 restarts")
+		verifyMounterPodNoRestarts := func(pod *corev1.Pod) {
+			gomega.Expect(pod.Status.ContainerStatuses).ToNot(gomega.BeEmpty(), "expected mounter pod to have container statuses")
+			for _, cs := range pod.Status.ContainerStatuses {
+				gomega.Expect(cs.RestartCount).To(gomega.Equal(int32(0)), fmt.Sprintf("expected mounter pod container %q to have 0 restarts, got %d", cs.Name, cs.RestartCount))
+				gomega.Expect(cs.State.Running).ToNot(gomega.BeNil(), fmt.Sprintf("expected mounter pod container %q to be running", cs.Name))
+			}
+		}
+
+		initialMounterPod := specs.GetMounterPod(ctx, f.ClientSet, f.Namespace.Name, nodeName)
+		verifyMounterPodNoRestarts(initialMounterPod)
+		initialWorkloadUID := workloadPod.GetUID()
+		workloadPod.WaitForContainerRestart(ctx, specs.TesterContainerName, 0)
+
+		ginkgo.By("Verifying initial constant I/O: recording pre-restart heartbeat state")
+		workloadPod.VerifyRWMount(f, mountPath)
+		var preRestartCount int
+		var preRestartLastLine string
+		// Commands return 0 if file is missing to let Eventually retry instead of failing immediately.
+		gomega.Eventually(ctx, func(g gomega.Gomega) {
+			output := workloadPod.VerifyExecInPodSucceedWithOutput(f, specs.TesterContainerName, fmt.Sprintf("[ -f %s ] && wc -l < %s || echo 0", heartbeatFile, heartbeatFile))
+			count, err := strconv.Atoi(strings.TrimSpace(output))
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			g.Expect(count).To(gomega.BeNumerically(">", 0), "expected at least one heartbeat written before restart")
+			preRestartCount = count
+
+			lastLine := workloadPod.VerifyExecInPodSucceedWithOutput(f, specs.TesterContainerName, fmt.Sprintf("[ -f %s ] && tail -n 1 %s || true", heartbeatFile, heartbeatFile))
+			preRestartLastLine = strings.TrimSpace(lastLine)
+			g.Expect(preRestartLastLine).ToNot(gomega.BeEmpty(), "expected non-empty last heartbeat line")
+		}, "30s", "2s").Should(gomega.Succeed())
+
+		ginkgo.By("Triggering container exit with code 88 to activate RestartAllContainers restartPolicyRule")
+		workloadPod.VerifyExecInPodSucceed(f, specs.TesterContainerName, "(sleep 1 && kill -15 1) &")
+
+		ginkgo.By("Verifying Kubelet restarts the workload container in-place (restart count increments to 1)")
+		workloadPod.WaitForContainerRestart(ctx, specs.TesterContainerName, 1)
+
+		ginkgo.By("Verifying workload pod identity is preserved (in-place restart, not pod recreation)")
+		gomega.Expect(workloadPod.GetUID()).To(gomega.Equal(initialWorkloadUID), "expected workload pod UID to be preserved across container restart")
+		gomega.Expect(workloadPod.GetNode()).To(gomega.Equal(nodeName), "expected workload pod to remain on the same node")
+
+		ginkgo.By("Verifying the external Mounter Pod remains untouched with 0 restarts")
+		updatedMounterPod := specs.GetMounterPod(ctx, f.ClientSet, f.Namespace.Name, nodeName)
+		gomega.Expect(updatedMounterPod.UID).To(gomega.Equal(initialMounterPod.UID), "expected mounter pod UID to be unchanged")
+		verifyMounterPodNoRestarts(updatedMounterPod)
+
+		ginkgo.By("Verifying the restarted container preserved pre-restart data and kept writing new heartbeats without error")
+		workloadPod.VerifyRWMount(f, mountPath)
+		// Verify pre-restart data persists on the shared mount.
+		workloadPod.VerifyReadFile(f, heartbeatFile, preRestartLastLine)
+
+		// Verify the restarted container kept writing new heartbeats (count increased beyond pre-restart count).
+		// Command returns 0 if file is missing to let Eventually retry instead of failing immediately.
+		gomega.Eventually(ctx, func(g gomega.Gomega) {
+			output := workloadPod.VerifyExecInPodSucceedWithOutput(f, specs.TesterContainerName, fmt.Sprintf("[ -f %s ] && wc -l < %s || echo 0", heartbeatFile, heartbeatFile))
+			count, err := strconv.Atoi(strings.TrimSpace(output))
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			g.Expect(count).To(gomega.BeNumerically(">", preRestartCount),
+				fmt.Sprintf("expected heartbeat count (%d) to increase beyond pre-restart count (%d)", count, preRestartCount))
+		}, "30s", "2s").Should(gomega.Succeed())
+
+		ginkgo.By("Verifying that no errors occurred during container I/O operations")
+		logs, err := e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, workloadPod.GetPodName(), specs.TesterContainerName)
+		framework.ExpectNoError(err, "failed to get workload container logs")
+		gomega.Expect(strings.ToLower(logs)).NotTo(gomega.ContainSubstring("error"), "expected no errors in workload container logs")
 	})
 }

--- a/test/go.mod
+++ b/test/go.mod
@@ -6,7 +6,7 @@ replace github.com/googlecloudplatform/gcs-fuse-csi-driver => ../
 
 replace (
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc => go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.60.0
-	k8s.io/api => k8s.io/api v0.33.3
+	// TODO(b/558744868): When upgrading k8s.io/api and k8s.io/client-go to >= v0.35.0 update the in place pod restart tests.
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.33.3
 	k8s.io/apimachinery => k8s.io/apimachinery v0.33.3
 	k8s.io/apiserver => k8s.io/apiserver v0.33.3


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:
This PR adds an E2E test to verify that in-place container restarts within a workload pod do not disrupt the GCSFuse mount in the shared node mount architecture:

1. Deploys a workload pod referencing a shared-mount PVC with container `restartPolicy: Always`.
2. Confirms that both the workload pod and the external Mounter Pod are created and running with 0 restarts.
3. Writes a pre-restart file to the shared mount and verifies contents.
4. Triggers an in-place container restart by sending `SIGTERM` to PID 1 inside the workload container.
5. Verifies that Kubelet restarts the workload container in-place (restart count increments to 1) while preserving Pod UID and Node assignment.
6. Verifies that the external Mounter Pod remains untouched with 0 restarts.
7. Verifies that the restarted container immediately resumes reading pre-existing data and writing new data without errors.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
NONE
**Special notes for your reviewer**:
NONE
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```