### PR TITLE
Automated cherry pick of #1623: Bump GCSFuse binary to 3.11.4

### DIFF
--- a/cmd/sidecar_mounter/gcsfuse_binary
+++ b/cmd/sidecar_mounter/gcsfuse_binary
@@ -1,1 +1,1 @@
-gs://gke-release-staging/gcsfuse/v3.11.3-gke.0/gcsfuse_bin
+gs://gke-release-staging/gcsfuse/v3.11.4-gke.0/gcsfuse_bin


### PR DESCRIPTION
Cherry pick of #1623 on release-1.24.

#1623: Bump GCSFuse binary to 3.11.4

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```